### PR TITLE
Add COMO JUGAR learning screen

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { GAME_HEIGHT, GAME_WIDTH } from './config.js';
 import { BootScene } from './scenes/BootScene.js';
 import { FightScene } from './scenes/FightScene.js';
 import { InspectorScene } from './scenes/InspectorScene.js';
+import { LearningScene } from './scenes/LearningScene.js';
 import { LobbyScene } from './scenes/LobbyScene.js';
 import { MusicScene } from './scenes/MusicScene.js';
 import { PreFightScene } from './scenes/PreFightScene.js';
@@ -45,6 +46,7 @@ const config = {
     VictoryScene,
     InspectorScene,
     MusicScene,
+    LearningScene,
   ],
 };
 

--- a/src/scenes/LearningScene.js
+++ b/src/scenes/LearningScene.js
@@ -1,0 +1,319 @@
+import Phaser from 'phaser';
+import { GAME_HEIGHT, GAME_WIDTH } from '../config.js';
+
+const BASICO_CARDS = [
+  {
+    title: 'CONTROLES',
+    body: 'Joystick izquierdo para moverte.\n5 botones a la derecha:\nPL (puno liviano), PaL (patada liviana),\nPP (puno pesado), PaP (patada pesada),\nES (especial).',
+  },
+  {
+    title: 'BLOQUEAR',
+    body: 'Mantene abajo en el joystick para\nbloquear. Reduce el dano un 80% y\nachica tu hitbox. Ideal contra ataques\npesados.',
+  },
+  {
+    title: 'GOLPES LIVIANOS',
+    body: 'Son rapidos y seguros. Salen rapido,\nse recuperan rapido. Ideales para\nempezar combos y mantener presion.',
+  },
+  {
+    title: 'NO ABUSES GOLPES PESADOS',
+    body: 'Los golpes pesados hacen mucho dano\npero si fallan quedas expuesto muchos\nframes. Usalos cuando estes seguro\nde que van a conectar.',
+  },
+  {
+    title: 'MIRA TU STAMINA',
+    body: 'Cada ataque gasta stamina (STA).\nSi atacas mucho seguido te quedas\nsin stamina y no podes atacar.\nDeja respirar a tu personaje.',
+  },
+];
+
+const AVANZADO_CARDS = [
+  {
+    title: 'FASES DE ATAQUE',
+    body: 'Todo ataque tiene 3 fases:\n- Startup: preparacion (vulnerable)\n- Activo: frames que hacen dano\n- Recuperacion: volviendo a neutral\nConocer estas fases es clave.',
+  },
+  {
+    title: 'VENTAJA DE FRAMES',
+    body: 'Despues de un bloqueo, el que se\nrecupera primero tiene "ventaja".\nGolpes livianos dejan ventaja positiva.\nPesados pueden dejar ventaja negativa.',
+  },
+  {
+    title: 'CANCELAR EN ESPECIAL',
+    body: 'Si un golpe normal conecta, podes\ncancelar la recuperacion en un especial.\nEsto se llama "hit confirm":\nnormal que pega → especial.',
+  },
+  {
+    title: 'ESCALADO DE COMBO',
+    body: 'El dano escala en combo:\n1er golpe: 100%\n2do golpe: 80%\n3er golpe: 65%\n4to golpe en adelante: 50%',
+  },
+  {
+    title: 'MOVIMIENTO AEREO',
+    body: 'Podes hacer doble salto en el aire.\nWall jump: salta contra una pared.\nWall slide: deslizate contra la pared\npara bajar mas lento.',
+  },
+  {
+    title: 'RECURSOS',
+    body: 'HP: vida. Llega a 0 y perdes.\nESP: barra especial. Necesitas 50+\npara tirar un especial.\nSTA: stamina. Se gasta al atacar,\nse regenera al no atacar.',
+  },
+];
+
+const CONTENT_TOP = 52;
+const CONTENT_BOTTOM = GAME_HEIGHT - 28;
+const CONTENT_HEIGHT = CONTENT_BOTTOM - CONTENT_TOP;
+const CARD_WIDTH = GAME_WIDTH - 40;
+const CARD_PADDING = 8;
+const CARD_GAP = 8;
+const TITLE_FONT_SIZE = 11;
+const BODY_FONT_SIZE = 10;
+const BODY_LINE_HEIGHT = 1.2;
+
+export class LearningScene extends Phaser.Scene {
+  constructor() {
+    super('LearningScene');
+  }
+
+  create() {
+    this.cameras.main.fadeIn(300, 0, 0, 0);
+
+    // Dark background
+    this.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2, GAME_WIDTH, GAME_HEIGHT, 0x0a0a1a);
+
+    // Title
+    this.add
+      .text(GAME_WIDTH / 2, 14, 'COMO JUGAR', {
+        fontFamily: 'Arial Black, Arial',
+        fontSize: '16px',
+        color: '#ffcc00',
+        stroke: '#000000',
+        strokeThickness: 3,
+      })
+      .setOrigin(0.5);
+
+    // Tab buttons
+    this.activeTab = 'basico';
+    this._createTabs();
+
+    // Content container + mask
+    this.contentContainer = this.add.container(0, 0);
+    const maskShape = this.make.graphics();
+    maskShape.fillRect(0, CONTENT_TOP, GAME_WIDTH, CONTENT_HEIGHT);
+    const mask = maskShape.createGeometryMask();
+    this.contentContainer.setMask(mask);
+
+    this._buildCards(BASICO_CARDS);
+
+    // Scroll state
+    this.scrollY = 0;
+    this.maxScroll = 0;
+
+    // Drag scrolling
+    this.dragStartY = null;
+    this.dragStartScroll = 0;
+    this.input.on('pointerdown', (pointer) => {
+      if (pointer.y >= CONTENT_TOP && pointer.y <= CONTENT_BOTTOM) {
+        this.dragStartY = pointer.y;
+        this.dragStartScroll = this.scrollY;
+      }
+    });
+    this.input.on('pointermove', (pointer) => {
+      if (this.dragStartY !== null && pointer.isDown) {
+        const dy = this.dragStartY - pointer.y;
+        this._setScroll(this.dragStartScroll + dy);
+      }
+    });
+    this.input.on('pointerup', () => {
+      this.dragStartY = null;
+    });
+
+    // Mouse wheel
+    this.input.on('wheel', (_pointer, _gos, _dx, dy) => {
+      this._setScroll(this.scrollY + dy * 0.5);
+    });
+
+    // VOLVER button
+    this._createButton(GAME_WIDTH - 50, GAME_HEIGHT - 13, 'VOLVER', () => {
+      this.cameras.main.fadeOut(300, 0, 0, 0);
+      this.cameras.main.once('camerafadeoutcomplete', () => {
+        this.scene.start('TitleScene');
+      });
+    });
+
+    // Scroll indicator
+    this.scrollIndicator = this.add
+      .text(GAME_WIDTH / 2, GAME_HEIGHT - 13, '', {
+        fontFamily: 'Arial',
+        fontSize: '9px',
+        color: '#666688',
+      })
+      .setOrigin(0.5);
+    this._updateScrollIndicator();
+
+    this.transitioning = false;
+  }
+
+  _createTabs() {
+    const tabY = 36;
+    const tabW = 80;
+    const tabH = 18;
+    const gap = 4;
+
+    // Destroy old tabs if they exist
+    if (this.tabObjects) {
+      for (const obj of this.tabObjects) obj.destroy();
+    }
+    this.tabObjects = [];
+
+    const basicoX = GAME_WIDTH / 2 - tabW / 2 - gap / 2;
+    const avanzadoX = GAME_WIDTH / 2 + tabW / 2 + gap / 2;
+
+    // BASICO tab
+    const bBg = this.add
+      .rectangle(basicoX, tabY, tabW, tabH, this.activeTab === 'basico' ? 0x997700 : 0x222244)
+      .setStrokeStyle(1, this.activeTab === 'basico' ? 0xffcc00 : 0x4444aa)
+      .setInteractive({ useHandCursor: true });
+    const bText = this.add
+      .text(basicoX, tabY, 'BASICO', {
+        fontFamily: 'Arial',
+        fontSize: '10px',
+        color: this.activeTab === 'basico' ? '#ffcc00' : '#ffffff',
+        fontStyle: this.activeTab === 'basico' ? 'bold' : 'normal',
+      })
+      .setOrigin(0.5);
+    bBg.on('pointerdown', () => {
+      if (this.activeTab === 'basico') return;
+      this.activeTab = 'basico';
+      this._createTabs();
+      this._buildCards(BASICO_CARDS);
+      this.scrollY = 0;
+      this._applyScroll();
+    });
+
+    // AVANZADO tab
+    const aBg = this.add
+      .rectangle(avanzadoX, tabY, tabW, tabH, this.activeTab === 'avanzado' ? 0x997700 : 0x222244)
+      .setStrokeStyle(1, this.activeTab === 'avanzado' ? 0xffcc00 : 0x4444aa)
+      .setInteractive({ useHandCursor: true });
+    const aText = this.add
+      .text(avanzadoX, tabY, 'AVANZADO', {
+        fontFamily: 'Arial',
+        fontSize: '10px',
+        color: this.activeTab === 'avanzado' ? '#ffcc00' : '#ffffff',
+        fontStyle: this.activeTab === 'avanzado' ? 'bold' : 'normal',
+      })
+      .setOrigin(0.5);
+    aBg.on('pointerdown', () => {
+      if (this.activeTab === 'avanzado') return;
+      this.activeTab = 'avanzado';
+      this._createTabs();
+      this._buildCards(AVANZADO_CARDS);
+      this.scrollY = 0;
+      this._applyScroll();
+    });
+
+    this.tabObjects.push(bBg, bText, aBg, aText);
+  }
+
+  _buildCards(cards) {
+    // Clear existing content
+    this.contentContainer.removeAll(true);
+
+    let yOffset = CONTENT_TOP + CARD_GAP;
+
+    for (const card of cards) {
+      // Measure body text height
+      const bodyText = this.add.text(0, 0, card.body, {
+        fontFamily: 'Arial',
+        fontSize: `${BODY_FONT_SIZE}px`,
+        color: '#dddddd',
+        lineSpacing: BODY_LINE_HEIGHT,
+        wordWrap: { width: CARD_WIDTH - CARD_PADDING * 2 },
+      });
+      const bodyHeight = bodyText.height;
+      bodyText.destroy();
+
+      const cardHeight = CARD_PADDING + TITLE_FONT_SIZE + 4 + bodyHeight + CARD_PADDING;
+      const cardX = GAME_WIDTH / 2;
+      const cardY = yOffset + cardHeight / 2;
+
+      // Card background
+      const bg = this.add
+        .rectangle(cardX, cardY, CARD_WIDTH, cardHeight, 0x1a1a3e)
+        .setStrokeStyle(1, 0x333366);
+      this.contentContainer.add(bg);
+
+      // Card title
+      const title = this.add
+        .text(cardX - CARD_WIDTH / 2 + CARD_PADDING, yOffset + CARD_PADDING, card.title, {
+          fontFamily: 'Arial Black, Arial',
+          fontSize: `${TITLE_FONT_SIZE}px`,
+          color: '#ffcc00',
+        })
+        .setOrigin(0, 0);
+      this.contentContainer.add(title);
+
+      // Card body
+      const body = this.add
+        .text(
+          cardX - CARD_WIDTH / 2 + CARD_PADDING,
+          yOffset + CARD_PADDING + TITLE_FONT_SIZE + 4,
+          card.body,
+          {
+            fontFamily: 'Arial',
+            fontSize: `${BODY_FONT_SIZE}px`,
+            color: '#dddddd',
+            lineSpacing: BODY_LINE_HEIGHT,
+            wordWrap: { width: CARD_WIDTH - CARD_PADDING * 2 },
+          },
+        )
+        .setOrigin(0, 0);
+      this.contentContainer.add(body);
+
+      yOffset += cardHeight + CARD_GAP;
+    }
+
+    const totalContentHeight = yOffset - CONTENT_TOP;
+    this.maxScroll = Math.max(0, totalContentHeight - CONTENT_HEIGHT);
+    this._updateScrollIndicator();
+  }
+
+  _setScroll(value) {
+    this.scrollY = Phaser.Math.Clamp(value, 0, this.maxScroll);
+    this._applyScroll();
+    this._updateScrollIndicator();
+  }
+
+  _applyScroll() {
+    this.contentContainer.y = -this.scrollY;
+  }
+
+  _updateScrollIndicator() {
+    if (!this.scrollIndicator) return;
+    if (this.maxScroll > 0) {
+      this.scrollIndicator.setText('desliza para ver mas');
+    } else {
+      this.scrollIndicator.setText('');
+    }
+  }
+
+  _createButton(x, y, label, callback) {
+    const bg = this.add
+      .rectangle(x, y, 70, 18, 0x222244)
+      .setStrokeStyle(1, 0x4444aa)
+      .setInteractive({ useHandCursor: true });
+
+    const text = this.add
+      .text(x, y, label, {
+        fontFamily: 'Arial',
+        fontSize: '10px',
+        color: '#ffffff',
+      })
+      .setOrigin(0.5);
+
+    bg.on('pointerover', () => {
+      bg.setFillStyle(0x333366);
+      text.setColor('#ffcc00');
+    });
+    bg.on('pointerout', () => {
+      bg.setFillStyle(0x222244);
+      text.setColor('#ffffff');
+    });
+    bg.on('pointerdown', () => {
+      if (this.game.audioManager) this.game.audioManager.play('ui_confirm');
+      callback();
+    });
+  }
+}

