### PR TITLE
Add back navigation and room code sharing

### DIFF
--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -875,15 +875,37 @@ export class FightScene extends Phaser.Scene {
       fontSize: '28px', fontFamily: 'monospace', color: '#ffffff',
       stroke: '#000000', strokeThickness: 4
     }).setOrigin(0.5);
-    const hint = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 15, 'Toca o pulsa ESC para continuar', {
-      fontSize: '8px', fontFamily: 'monospace', color: '#aaaaaa',
-      stroke: '#000000', strokeThickness: 2
-    }).setOrigin(0.5);
-    this._pauseOverlay.add([bg, title, hint]);
 
-    // Allow tap on overlay to resume
-    bg.setInteractive();
-    bg.on('pointerdown', () => this._resumeGame());
+    // CONTINUAR button
+    const contBg = this.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 5, 110, 20, 0x222244)
+      .setStrokeStyle(1, 0x4444aa).setInteractive({ useHandCursor: true });
+    const contText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 5, 'CONTINUAR', {
+      fontSize: '9px', fontFamily: 'Arial', color: '#ffffff'
+    }).setOrigin(0.5);
+    contBg.on('pointerover', () => { contBg.setFillStyle(0x333366); contText.setColor('#ffcc00'); });
+    contBg.on('pointerout', () => { contBg.setFillStyle(0x222244); contText.setColor('#ffffff'); });
+    contBg.on('pointerdown', () => this._resumeGame());
+
+    // SALIR button
+    const salirBg = this.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 30, 110, 20, 0x222244)
+      .setStrokeStyle(1, 0x4444aa).setInteractive({ useHandCursor: true });
+    const salirText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 30, 'SALIR', {
+      fontSize: '9px', fontFamily: 'Arial', color: '#ffffff'
+    }).setOrigin(0.5);
+    salirBg.on('pointerover', () => { salirBg.setFillStyle(0x333366); salirText.setColor('#ffcc00'); });
+    salirBg.on('pointerout', () => { salirBg.setFillStyle(0x222244); salirText.setColor('#ffffff'); });
+    salirBg.on('pointerdown', () => {
+      this._resumeGame();
+      if (this.gameMode === 'online' && this.networkManager) {
+        this.networkManager.destroy();
+      }
+      this.cameras.main.fadeOut(300, 0, 0, 0);
+      this.cameras.main.once('camerafadeoutcomplete', () => {
+        this.scene.start('TitleScene');
+      });
+    });
+
+    this._pauseOverlay.add([bg, title, contBg, contText, salirBg, salirText]);
   }
 
   _resumeGame() {

--- a/src/scenes/LobbyScene.js
+++ b/src/scenes/LobbyScene.js
@@ -53,7 +53,7 @@ export class LobbyScene extends Phaser.Scene {
       strokeThickness: 4
     }).setOrigin(0.5);
 
-    this.statusText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 20, '', {
+    this.statusText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 30, '', {
       fontFamily: 'Arial',
       fontSize: '12px',
       color: '#ccccee',
@@ -61,15 +61,29 @@ export class LobbyScene extends Phaser.Scene {
       wordWrap: { width: 400 }
     }).setOrigin(0.5);
 
-    this.linkText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 10, '', {
+    this.codeLabel = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 8, '', {
+      fontFamily: 'Arial',
+      fontSize: '9px',
+      color: '#888899'
+    }).setOrigin(0.5);
+
+    this.codeText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 12, '', {
       fontFamily: 'monospace',
-      fontSize: '10px',
+      fontSize: '24px',
+      color: '#ffffff',
+      stroke: '#000000',
+      strokeThickness: 3
+    }).setOrigin(0.5);
+
+    this.linkText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 32, '', {
+      fontFamily: 'monospace',
+      fontSize: '8px',
       color: '#88ccff',
       align: 'center',
       wordWrap: { width: 400 }
     }).setOrigin(0.5);
 
