### PR TITLE
Add spectator mode with shouts and potions

### DIFF
--- a/party/server.js
+++ b/party/server.js
@@ -6,9 +6,40 @@ export default class FightRoom {
     /** @type {(PlayerSlot|null)[]} */
     this.players = [null, null];
     this.started = false;
+    this.spectators = new Set();
+    this.fightInfo = null;
+    /** @type {Map<string, number>} shout rate-limit: connId -> last shout timestamp */
+    this._shoutCooldowns = new Map();
+    /** @type {Map<string, number>} potion rate-limit: connId -> last potion timestamp */
+    this._potionCooldowns = new Map();
   }
 
   onConnect(connection, ctx) {
+    // Check if spectator
+    const url = new URL(ctx.request.url);
+    const isSpectator = url.searchParams.get('spectate') === '1';
+
+    if (isSpectator) {
+      this.spectators.add(connection.id);
+      const count = this.spectators.size;
+      connection.send(JSON.stringify({ type: 'assign_spectator', spectatorCount: count }));
+      this._broadcast({ type: 'spectator_count', count });
+      // Send fight state catch-up if fight already started
+      if (this.fightInfo) {
+        connection.send(JSON.stringify({
+          type: 'fight_state',
+          p1Id: this.fightInfo.p1Id,
+          p2Id: this.fightInfo.p2Id,
+          stageId: this.fightInfo.stageId,
+          started: this.started,
+          p1Rounds: this.players[0]?.ready ? 0 : 0,
+          p2Rounds: this.players[1]?.ready ? 0 : 0,
+          roundNumber: 1
+        }));
+      }
+      return;
+    }
+
     // Clean up stale slots whose connections no longer exist
     this._cleanupStaleSlots();
 
@@ -26,6 +57,11 @@ export default class FightRoom {
     // Tell this player their slot
     connection.send(JSON.stringify({ type: 'assign', player: slot }));
 
+    // Send spectator count if there are spectators
+    if (this.spectators.size > 0) {
+      connection.send(JSON.stringify({ type: 'spectator_count', count: this.spectators.size }));
+    }
+
     // If both connected, notify both
     if (this.players[0] && this.players[1]) {
       this._broadcast({ type: 'opponent_joined' });
@@ -35,6 +71,36 @@ export default class FightRoom {
   onMessage(message, connection) {
     const data = JSON.parse(/** @type {string} */ (message));
     const slot = this._slotOf(connection.id);
+    const isSpectator = this._isSpectator(connection.id);
+
+    // Handle spectator messages
+    if (isSpectator) {
+      switch (data.type) {
+        case 'shout': {
+          const now = Date.now();
+          const last = this._shoutCooldowns.get(connection.id) || 0;
+          if (now - last < 2000) return; // 2s rate limit
+          this._shoutCooldowns.set(connection.id, now);
+          this._broadcast({ type: 'shout', text: String(data.text).slice(0, 20) });
+          break;
+        }
+        case 'potion': {
+          const now = Date.now();
+          const last = this._potionCooldowns.get(connection.id) || 0;
+          if (now - last < 15000) return; // 15s rate limit
+          this._potionCooldowns.set(connection.id, now);
+          const target = data.target === 0 ? 0 : 1;
+          const potionType = data.potionType === 'special' ? 'special' : 'hp';
+          // Send potion request to host only
+          this._sendToHost({ type: 'potion', target, potionType });
+          // Broadcast visual feedback to all
+          this._broadcast({ type: 'potion_applied', target, potionType });
+          break;
+        }
+      }
+      return;
+    }
+
     if (slot === -1) return;
 
     switch (data.type) {
@@ -50,6 +116,11 @@ export default class FightRoom {
           this.started = true;
           const stageIds = ['dojo', 'rooftop', 'beach', 'arcade', 'park'];
           const stageId = stageIds[Math.floor(Math.random() * stageIds.length)];
+          this.fightInfo = {
+            p1Id: this.players[0].fighterId,
+            p2Id: this.players[1].fighterId,
+            stageId
+          };
           this._broadcast({
             type: 'start',
             p1Id: this.players[0].fighterId,
@@ -60,8 +131,14 @@ export default class FightRoom {
         break;
       }
       case 'input':
+        this._sendToOther(slot, data);
+        this._broadcastToSpectators({ ...data, slot });
+        break;
       case 'sync':
       case 'round_event':
+        this._sendToOther(slot, data);
+        this._broadcastToSpectators(data);
+        break;
       case 'rematch':
         // Relay directly to opponent
         this._sendToOther(slot, data);
@@ -75,23 +152,38 @@ export default class FightRoom {
           }
         }
         this.started = false;
+        this.fightInfo = null;
         this._sendToOther(slot, data);
         break;
     }
   }
 
   onClose(connection) {
+    // Handle spectator disconnect
+    if (this._isSpectator(connection.id)) {
+      this.spectators.delete(connection.id);
+      this._shoutCooldowns.delete(connection.id);
+      this._potionCooldowns.delete(connection.id);
+      this._broadcast({ type: 'spectator_count', count: this.spectators.size });
+      return;
+    }
+
     const slot = this._slotOf(connection.id);
     if (slot === -1) return;
 
     this.players[slot] = null;
     this._sendToOther(slot, { type: 'disconnect' });
+    this._broadcastToSpectators({ type: 'disconnect' });
   }
 
   _slotOf(connId) {
     if (this.players[0]?.id === connId) return 0;
     if (this.players[1]?.id === connId) return 1;
     return -1;
+  }
+
+  _isSpectator(connId) {
+    return this.spectators.has(connId);
   }
 
   /** Remove player slots whose connection is no longer alive */
@@ -117,6 +209,29 @@ export default class FightRoom {
       if (conn.id === other.id) {
         conn.send(json);
         break;
+      }
+    }
+  }
+
+  _sendToHost(msg) {
+    const host = this.players[0];
+    if (!host) return;
+
+    const json = JSON.stringify(msg);
+    for (const conn of this.party.getConnections()) {
+      if (conn.id === host.id) {
+        conn.send(json);
+        break;
+      }
+    }
+  }
+
+  _broadcastToSpectators(msg) {
+    if (this.spectators.size === 0) return;
+    const json = JSON.stringify(msg);
+    for (const conn of this.party.getConnections()) {
+      if (this.spectators.has(conn.id)) {
+        conn.send(json);
       }
     }
   }

--- a/party/server.js
+++ b/party/server.js
@@ -174,6 +174,12 @@ export default class FightRoom {
     this.players[slot] = null;
     this._sendToOther(slot, { type: 'disconnect' });
     this._broadcastToSpectators({ type: 'disconnect' });
+
+    // If both players gone, clear fight state so late spectators don't get stale data
+    if (!this.players[0] && !this.players[1]) {
+      this.started = false;
+      this.fightInfo = null;
+    }
   }
 
   _slotOf(connId) {

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import { SelectScene } from './scenes/SelectScene.js';
 import { PreFightScene } from './scenes/PreFightScene.js';
 import { FightScene } from './scenes/FightScene.js';
 import { LobbyScene } from './scenes/LobbyScene.js';
+import { SpectatorLobbyScene } from './scenes/SpectatorLobbyScene.js';
 import { VictoryScene } from './scenes/VictoryScene.js';
 import { InspectorScene } from './scenes/InspectorScene.js';
 import { AudioManager } from './systems/AudioManager.js';
@@ -28,7 +29,7 @@ const config = {
     mode: Phaser.Scale.FIT,
     autoCenter: Phaser.Scale.CENTER_BOTH
   },
-  scene: [BootScene, TitleScene, LobbyScene, SelectScene, PreFightScene, FightScene, VictoryScene, InspectorScene]
+  scene: [BootScene, TitleScene, LobbyScene, SpectatorLobbyScene, SelectScene, PreFightScene, FightScene, VictoryScene, InspectorScene]
 };
 
 window.game = new Phaser.Game(config);

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -91,10 +91,12 @@ export class BootScene extends Phaser.Scene {
     this.generateRect('special_bar_bg', 100, 8, 0x333333);
     this.generateRect('special_bar_fill', 100, 8, 0xffcc00);
 
-    // If URL has ?room=, go directly to lobby as joiner
+    // If URL has ?room=, go directly to lobby as joiner or spectator
     const params = new URLSearchParams(window.location.search);
     const roomId = params.get('room');
-    if (roomId) {
+    if (roomId && params.get('spectate') === '1') {
+      this.scene.start('SpectatorLobbyScene', { roomId });
+    } else if (roomId) {
       this.scene.start('LobbyScene', { roomId });
     } else {
       this.scene.start('TitleScene');

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -1,7 +1,7 @@
 import Phaser from 'phaser';
 import {
   GAME_WIDTH, GAME_HEIGHT, GROUND_Y, STAGE_LEFT, STAGE_RIGHT,
-  MAX_HP, MAX_SPECIAL, ROUNDS_TO_WIN, FIGHTER_COLORS
+  MAX_HP, MAX_SPECIAL, ROUNDS_TO_WIN
 } from '../config.js';
 import { Fighter } from '../entities/Fighter.js';
 import { InputManager } from '../systems/InputManager.js';
@@ -71,23 +71,45 @@ export class FightScene extends Phaser.Scene {
     );
 
     // -- Systems --
-    this.inputManager = new InputManager(this);
-    this.touchControls = new TouchControls(this, this.inputManager);
     this.combat = new CombatSystem(this);
 
     // -- Projectiles array --
     this.projectiles = [];
 
+    // -- Active shouts tracking --
+    this._activeShouts = [];
+
     // -- Build HUD --
     this._createHUD();
 
-    // -- AI controller (local mode only) --
-    if (this.gameMode !== 'online') {
-      this.aiController = new AIController(this, this.p2Fighter, this.p1Fighter, this.aiDifficulty);
-    } else {
+    if (this.gameMode === 'spectator') {
+      // Spectator: no input, no AI, no dev console
+      this.inputManager = null;
+      this.touchControls = null;
       this.aiController = null;
+      this.devConsole = null;
+      this.spaceKey = null;
       this.frameCounter = 0;
-      this._setupOnlineMode();
+      this._setupSpectatorMode();
+    } else {
+      this.inputManager = new InputManager(this);
+      this.touchControls = new TouchControls(this, this.inputManager);
+
+      // -- AI controller (local mode only) --
+      if (this.gameMode !== 'online') {
+        this.aiController = new AIController(this, this.p2Fighter, this.p1Fighter, this.aiDifficulty);
+      } else {
+        this.aiController = null;
+        this.frameCounter = 0;
+        this._setupOnlineMode();
+      }
+
+      // -- Dev console (backtick to toggle) --
+      DevConsole._AIController = AIController;
+      this.devConsole = new DevConsole(this);
+
+      // -- Space key for restart --
+      this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
     }
 
     // -- Audio --
@@ -95,13 +117,6 @@ export class FightScene extends Phaser.Scene {
     audio.setScene(this);
     audio.playMusic('bgm_fight');
     audio.createMuteButton(this);
-
-    // -- Dev console (backtick to toggle) --
-    DevConsole._AIController = AIController;
-    this.devConsole = new DevConsole(this);
-
-    // -- Space key for restart --
-    this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
 
     // -- Start first round intro --
     this._showRoundIntro();
@@ -127,9 +142,18 @@ export class FightScene extends Phaser.Scene {
     // Update touch controls each frame
     if (this.touchControls) this.touchControls.update();
 
+    if (this.gameMode === 'spectator') {
+      // Spectator: apply remote inputs for animation, update HUD, no combat
+      if (this.combat.roundActive) {
+        this._handleSpectatorUpdate();
+      }
+      this._updateHUD();
+      return;
+    }
+
     if (!this.combat.roundActive) {
       // Allow restart after match over (Space key or tap)
-      if (this.combat.matchOver && Phaser.Input.Keyboard.JustDown(this.spaceKey)) {
+      if (this.combat.matchOver && this.spaceKey && Phaser.Input.Keyboard.JustDown(this.spaceKey)) {
         this.scene.restart();
       }
       return;
@@ -415,6 +439,24 @@ export class FightScene extends Phaser.Scene {
         }
       });
     }
+
+    // All online players: register shout display + potion visuals + spectator count
+    nm.onShout((text) => this._displayShout(text));
+    nm.onPotionApplied((target, potionType) => this._showPotionEffect(target, potionType));
+    nm.onSpectatorCount((count) => this._updateSpectatorCount(count));
+
+    // Host: handle potion requests from spectators
+    if (this.isHost) {
+      nm.onPotion((target, potionType) => {
+        if (!this.combat.roundActive) return;
+        const fighter = target === 0 ? this.p1Fighter : this.p2Fighter;
+        if (potionType === 'hp') {
+          fighter.hp = Math.min(MAX_HP, fighter.hp + 10);
+        } else {
+          fighter.special = Math.min(MAX_SPECIAL, fighter.special + 15);
+        }
+      });
+    }
   }
 
   _handleOnlineUpdate(time, delta) {
@@ -510,6 +552,218 @@ export class FightScene extends Phaser.Scene {
     else if (inputState.lk) fighter.attack('lightKick');
     else if (inputState.hk) fighter.attack('heavyKick');
     else if (inputState.sp) fighter.attack('special');
+  }
+
+  // =========================================================================
+  // SPECTATOR MODE
+  // =========================================================================
+  _setupSpectatorMode() {
+    const nm = this.networkManager;
+
+    // Receive authoritative state syncs from host
+    nm.onSync((msg) => {
+      this.p1Fighter.hp = msg.p1hp;
+      this.p1Fighter.special = msg.p1sp;
+      this.p2Fighter.hp = msg.p2hp;
+      this.p2Fighter.special = msg.p2sp;
+      this.combat.timer = msg.timer;
+      this.p1Fighter.sprite.x = msg.p1x;
+      this.p2Fighter.sprite.x = msg.p2x;
+    });
+
+    nm.onRoundEvent((msg) => {
+      this.combat.stopRound();
+      this.combat.p1RoundsWon = msg.p1Rounds;
+      this.combat.p2RoundsWon = msg.p2Rounds;
+      this.combat.roundNumber = msg.roundNumber;
+
+      if (msg.event === 'ko' || msg.event === 'timeup') {
+        if (msg.matchOver) {
+          this.combat.matchOver = true;
+          this.onMatchOver(msg.winnerIndex);
+        } else {
+          this.onRoundOver(msg.winnerIndex);
+        }
+      }
+    });
+
+    nm.onShout((text) => this._displayShout(text));
+    nm.onPotionApplied((target, potionType) => this._showPotionEffect(target, potionType));
+    nm.onSpectatorCount((count) => this._updateSpectatorCount(count));
+
+    nm.onDisconnect(() => {
+      this.combat.roundActive = false;
+      this.centerText.setText('DESCONECTADO');
+      this.subtitleText.setText('Un jugador abandono la pelea');
+      this.p1Fighter.stop();
+      this.p2Fighter.stop();
+    });
+
+    // Spectator badge
+    this.add.text(GAME_WIDTH - 8, 40, 'ESPECTADOR', {
+      fontSize: '7px', fontFamily: 'Arial', color: '#88ccff',
+      stroke: '#000000', strokeThickness: 2
+    }).setOrigin(1, 0).setDepth(25);
+
+    // Spectator count display
+    this._spectatorCountText = this.add.text(GAME_WIDTH - 8, 49, '', {
+      fontSize: '7px', fontFamily: 'Arial', color: '#aaaacc',
+      stroke: '#000000', strokeThickness: 2
+    }).setOrigin(1, 0).setDepth(25);
+
+    // Build spectator UI overlay
+    this._createSpectatorOverlay();
+  }
+
+  _handleSpectatorUpdate() {
+    const nm = this.networkManager;
+
+    // Apply inputs from both players for animations
+    const p1Input = nm.getRemoteInputForSlot(0);
+    this._applyInputToFighter(this.p1Fighter, p1Input);
+
+    const p2Input = nm.getRemoteInputForSlot(1);
+    this._applyInputToFighter(this.p2Fighter, p2Input);
+
+    // Body collision + facing
+    this.combat.resolveBodyCollision(this.p1Fighter, this.p2Fighter);
+    this.p1Fighter.faceOpponent(this.p2Fighter);
+    this.p2Fighter.faceOpponent(this.p1Fighter);
+  }
+
+  _createSpectatorOverlay() {
+    const barY = GAME_HEIGHT - 25;
+    // Semi-transparent dark bar
+    this.add.rectangle(GAME_WIDTH / 2, barY + 12, GAME_WIDTH, 25, 0x000000)
+      .setAlpha(0.6).setDepth(25);
+
+    const shouts = ['DALE!', 'NOOO!', 'VAMOS!', 'OLE!'];
+    const shoutCooldowns = {};
+    const btnW = 48;
+    const shoutStartX = 30;
+
+    shouts.forEach((text, i) => {
+      const x = shoutStartX + i * (btnW + 4);
+      shoutCooldowns[text] = 0;
+      this._createSpectatorButton(x, barY + 12, btnW, 18, text, 0x224488, () => {
+        const now = Date.now();
+        if (now - shoutCooldowns[text] < 2000) return;
+        shoutCooldowns[text] = now;
+        this.networkManager.sendShout(text);
+      });
+    });
+
+    // Potion buttons
+    const potions = [
+      { label: 'vida J1', target: 0, potionType: 'hp' },
+      { label: 'esp J1', target: 0, potionType: 'special' },
+      { label: 'vida J2', target: 1, potionType: 'hp' },
+      { label: 'esp J2', target: 1, potionType: 'special' }
+    ];
+    const potionStartX = GAME_WIDTH - 30 - (potions.length - 1) * (btnW + 4);
+    this._potionButtons = [];
+    let potionCooldown = 0;
+
+    potions.forEach((p, i) => {
+      const x = potionStartX + i * (btnW + 4);
+      const btn = this._createSpectatorButton(x, barY + 12, btnW, 18, p.label, 0x446622, () => {
+        const now = Date.now();
+        if (now - potionCooldown < 15000) return;
+        potionCooldown = now;
+        this.networkManager.sendPotion(p.target, p.potionType);
+        // Gray out all potion buttons during cooldown
+        this._potionButtons.forEach(b => b.bg.setFillStyle(0x333333));
+        this.time.delayedCall(15000, () => {
+          this._potionButtons.forEach(b => b.bg.setFillStyle(0x446622));
+        });
+      });
+      this._potionButtons.push(btn);
+    });
+  }
+
+  _createSpectatorButton(x, y, w, h, label, color, callback) {
+    const bg = this.add.rectangle(x, y, w, h, color)
+      .setStrokeStyle(1, 0x666688)
+      .setInteractive({ useHandCursor: true })
+      .setDepth(26);
+    const text = this.add.text(x, y, label, {
+      fontSize: '7px', fontFamily: 'Arial', color: '#ffffff'
+    }).setOrigin(0.5).setDepth(27);
+
+    bg.on('pointerover', () => text.setColor('#ffcc00'));
+    bg.on('pointerout', () => text.setColor('#ffffff'));
+    bg.on('pointerdown', callback);
+
+    return { bg, text };
+  }
+
+  // =========================================================================
+  // SHOUTS & POTIONS (all modes)
+  // =========================================================================
+  _displayShout(text) {
+    // Max 3 active shouts
+    if (this._activeShouts.length >= 3) return;
+
+    const x = Phaser.Math.Between(120, 360);
+    const startY = 195;
+    const shoutText = this.add.text(x, startY, text, {
+      fontSize: '12px', fontFamily: 'Arial Black, Arial', color: '#ffcc00',
+      stroke: '#000000', strokeThickness: 3
+    }).setOrigin(0.5).setDepth(25);
+
+    this._activeShouts.push(shoutText);
+
+    this.tweens.add({
+      targets: shoutText,
+      y: startY - 30,
+      alpha: 0,
+      duration: 2000,
+      ease: 'Power1',
+      onComplete: () => {
+        const idx = this._activeShouts.indexOf(shoutText);
+        if (idx !== -1) this._activeShouts.splice(idx, 1);
+        shoutText.destroy();
+      }
+    });
+  }
+
+  _showPotionEffect(target, potionType) {
+    const fighter = target === 0 ? this.p1Fighter : this.p2Fighter;
+    const tintColor = potionType === 'hp' ? 0x00ff66 : 0xffff00;
+    const label = potionType === 'hp' ? '+10 HP' : '+15 ESP';
+
+    // Tint flash
+    fighter.sprite.setTint(tintColor);
+    this.time.delayedCall(300, () => fighter.sprite.clearTint());
+
+    // Floating text
+    const floatText = this.add.text(fighter.sprite.x, fighter.sprite.y - 40, label, {
+      fontSize: '10px', fontFamily: 'Arial', color: potionType === 'hp' ? '#00ff66' : '#ffff00',
+      stroke: '#000000', strokeThickness: 2
+    }).setOrigin(0.5).setDepth(25);
+
+    this.tweens.add({
+      targets: floatText,
+      y: floatText.y - 20,
+      alpha: 0,
+      duration: 1200,
+      onComplete: () => floatText.destroy()
+    });
+  }
+
+  _updateSpectatorCount(count) {
+    if (!this._spectatorCountText) {
+      // Create spectator count text for online players too
+      this._spectatorCountText = this.add.text(GAME_WIDTH - 8, 40, '', {
+        fontSize: '7px', fontFamily: 'Arial', color: '#aaaacc',
+        stroke: '#000000', strokeThickness: 2
+      }).setOrigin(1, 0).setDepth(25);
+    }
+    if (count > 0) {
+      this._spectatorCountText.setText(`${count} espectador${count !== 1 ? 'es' : ''}`);
+    } else {
+      this._spectatorCountText.setText('');
+    }
   }
 
   // =========================================================================

--- a/src/scenes/LobbyScene.js
+++ b/src/scenes/LobbyScene.js
@@ -112,6 +112,13 @@ export class LobbyScene extends Phaser.Scene {
           navigator.clipboard.writeText(link).catch(() => {});
           this.subText.setText('Enlace copiado!');
         });
+
+        // Add spectator link button
+        const spectatorLink = `${window.location.origin}${window.location.pathname}?room=${this.roomId}&spectate=1`;
+        this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 80, 'ENLACE ESPECTADOR', () => {
+          navigator.clipboard.writeText(spectatorLink).catch(() => {});
+          this.subText.setText('Enlace espectador copiado!');
+        });
       } else {
         this.statusText.setText('Conectado! Esperando...');
       }

--- a/src/scenes/SpectatorLobbyScene.js
+++ b/src/scenes/SpectatorLobbyScene.js
@@ -1,0 +1,115 @@
+import Phaser from 'phaser';
+import { GAME_WIDTH, GAME_HEIGHT } from '../config.js';
+import { NetworkManager } from '../systems/NetworkManager.js';
+
+function getPartyHost() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('partyHost')) return params.get('partyHost');
+  const loc = window.location.hostname;
+  if (loc === 'localhost' || loc === '127.0.0.1') {
+    return 'localhost:1999';
+  }
+  return 'a-los-traques.simon0191.partykit.dev';
+}
+
+export class SpectatorLobbyScene extends Phaser.Scene {
+  constructor() {
+    super('SpectatorLobbyScene');
+  }
+
+  init(data) {
+    this.roomId = data.roomId;
+  }
+
+  create() {
+    const audio = this.game.audioManager;
+    audio.setScene(this);
+    audio.createMuteButton(this);
+
+    this.cameras.main.fadeIn(300, 0, 0, 0);
+
+    this.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2, GAME_WIDTH, GAME_HEIGHT, 0x0a0a1e);
+
+    this.add.text(GAME_WIDTH / 2, 30, 'ESPECTADOR', {
+      fontFamily: 'Arial Black, Arial',
+      fontSize: '24px',
+      color: '#88ccff',
+      stroke: '#000000',
+      strokeThickness: 4
+    }).setOrigin(0.5);
+
+    this.statusText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 10, 'Conectando...', {
+      fontFamily: 'Arial',
+      fontSize: '12px',
+      color: '#ccccee',
+      align: 'center',
+      wordWrap: { width: 400 }
+    }).setOrigin(0.5);
+
+    this.subText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 15, '', {
+      fontFamily: 'Arial',
+      fontSize: '9px',
+      color: '#888899'
+    }).setOrigin(0.5);
+
+    // Back button
+    const bg = this.add.rectangle(60, GAME_HEIGHT - 20, 110, 20, 0x222244)
+      .setStrokeStyle(1, 0x4444aa)
+      .setInteractive({ useHandCursor: true });
+    const text = this.add.text(60, GAME_HEIGHT - 20, 'VOLVER', {
+      fontFamily: 'Arial', fontSize: '9px', color: '#ffffff'
+    }).setOrigin(0.5);
+    bg.on('pointerover', () => { bg.setFillStyle(0x333366); text.setColor('#ffcc00'); });
+    bg.on('pointerout', () => { bg.setFillStyle(0x222244); text.setColor('#ffffff'); });
+    bg.on('pointerdown', () => {
+      this.game.audioManager.play('ui_confirm');
+      if (this.network) this.network.destroy();
+      this.scene.start('TitleScene');
+    });
+
+    // Connect as spectator
+    const host = getPartyHost();
+    this.subText.setText(host);
+    this.network = new NetworkManager(this.roomId, host, { spectator: true });
+
+    this.network.onError(() => {
+      this.statusText.setText('Error de conexion');
+      this.subText.setText('Asegura que el servidor este corriendo');
+    });
+
+    this.network.onAssignSpectator((count) => {
+      this.statusText.setText('Conectado como espectador');
+      this.subText.setText(`${count} espectador${count !== 1 ? 'es' : ''} conectado${count !== 1 ? 's' : ''}`);
+    });
+
+    this.network.onSpectatorCount((count) => {
+      this.subText.setText(`${count} espectador${count !== 1 ? 'es' : ''} conectado${count !== 1 ? 's' : ''}`);
+    });
+
+    this.network.onFightState((msg) => {
+      if (msg.started) {
+        this._goToFight(msg.p1Id, msg.p2Id, msg.stageId);
+      } else {
+        this.statusText.setText('Esperando que empiece la pelea...');
+      }
+    });
+
+    this.network.onStart((msg) => {
+      this._goToFight(msg.p1Id, msg.p2Id, msg.stageId);
+    });
+  }
+
+  _goToFight(p1Id, p2Id, stageId) {
+    this.statusText.setText('Pelea iniciada!');
+    this.cameras.main.fadeOut(300, 0, 0, 0);
+    this.cameras.main.once('camerafadeoutcomplete', () => {
+      this.scene.start('FightScene', {
+        p1Id,
+        p2Id,
+        stageId,
+        gameMode: 'spectator',
+        networkManager: this.network
+      });
+    });
+  }
+}

--- a/src/scenes/SpectatorLobbyScene.js
+++ b/src/scenes/SpectatorLobbyScene.js
@@ -97,6 +97,11 @@ export class SpectatorLobbyScene extends Phaser.Scene {
     this.network.onStart((msg) => {
       this._goToFight(msg.p1Id, msg.p2Id, msg.stageId);
     });
+
+    this.network.onDisconnect(() => {
+      this.statusText.setText('La pelea termino');
+      this.subText.setText('Los jugadores se desconectaron');
+    });
   }
 
   _goToFight(p1Id, p2Id, stageId) {

--- a/src/systems/CombatSystem.js
+++ b/src/systems/CombatSystem.js
@@ -19,7 +19,8 @@ export class CombatSystem {
     // Start timer countdown
     // In online mode, only the host counts down and triggers timeUp.
     // The guest's timer is overwritten by sync messages from the host.
-    const isOnlineGuest = this.scene.gameMode === 'online' && !this.scene.isHost;
+    const isOnlineGuest = (this.scene.gameMode === 'online' && !this.scene.isHost)
+      || this.scene.gameMode === 'spectator';
     this.timerEvent = this.scene.time.addEvent({
       delay: 1000,
       callback: () => {

--- a/src/systems/NetworkManager.js
+++ b/src/systems/NetworkManager.js
@@ -6,12 +6,14 @@ export class NetworkManager {
   /**
    * @param {string} roomId
    * @param {string} host - PartyKit host (e.g. 'localhost:1999' or 'a-los-traques.username.partykit.dev')
+   * @param {{ spectator?: boolean }} [options]
    */
-  constructor(roomId, host) {
+  constructor(roomId, host, { spectator = false } = {}) {
     this.roomId = roomId;
     this.playerSlot = -1;
     this.connected = false;
     this.localFrame = 0;
+    this.isSpectator = false;
 
     // Callbacks
     this._onAssign = null;
@@ -26,22 +28,40 @@ export class NetworkManager {
     this._onSync = null;
     this._onRoundEvent = null;
     this._onLeave = null;
+    this._onAssignSpectator = null;
+    this._onSpectatorCount = null;
+    this._onShout = null;
+    this._onFightState = null;
+    this._onPotionApplied = null;
+    this._onPotion = null;
 
     // Input buffer: frame -> inputState
     this.remoteInputBuffer = {};
     this.lastRemoteInput = null;
 
+    // Spectator input buffers (one per player slot)
+    this.remoteInputBufferP1 = {};
+    this.lastRemoteInputP1 = null;
+    this.remoteInputBufferP2 = {};
+    this.lastRemoteInputP2 = null;
+
     // Determine protocol based on host
     const isLocal = host.includes('localhost') || host.includes('127.0.0.1');
     const protocol = isLocal ? 'http' : 'https';
 
-    this.socket = new PartySocket({
+    const socketOptions = {
       host: host,
       room: roomId,
       protocol: protocol,
       maxRetries: 3,
       startClosed: false
-    });
+    };
+
+    if (spectator) {
+      socketOptions.query = { spectate: '1' };
+    }
+
+    this.socket = new PartySocket(socketOptions);
 
     this.socket.addEventListener('message', (event) => {
       this._handleMessage(JSON.parse(event.data));
@@ -76,9 +96,17 @@ export class NetworkManager {
         if (this._onStart) this._onStart(msg);
         break;
       case 'input':
-        this.remoteInputBuffer[msg.frame] = msg.state;
-        this.lastRemoteInput = msg.state;
-        if (this._onRemoteInput) this._onRemoteInput(msg.frame, msg.state);
+        if (this.isSpectator && msg.slot != null) {
+          // Spectator: route input to correct player buffer
+          const buf = msg.slot === 0 ? 'remoteInputBufferP1' : 'remoteInputBufferP2';
+          const lastKey = msg.slot === 0 ? 'lastRemoteInputP1' : 'lastRemoteInputP2';
+          this[buf][msg.frame] = msg.state;
+          this[lastKey] = msg.state;
+        } else {
+          this.remoteInputBuffer[msg.frame] = msg.state;
+          this.lastRemoteInput = msg.state;
+        }
+        if (this._onRemoteInput) this._onRemoteInput(msg.frame, msg.state, msg.slot);
         break;
       case 'disconnect':
         if (this._onDisconnect) this._onDisconnect();
@@ -98,6 +126,25 @@ export class NetworkManager {
       case 'leave':
         if (this._onLeave) this._onLeave();
         break;
+      case 'assign_spectator':
+        this.isSpectator = true;
+        if (this._onAssignSpectator) this._onAssignSpectator(msg.spectatorCount);
+        break;
+      case 'spectator_count':
+        if (this._onSpectatorCount) this._onSpectatorCount(msg.count);
+        break;
+      case 'shout':
+        if (this._onShout) this._onShout(msg.text);
+        break;
+      case 'fight_state':
+        if (this._onFightState) this._onFightState(msg);
+        break;
+      case 'potion_applied':
+        if (this._onPotionApplied) this._onPotionApplied(msg.target, msg.potionType);
+        break;
+      case 'potion':
+        if (this._onPotion) this._onPotion(msg.target, msg.potionType);
+        break;
     }
   }
 
@@ -114,6 +161,12 @@ export class NetworkManager {
   onSync(cb) { this._onSync = cb; }
   onRoundEvent(cb) { this._onRoundEvent = cb; }
   onLeave(cb) { this._onLeave = cb; }
+  onAssignSpectator(cb) { this._onAssignSpectator = cb; }
+  onSpectatorCount(cb) { this._onSpectatorCount = cb; }
+  onShout(cb) { this._onShout = cb; }
+  onFightState(cb) { this._onFightState = cb; }
+  onPotionApplied(cb) { this._onPotionApplied = cb; }
+  onPotion(cb) { this._onPotion = cb; }
 
   // --- Public API: send messages ---
   sendReady(fighterId) {
@@ -138,6 +191,14 @@ export class NetworkManager {
 
   sendRoundEvent(event) {
     this._send({ type: 'round_event', ...event });
+  }
+
+  sendShout(text) {
+    this._send({ type: 'shout', text });
+  }
+
+  sendPotion(target, potionType) {
+    this._send({ type: 'potion', target, potionType });
   }
 
   /**
@@ -169,12 +230,44 @@ export class NetworkManager {
     return { left: false, right: false, up: false, down: false, lp: false, hp: false, lk: false, hk: false, sp: false };
   }
 
+  /**
+   * Get the latest remote input for a specific player slot (spectator mode).
+   * @param {number} slot - 0 for P1, 1 for P2
+   * @returns {object} input state
+   */
+  getRemoteInputForSlot(slot) {
+    const buf = slot === 0 ? this.remoteInputBufferP1 : this.remoteInputBufferP2;
+    const lastKey = slot === 0 ? 'lastRemoteInputP1' : 'lastRemoteInputP2';
+
+    const frames = Object.keys(buf).map(Number);
+    if (frames.length > 0) {
+      const latest = Math.max(...frames);
+      const input = buf[latest];
+      if (slot === 0) {
+        this.remoteInputBufferP1 = {};
+        this.lastRemoteInputP1 = { ...input, lp: false, hp: false, lk: false, hk: false, sp: false };
+      } else {
+        this.remoteInputBufferP2 = {};
+        this.lastRemoteInputP2 = { ...input, lp: false, hp: false, lk: false, hk: false, sp: false };
+      }
+      return input;
+    }
+    if (this[lastKey]) {
+      return { ...this[lastKey] };
+    }
+    return { left: false, right: false, up: false, down: false, lp: false, hp: false, lk: false, hk: false, sp: false };
+  }
+
   getPlayerSlot() { return this.playerSlot; }
   getInputDelay() { return INPUT_DELAY; }
 
   resetForReselect() {
     this.remoteInputBuffer = {};
     this.lastRemoteInput = null;
+    this.remoteInputBufferP1 = {};
+    this.lastRemoteInputP1 = null;
+    this.remoteInputBufferP2 = {};
+    this.lastRemoteInputP2 = null;
     this.localFrame = 0;
     this._onOpponentReady = null;
     this._onStart = null;


### PR DESCRIPTION
## Summary
- Spectators join via `?room=XXXX&spectate=1` link, watch fights in real-time
- Spectators can send floating shout messages (DALE!, NOOO!, VAMOS!, OLE!) visible to all
- Spectators can send HP/special potions to either player (host applies them authoritatively)
- Server tracks spectators separately from players, with rate limiting on shouts (2s) and potions (15s)
- LobbyScene shows "ENLACE ESPECTADOR" copy button for room creators
- Late-joining spectators get fight state catch-up; stale rooms are cleaned up when both players disconnect

## Test plan
- [ ] Create online game, copy spectator link, open in another tab
- [ ] Verify spectator sees fight in real-time (HP, positions, timer)
- [ ] Test shout buttons send floating text visible to all
- [ ] Test potion buttons apply HP/special boosts with visual feedback
- [ ] Test mid-fight spectator join (should catch up via fight_state)
- [ ] Test multiple spectators (count updates for all)
- [ ] Test player disconnect shows message for spectators
- [ ] Test stale room cleanup (spectator joining after fight ends)

Generated with [Claude Code](https://claude.com/claude-code)