### PR TITLE
Multiplayer audit: reliability fixes + ping indicator

### DIFF
--- a/party/server.js
+++ b/party/server.js
@@ -182,10 +182,13 @@ export default class FightRoom {
     this._sendToOther(slot, { type: 'disconnect' });
     this._broadcastToSpectators({ type: 'disconnect' });
 
-    // If both players gone, clear fight state so late spectators don't get stale data
-    if (!this.players[0] && !this.players[1]) {
-      this.started = false;
-      this.fightInfo = null;
+    // Reset room to pre-match state so reconnection can start a new match
+    this.started = false;
+    this.fightInfo = null;
+    const otherSlot = slot === 0 ? 1 : 0;
+    if (this.players[otherSlot]) {
+      this.players[otherSlot].ready = false;
+      this.players[otherSlot].fighterId = null;
     }
   }
 

--- a/party/server.js
+++ b/party/server.js
@@ -69,7 +69,12 @@ export default class FightRoom {
   }
 
   onMessage(message, connection) {
-    const data = JSON.parse(/** @type {string} */ (message));
+    let data;
+    try {
+      data = JSON.parse(/** @type {string} */ (message));
+    } catch {
+      return;
+    }
     const slot = this._slotOf(connection.id);
     const isSpectator = this._isSpectator(connection.id);
 
@@ -105,6 +110,7 @@ export default class FightRoom {
 
     switch (data.type) {
       case 'ready': {
+        if (this.started || this.players[slot].ready) break;
         this.players[slot].fighterId = data.fighterId;
         this.players[slot].ready = true;
 
@@ -136,6 +142,7 @@ export default class FightRoom {
         break;
       case 'sync':
       case 'round_event':
+        if (slot !== 0) break;
         this._sendToOther(slot, data);
         this._broadcastToSpectators(data);
         break;

--- a/party/server.js
+++ b/party/server.js
@@ -146,6 +146,10 @@ export default class FightRoom {
         this._sendToOther(slot, data);
         this._broadcastToSpectators(data);
         break;
+      case 'ping':
+        // Echo back directly to sender
+        connection.send(JSON.stringify({ type: 'pong', t: data.t }));
+        break;
       case 'rematch':
         // Relay directly to opponent
         this._sendToOther(slot, data);

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -346,6 +346,23 @@ export class FightScene extends Phaser.Scene {
       this.pauseBtn.on('pointerdown', () => this._togglePause());
     }
 
+    // --- Ping + room code (online/spectator, bottom center) ---
+    if ((this.gameMode === 'online' || this.gameMode === 'spectator') && this.networkManager) {
+      const infoY = GAME_HEIGHT - 8;
+      this._roomCodeText = this.add.text(GAME_WIDTH / 2, infoY, `SALA: ${this.networkManager.roomId}`, {
+        fontSize: '7px', fontFamily: 'monospace', color: '#aaaacc',
+        stroke: '#000000', strokeThickness: 2
+      }).setOrigin(0.5, 1).setDepth(depth + 3);
+
+      if (this.gameMode === 'online') {
+        this._pingText = this.add.text(GAME_WIDTH / 2, infoY - 10, '', {
+          fontSize: '7px', fontFamily: 'monospace', color: '#44ff44',
+          stroke: '#000000', strokeThickness: 2
+        }).setOrigin(0.5, 1).setDepth(depth + 3);
+        this._pingUpdateCounter = 0;
+      }
+    }
+
     // --- Center text (for announcements) ---
     this.centerText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 40, '', {
       fontSize: '28px', fontFamily: 'monospace', color: '#ffffff',
@@ -409,6 +426,19 @@ export class FightScene extends Phaser.Scene {
     for (let i = 0; i < ROUNDS_TO_WIN; i++) {
       this.roundDotsP1[i].setFillStyle(i < this.combat.p1RoundsWon ? 0x00cc44 : 0x333333);
       this.roundDotsP2[i].setFillStyle(i < this.combat.p2RoundsWon ? 0xcc2200 : 0x333333);
+    }
+
+    // Ping indicator (update ~1x per second)
+    if (this._pingText && this.networkManager) {
+      this._pingUpdateCounter = (this._pingUpdateCounter || 0) + 1;
+      if (this._pingUpdateCounter >= 60) {
+        this._pingUpdateCounter = 0;
+        const ms = this.networkManager.latency;
+        this._pingText.setText(`${ms}ms`);
+        if (ms > 150) this._pingText.setColor('#ff4444');
+        else if (ms > 80) this._pingText.setColor('#ffcc00');
+        else this._pingText.setColor('#44ff44');
+      }
     }
   }
 

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -473,6 +473,10 @@ export class FightScene extends Phaser.Scene {
     // Sync counter: host sends state every N frames
     this._syncInterval = 3;
 
+    // Dedup guards for guest receiving round events
+    this._lastProcessedRound = 0;
+    this._matchOverProcessed = false;
+
     nm.onDisconnect(() => {
       this.combat.roundActive = false;
       this._onlineDisconnected = true;
@@ -493,12 +497,23 @@ export class FightScene extends Phaser.Scene {
         this.p2Fighter.special = msg.p2sp;
         this.p2Fighter.stamina = msg.p2sta != null ? msg.p2sta : this.p2Fighter.stamina;
         this.combat.timer = msg.timer;
-        // Sync positions to prevent drift
-        this.p1Fighter.sprite.x = msg.p1x;
-        this.p2Fighter.sprite.x = msg.p2x;
+        // Sync positions to prevent drift (lerp for smooth movement, teleport for large diffs)
+        const p1dx = Math.abs(this.p1Fighter.sprite.x - msg.p1x);
+        this.p1Fighter.sprite.x = p1dx > 50 ? msg.p1x : this.p1Fighter.sprite.x + (msg.p1x - this.p1Fighter.sprite.x) * 0.3;
+        const p2dx = Math.abs(this.p2Fighter.sprite.x - msg.p2x);
+        this.p2Fighter.sprite.x = p2dx > 50 ? msg.p2x : this.p2Fighter.sprite.x + (msg.p2x - this.p2Fighter.sprite.x) * 0.3;
       });
 
       nm.onRoundEvent((msg) => {
+        // Dedup: skip already-processed round events
+        if (msg.matchOver) {
+          if (this._matchOverProcessed) return;
+          this._matchOverProcessed = true;
+        } else if (msg.event === 'ko' || msg.event === 'timeup') {
+          if (msg.roundNumber <= this._lastProcessedRound) return;
+          this._lastProcessedRound = msg.roundNumber;
+        }
+
         // Host tells us about round outcomes
         this.combat.stopRound();
         this.combat.p1RoundsWon = msg.p1Rounds;
@@ -594,17 +609,20 @@ export class FightScene extends Phaser.Scene {
     this._updateHUD();
   }
 
-  /** Send round event from host to guest via network */
+  /** Send round event from host to guest via network (3x with 200ms spacing for reliability) */
   _sendRoundEvent(event, winnerIndex) {
     if (this.gameMode === 'online' && this.isHost && this.networkManager) {
-      this.networkManager.sendRoundEvent({
+      const payload = {
         event,
         winnerIndex,
         p1Rounds: this.combat.p1RoundsWon,
         p2Rounds: this.combat.p2RoundsWon,
         roundNumber: this.combat.roundNumber,
         matchOver: this.combat.matchOver
-      });
+      };
+      this.networkManager.sendRoundEvent(payload);
+      setTimeout(() => this.networkManager && this.networkManager.sendRoundEvent(payload), 200);
+      setTimeout(() => this.networkManager && this.networkManager.sendRoundEvent(payload), 400);
     }
   }
 
@@ -645,8 +663,11 @@ export class FightScene extends Phaser.Scene {
       this.p2Fighter.hp = msg.p2hp;
       this.p2Fighter.special = msg.p2sp;
       this.combat.timer = msg.timer;
-      this.p1Fighter.sprite.x = msg.p1x;
-      this.p2Fighter.sprite.x = msg.p2x;
+      // Lerp positions for smooth movement, teleport for large diffs
+      const sp1dx = Math.abs(this.p1Fighter.sprite.x - msg.p1x);
+      this.p1Fighter.sprite.x = sp1dx > 50 ? msg.p1x : this.p1Fighter.sprite.x + (msg.p1x - this.p1Fighter.sprite.x) * 0.3;
+      const sp2dx = Math.abs(this.p2Fighter.sprite.x - msg.p2x);
+      this.p2Fighter.sprite.x = sp2dx > 50 ? msg.p2x : this.p2Fighter.sprite.x + (msg.p2x - this.p2Fighter.sprite.x) * 0.3;
     });
 
     nm.onRoundEvent((msg) => {

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -275,6 +275,22 @@ export class SelectScene extends Phaser.Scene {
           this._showOpponentSelection(fighterId);
         }
       });
+
+      this.networkManager.onDisconnect(() => {
+        this.transitioning = true;
+        this.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2, 'Oponente desconectado', {
+          fontSize: '14px', fontFamily: 'monospace', color: '#ff4444',
+          stroke: '#000000', strokeThickness: 3
+        }).setOrigin(0.5).setDepth(50);
+        this.time.delayedCall(1500, () => {
+          this.networkManager.destroy();
+          this.networkManager = null;
+          this.cameras.main.fadeOut(300, 0, 0, 0);
+          this.cameras.main.once('camerafadeoutcomplete', () => {
+            this.scene.start('TitleScene');
+          });
+        });
+      });
     }
   }
 

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -265,6 +265,14 @@ export class SelectScene extends Phaser.Scene {
     // Update display
     this.updateP1Display();
 
+    // Room code display (online mode, bottom center)
+    if (this.gameMode === 'online' && this.networkManager) {
+      this.add.text(GAME_WIDTH / 2, GAME_HEIGHT - 8, `SALA: ${this.networkManager.roomId}`, {
+        fontSize: '7px', fontFamily: 'monospace', color: '#aaaacc',
+        stroke: '#000000', strokeThickness: 2
+      }).setOrigin(0.5, 1).setDepth(10);
+    }
+
     // In online mode, reset stale state and listen for opponent ready early
     if (this.gameMode === 'online' && this.networkManager) {
       this.networkManager.resetForReselect();

--- a/src/scenes/TitleScene.js
+++ b/src/scenes/TitleScene.js
@@ -181,6 +181,11 @@ export class TitleScene extends Phaser.Scene {
     window._suppressFixHeight = true;
     this._joinInput.focus();
 
+    this._stopKeydown = (e) => e.stopPropagation();
+    this._stopKeyup = (e) => e.stopPropagation();
+    this._joinInput.addEventListener('keydown', this._stopKeydown);
+    this._joinInput.addEventListener('keyup', this._stopKeyup);
+
     this._joinInput.addEventListener('input', () => {
       let val = this._joinInput.value.toUpperCase();
       val = val.split('').filter(c => VALID_CHARS.includes(c)).join('');
@@ -229,9 +234,13 @@ export class TitleScene extends Phaser.Scene {
 
   _hideJoinOverlay() {
     if (this._joinInput) {
+      this._joinInput.removeEventListener('keydown', this._stopKeydown);
+      this._joinInput.removeEventListener('keyup', this._stopKeyup);
       this._joinInput.blur();
       this._joinInput.remove();
       this._joinInput = null;
+      this._stopKeydown = null;
+      this._stopKeyup = null;
       // iOS keyboard dismissal is animated — keep fixHeight suppressed
       // so intermediate visualViewport resize events don't shrink the container.
       // Re-enable after the keyboard animation completes and force a refresh.

--- a/src/scenes/VictoryScene.js
+++ b/src/scenes/VictoryScene.js
@@ -172,6 +172,13 @@ export class VictoryScene extends Phaser.Scene {
         this.add.text(GAME_WIDTH / 2, 235, 'Oponente desconectado', {
           fontFamily: 'Arial', fontSize: '8px', color: '#ff4444'
         }).setOrigin(0.5);
+        this.time.delayedCall(1500, () => {
+          this.networkManager.destroy();
+          this.cameras.main.fadeOut(300, 0, 0, 0);
+          this.cameras.main.once('camerafadeoutcomplete', () => {
+            this.scene.start('TitleScene');
+          });
+        });
       });
     }
   }

--- a/src/systems/NetworkManager.js
+++ b/src/systems/NetworkManager.js
@@ -2,6 +2,16 @@ import PartySocket from 'partysocket';
 
 const INPUT_DELAY = 3;
 
+// Message types that support callback buffering (B5)
+const BUFFERABLE_TYPES = ['sync', 'round_event', 'start'];
+
+// Map message types to their callback property names
+const TYPE_TO_CALLBACK = {
+  sync: '_onSync',
+  round_event: '_onRoundEvent',
+  start: '_onStart',
+};
+
 export class NetworkManager {
   /**
    * @param {string} roomId
@@ -15,18 +25,18 @@ export class NetworkManager {
     this.localFrame = 0;
     this.isSpectator = false;
 
-    // Callbacks
+    // Callbacks (managed via setter properties for bufferable types)
     this._onAssign = null;
     this._onOpponentJoined = null;
     this._onOpponentReady = null;
-    this._onStart = null;
+    this.__onStart = null;
     this._onRemoteInput = null;
     this._onDisconnect = null;
     this._onRematch = null;
     this._onFull = null;
     this._onError = null;
-    this._onSync = null;
-    this._onRoundEvent = null;
+    this.__onSync = null;
+    this.__onRoundEvent = null;
     this._onLeave = null;
     this._onAssignSpectator = null;
     this._onSpectatorCount = null;
@@ -34,6 +44,33 @@ export class NetworkManager {
     this._onFightState = null;
     this._onPotionApplied = null;
     this._onPotion = null;
+
+    // B5: Pending callback messages queue
+    this._pendingCallbackMessages = {
+      sync: [],
+      round_event: [],
+      start: [],
+    };
+
+    // B5: Define setter properties that flush pending messages when callback is set
+    for (const type of BUFFERABLE_TYPES) {
+      const privateProp = `__on${type.charAt(0).toUpperCase()}${type.slice(1).replace(/_([a-z])/g, (_, c) => c.toUpperCase())}`;
+      const publicProp = `_on${type.charAt(0).toUpperCase()}${type.slice(1).replace(/_([a-z])/g, (_, c) => c.toUpperCase())}`;
+      Object.defineProperty(this, publicProp, {
+        get() { return this[privateProp]; },
+        set(cb) {
+          this[privateProp] = cb;
+          if (cb && this._pendingCallbackMessages[type] && this._pendingCallbackMessages[type].length > 0) {
+            const pending = this._pendingCallbackMessages[type].splice(0);
+            for (const msg of pending) {
+              cb(msg);
+            }
+          }
+        },
+        configurable: true,
+        enumerable: true,
+      });
+    }
 
     // Input buffer: frame -> inputState
     this.remoteInputBuffer = {};
@@ -44,6 +81,9 @@ export class NetworkManager {
     this.lastRemoteInputP1 = null;
     this.remoteInputBufferP2 = {};
     this.lastRemoteInputP2 = null;
+
+    // B4: Pending messages queue for when disconnected
+    this._pendingMessages = [];
 
     // Determine protocol based on host
     const isLocal = host.includes('localhost') || host.includes('127.0.0.1');
@@ -63,21 +103,37 @@ export class NetworkManager {
 
     this.socket = new PartySocket(socketOptions);
 
-    this.socket.addEventListener('message', (event) => {
-      this._handleMessage(JSON.parse(event.data));
-    });
-
-    this.socket.addEventListener('open', () => {
+    // B2: Store bound handler references for cleanup
+    this._boundOnMessage = (event) => {
+      // B1: Wrap JSON.parse in try-catch
+      try {
+        this._handleMessage(JSON.parse(event.data));
+      } catch (e) {
+        // Silently ignore malformed messages
+        return;
+      }
+    };
+    this._boundOnOpen = () => {
       this.connected = true;
-    });
-
-    this.socket.addEventListener('close', () => {
+      // B4: Flush pending messages on reconnect
+      if (this._pendingMessages.length > 0) {
+        const pending = this._pendingMessages.splice(0);
+        for (const msg of pending) {
+          this._send(msg);
+        }
+      }
+    };
+    this._boundOnClose = () => {
       this.connected = false;
-    });
-
-    this.socket.addEventListener('error', () => {
+    };
+    this._boundOnError = () => {
       if (this._onError) this._onError();
-    });
+    };
+
+    this.socket.addEventListener('message', this._boundOnMessage);
+    this.socket.addEventListener('open', this._boundOnOpen);
+    this.socket.addEventListener('close', this._boundOnClose);
+    this.socket.addEventListener('error', this._boundOnError);
   }
 
   _handleMessage(msg) {
@@ -93,7 +149,11 @@ export class NetworkManager {
         if (this._onOpponentReady) this._onOpponentReady(msg.fighterId);
         break;
       case 'start':
-        if (this._onStart) this._onStart(msg);
+        if (this._onStart) {
+          this._onStart(msg);
+        } else {
+          this._pendingCallbackMessages.start.push(msg);
+        }
         break;
       case 'input':
         if (this.isSpectator && msg.slot != null) {
@@ -118,10 +178,18 @@ export class NetworkManager {
         if (this._onFull) this._onFull();
         break;
       case 'sync':
-        if (this._onSync) this._onSync(msg);
+        if (this._onSync) {
+          this._onSync(msg);
+        } else {
+          this._pendingCallbackMessages.sync.push(msg);
+        }
         break;
       case 'round_event':
-        if (this._onRoundEvent) this._onRoundEvent(msg);
+        if (this._onRoundEvent) {
+          this._onRoundEvent(msg);
+        } else {
+          this._pendingCallbackMessages.round_event.push(msg);
+        }
         break;
       case 'leave':
         if (this._onLeave) this._onLeave();
@@ -205,14 +273,27 @@ export class NetworkManager {
    * Get the latest remote input, consuming any pending one-shot attacks.
    * Frame parameter is unused — we always consume the newest input since
    * host/guest frame counters are not synchronized.
+   * B3: OR-merge attack flags across all buffered frames to avoid losing inputs.
    * @returns {object} input state
    */
   getRemoteInput() {
-    // If there are buffered inputs, consume the latest one
+    // If there are buffered inputs, consume them all
     const frames = Object.keys(this.remoteInputBuffer).map(Number);
     if (frames.length > 0) {
       const latest = Math.max(...frames);
-      const input = this.remoteInputBuffer[latest];
+      const input = { ...this.remoteInputBuffer[latest] };
+
+      // B3: OR-merge attack flags from ALL buffered frames
+      const attackFlags = ['lp', 'hp', 'lk', 'hk', 'sp'];
+      for (const frame of frames) {
+        const frameInput = this.remoteInputBuffer[frame];
+        for (const flag of attackFlags) {
+          if (frameInput[flag]) {
+            input[flag] = true;
+          }
+        }
+      }
+
       // Clear all buffered inputs — they've been consumed
       this.remoteInputBuffer = {};
       // Update lastRemoteInput for movement continuity,
@@ -232,6 +313,7 @@ export class NetworkManager {
 
   /**
    * Get the latest remote input for a specific player slot (spectator mode).
+   * B3: OR-merge attack flags across all buffered frames.
    * @param {number} slot - 0 for P1, 1 for P2
    * @returns {object} input state
    */
@@ -242,7 +324,19 @@ export class NetworkManager {
     const frames = Object.keys(buf).map(Number);
     if (frames.length > 0) {
       const latest = Math.max(...frames);
-      const input = buf[latest];
+      const input = { ...buf[latest] };
+
+      // B3: OR-merge attack flags from ALL buffered frames
+      const attackFlags = ['lp', 'hp', 'lk', 'hk', 'sp'];
+      for (const frame of frames) {
+        const frameInput = buf[frame];
+        for (const flag of attackFlags) {
+          if (frameInput[flag]) {
+            input[flag] = true;
+          }
+        }
+      }
+
       if (slot === 0) {
         this.remoteInputBufferP1 = {};
         this.lastRemoteInputP1 = { ...input, lp: false, hp: false, lk: false, hk: false, sp: false };
@@ -280,14 +374,48 @@ export class NetworkManager {
 
   destroy() {
     if (this.socket) {
+      // B2: Remove event listeners before closing
+      this.socket.removeEventListener('message', this._boundOnMessage);
+      this.socket.removeEventListener('open', this._boundOnOpen);
+      this.socket.removeEventListener('close', this._boundOnClose);
+      this.socket.removeEventListener('error', this._boundOnError);
       this.socket.close();
       this.socket = null;
     }
+
+    // B2: Null out all callback properties
+    this._onAssign = null;
+    this._onOpponentJoined = null;
+    this._onOpponentReady = null;
+    this._onStart = null;
+    this._onRemoteInput = null;
+    this._onDisconnect = null;
+    this._onRematch = null;
+    this._onFull = null;
+    this._onError = null;
+    this._onSync = null;
+    this._onRoundEvent = null;
+    this._onLeave = null;
+    this._onAssignSpectator = null;
+    this._onSpectatorCount = null;
+    this._onShout = null;
+    this._onFightState = null;
+    this._onPotionApplied = null;
+    this._onPotion = null;
+
+    // Clear bound handler references
+    this._boundOnMessage = null;
+    this._boundOnOpen = null;
+    this._boundOnClose = null;
+    this._boundOnError = null;
   }
 
   _send(msg) {
     if (this.socket && this.connected) {
       this.socket.send(JSON.stringify(msg));
+    } else {
+      // B4: Queue messages when disconnected, flush on reconnect
+      this._pendingMessages.push(msg);
     }
   }
 }

--- a/src/systems/NetworkManager.js
+++ b/src/systems/NetworkManager.js
@@ -24,6 +24,8 @@ export class NetworkManager {
     this.connected = false;
     this.localFrame = 0;
     this.isSpectator = false;
+    this.latency = 0;
+    this._pingInterval = null;
 
     // Callbacks (managed via setter properties for bufferable types)
     this._onAssign = null;
@@ -122,6 +124,12 @@ export class NetworkManager {
           this._send(msg);
         }
       }
+      // Start ping measurement
+      if (!this._pingInterval) {
+        this._pingInterval = setInterval(() => {
+          this._send({ type: 'ping', t: Date.now() });
+        }, 3000);
+      }
     };
     this._boundOnClose = () => {
       this.connected = false;
@@ -212,6 +220,9 @@ export class NetworkManager {
         break;
       case 'potion':
         if (this._onPotion) this._onPotion(msg.target, msg.potionType);
+        break;
+      case 'pong':
+        this.latency = Date.now() - msg.t;
         break;
     }
   }
@@ -373,6 +384,10 @@ export class NetworkManager {
   }
 
   destroy() {
+    if (this._pingInterval) {
+      clearInterval(this._pingInterval);
+      this._pingInterval = null;
+    }
     if (this.socket) {
       // B2: Remove event listeners before closing
       this.socket.removeEventListener('message', this._boundOnMessage);

--- a/tests/party/server.test.js
+++ b/tests/party/server.test.js
@@ -427,6 +427,30 @@ describe('FightRoom', () => {
     });
   });
 
+  // ---- Ping/pong ----
+
+  describe('ping/pong', () => {
+    it('echoes pong with same timestamp back to sender', () => {
+      room.onConnect(conn1, makeCtx());
+      conn1.send.mockClear();
+
+      room.onMessage(JSON.stringify({ type: 'ping', t: 1234567890 }), conn1);
+
+      const msgs = conn1.send.mock.calls.map(c => JSON.parse(c[0]));
+      expect(msgs).toEqual([{ type: 'pong', t: 1234567890 }]);
+    });
+
+    it('does not relay ping to other players', () => {
+      room.onConnect(conn1, makeCtx());
+      room.onConnect(conn2, makeCtx());
+      conn2.send.mockClear();
+
+      room.onMessage(JSON.stringify({ type: 'ping', t: 999 }), conn1);
+
+      expect(conn2.send).not.toHaveBeenCalled();
+    });
+  });
+
   // ---- Message routing ----
 
   describe('message routing', () => {

--- a/tests/party/server.test.js
+++ b/tests/party/server.test.js
@@ -251,6 +251,24 @@ describe('FightRoom', () => {
       expect(msgs.some(m => m.type === 'disconnect')).toBe(true);
     });
 
+    it('resets room state when one player disconnects after match started', () => {
+      room.onConnect(conn1, makeCtx());
+      room.onConnect(conn2, makeCtx());
+      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
+      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'jeka' }), conn2);
+      expect(room.started).toBe(true);
+
+      room.onClose(conn1);
+
+      // Room should be reset to pre-match state
+      expect(room.started).toBe(false);
+      expect(room.fightInfo).toBeNull();
+      expect(room.players[0]).toBeNull();
+      // Remaining player's ready and fighterId should be reset
+      expect(room.players[1].ready).toBe(false);
+      expect(room.players[1].fighterId).toBeNull();
+    });
+
     it('resets started and fightInfo when both players gone', () => {
       room.onConnect(conn1, makeCtx());
       room.onConnect(conn2, makeCtx());

--- a/tests/party/server.test.js
+++ b/tests/party/server.test.js
@@ -321,6 +321,94 @@ describe('FightRoom', () => {
     });
   });
 
+  // ---- Malformed input ----
+
+  describe('malformed input', () => {
+    it('does not crash or relay on non-JSON input', () => {
+      room.onConnect(conn1, makeCtx());
+      room.onConnect(conn2, makeCtx());
+      conn1.send.mockClear();
+      conn2.send.mockClear();
+
+      expect(() => room.onMessage('not json!!!', conn1)).not.toThrow();
+      expect(conn2.send).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- Double-ready prevention ----
+
+  describe('double-ready prevention', () => {
+    beforeEach(() => {
+      room.onConnect(conn1, makeCtx());
+      room.onConnect(conn2, makeCtx());
+      conn1.send.mockClear();
+      conn2.send.mockClear();
+    });
+
+    it('ignores second ready from same player', () => {
+      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
+      expect(room.players[0].fighterId).toBe('simon');
+
+      conn2.send.mockClear();
+      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'changed' }), conn1);
+      // fighterId should not change
+      expect(room.players[0].fighterId).toBe('simon');
+      // No second opponent_ready sent
+      const c2Msgs = conn2.send.mock.calls.map(c => JSON.parse(c[0]));
+      expect(c2Msgs.filter(m => m.type === 'opponent_ready').length).toBe(0);
+    });
+
+    it('ignores ready after game has started', () => {
+      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
+      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'jeka' }), conn2);
+      expect(room.started).toBe(true);
+
+      // Use leave to reset ready flags but keep started via direct manipulation
+      room.players[0].ready = false;
+      room.players[0].fighterId = null;
+      // started is still true
+
+      conn2.send.mockClear();
+      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'hacked' }), conn1);
+      // Should be ignored because started is true
+      expect(room.players[0].fighterId).toBeNull();
+      expect(conn2.send).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- Host-only sync/round_event ----
+
+  describe('host-only authoritative messages', () => {
+    beforeEach(() => {
+      room.onConnect(conn1, makeCtx());
+      room.onConnect(conn2, makeCtx());
+      conn1.send.mockClear();
+      conn2.send.mockClear();
+    });
+
+    it('drops sync from non-host (slot 1)', () => {
+      room.onMessage(JSON.stringify({ type: 'sync', frame: 1, hp: [100, 80] }), conn2);
+      expect(conn1.send).not.toHaveBeenCalled();
+    });
+
+    it('drops round_event from non-host (slot 1)', () => {
+      room.onMessage(JSON.stringify({ type: 'round_event', event: 'ko' }), conn2);
+      expect(conn1.send).not.toHaveBeenCalled();
+    });
+
+    it('allows sync from host (slot 0)', () => {
+      room.onMessage(JSON.stringify({ type: 'sync', frame: 1 }), conn1);
+      const c2Msgs = conn2.send.mock.calls.map(c => JSON.parse(c[0]));
+      expect(c2Msgs.some(m => m.type === 'sync')).toBe(true);
+    });
+
+    it('allows round_event from host (slot 0)', () => {
+      room.onMessage(JSON.stringify({ type: 'round_event', event: 'ko' }), conn1);
+      const c2Msgs = conn2.send.mock.calls.map(c => JSON.parse(c[0]));
+      expect(c2Msgs.some(m => m.type === 'round_event')).toBe(true);
+    });
+  });
+
   // ---- Message routing ----
 
   describe('message routing', () => {

--- a/tests/systems/network-manager.test.js
+++ b/tests/systems/network-manager.test.js
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock PartySocket before importing NetworkManager
+vi.mock('partysocket', () => {
+  class MockPartySocket {
+    constructor() {
+      this._listeners = {};
+    }
+    addEventListener(event, handler) {
+      if (!this._listeners[event]) this._listeners[event] = [];
+      this._listeners[event].push(handler);
+    }
+    removeEventListener(event, handler) {
+      if (!this._listeners[event]) return;
+      this._listeners[event] = this._listeners[event].filter(h => h !== handler);
+    }
+    send(data) {}
+    close() {}
+    // Test helper: emit an event
+    _emit(event, data) {
+      if (this._listeners[event]) {
+        for (const h of this._listeners[event]) {
+          h(data);
+        }
+      }
+    }
+  }
+  return { default: MockPartySocket };
+});
+
+// Import after mock is set up
+const { NetworkManager } = await import('../../src/systems/NetworkManager.js');
+
+// --- Helpers ---
+
+function makeManager() {
+  return new NetworkManager('test-room', 'localhost:1999');
+}
+
+// --- Tests ---
+
+describe('NetworkManager', () => {
+  // ---- B1: Malformed JSON ----
+
+  describe('B1: malformed message handling', () => {
+    it('does not throw on malformed JSON', () => {
+      const nm = makeManager();
+      expect(() => {
+        nm.socket._emit('message', { data: 'not valid json{{{' });
+      }).not.toThrow();
+    });
+
+    it('does not throw on empty message data', () => {
+      const nm = makeManager();
+      expect(() => {
+        nm.socket._emit('message', { data: '' });
+      }).not.toThrow();
+    });
+  });
+
+  // ---- B2: destroy() cleanup ----
+
+  describe('B2: destroy() removes listeners and nulls callbacks', () => {
+    it('removes all socket event listeners on destroy', () => {
+      const nm = makeManager();
+      const socket = nm.socket;
+
+      // Verify listeners are registered
+      expect(socket._listeners['message'].length).toBe(1);
+      expect(socket._listeners['open'].length).toBe(1);
+      expect(socket._listeners['close'].length).toBe(1);
+      expect(socket._listeners['error'].length).toBe(1);
+
+      nm.destroy();
+
+      // All listeners should be removed
+      expect(socket._listeners['message'].length).toBe(0);
+      expect(socket._listeners['open'].length).toBe(0);
+      expect(socket._listeners['close'].length).toBe(0);
+      expect(socket._listeners['error'].length).toBe(0);
+    });
+
+    it('nulls out all callback properties on destroy', () => {
+      const nm = makeManager();
+
+      // Set some callbacks
+      nm.onAssign(() => {});
+      nm.onSync(() => {});
+      nm.onStart(() => {});
+      nm.onRoundEvent(() => {});
+      nm.onDisconnect(() => {});
+      nm.onRematch(() => {});
+      nm.onShout(() => {});
+      nm.onPotion(() => {});
+
+      nm.destroy();
+
+      // All callback properties should be null
+      const callbackNames = [
+        '_onAssign', '_onOpponentJoined', '_onOpponentReady', '_onStart',
+        '_onRemoteInput', '_onDisconnect', '_onRematch', '_onFull',
+        '_onError', '_onSync', '_onRoundEvent', '_onLeave',
+        '_onAssignSpectator', '_onSpectatorCount', '_onShout',
+        '_onFightState', '_onPotionApplied', '_onPotion',
+      ];
+      for (const name of callbackNames) {
+        expect(nm[name]).toBeNull();
+      }
+    });
+
+    it('nulls out socket reference on destroy', () => {
+      const nm = makeManager();
+      nm.destroy();
+      expect(nm.socket).toBeNull();
+    });
+  });
+
+  // ---- B3: Attack merging ----
+
+  describe('B3: getRemoteInput() merges attacks from multiple buffered frames', () => {
+    it('OR-merges attack flags across all buffered frames', () => {
+      const nm = makeManager();
+
+      // Frame 1: light punch
+      nm.remoteInputBuffer[1] = {
+        left: false, right: true, up: false, down: false,
+        lp: true, hp: false, lk: false, hk: false, sp: false,
+      };
+      // Frame 2: heavy kick (lp is false here)
+      nm.remoteInputBuffer[2] = {
+        left: false, right: true, up: false, down: false,
+        lp: false, hp: false, lk: false, hk: true, sp: false,
+      };
+      // Frame 3: no attacks, just movement
+      nm.remoteInputBuffer[3] = {
+        left: true, right: false, up: false, down: false,
+        lp: false, hp: false, lk: false, hk: false, sp: false,
+      };
+
+      const result = nm.getRemoteInput();
+
+      // Movement should come from latest frame (3)
+      expect(result.left).toBe(true);
+      expect(result.right).toBe(false);
+      // Attacks should be OR-merged: lp from frame 1, hk from frame 2
+      expect(result.lp).toBe(true);
+      expect(result.hk).toBe(true);
+      // Others should remain false
+      expect(result.hp).toBe(false);
+      expect(result.lk).toBe(false);
+      expect(result.sp).toBe(false);
+    });
+
+    it('OR-merges attacks in getRemoteInputForSlot()', () => {
+      const nm = makeManager();
+
+      nm.remoteInputBufferP1[1] = {
+        left: false, right: false, up: false, down: false,
+        lp: false, hp: true, lk: false, hk: false, sp: false,
+      };
+      nm.remoteInputBufferP1[2] = {
+        left: false, right: false, up: false, down: false,
+        lp: false, hp: false, lk: false, hk: false, sp: true,
+      };
+
+      const result = nm.getRemoteInputForSlot(0);
+
+      // Both hp (frame 1) and sp (frame 2) should be merged
+      expect(result.hp).toBe(true);
+      expect(result.sp).toBe(true);
+    });
+
+    it('strips attacks from lastRemoteInput after consume', () => {
+      const nm = makeManager();
+      nm.remoteInputBuffer[1] = {
+        left: false, right: true, up: false, down: false,
+        lp: true, hp: false, lk: false, hk: false, sp: false,
+      };
+
+      nm.getRemoteInput();
+
+      // Next call should not have attacks
+      const repeat = nm.getRemoteInput();
+      expect(repeat.lp).toBe(false);
+      expect(repeat.right).toBe(true);
+    });
+  });
+
+  // ---- B4: Message queuing when disconnected ----
+
+  describe('B4: _send() queues when disconnected, flushes on open', () => {
+    it('queues messages when not connected', () => {
+      const nm = makeManager();
+      nm.connected = false;
+      const sendSpy = vi.spyOn(nm.socket, 'send');
+
+      nm.sendReady('simon');
+      nm.sendInput(1, { left: true });
+
+      // Nothing should be sent yet
+      expect(sendSpy).not.toHaveBeenCalled();
+      // Messages should be queued
+      expect(nm._pendingMessages.length).toBe(2);
+    });
+
+    it('flushes queued messages on reconnect', () => {
+      const nm = makeManager();
+      nm.connected = false;
+
+      nm.sendReady('simon');
+      nm.sendShout('hola');
+
+      expect(nm._pendingMessages.length).toBe(2);
+
+      const sendSpy = vi.spyOn(nm.socket, 'send');
+
+      // Simulate reconnect
+      nm.socket._emit('open', {});
+
+      expect(nm.connected).toBe(true);
+      expect(sendSpy).toHaveBeenCalledTimes(2);
+      expect(nm._pendingMessages.length).toBe(0);
+
+      // Verify message contents
+      const sent = sendSpy.mock.calls.map(c => JSON.parse(c[0]));
+      expect(sent[0]).toMatchObject({ type: 'ready', fighterId: 'simon' });
+      expect(sent[1]).toMatchObject({ type: 'shout', text: 'hola' });
+    });
+  });
+
+  // ---- B5: Callback buffering ----
+
+  describe('B5: buffers messages for unregistered callbacks', () => {
+    it('buffers sync messages and replays when callback is set', () => {
+      const nm = makeManager();
+      const syncMsg = { type: 'sync', frame: 10, hp1: 100, hp2: 80 };
+
+      // Receive sync before callback is set
+      nm._handleMessage(syncMsg);
+
+      const received = [];
+      nm.onSync((msg) => received.push(msg));
+
+      expect(received.length).toBe(1);
+      expect(received[0]).toMatchObject({ frame: 10, hp1: 100 });
+    });
+
+    it('buffers start messages and replays when callback is set', () => {
+      const nm = makeManager();
+      const startMsg = { type: 'start', p1Id: 'simon', p2Id: 'jeka', stageId: 'dojo' };
+
+      nm._handleMessage(startMsg);
+
+      const received = [];
+      nm.onStart((msg) => received.push(msg));
+
+      expect(received.length).toBe(1);
+      expect(received[0]).toMatchObject({ p1Id: 'simon', p2Id: 'jeka' });
+    });
+
+    it('does not buffer when callback is already set', () => {
+      const nm = makeManager();
+      const received = [];
+      nm.onSync((msg) => received.push(msg));
+
+      nm._handleMessage({ type: 'sync', frame: 1 });
+      nm._handleMessage({ type: 'sync', frame: 2 });
+
+      expect(received.length).toBe(2);
+      expect(nm._pendingCallbackMessages.sync.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Server hardening**: validate malformed input, prevent double-ready crashes, restrict non-host sync messages
- **NetworkManager reliability**: fix listener leaks on reconnect, prevent lost attacks from race conditions, handle dropped messages gracefully
- **Scene-level fixes**: proper disconnect handling in FightScene/SelectScene, round reliability improvements, lerp-based position sync
- **Post-match reconnection**: reset room state on disconnect, navigate away cleanly, fix input re-binding
- **Ping indicator + room code**: show latency (color-coded) and room code ("SALA: XXXX") during online matches and on character select

## Test plan

- [x] All 75 tests pass (server hardening, ping/pong, rate limiting, routing)
- [ ] Manual test: create online room, verify room code displays on select and fight screens
- [ ] Manual test: verify ping indicator updates ~1/sec with color coding (green < 80ms, yellow < 150ms, red > 150ms)
- [ ] Manual test: disconnect/reconnect flow works cleanly across match boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)