-    this.subText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 35, '', {
+    this.subText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 45, '', {
       fontFamily: 'Arial',
       fontSize: '9px',
       color: '#888899'
@@ -101,21 +115,23 @@ export class LobbyScene extends Phaser.Scene {
       if (this.isCreator) {
         const link = `${window.location.origin}${window.location.pathname}?room=${this.roomId}`;
         this.statusText.setText('Esperando oponente...');
+        this.codeLabel.setText('CODIGO:');
+        this.codeText.setText(this.roomId.split('').join(' '));
         this.linkText.setText(link);
-        this.subText.setText('Comparte el enlace con tu amigo');
+        this.subText.setText('Comparte el codigo con tu amigo');
 
         // Copy to clipboard
         navigator.clipboard.writeText(link).catch(() => {});
 
         // Add copy button
-        this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 55, 'COPIAR ENLACE', () => {
+        this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 60, 'COPIAR ENLACE', () => {
           navigator.clipboard.writeText(link).catch(() => {});
           this.subText.setText('Enlace copiado!');
         });
 
         // Add spectator link button
         const spectatorLink = `${window.location.origin}${window.location.pathname}?room=${this.roomId}&spectate=1`;
-        this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 80, 'ENLACE ESPECTADOR', () => {
+        this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 82, 'ENLACE ESPECTADOR', () => {
           navigator.clipboard.writeText(spectatorLink).catch(() => {});
           this.subText.setText('Enlace espectador copiado!');
         });

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -214,6 +214,19 @@ export class SelectScene extends Phaser.Scene {
       this.p2StatBars.push(bar);
     });
 
+    // Back button
+    this._createButton(60, GAME_HEIGHT - 20, 'VOLVER', () => {
+      if (this.p1Confirmed || this.transitioning) return;
+      this.game.audioManager.play('ui_cancel');
+      if (this.gameMode === 'online' && this.networkManager) {
+        this.networkManager.destroy();
+      }
+      this.cameras.main.fadeOut(300, 0, 0, 0);
+      this.cameras.main.once('camerafadeoutcomplete', () => {
+        this.scene.start('TitleScene');
+      });
+    });
+
     // Confirmed overlay text
     this.confirmedText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT - 12, '', {
       fontFamily: 'Arial',
@@ -386,6 +399,27 @@ export class SelectScene extends Phaser.Scene {
       const val = p2Fighter.stats[stat];
       this.p2StatBars[i].width = (val / 5) * 60;
     });
+  }
+
+  _createButton(x, y, label, callback) {
+    const bg = this.add.rectangle(x, y, 110, 20, 0x222244)
+      .setStrokeStyle(1, 0x4444aa)
+      .setInteractive({ useHandCursor: true });
+
+    const text = this.add.text(x, y, label, {
+      fontFamily: 'Arial',
+      fontSize: '9px',
+      color: '#ffffff'
+    }).setOrigin(0.5);
+
+    bg.on('pointerover', () => { bg.setFillStyle(0x333366); text.setColor('#ffcc00'); });
+    bg.on('pointerout', () => { bg.setFillStyle(0x222244); text.setColor('#ffffff'); });
+    bg.on('pointerdown', () => {
+      this.game.audioManager.play('ui_confirm');
+      callback();
+    });
+
+    return { bg, text };
   }
 
   goToPreFight() {

--- a/src/scenes/TitleScene.js
+++ b/src/scenes/TitleScene.js
@@ -62,15 +62,19 @@ export class TitleScene extends Phaser.Scene {
     this.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 5, 200, 2, 0xccccff, 0.6);
 
     // Mode buttons
-    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 40, 'VS MAQUINA', () => {
+    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 33, 'VS MAQUINA', () => {
       this.goToSelect();
     });
 
-    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 68, 'EN LINEA', () => {
+    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 57, 'EN LINEA', () => {
       this.goToLobby();
     });
 
-    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 96, 'INSPECTOR', () => {
+    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 81, 'UNIRSE', () => {
+      this._showJoinOverlay();
+    });
+
+    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 105, 'INSPECTOR', () => {
       this.goToInspector();
     });
 
@@ -130,6 +134,101 @@ export class TitleScene extends Phaser.Scene {
       this.game.audioManager.play('ui_confirm');
       callback();
     });
+  }
+
+  _showJoinOverlay() {
+    if (this._joinOverlay) return;
+    const VALID_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+    this._joinOverlay = this.add.container(0, 0).setDepth(50);
+
+    const bg = this.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2, GAME_WIDTH, GAME_HEIGHT, 0x000000, 0.85);
+    this._joinOverlay.add(bg);
+
+    const title = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 50, 'CODIGO DE SALA', {
+      fontFamily: 'Arial Black, Arial',
+      fontSize: '16px',
+      color: '#ffcc00',
+      stroke: '#000000',
+      strokeThickness: 3
+    }).setOrigin(0.5);
+    this._joinOverlay.add(title);
+
+    this._joinCodeText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 15, '_ _ _ _', {
+      fontFamily: 'monospace',
+      fontSize: '24px',
+      color: '#ffffff',
+      stroke: '#000000',
+      strokeThickness: 3
+    }).setOrigin(0.5);
+    this._joinOverlay.add(this._joinCodeText);
+
+    // Hidden HTML input to trigger iOS keyboard
+    this._joinInput = document.createElement('input');
+    this._joinInput.type = 'text';
+    this._joinInput.maxLength = 4;
+    this._joinInput.autocapitalize = 'characters';
+    this._joinInput.inputMode = 'text';
+    this._joinInput.style.cssText = 'position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);opacity:0.01;font-size:16px;width:80px;z-index:1000;';
+    document.body.appendChild(this._joinInput);
+    this._joinInput.focus();
+
+    this._joinInput.addEventListener('input', () => {
+      let val = this._joinInput.value.toUpperCase();
+      val = val.split('').filter(c => VALID_CHARS.includes(c)).join('');
+      if (val.length > 4) val = val.slice(0, 4);
+      this._joinInput.value = val;
+      const display = val.padEnd(4, '_').split('').join(' ');
+      this._joinCodeText.setText(display);
+    });
+
+    // ENTRAR button
+    const entrarBg = this.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 20, 140, 24, 0x222244)
+      .setStrokeStyle(1, 0x4444aa).setInteractive({ useHandCursor: true });
+    const entrarText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 20, 'ENTRAR', {
+      fontFamily: 'Arial', fontSize: '12px', color: '#ffffff'
+    }).setOrigin(0.5);
+    entrarBg.on('pointerover', () => { entrarBg.setFillStyle(0x333366); entrarText.setColor('#ffcc00'); });
+    entrarBg.on('pointerout', () => { entrarBg.setFillStyle(0x222244); entrarText.setColor('#ffffff'); });
+    entrarBg.on('pointerdown', () => {
+      const code = this._joinInput.value.toUpperCase().split('').filter(c => VALID_CHARS.includes(c)).join('');
+      if (code.length !== 4) return;
+      this.game.audioManager.play('ui_confirm');
+      this._hideJoinOverlay();
+      if (this.transitioning) return;
+      this.transitioning = true;
+      this.cameras.main.fadeOut(300, 0, 0, 0);
+      this.cameras.main.once('camerafadeoutcomplete', () => {
+        this.scene.start('LobbyScene', { roomId: code });
+      });
+    });
+    this._joinOverlay.add([entrarBg, entrarText]);
+
+    // CANCELAR button
+    const cancelBg = this.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 48, 140, 24, 0x222244)
+      .setStrokeStyle(1, 0x4444aa).setInteractive({ useHandCursor: true });
+    const cancelText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 48, 'CANCELAR', {
+      fontFamily: 'Arial', fontSize: '12px', color: '#ffffff'
+    }).setOrigin(0.5);
+    cancelBg.on('pointerover', () => { cancelBg.setFillStyle(0x333366); cancelText.setColor('#ffcc00'); });
+    cancelBg.on('pointerout', () => { cancelBg.setFillStyle(0x222244); cancelText.setColor('#ffffff'); });
+    cancelBg.on('pointerdown', () => {
+      this.game.audioManager.play('ui_cancel');
+      this._hideJoinOverlay();
+    });
+    this._joinOverlay.add([cancelBg, cancelText]);
+  }
+
+  _hideJoinOverlay() {
+    if (this._joinInput) {
+      this._joinInput.remove();
+      this._joinInput = null;
+    }
+    if (this._joinOverlay) {
+      this._joinOverlay.destroy();
+      this._joinOverlay = null;
+    }
+    this._joinCodeText = null;
   }
 
   update() {

--- a/src/scenes/VictoryScene.js
+++ b/src/scenes/VictoryScene.js
@@ -109,7 +109,7 @@ export class VictoryScene extends Phaser.Scene {
     }).setOrigin(0.5);
 
     // Buttons
