### PR TITLE
Fix multiplayer screen shrinking after iOS keyboard dismissal

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,8 @@
   <script>
     // Size game container to actual visible viewport (not behind browser chrome)
     var gc = document.getElementById('game-container');
-    function fixHeight() {
+    window.fixHeight = function fixHeight() {
+      if (window._suppressFixHeight) return;
       var vh = window.visualViewport ? window.visualViewport.height : window.innerHeight;
       var vw = window.visualViewport ? window.visualViewport.width : window.innerWidth;
       gc.style.width = vw + 'px';
@@ -78,10 +79,10 @@
       // Tell Phaser to re-measure if game exists
       if (window.game && window.game.scale) window.game.scale.refresh();
     }
-    fixHeight();
-    window.addEventListener('resize', fixHeight);
+    window.fixHeight();
+    window.addEventListener('resize', window.fixHeight);
     if (window.visualViewport) {
-      window.visualViewport.addEventListener('resize', fixHeight);
+      window.visualViewport.addEventListener('resize', window.fixHeight);
     }
   </script>
   <script type="module" src="/src/main.js"></script>

--- a/src/scenes/TitleScene.js
+++ b/src/scenes/TitleScene.js
@@ -178,6 +178,7 @@ export class TitleScene extends Phaser.Scene {
     this._joinInput.inputMode = 'text';
     this._joinInput.style.cssText = 'position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);opacity:0.01;font-size:16px;width:80px;z-index:1000;';
     document.body.appendChild(this._joinInput);
+    window._suppressFixHeight = true;
     this._joinInput.focus();
 
     this._joinInput.addEventListener('input', () => {
@@ -228,8 +229,16 @@ export class TitleScene extends Phaser.Scene {
 
   _hideJoinOverlay() {
     if (this._joinInput) {
+      this._joinInput.blur();
       this._joinInput.remove();
       this._joinInput = null;
+      // iOS keyboard dismissal is animated — keep fixHeight suppressed
+      // so intermediate visualViewport resize events don't shrink the container.
+      // Re-enable after the keyboard animation completes and force a refresh.
+      setTimeout(() => {
+        window._suppressFixHeight = false;
+        if (typeof window.fixHeight === 'function') window.fixHeight();
+      }, 500);
     }
     if (this._joinOverlay) {
       this._joinOverlay.destroy();


### PR DESCRIPTION
## Summary
- Suppress `fixHeight()` viewport resizing while the join-room HTML input is active, preventing iOS keyboard open/close events from shrinking the game container
- Blur input before DOM removal so iOS properly dismisses the keyboard
- Re-enable `fixHeight()` after a 500ms delay to let the keyboard dismissal animation complete, then force a viewport refresh

## Test plan
- [ ] On iPhone Safari in landscape, tap UNIRSE, type a room code, tap ENTRAR — verify the game fills the full screen after transitioning to LobbyScene and SelectScene
- [ ] On iPhone Safari in landscape, tap UNIRSE, then CANCELAR — verify the screen returns to full size
- [ ] Verify fighter selection screen is fully interactive after joining a multiplayer room
- [ ] Run `npx vitest run` — all 52 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)