--- a/src/scenes/TitleScene.js
+++ b/src/scenes/TitleScene.js
@@ -34,9 +34,12 @@ export class TitleScene extends Phaser.Scene {
     // Dark overlay for readability
     this.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2, GAME_WIDTH, GAME_HEIGHT, 0x000000, 0.4);
 
+    // Layout anchor — shifted up to fit all buttons on screen
+    const cy = GAME_HEIGHT / 2 - 30;
+
     // Game title
     this.add
-      .text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 50, 'A LOS TRAQUES', {
+      .text(GAME_WIDTH / 2, cy - 50, 'A LOS TRAQUES', {
         fontFamily: 'Arial Black, Arial',
         fontSize: '36px',
         color: '#ffffff',
@@ -48,7 +51,7 @@ export class TitleScene extends Phaser.Scene {
 
     // Subtitle
     this.add
-      .text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 15, 'Pelea de Amigos', {
+      .text(GAME_WIDTH / 2, cy - 15, 'Pelea de Amigos', {
         fontFamily: 'Arial',
         fontSize: '16px',
         color: '#ccccff',
@@ -57,30 +60,30 @@ export class TitleScene extends Phaser.Scene {
       .setOrigin(0.5);
 
     // Decorative line
-    this.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 5, 200, 2, 0xccccff, 0.6);
+    this.add.rectangle(GAME_WIDTH / 2, cy + 5, 200, 2, 0xccccff, 0.6);
 
     // Mode buttons
-    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 33, 'VS MAQUINA', () => {
+    this._createButton(GAME_WIDTH / 2, cy + 33, 'VS MAQUINA', () => {
       this.goToSelect();
     });
 
-    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 57, 'EN LINEA', () => {
+    this._createButton(GAME_WIDTH / 2, cy + 57, 'EN LINEA', () => {
       this.goToLobby();
     });
 
-    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 81, 'UNIRSE', () => {
+    this._createButton(GAME_WIDTH / 2, cy + 81, 'UNIRSE', () => {
       this._showJoinOverlay();
     });
 
-    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 105, 'COMO JUGAR', () => {
+    this._createButton(GAME_WIDTH / 2, cy + 105, 'COMO JUGAR', () => {
       this.goToLearning();
     });
 
-    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 129, 'INSPECTOR', () => {
+    this._createButton(GAME_WIDTH / 2, cy + 129, 'INSPECTOR', () => {
       this.goToInspector();
     });
 
-    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 153, 'MUSICA', () => {
+    this._createButton(GAME_WIDTH / 2, cy + 153, 'MUSICA', () => {
       this.goToMusic();
     });
 

--- a/src/scenes/TitleScene.js
+++ b/src/scenes/TitleScene.js
@@ -72,11 +72,15 @@ export class TitleScene extends Phaser.Scene {
       this._showJoinOverlay();
     });
 
-    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 105, 'INSPECTOR', () => {
+    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 105, 'COMO JUGAR', () => {
+      this.goToLearning();
+    });
+
+    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 129, 'INSPECTOR', () => {
       this.goToInspector();
     });
 
-    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 129, 'MUSICA', () => {
+    this._createButton(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 153, 'MUSICA', () => {
       this.goToMusic();
     });
 
@@ -116,6 +120,15 @@ export class TitleScene extends Phaser.Scene {
     this.cameras.main.fadeOut(300, 0, 0, 0);
     this.cameras.main.once('camerafadeoutcomplete', () => {
       this.scene.start('InspectorScene');
+    });
+  }
+
+  goToLearning() {
+    if (this.transitioning) return;
+    this.transitioning = true;
+    this.cameras.main.fadeOut(300, 0, 0, 0);
+    this.cameras.main.once('camerafadeoutcomplete', () => {
+      this.scene.start('LearningScene');
     });
   }
 


### PR DESCRIPTION
## Summary
- New `LearningScene` with scrollable card-based tutorial (drag + wheel scrolling, geometry mask)
- Two tabs: BASICO (5 cards: controls, blocking, light attacks, heavy attack risk, stamina) and AVANZADO (6 cards: attack phases, frame advantage, special cancels, combo scaling, aerial movement, resources)
- "COMO JUGAR" button added to title screen between UNIRSE and INSPECTOR
- All UI text in Spanish, consistent with existing scene styling

## Test plan
- [ ] Navigate to COMO JUGAR from title screen
- [ ] Verify both BASICO and AVANZADO tabs display correct cards
- [ ] Test scroll via drag and mouse wheel, verify content clips properly
- [ ] Press VOLVER to return to title screen
- [ ] Confirm lint (`bun run lint`) and tests (`bun run test:run`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)