-    this.createButton(GAME_WIDTH / 2 - 70, 252, 'REVANCHA', () => {
+    this.createButton(GAME_WIDTH / 2 - 115, 252, 'REVANCHA', () => {
       if (this.gameMode === 'online' && this.networkManager) {
         this.networkManager.sendRematch();
         this._waitingRematch = true;
@@ -126,7 +126,7 @@ export class VictoryScene extends Phaser.Scene {
       }
     });
 
-    this.createButton(GAME_WIDTH / 2 + 70, 252, 'ELEGIR OTRO', () => {
+    this.createButton(GAME_WIDTH / 2, 252, 'ELEGIR OTRO', () => {
       if (this.gameMode === 'online' && this.networkManager) {
         this.networkManager.sendLeave();
         this._goToSelect();
@@ -136,6 +136,16 @@ export class VictoryScene extends Phaser.Scene {
           this.scene.start('SelectScene', { gameMode: 'local' });
         });
       }
+    });
+
+    this.createButton(GAME_WIDTH / 2 + 115, 252, 'MENU', () => {
+      if (this.gameMode === 'online' && this.networkManager) {
+        this.networkManager.destroy();
+      }
+      this.cameras.main.fadeOut(300, 0, 0, 0);
+      this.cameras.main.once('camerafadeoutcomplete', () => {
+        this.scene.start('TitleScene');
+      });
     });
 
     // In online mode, listen for rematch/leave from opponent even before pressing button
@@ -190,7 +200,7 @@ export class VictoryScene extends Phaser.Scene {
   }
 
   createButton(x, y, label, callback) {
-    const bg = this.add.rectangle(x, y, 110, 22, 0x222244)
+    const bg = this.add.rectangle(x, y, 100, 22, 0x222244)
       .setStrokeStyle(1, 0x4444aa)
       .setInteractive({ useHandCursor: true });
 


### PR DESCRIPTION
## Summary
- **SelectScene**: Add "VOLVER" back button to return to TitleScene (disabled after confirming fighter)
- **FightScene**: Replace tap-to-resume pause with explicit "CONTINUAR" and "SALIR" buttons
- **VictoryScene**: Add "MENU" button alongside existing REVANCHA and ELEGIR OTRO
- **LobbyScene**: Display room code prominently in large 24px monospace (e.g. `A B C D`) for easy verbal sharing
- **TitleScene**: Add "UNIRSE" button with room code input overlay using hidden HTML input to trigger iOS keyboard

## Test plan
- [ ] Local flow: Title → Select (VOLVER → Title) → confirm → Fight → pause → SALIR → Title
- [ ] Local flow: Fight → Victory → MENU → Title
- [ ] Online flow: Title → EN LINEA → Lobby (verify large room code) → back
- [ ] Online flow: Title → UNIRSE → enter 4-char code → ENTRAR → joins Lobby as joiner
- [ ] Mobile: UNIRSE overlay triggers iOS keyboard, code entry works, CANCELAR dismisses
- [ ] `npm run dev` loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)