### PR TITLE
Fix white screen crash for fighters without sprites

### DIFF
--- a/src/entities/Fighter.js
+++ b/src/entities/Fighter.js
@@ -17,8 +17,13 @@ export class Fighter {
     this.sprite.body.setGravityY(GRAVITY);
 
     // Check if this fighter has real sprite animations
+    // We verify the texture has more than 1 frame, because Phaser registers
+    // animations even when the spritesheet PNG 404s (falling back to a
+    // single-frame placeholder texture), which causes a crash on play().
     this.fighterId = fighterData.id;
-    this.hasAnims = scene.anims.exists(`${this.fighterId}_idle`);
+    const idleTexKey = `fighter_${this.fighterId}_idle`;
+    const idleTex = scene.textures.exists(idleTexKey) && scene.textures.get(idleTexKey);
+    this.hasAnims = idleTex && idleTex.frameTotal > 2;
     if (this.hasAnims) {
       this.sprite.play(`${this.fighterId}_idle`);
     }

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -20,7 +20,7 @@ const ANIM_DEFS = {
 };
 
 // Fighters that have real sprite assets (add IDs here as they're generated)
-const FIGHTERS_WITH_SPRITES = ['simon', 'jeka', 'chicha', 'cata', 'carito', 'mao', 'peks', 'lini', 'alv', 'sun', 'gartner', 'richi', 'cami', 'migue'];
+const FIGHTERS_WITH_SPRITES = ['simon', 'jeka'];
 
 export class BootScene extends Phaser.Scene {
   constructor() {


### PR DESCRIPTION
## Summary
- **Root cause**: `FIGHTERS_WITH_SPRITES` listed all 14 fighters, but only `simon` and `jeka` have actual sprite PNGs. Phaser registered animation keys even for 404'd spritesheets, so `hasAnims` was `true` but `play()` crashed on undefined frame duration.
- Trimmed `FIGHTERS_WITH_SPRITES` to only fighters with real assets, eliminating 404s on load
- Made `hasAnims` check texture frame count instead of animation key existence, preventing future crashes if a spritesheet fails to load

## Test plan
- [x] Select a fighter without sprites (e.g. chicha) in VS bot mode — should load fight scene with placeholder texture instead of white screen
- [ ] Select simon or jeka — should still play animations normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)