### PR TITLE
Improve multiplayer networking: determinism, desync detection, input redundancy, adaptive delay

### DIFF
--- a/docs/multiplayer-security.md
+++ b/docs/multiplayer-security.md
@@ -27,7 +27,7 @@ flowchart LR
     S <-- "shout, potion" --> Spec
 ```
 
-Both peers run identical deterministic fixed-point simulations. FP integer math ensures bit-for-bit agreement — both independently detect KO, timeup, and round transitions. P1's only special role is sending sync snapshots and round events for spectators.
+Both peers run identical deterministic fixed-point simulations. FP integer math ensures bit-for-bit agreement — both independently detect KO, timeup, and round transitions. P1's additional roles: sending sync snapshots and round events for spectators, and sending authoritative resync snapshots on desync detection.
 
 ## Server-Side Protections (`party/server.js`)
 
@@ -62,6 +62,20 @@ Both peers run identical deterministic fixed-point simulations. FP integer math 
 | `_broadcast()` | Everyone |
 
 Spectator slot check: `if (slot === -1) return;` blocks all player message types from spectators.
+
+### Authority Enforcement
+
+```mermaid
+flowchart TD
+    subgraph "Server enforces sender authority"
+        sync["sync, round_event"] -->|"slot !== 0 → drop"| D1[Dropped]
+        resync["resync"] -->|"slot !== 0 → drop"| D2[Dropped]
+        checksum["checksum,\nresync_request"] -->|"any peer"| R1[Relayed]
+        input["input"] -->|"any peer"| R2[Relayed + spectators]
+    end
+```
+
+Only P1 (slot 0) can send authoritative state messages (`sync`, `round_event`, `resync`). The server drops these from slot 1, preventing P2 from injecting false game state.
 
 ## Client-Side Guards
 

--- a/docs/rollback-netcode.md
+++ b/docs/rollback-netcode.md
@@ -72,8 +72,8 @@ flowchart TD
 
 | Parameter | Value | Notes |
 |-----------|-------|-------|
-| `inputDelay` | 2 frames | Local input buffering |
-| `maxRollbackFrames` | 7 (~117ms) | Max frames to re-simulate on misprediction |
+| `inputDelay` | 3 frames (ONLINE_INPUT_DELAY), adaptive 1-5 | Local input buffering, adjusts to RTT |
+| `maxRollbackFrames` | 7 (~117ms), scales with inputDelay | Max frames to re-simulate on misprediction |
 | `FIXED_DELTA` | 16.667ms (60fps) | Deterministic timestep |
 | Input encoding | 9 bits | `l, r, u, d, lp, hp, lk, hk, sp` packed as integer |
 | `FP_SCALE` | 1000x | Integer math for determinism |

--- a/docs/rollback-netcode.md
+++ b/docs/rollback-netcode.md
@@ -40,6 +40,7 @@ P1 has additional **non-gameplay** responsibilities:
 - Sends sync snapshots to spectators (every 3 frames)
 - Sends `round_event` messages for spectators (3x with 200ms spacing)
 - Handles potion requests from spectators
+- Sends authoritative resync snapshots on desync detection
 
 ## Simulation Step
 
@@ -77,6 +78,18 @@ flowchart TD
 | `FIXED_DELTA` | 16.667ms (60fps) | Deterministic timestep |
 | Input encoding | 9 bits | `l, r, u, d, lp, hp, lk, hk, sp` packed as integer |
 | `FP_SCALE` | 1000x | Integer math for determinism |
+
+## Desync Detection & Recovery
+
+Both peers exchange state checksums every 30 frames via `hashGameState()` (XOR-rotate over 16 key fields). On mismatch:
+
+1. **Detection**: `DESYNC` warning appears in HUD, `desyncCount` incremented
+2. **P1 proactive resync**: P1 immediately sends its current game state snapshot via `sendResync()`
+3. **P2 request resync**: If P2 detects the desync, it sends `resync_request`. P1 responds with its snapshot
+4. **P2 applies resync**: `applyResync()` restores P1's state, resets frame counter and all rollback histories
+5. **Cooldown**: 60-frame (1s) minimum between resync attempts to prevent spam
+
+The resync looks like a single rollback frame to P2 — a brief visual snap, acceptable since desyncs indicate a bug.
 
 ## Key Files
 

--- a/docs/rollback-netcode.md
+++ b/docs/rollback-netcode.md
@@ -12,7 +12,7 @@ flowchart TB
     end
 
     subgraph Server["PartyKit Server (relay)"]
-        Relay["Pure relay — no game logic\nRoutes: input, sync, round_event, ping/pong\nBroadcasts to spectators"]
+        Relay["Pure relay — no game logic\nRoutes: input, sync, round_event,\nchecksum, resync, ping/pong\nBroadcasts to spectators"]
     end
 
     subgraph P2["P2 (slot 1) — Peer"]
@@ -20,10 +20,10 @@ flowchart TB
         P2Sim["simulateFrame()\nIdentical FP integer math"]
     end
 
-    P1Enc -- "input + frame" --> Server
-    Server -- "input + frame" --> P2Sim
-    P2Enc -- "input + frame" --> Server
-    Server -- "input + frame" --> P1Sim
+    P1Enc -- "input + frame + history" --> Server
+    Server -- "input + frame + history" --> P2Sim
+    P2Enc -- "input + frame + history" --> Server
+    Server -- "input + frame + history" --> P1Sim
 
     subgraph Spectators
         Spec["Receive P1 sync snapshots\nNo rollback — passive display"]
@@ -58,48 +58,161 @@ Each frame, `simulateFrame()` runs these steps in order using fixed-point intege
 
 ```mermaid
 flowchart TD
-    A["Store local input at frame + inputDelay"] --> B[Send input to network]
-    B --> C[Drain confirmed remote inputs]
-    C --> D{Misprediction?}
-    D -- Yes --> E["Restore snapshot\nRe-simulate with muteEffects=true"]
-    E --> F[Predict remote input]
-    D -- No --> F["Predict remote input\n(repeat movement, zero attacks)"]
-    F --> G[Save snapshot via captureGameState]
-    G --> H["Simulate frame\ncurrentFrame++"]
-    H --> I[Prune old snapshots/inputs beyond window]
+    A["1. Store local input at\nframe + inputDelay"] --> B["2. Send input + 2 frames\nof history to network"]
+    B --> C["3. Drain confirmed\nremote inputs"]
+    C --> D{4. Misprediction?}
+    D -- Yes --> E["5. Restore snapshot\nRe-simulate with\nmuteEffects=true"]
+    E --> F["6. Predict remote input"]
+    D -- No --> F["6. Predict remote input\n(repeat movement,\nzero attacks)"]
+    F --> G["7. Save snapshot via\ncaptureGameState"]
+    G --> H["8. Simulate frame\ncurrentFrame++"]
+    H --> I["9. Prune old snapshots\nbeyond rollback window"]
+    I --> J{"10. Frame %\n30 == 0?"}
+    J -- Yes --> K["Send checksum\nvia hashGameState"]
+    J -- No --> L{"11. Frame %\n180 == 0?"}
+    K --> L
+    L -- Yes --> M["Recalculate\ninputDelay from RTT"]
+    L -- No --> N[Done]
+    M --> N
 ```
 
 ## Parameters
 
 | Parameter | Value | Notes |
 |-----------|-------|-------|
-| `inputDelay` | 3 frames (ONLINE_INPUT_DELAY), adaptive 1-5 | Local input buffering, adjusts to RTT |
-| `maxRollbackFrames` | 7 (~117ms), scales with inputDelay | Max frames to re-simulate on misprediction |
+| `inputDelay` | 3 frames (`ONLINE_INPUT_DELAY`), adaptive 1-5 | Local input buffering, adjusts to RTT every 180 frames |
+| `maxRollbackFrames` | 7 (~117ms), scales with `inputDelay` | `max(7, inputDelay * 2 + 1)` |
 | `FIXED_DELTA` | 16.667ms (60fps) | Deterministic timestep |
 | Input encoding | 9 bits | `l, r, u, d, lp, hp, lk, hk, sp` packed as integer |
 | `FP_SCALE` | 1000x | Integer math for determinism |
+| Input redundancy | 2 frames | Each packet includes last 2 inputs as backup |
+| Checksum interval | 30 frames (~0.5s) | XOR-rotate hash over 16 game state fields |
+| Adaptive delay interval | 180 frames (~3s) | RTT-based delay recalculation |
+| Resync cooldown | 60 frames (~1s) | Min time between resync attempts |
+
+## Input Redundancy
+
+Each input packet includes the last 2 frames of local input history so a single lost WebSocket message doesn't drop an attack.
+
+```mermaid
+sequenceDiagram
+    participant P1
+    participant Server
+    participant P2
+
+    Note over P1: Frame 5: press heavy punch
+    P1->>Server: input(frame=7, state=hp, history=[[6,idle],[5,hp]])
+    Note over Server: Relay entire message
+    Server->>P2: input(frame=7, state=hp, history=[[6,idle],[5,hp]])
+
+    Note over P2: Frame 6 was missing!
+    Note over P2: Fill gap from history[0]
+    Note over P2: Frame 5 already confirmed
+    Note over P2: Skip history[1] (no overwrite)
+```
+
+The receiver fills gaps in `remoteInputBuffer` from `history` entries without overwriting already-confirmed data.
+
+## Adaptive Input Delay
+
+Input delay is recalculated every 180 frames (~3s) based on smoothed RTT:
+
+```mermaid
+flowchart LR
+    RTT["Measure RTT\nvia ping/pong"] --> OWF["oneWayFrames =\nceil(RTT / 2 / 16.667)"]
+    OWF --> OPT["optimal =\nclamp(oneWayFrames + 1, 1, 5)"]
+    OPT --> INC{"optimal >\ncurrent?"}
+    INC -- Yes --> UP["Increase by 1\n(gradual)"]
+    INC -- No --> DOWN["Set to optimal\n(immediate)"]
+    UP --> MRF["maxRollbackFrames =\nmax(7, delay * 2 + 1)"]
+    DOWN --> MRF
+```
+
+| RTT | One-way frames | Optimal delay | Max rollback |
+|-----|---------------|---------------|-------------|
+| 0-16ms (LAN) | 0-1 | 1-2 frames | 7 |
+| 50ms | 2 | 3 frames | 7 |
+| 100ms | 3 | 4 frames | 9 |
+| 150ms+ | 5+ | 5 frames | 11 |
 
 ## Desync Detection & Recovery
 
-Both peers exchange state checksums every 30 frames via `hashGameState()` (XOR-rotate over 16 key fields). On mismatch:
+Both peers exchange state checksums every 30 frames. On mismatch, P1 sends an authoritative state snapshot to resync P2.
 
-1. **Detection**: `DESYNC` warning appears in HUD, `desyncCount` incremented
-2. **P1 proactive resync**: P1 immediately sends its current game state snapshot via `sendResync()`
-3. **P2 request resync**: If P2 detects the desync, it sends `resync_request`. P1 responds with its snapshot
-4. **P2 applies resync**: `applyResync()` restores P1's state, resets frame counter and all rollback histories
-5. **Cooldown**: 60-frame (1s) minimum between resync attempts to prevent spam
+### Detection
 
-The resync looks like a single rollback frame to P2 — a brief visual snap, acceptable since desyncs indicate a bug.
+`hashGameState()` computes an XOR-rotate hash over 16 key integer fields:
+
+```
+p1: simX, simY, hp, special, stamina, attackCooldown, hurtTimer
+p2: simX, simY, hp, special, stamina, attackCooldown, hurtTimer
+combat: timer, roundNumber
+```
+
+### Recovery Flow
+
+```mermaid
+sequenceDiagram
+    participant P1
+    participant Server
+    participant P2
+
+    Note over P1,P2: Frame 30: both compute checksums
+
+    P1->>Server: checksum(frame=29, hash=A)
+    P2->>Server: checksum(frame=29, hash=B)
+    Server->>P2: checksum(frame=29, hash=A)
+    Server->>P1: checksum(frame=29, hash=B)
+
+    Note over P1: A ≠ B → desync detected!
+    Note over P2: B ≠ A → desync detected!
+
+    P1->>Server: resync(snapshot={frame, p1, p2, combat})
+    Server->>P2: resync(snapshot)
+
+    Note over P2: applyResync():<br/>1. restoreGameState(snapshot)<br/>2. Reset frame counter<br/>3. Clear all histories<br/>4. Save new baseline snapshot<br/>5. Clear DESYNC warning
+
+    P2->>Server: resync_request(frame=29)
+    Note over Server: P2's request arrives after<br/>P1 already sent resync.<br/>P1 sends another (harmless).
+    Server->>P1: resync_request
+    P1->>Server: resync(snapshot)
+    Server->>P2: resync(snapshot)
+    Note over P2: Second applyResync:<br/>newer frame replaces state
+```
+
+### Resync State Machine (P2)
+
+```mermaid
+stateDiagram-v2
+    [*] --> synced
+    synced --> desync_detected : checksum mismatch
+    desync_detected --> resync_pending : send resync_request
+    desync_detected --> synced : receive resync from P1
+    resync_pending --> synced : receive resync from P1
+    resync_pending --> resync_pending : cooldown not elapsed
+    synced --> synced : checksum match
+```
+
+### Server Relay Rules
+
+| Message | From | Relayed to | Spectators |
+|---------|------|-----------|------------|
+| `checksum` | Either peer | Other peer | No |
+| `resync_request` | Either peer | Other peer | No |
+| `resync` | Slot 0 only | Other peer | No |
+| `resync` | Slot 1 | **Dropped** | No |
 
 ## Key Files
 
 | File | Role |
 |------|------|
-| `FixedPoint.js` | FP constants + helpers |
-| `GameState.js` | Snapshot/restore (simX, simY, hp, etc.) |
+| `FixedPoint.js` | FP constants + helpers, `ONLINE_INPUT_DELAY` |
+| `GameState.js` | Snapshot/restore, `hashGameState()` for checksums |
 | `InputBuffer.js` | 9-bit input encoding/decoding |
 | `SimulationStep.js` | Single-frame deterministic advance |
-| `RollbackManager.js` | Orchestration (predict, rollback, re-simulate) |
+| `RollbackManager.js` | Orchestration: predict, rollback, re-simulate, checksum, adaptive delay, resync |
+| `NetworkManager.js` | Network layer: send/receive input, checksum, resync messages |
 | `Fighter.js` | FP physics + frame-based timers |
 | `CombatSystem.js` | FP collision + hit detection |
-| `FightScene.js` | Integration + render |
+| `FightScene.js` | Integration: wires rollback + desync + resync + HUD |
+| `party/server.js` | Relay: routes messages between peers, enforces resync authority |

--- a/party/server.js
+++ b/party/server.js
@@ -194,6 +194,12 @@ export default class FightRoom {
         this._broadcastToSpectators({ ...data, slot });
         break;
       case 'checksum':
+      case 'resync_request':
+        this._sendToOther(slot, data);
+        break;
+      case 'resync':
+        // Only P1 (slot 0) can send authoritative resync snapshots
+        if (slot !== 0) break;
         this._sendToOther(slot, data);
         break;
       case 'sync':

--- a/party/server.js
+++ b/party/server.js
@@ -193,6 +193,9 @@ export default class FightRoom {
         this._sendToOther(slot, data);
         this._broadcastToSpectators({ ...data, slot });
         break;
+      case 'checksum':
+        this._sendToOther(slot, data);
+        break;
       case 'sync':
       case 'round_event':
         if (slot !== 0) break;

--- a/src/entities/combat-block.js
+++ b/src/entities/combat-block.js
@@ -1,8 +1,9 @@
 /**
- * Calculate reduced damage when blocking (20% of original, floored).
+ * Calculate reduced damage when blocking (20% of original, truncated).
+ * Uses integer division for deterministic cross-platform results.
  * @param {number} damage
  * @returns {number}
  */
 export function calculateBlockDamage(damage) {
-  return Math.floor(damage * 0.2);
+  return Math.trunc(damage / 5);
 }

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -670,6 +670,13 @@ export class FightScene extends Phaser.Scene {
       maxRollbackFrames: 7,
     });
 
+    // Wire desync detection
+    nm.onChecksum((frame, hash) => this.rollbackManager.handleRemoteChecksum(frame, hash));
+    this.rollbackManager._onDesync = (frame, localHash, remoteHash) => {
+      console.warn(`[DESYNC] frame=${frame} local=${localHash} remote=${remoteHash}`);
+      this._showDesyncWarning();
+    };
+
     // Sync counter for spectator snapshots: P1 sends state every N frames
     this._syncInterval = 3;
 
@@ -772,6 +779,20 @@ export class FightScene extends Phaser.Scene {
 
     this.combat.checkHit(this.p1Fighter, this.p2Fighter);
     this.combat.checkHit(this.p2Fighter, this.p1Fighter);
+  }
+
+  _showDesyncWarning() {
+    if (this._desyncWarning) return;
+    this._desyncWarning = this.add
+      .text(GAME_WIDTH / 2, GAME_HEIGHT - 28, 'DESYNC', {
+        fontSize: '7px',
+        fontFamily: 'monospace',
+        color: '#ff4444',
+        stroke: '#000000',
+        strokeThickness: 2,
+      })
+      .setOrigin(0.5, 1)
+      .setDepth(25);
   }
 
   _handleOnlineUpdate(_time, _delta) {

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -670,12 +670,48 @@ export class FightScene extends Phaser.Scene {
       maxRollbackFrames: 7,
     });
 
-    // Wire desync detection
+    // Wire desync detection + resync
     nm.onChecksum((frame, hash) => this.rollbackManager.handleRemoteChecksum(frame, hash));
     this.rollbackManager._onDesync = (frame, localHash, remoteHash) => {
       console.warn(`[DESYNC] frame=${frame} local=${localHash} remote=${remoteHash}`);
       this._showDesyncWarning();
+
+      if (this.isHost) {
+        // P1 proactively sends authoritative state
+        const snapshot = this.rollbackManager.captureResyncSnapshot(
+          this.p1Fighter,
+          this.p2Fighter,
+          this.combat,
+        );
+        nm.sendResync(snapshot);
+      } else if (this.rollbackManager.shouldRequestResync()) {
+        // P2 requests resync from P1
+        this.rollbackManager._resyncPending = true;
+        nm.sendResyncRequest(frame);
+      }
     };
+
+    // P1 responds to resync requests from P2
+    nm.onResyncRequest(() => {
+      if (!this.isHost) return;
+      const snapshot = this.rollbackManager.captureResyncSnapshot(
+        this.p1Fighter,
+        this.p2Fighter,
+        this.combat,
+      );
+      nm.sendResync(snapshot);
+    });
+
+    // P2 applies resync snapshots from P1
+    nm.onResync((msg) => {
+      if (this.isHost) return;
+      console.warn(`[RESYNC] Applying P1 snapshot at frame ${msg.snapshot.frame}`);
+      this.rollbackManager.applyResync(msg.snapshot, this.p1Fighter, this.p2Fighter, this.combat);
+      if (this._desyncWarning) {
+        this._desyncWarning.destroy();
+        this._desyncWarning = null;
+      }
+    });
 
     // Sync counter for spectator snapshots: P1 sends state every N frames
     this._syncInterval = 3;

--- a/src/systems/GameState.js
+++ b/src/systems/GameState.js
@@ -124,3 +124,35 @@ export function restoreGameState(snapshot, p1, p2, combat) {
   restoreFighterState(p2, snapshot.p2);
   restoreCombatState(combat, snapshot.combat);
 }
+
+/**
+ * Compute a fast hash of a game state snapshot for desync detection.
+ * XOR-rotate hash over key integer fields from both fighters + combat state.
+ * @param {object} snapshot - result of captureGameState()
+ * @returns {number} 32-bit integer hash
+ */
+export function hashGameState(snapshot) {
+  let h = 0;
+  const vals = [
+    snapshot.p1.simX,
+    snapshot.p1.simY,
+    snapshot.p1.hp,
+    snapshot.p1.special,
+    snapshot.p1.stamina,
+    snapshot.p1.attackCooldown,
+    snapshot.p1.hurtTimer,
+    snapshot.p2.simX,
+    snapshot.p2.simY,
+    snapshot.p2.hp,
+    snapshot.p2.special,
+    snapshot.p2.stamina,
+    snapshot.p2.attackCooldown,
+    snapshot.p2.hurtTimer,
+    snapshot.combat.timer,
+    snapshot.combat.roundNumber,
+  ];
+  for (const v of vals) {
+    h = ((h << 5) | (h >>> 27)) ^ (v | 0);
+  }
+  return h;
+}

--- a/src/systems/NetworkManager.js
+++ b/src/systems/NetworkManager.js
@@ -1,4 +1,5 @@
 import PartySocket from 'partysocket';
+import { decodeInput } from './InputBuffer.js';
 
 const PONG_TIMEOUT_MS = 6000;
 
@@ -213,7 +214,7 @@ export class NetworkManager {
           if (msg.history) {
             for (const [hFrame, encodedInput] of msg.history) {
               if (!(hFrame in this.remoteInputBuffer)) {
-                this.remoteInputBuffer[hFrame] = encodedInput;
+                this.remoteInputBuffer[hFrame] = decodeInput(encodedInput);
               }
             }
           }

--- a/src/systems/NetworkManager.js
+++ b/src/systems/NetworkManager.js
@@ -53,6 +53,8 @@ export class NetworkManager {
     this._onSocketOpen = null;
     this._onRejoinAvailable = null;
     this._onChecksum = null;
+    this._onResyncRequest = null;
+    this._onResync = null;
 
     // B5: Pending callback messages queue
     this._pendingCallbackMessages = {
@@ -221,6 +223,12 @@ export class NetworkManager {
       case 'checksum':
         if (this._onChecksum) this._onChecksum(msg.frame, msg.hash);
         break;
+      case 'resync_request':
+        if (this._onResyncRequest) this._onResyncRequest(msg);
+        break;
+      case 'resync':
+        if (this._onResync) this._onResync(msg);
+        break;
       case 'disconnect':
         if (this._onDisconnect) this._onDisconnect();
         break;
@@ -358,6 +366,12 @@ export class NetworkManager {
   onChecksum(cb) {
     this._onChecksum = cb;
   }
+  onResyncRequest(cb) {
+    this._onResyncRequest = cb;
+  }
+  onResync(cb) {
+    this._onResync = cb;
+  }
 
   // --- Public API: send messages ---
   sendReady(fighterId) {
@@ -374,6 +388,14 @@ export class NetworkManager {
 
   sendChecksum(frame, hash) {
     this._send({ type: 'checksum', frame, hash });
+  }
+
+  sendResyncRequest(frame) {
+    this._send({ type: 'resync_request', frame });
+  }
+
+  sendResync(snapshot) {
+    this._send({ type: 'resync', snapshot });
   }
 
   sendRematch() {
@@ -576,6 +598,8 @@ export class NetworkManager {
     this._onSocketOpen = null;
     this._onRejoinAvailable = null;
     this._onChecksum = null;
+    this._onResyncRequest = null;
+    this._onResync = null;
   }
 
   destroy() {
@@ -619,6 +643,8 @@ export class NetworkManager {
     this._onSocketOpen = null;
     this._onRejoinAvailable = null;
     this._onChecksum = null;
+    this._onResyncRequest = null;
+    this._onResync = null;
 
     // Clear bound handler references
     this._boundOnMessage = null;

--- a/src/systems/NetworkManager.js
+++ b/src/systems/NetworkManager.js
@@ -1,6 +1,5 @@
 import PartySocket from 'partysocket';
 
-const INPUT_DELAY = 3;
 const PONG_TIMEOUT_MS = 6000;
 
 // Message types that support callback buffering (B5)
@@ -53,6 +52,7 @@ export class NetworkManager {
     this._onSocketClose = null;
     this._onSocketOpen = null;
     this._onRejoinAvailable = null;
+    this._onChecksum = null;
 
     // B5: Pending callback messages queue
     this._pendingCallbackMessages = {
@@ -207,8 +207,19 @@ export class NetworkManager {
         } else {
           this.remoteInputBuffer[msg.frame] = msg.state;
           this.lastRemoteInput = msg.state;
+          // Process redundant input history — fill gaps without overwriting confirmed data
+          if (msg.history) {
+            for (const [hFrame, encodedInput] of msg.history) {
+              if (!(hFrame in this.remoteInputBuffer)) {
+                this.remoteInputBuffer[hFrame] = encodedInput;
+              }
+            }
+          }
         }
         if (this._onRemoteInput) this._onRemoteInput(msg.frame, msg.state, msg.slot);
+        break;
+      case 'checksum':
+        if (this._onChecksum) this._onChecksum(msg.frame, msg.hash);
         break;
       case 'disconnect':
         if (this._onDisconnect) this._onDisconnect();
@@ -344,14 +355,25 @@ export class NetworkManager {
   onRejoinAvailable(cb) {
     this._onRejoinAvailable = cb;
   }
+  onChecksum(cb) {
+    this._onChecksum = cb;
+  }
 
   // --- Public API: send messages ---
   sendReady(fighterId) {
     this._send({ type: 'ready', fighterId });
   }
 
-  sendInput(frame, inputState) {
-    this._send({ type: 'input', frame, state: inputState });
+  sendInput(frame, inputState, history) {
+    const msg = { type: 'input', frame, state: inputState };
+    if (history && history.length > 0) {
+      msg.history = history;
+    }
+    this._send(msg);
+  }
+
+  sendChecksum(frame, hash) {
+    this._send({ type: 'checksum', frame, hash });
   }
 
   sendRematch() {
@@ -531,9 +553,6 @@ export class NetworkManager {
   getPlayerSlot() {
     return this.playerSlot;
   }
-  getInputDelay() {
-    return INPUT_DELAY;
-  }
 
   resetForReselect() {
     this.remoteInputBuffer = {};
@@ -556,6 +575,7 @@ export class NetworkManager {
     this._onSocketClose = null;
     this._onSocketOpen = null;
     this._onRejoinAvailable = null;
+    this._onChecksum = null;
   }
 
   destroy() {
@@ -598,6 +618,7 @@ export class NetworkManager {
     this._onSocketClose = null;
     this._onSocketOpen = null;
     this._onRejoinAvailable = null;
+    this._onChecksum = null;
 
     // Clear bound handler references
     this._boundOnMessage = null;

--- a/src/systems/RollbackManager.js
+++ b/src/systems/RollbackManager.js
@@ -59,6 +59,11 @@ export class RollbackManager {
 
     // Adaptive delay state
     this._adaptiveDelayEnabled = true;
+
+    // Resync state
+    this._resyncPending = false;
+    this._lastResyncFrame = -1;
+    this._resyncCooldown = 60; // min frames between resync attempts
   }
 
   /**
@@ -189,6 +194,69 @@ export class RollbackManager {
         this._onDesync(frame, localHash, remoteHash);
       }
     }
+  }
+
+  /**
+   * Apply an authoritative state snapshot from P1 to resync after desync.
+   * Resets all rollback state and continues simulation from the snapshot's frame.
+   * @param {object} snapshot - Full game state snapshot from captureGameState()
+   * @param {import('../entities/Fighter.js').Fighter} p1
+   * @param {import('../entities/Fighter.js').Fighter} p2
+   * @param {import('./CombatSystem.js').CombatSystem} combat
+   */
+  applyResync(snapshot, p1, p2, combat) {
+    // Ignore stale resync snapshots
+    if (snapshot.frame <= this.currentFrame - this.maxRollbackFrames) return;
+
+    restoreGameState(snapshot, p1, p2, combat);
+    this.currentFrame = snapshot.frame;
+
+    // Clear all stale histories
+    this.stateSnapshots.clear();
+    this.localInputHistory.clear();
+    this.remoteInputHistory.clear();
+    this.predictedRemoteInputs.clear();
+    this._localChecksums.clear();
+
+    // Save restored state as new baseline
+    this.stateSnapshots.set(this.currentFrame, captureGameState(this.currentFrame, p1, p2, combat));
+
+    // Reset prediction state
+    this.lastConfirmedRemoteInput = EMPTY_INPUT;
+    this.lastConfirmedRemoteFrame = this.currentFrame - 1;
+
+    this._resyncPending = false;
+    this._lastResyncFrame = this.currentFrame;
+  }
+
+  /**
+   * Capture the latest available snapshot for resync.
+   * Called by P1 when it needs to send authoritative state.
+   * @param {import('../entities/Fighter.js').Fighter} p1
+   * @param {import('../entities/Fighter.js').Fighter} p2
+   * @param {import('./CombatSystem.js').CombatSystem} combat
+   * @returns {object} game state snapshot
+   */
+  captureResyncSnapshot(p1, p2, combat) {
+    const latestFrame = this.currentFrame - 1;
+    const existing = this.stateSnapshots.get(latestFrame);
+    if (existing) return existing;
+    return captureGameState(this.currentFrame, p1, p2, combat);
+  }
+
+  /**
+   * Whether a resync request should be sent (cooldown check).
+   * @returns {boolean}
+   */
+  shouldRequestResync() {
+    if (this._resyncPending) return false;
+    if (
+      this._lastResyncFrame >= 0 &&
+      this.currentFrame - this._lastResyncFrame < this._resyncCooldown
+    ) {
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/src/systems/RollbackManager.js
+++ b/src/systems/RollbackManager.js
@@ -5,9 +5,19 @@
  * a snapshot and re-simulates forward.
  */
 
-import { captureGameState, restoreGameState } from './GameState.js';
+import { ONLINE_INPUT_DELAY } from './FixedPoint.js';
+import { captureGameState, hashGameState, restoreGameState } from './GameState.js';
 import { EMPTY_INPUT, encodeInput, inputsEqual, predictInput } from './InputBuffer.js';
 import { simulateFrame } from './SimulationStep.js';
+
+/** How many past inputs to include in each packet for redundancy */
+const INPUT_REDUNDANCY = 2;
+
+/** How often (in frames) to send/check checksums */
+const CHECKSUM_INTERVAL = 30;
+
+/** How often (in frames) to recalculate adaptive input delay */
+const ADAPTIVE_DELAY_INTERVAL = 180;
 
 export class RollbackManager {
   /**
@@ -15,7 +25,11 @@ export class RollbackManager {
    * @param {number} localSlot - 0 for P1, 1 for P2
    * @param {{ inputDelay?: number, maxRollbackFrames?: number }} [options]
    */
-  constructor(networkManager, localSlot, { inputDelay = 2, maxRollbackFrames = 7 } = {}) {
+  constructor(
+    networkManager,
+    localSlot,
+    { inputDelay = ONLINE_INPUT_DELAY, maxRollbackFrames = 7 } = {},
+  ) {
     this.nm = networkManager;
     this.localSlot = localSlot;
     this.inputDelay = inputDelay;
@@ -37,6 +51,14 @@ export class RollbackManager {
 
     // Stats
     this.rollbackCount = 0;
+
+    // Desync detection
+    this._localChecksums = new Map(); // frame → hash
+    this.desyncCount = 0;
+    this._onDesync = null;
+
+    // Adaptive delay state
+    this._adaptiveDelayEnabled = true;
   }
 
   /**
@@ -54,8 +76,15 @@ export class RollbackManager {
     const targetFrame = this.currentFrame + this.inputDelay;
     this.localInputHistory.set(targetFrame, encodedLocal);
 
-    // 2. Send local input to network with frame number
-    this.nm.sendInput(targetFrame, rawLocalInput);
+    // 2. Send local input to network with frame number + redundant history
+    const history = [];
+    for (let i = 1; i <= INPUT_REDUNDANCY; i++) {
+      const hf = targetFrame - i;
+      if (this.localInputHistory.has(hf)) {
+        history.push([hf, this.localInputHistory.get(hf)]);
+      }
+    }
+    this.nm.sendInput(targetFrame, rawLocalInput, history);
 
     // 3. Drain confirmed remote inputs from NetworkManager
     const confirmed = this.nm.drainConfirmedInputs();
@@ -124,6 +153,42 @@ export class RollbackManager {
 
     // 10. Prune old data beyond rollback window
     this._pruneOldData();
+
+    // 11. Periodic checksum exchange for desync detection
+    if (this.currentFrame > 0 && this.currentFrame % CHECKSUM_INTERVAL === 0) {
+      const snapshot = this.stateSnapshots.get(this.currentFrame - 1);
+      if (snapshot) {
+        const hash = hashGameState(snapshot);
+        const checksumFrame = this.currentFrame - 1;
+        this._localChecksums.set(checksumFrame, hash);
+        this.nm.sendChecksum(checksumFrame, hash);
+      }
+    }
+
+    // 12. Adaptive input delay recalculation
+    if (
+      this._adaptiveDelayEnabled &&
+      this.currentFrame > 0 &&
+      this.currentFrame % ADAPTIVE_DELAY_INTERVAL === 0
+    ) {
+      this._recalculateInputDelay();
+    }
+  }
+
+  /**
+   * Handle a remote checksum message. Compare against local hash for that frame.
+   * @param {number} frame
+   * @param {number} remoteHash
+   */
+  handleRemoteChecksum(frame, remoteHash) {
+    const localHash = this._localChecksums.get(frame);
+    if (localHash === undefined) return; // We don't have this frame's hash yet
+    if (localHash !== remoteHash) {
+      this.desyncCount++;
+      if (this._onDesync) {
+        this._onDesync(frame, localHash, remoteHash);
+      }
+    }
   }
 
   /**
@@ -150,6 +215,24 @@ export class RollbackManager {
   }
 
   /**
+   * Recalculate input delay based on smoothed RTT.
+   * Adjusts gradually to avoid jarring jumps.
+   */
+  _recalculateInputDelay() {
+    const rtt = this.nm.rtt || 0;
+    const oneWayFrames = Math.ceil(rtt / 2 / 16.667);
+    const optimal = Math.max(1, Math.min(5, oneWayFrames + 1));
+    // Only increase by 1 per check to avoid jarring jumps
+    if (optimal > this.inputDelay) {
+      this.inputDelay = Math.min(this.inputDelay + 1, optimal);
+    } else {
+      this.inputDelay = optimal;
+    }
+    // Scale rollback window with delay
+    this.maxRollbackFrames = Math.max(7, this.inputDelay * 2 + 1);
+  }
+
+  /**
    * Prune old snapshots, inputs, and predictions beyond the rollback window.
    */
   _pruneOldData() {
@@ -161,6 +244,7 @@ export class RollbackManager {
       this.localInputHistory,
       this.remoteInputHistory,
       this.predictedRemoteInputs,
+      this._localChecksums,
     ]) {
       for (const key of map.keys()) {
         if (key < minFrame) {

--- a/tests/party/server.test.js
+++ b/tests/party/server.test.js
@@ -845,5 +845,27 @@ describe('FightRoom', () => {
 
       expect(conn3.send).not.toHaveBeenCalled();
     });
+
+    it('checksum relayed to opponent only, not spectators', () => {
+      room.onMessage(JSON.stringify({ type: 'checksum', frame: 30, hash: 12345 }), conn1);
+
+      const c2Msgs = conn2.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c2Msgs.some((m) => m.type === 'checksum' && m.frame === 30 && m.hash === 12345)).toBe(
+        true,
+      );
+
+      expect(conn3.send).not.toHaveBeenCalled();
+    });
+
+    it('checksum from slot 1 relayed to slot 0', () => {
+      room.onMessage(JSON.stringify({ type: 'checksum', frame: 60, hash: 99999 }), conn2);
+
+      const c1Msgs = conn1.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c1Msgs.some((m) => m.type === 'checksum' && m.frame === 60 && m.hash === 99999)).toBe(
+        true,
+      );
+
+      expect(conn3.send).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/party/server.test.js
+++ b/tests/party/server.test.js
@@ -867,5 +867,33 @@ describe('FightRoom', () => {
 
       expect(conn3.send).not.toHaveBeenCalled();
     });
+
+    it('resync_request relayed to other player', () => {
+      room.onMessage(JSON.stringify({ type: 'resync_request', frame: 30 }), conn2);
+
+      const c1Msgs = conn1.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c1Msgs.some((m) => m.type === 'resync_request' && m.frame === 30)).toBe(true);
+
+      expect(conn3.send).not.toHaveBeenCalled();
+    });
+
+    it('resync from slot 0 (P1) relayed to slot 1', () => {
+      const snapshot = { frame: 30, p1: {}, p2: {}, combat: {} };
+      room.onMessage(JSON.stringify({ type: 'resync', snapshot }), conn1);
+
+      const c2Msgs = conn2.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c2Msgs.some((m) => m.type === 'resync')).toBe(true);
+
+      expect(conn3.send).not.toHaveBeenCalled();
+    });
+
+    it('resync from slot 1 (non-P1) is dropped', () => {
+      const snapshot = { frame: 30, p1: {}, p2: {}, combat: {} };
+      room.onMessage(JSON.stringify({ type: 'resync', snapshot }), conn2);
+
+      // P1 should NOT receive it
+      expect(conn1.send).not.toHaveBeenCalled();
+      expect(conn3.send).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/systems/combat-math.test.js
+++ b/tests/systems/combat-math.test.js
@@ -37,15 +37,25 @@ describe('calculateDamage', () => {
 });
 
 describe('calculateBlockDamage', () => {
-  it('reduces damage to 20% (floored)', () => {
+  it('reduces damage to 20% (truncated)', () => {
     expect(calculateBlockDamage(10)).toBe(2);
-    expect(calculateBlockDamage(13)).toBe(2); // floor(2.6) = 2
+    expect(calculateBlockDamage(13)).toBe(2); // trunc(13/5) = 2
     expect(calculateBlockDamage(25)).toBe(5);
   });
 
-  it('floors fractional results', () => {
-    expect(calculateBlockDamage(7)).toBe(1); // floor(1.4) = 1
-    expect(calculateBlockDamage(3)).toBe(0); // floor(0.6) = 0
+  it('truncates fractional results', () => {
+    expect(calculateBlockDamage(7)).toBe(1); // trunc(7/5) = 1
+    expect(calculateBlockDamage(3)).toBe(0); // trunc(3/5) = 0
+  });
+
+  it('uses pure integer math (no floating point)', () => {
+    // Verify determinism: integer division produces identical results
+    // across all platforms, unlike Math.floor(damage * 0.2)
+    for (let d = 0; d <= 100; d++) {
+      const result = calculateBlockDamage(d);
+      expect(Number.isInteger(result)).toBe(true);
+      expect(result).toBe(Math.trunc(d / 5));
+    }
   });
 });
 

--- a/tests/systems/desync-detection.test.js
+++ b/tests/systems/desync-detection.test.js
@@ -1,0 +1,353 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FP_SCALE, GROUND_Y_FP, MAX_STAMINA_FP } from '../../src/systems/FixedPoint.js';
+import { hashGameState } from '../../src/systems/GameState.js';
+import { RollbackManager } from '../../src/systems/RollbackManager.js';
+
+// --- Helpers ---
+
+function makeSnapshot(overrides = {}) {
+  return {
+    frame: 0,
+    p1: {
+      simX: 144 * FP_SCALE,
+      simY: GROUND_Y_FP,
+      hp: 100,
+      special: 0,
+      stamina: MAX_STAMINA_FP,
+      attackCooldown: 0,
+      hurtTimer: 0,
+      ...overrides.p1,
+    },
+    p2: {
+      simX: 336 * FP_SCALE,
+      simY: GROUND_Y_FP,
+      hp: 100,
+      special: 0,
+      stamina: MAX_STAMINA_FP,
+      attackCooldown: 0,
+      hurtTimer: 0,
+      ...overrides.p2,
+    },
+    combat: {
+      timer: 60,
+      roundNumber: 1,
+      ...overrides.combat,
+    },
+  };
+}
+
+function mockNM() {
+  return {
+    getPlayerSlot: () => 0,
+    sendInput: vi.fn(),
+    sendChecksum: vi.fn(),
+    drainConfirmedInputs: vi.fn(() => []),
+    rtt: 0,
+  };
+}
+
+function mockFighter(xPx = 100) {
+  return {
+    simX: xPx * FP_SCALE,
+    simY: GROUND_Y_FP,
+    simVX: 0,
+    simVY: 0,
+    hp: 100,
+    special: 0,
+    stamina: MAX_STAMINA_FP,
+    state: 'idle',
+    attackCooldown: 0,
+    attackFrameElapsed: 0,
+    comboCount: 0,
+    blockTimer: 0,
+    hurtTimer: 0,
+    hitConnected: false,
+    currentAttack: null,
+    isOnGround: true,
+    _airborneTime: 0,
+    hasDoubleJumped: false,
+    facingRight: true,
+    _isTouchingWall: false,
+    _wallDir: 0,
+    _hasWallJumped: false,
+    _prevAnimState: null,
+    _specialTintTimer: 0,
+    data: { stats: { speed: 3, power: 3, defense: 3 } },
+    playerIndex: 0,
+    hasAnims: false,
+    fighterId: 'test',
+    update: vi.fn(),
+    moveLeft: vi.fn(),
+    moveRight: vi.fn(),
+    stop: vi.fn(),
+    jump: vi.fn(),
+    block: vi.fn(),
+    attack: vi.fn(() => true),
+    faceOpponent: vi.fn(),
+    getAttackHitbox: vi.fn(() => null),
+    getHurtbox: vi.fn(() => null),
+    syncSprite: vi.fn(),
+  };
+}
+
+function mockScene() {
+  return {
+    _muteEffects: false,
+    game: { audioManager: { play: vi.fn() } },
+    cameras: { main: { shake: vi.fn() } },
+    spawnHitSpark: vi.fn(),
+    time: { delayedCall: vi.fn() },
+    devConsole: null,
+  };
+}
+
+function mockCombat() {
+  return {
+    roundNumber: 1,
+    p1RoundsWon: 0,
+    p2RoundsWon: 0,
+    timer: 60,
+    roundActive: true,
+    matchOver: false,
+    _timerAccumulator: 0,
+    resolveBodyCollision: vi.fn(),
+    checkHit: vi.fn(),
+    tickTimer: vi.fn(),
+    scene: mockScene(),
+  };
+}
+
+const noInput = {
+  left: false,
+  right: false,
+  up: false,
+  down: false,
+  lp: false,
+  hp: false,
+  lk: false,
+  hk: false,
+  sp: false,
+};
+
+// --- Tests ---
+
+describe('hashGameState', () => {
+  it('produces the same hash for identical snapshots', () => {
+    const s1 = makeSnapshot();
+    const s2 = makeSnapshot();
+    expect(hashGameState(s1)).toBe(hashGameState(s2));
+  });
+
+  it('produces different hashes for different HP', () => {
+    const s1 = makeSnapshot();
+    const s2 = makeSnapshot({ p1: { hp: 99 } });
+    expect(hashGameState(s1)).not.toBe(hashGameState(s2));
+  });
+
+  it('produces different hashes for different positions', () => {
+    const s1 = makeSnapshot();
+    const s2 = makeSnapshot({ p2: { simX: 200 * FP_SCALE } });
+    expect(hashGameState(s1)).not.toBe(hashGameState(s2));
+  });
+
+  it('produces different hashes for different timer values', () => {
+    const s1 = makeSnapshot();
+    const s2 = makeSnapshot({ combat: { timer: 59 } });
+    expect(hashGameState(s1)).not.toBe(hashGameState(s2));
+  });
+
+  it('produces different hashes for different round numbers', () => {
+    const s1 = makeSnapshot();
+    const s2 = makeSnapshot({ combat: { roundNumber: 2 } });
+    expect(hashGameState(s1)).not.toBe(hashGameState(s2));
+  });
+
+  it('returns a 32-bit integer', () => {
+    const hash = hashGameState(makeSnapshot());
+    expect(Number.isInteger(hash)).toBe(true);
+  });
+
+  it('is sensitive to field differences (low collision rate)', () => {
+    // Generate many different snapshots and verify uniqueness
+    const hashes = new Set();
+    for (let hp = 0; hp <= 100; hp += 5) {
+      hashes.add(hashGameState(makeSnapshot({ p1: { hp } })));
+    }
+    // All 21 should be unique
+    expect(hashes.size).toBe(21);
+  });
+});
+
+describe('RollbackManager checksum exchange', () => {
+  let nm, scene, p1, p2, combat, rm;
+
+  beforeEach(() => {
+    nm = mockNM();
+    scene = mockScene();
+    p1 = mockFighter(144);
+    p2 = mockFighter(336);
+    combat = mockCombat();
+    rm = new RollbackManager(nm, 0, { inputDelay: 2, maxRollbackFrames: 7 });
+  });
+
+  it('sends checksum every 30 frames', () => {
+    for (let i = 0; i < 31; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+    // At frame 30 (after advancing 30 times, currentFrame becomes 30)
+    expect(nm.sendChecksum).toHaveBeenCalledTimes(1);
+    const [frame, hash] = nm.sendChecksum.mock.calls[0];
+    expect(frame).toBe(29); // snapshot of frame 29 (currentFrame - 1 at step 11)
+    expect(typeof hash).toBe('number');
+  });
+
+  it('does not send checksum before interval', () => {
+    for (let i = 0; i < 29; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+    expect(nm.sendChecksum).not.toHaveBeenCalled();
+  });
+
+  it('detects desync when remote hash differs', () => {
+    const desyncCb = vi.fn();
+    rm._onDesync = desyncCb;
+
+    // Advance to frame 30 so a local checksum is generated
+    for (let i = 0; i < 31; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+
+    const [frame, localHash] = nm.sendChecksum.mock.calls[0];
+    // Simulate receiving a different hash for the same frame
+    rm.handleRemoteChecksum(frame, localHash + 1);
+
+    expect(rm.desyncCount).toBe(1);
+    expect(desyncCb).toHaveBeenCalledWith(frame, localHash, localHash + 1);
+  });
+
+  it('does not flag desync when hashes match', () => {
+    const desyncCb = vi.fn();
+    rm._onDesync = desyncCb;
+
+    for (let i = 0; i < 31; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+
+    const [frame, localHash] = nm.sendChecksum.mock.calls[0];
+    rm.handleRemoteChecksum(frame, localHash);
+
+    expect(rm.desyncCount).toBe(0);
+    expect(desyncCb).not.toHaveBeenCalled();
+  });
+
+  it('ignores remote checksum for unknown frames', () => {
+    rm.handleRemoteChecksum(999, 12345);
+    expect(rm.desyncCount).toBe(0);
+  });
+});
+
+describe('RollbackManager input redundancy', () => {
+  it('sends input history with each packet', () => {
+    const nm = mockNM();
+    const scene = mockScene();
+    const p1 = mockFighter(144);
+    const p2 = mockFighter(336);
+    const combat = mockCombat();
+    const rm = new RollbackManager(nm, 0, { inputDelay: 2, maxRollbackFrames: 7 });
+
+    // First frame: no history available
+    rm.advance(noInput, scene, p1, p2, combat);
+    expect(nm.sendInput).toHaveBeenCalledWith(2, noInput, []);
+
+    // Second frame: 1 history entry
+    rm.advance(noInput, scene, p1, p2, combat);
+    const call2 = nm.sendInput.mock.calls[1];
+    expect(call2[0]).toBe(3); // targetFrame
+    expect(call2[2]).toHaveLength(1); // history: [frame 2]
+    expect(call2[2][0][0]).toBe(2); // frame number
+
+    // Third frame: 2 history entries
+    rm.advance(noInput, scene, p1, p2, combat);
+    const call3 = nm.sendInput.mock.calls[2];
+    expect(call3[2]).toHaveLength(2); // history: [frame 3, frame 2]
+  });
+});
+
+describe('RollbackManager adaptive input delay', () => {
+  it('increases delay for high RTT', () => {
+    const nm = mockNM();
+    const scene = mockScene();
+    const p1 = mockFighter(144);
+    const p2 = mockFighter(336);
+    const combat = mockCombat();
+    const rm = new RollbackManager(nm, 0, { inputDelay: 3, maxRollbackFrames: 7 });
+
+    // Simulate high latency
+    nm.rtt = 150; // 150ms RTT
+
+    // Advance 180 frames to trigger adaptive delay check
+    for (let i = 0; i < 181; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+
+    // oneWayFrames = ceil(75/16.667) = 5, optimal = min(5, 5+1) = 5
+    // Gradual increase: 3 -> 4 (max +1 per check)
+    expect(rm.inputDelay).toBe(4);
+  });
+
+  it('decreases delay for low RTT', () => {
+    const nm = mockNM();
+    const scene = mockScene();
+    const p1 = mockFighter(144);
+    const p2 = mockFighter(336);
+    const combat = mockCombat();
+    const rm = new RollbackManager(nm, 0, { inputDelay: 3, maxRollbackFrames: 7 });
+
+    // Simulate LAN latency
+    nm.rtt = 5; // 5ms RTT
+
+    for (let i = 0; i < 181; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+
+    // oneWayFrames = ceil(2.5/16.667) = 1, optimal = max(1, min(5, 1+1)) = 2
+    // Decrease is immediate: 3 -> 2
+    expect(rm.inputDelay).toBe(2);
+  });
+
+  it('clamps delay to minimum of 1', () => {
+    const nm = mockNM();
+    const scene = mockScene();
+    const p1 = mockFighter(144);
+    const p2 = mockFighter(336);
+    const combat = mockCombat();
+    const rm = new RollbackManager(nm, 0, { inputDelay: 3, maxRollbackFrames: 7 });
+
+    nm.rtt = 0;
+
+    for (let i = 0; i < 181; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+
+    // oneWayFrames = ceil(0) = 0, optimal = max(1, 0+1) = 1
+    expect(rm.inputDelay).toBeGreaterThanOrEqual(1);
+  });
+
+  it('scales maxRollbackFrames with delay', () => {
+    const nm = mockNM();
+    const scene = mockScene();
+    const p1 = mockFighter(144);
+    const p2 = mockFighter(336);
+    const combat = mockCombat();
+    const rm = new RollbackManager(nm, 0, { inputDelay: 3, maxRollbackFrames: 7 });
+
+    nm.rtt = 150;
+
+    for (let i = 0; i < 181; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+
+    // After delay increases to 4: maxRollback = max(7, 4*2+1) = 9
+    expect(rm.maxRollbackFrames).toBe(9);
+  });
+});

--- a/tests/systems/desync-detection.test.js
+++ b/tests/systems/desync-detection.test.js
@@ -351,3 +351,141 @@ describe('RollbackManager adaptive input delay', () => {
     expect(rm.maxRollbackFrames).toBe(9);
   });
 });
+
+describe('RollbackManager resync', () => {
+  let nm, scene, p1, p2, combat;
+
+  beforeEach(() => {
+    nm = mockNM();
+    scene = mockScene();
+    p1 = mockFighter(144);
+    p2 = mockFighter(336);
+    combat = mockCombat();
+  });
+
+  it('applyResync restores state and resets frame counter', () => {
+    const rm = new RollbackManager(nm, 1, { inputDelay: 2, maxRollbackFrames: 7 });
+
+    // Advance a few frames
+    for (let i = 0; i < 10; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+    expect(rm.currentFrame).toBe(10);
+
+    // Create a snapshot as if from P1 at frame 8
+    const snapshot = makeSnapshot({ p1: { hp: 75 }, combat: { timer: 55 } });
+    snapshot.frame = 8;
+
+    rm.applyResync(snapshot, p1, p2, combat);
+
+    expect(rm.currentFrame).toBe(8);
+    expect(p1.hp).toBe(75);
+    expect(combat.timer).toBe(55);
+  });
+
+  it('applyResync clears all histories', () => {
+    const rm = new RollbackManager(nm, 1, { inputDelay: 2, maxRollbackFrames: 7 });
+
+    for (let i = 0; i < 5; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+
+    expect(rm.stateSnapshots.size).toBeGreaterThan(0);
+    expect(rm.localInputHistory.size).toBeGreaterThan(0);
+    expect(rm.predictedRemoteInputs.size).toBeGreaterThan(0);
+
+    const snapshot = makeSnapshot();
+    snapshot.frame = 4;
+    rm.applyResync(snapshot, p1, p2, combat);
+
+    // Only the baseline snapshot should remain
+    expect(rm.stateSnapshots.size).toBe(1);
+    expect(rm.stateSnapshots.has(4)).toBe(true);
+    expect(rm.localInputHistory.size).toBe(0);
+    expect(rm.predictedRemoteInputs.size).toBe(0);
+    expect(rm._localChecksums.size).toBe(0);
+  });
+
+  it('applyResync resets resync pending flag', () => {
+    const rm = new RollbackManager(nm, 1, { inputDelay: 2, maxRollbackFrames: 7 });
+    rm._resyncPending = true;
+
+    const snapshot = makeSnapshot();
+    snapshot.frame = 0;
+    rm.applyResync(snapshot, p1, p2, combat);
+
+    expect(rm._resyncPending).toBe(false);
+  });
+
+  it('applyResync ignores very stale snapshots', () => {
+    const rm = new RollbackManager(nm, 1, { inputDelay: 2, maxRollbackFrames: 7 });
+
+    for (let i = 0; i < 20; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+
+    // Snapshot from frame 5 is too old (currentFrame=20, maxRollback=7, threshold=13)
+    const snapshot = makeSnapshot({ p1: { hp: 50 } });
+    snapshot.frame = 5;
+    rm.applyResync(snapshot, p1, p2, combat);
+
+    // Should be ignored — frame counter unchanged
+    expect(rm.currentFrame).toBe(20);
+    expect(p1.hp).toBe(100); // not changed to 50
+  });
+
+  it('captureResyncSnapshot returns latest snapshot', () => {
+    const rm = new RollbackManager(nm, 0, { inputDelay: 2, maxRollbackFrames: 7 });
+
+    for (let i = 0; i < 5; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+
+    const snapshot = rm.captureResyncSnapshot(p1, p2, combat);
+    expect(snapshot).toBeDefined();
+    expect(snapshot.frame).toBe(4); // currentFrame - 1
+  });
+
+  it('shouldRequestResync respects cooldown', () => {
+    const rm = new RollbackManager(nm, 1, { inputDelay: 2, maxRollbackFrames: 7 });
+
+    expect(rm.shouldRequestResync()).toBe(true);
+
+    // Simulate a resync at frame 10
+    rm._lastResyncFrame = 10;
+    rm.currentFrame = 30; // only 20 frames later, cooldown is 60
+
+    expect(rm.shouldRequestResync()).toBe(false);
+
+    rm.currentFrame = 71; // 61 frames later, past cooldown
+
+    expect(rm.shouldRequestResync()).toBe(true);
+  });
+
+  it('shouldRequestResync returns false when pending', () => {
+    const rm = new RollbackManager(nm, 1, { inputDelay: 2, maxRollbackFrames: 7 });
+    rm._resyncPending = true;
+
+    expect(rm.shouldRequestResync()).toBe(false);
+  });
+
+  it('applyResync is idempotent for same frame', () => {
+    const rm = new RollbackManager(nm, 1, { inputDelay: 2, maxRollbackFrames: 7 });
+
+    for (let i = 0; i < 5; i++) {
+      rm.advance(noInput, scene, p1, p2, combat);
+    }
+
+    const snapshot = makeSnapshot({ p1: { hp: 80 } });
+    snapshot.frame = 4;
+
+    rm.applyResync(snapshot, p1, p2, combat);
+    expect(rm.currentFrame).toBe(4);
+    expect(p1.hp).toBe(80);
+
+    // Apply again — should succeed without error
+    rm.applyResync(snapshot, p1, p2, combat);
+    expect(rm.currentFrame).toBe(4);
+    expect(p1.hp).toBe(80);
+  });
+});

--- a/tests/systems/network-manager.test.js
+++ b/tests/systems/network-manager.test.js
@@ -356,6 +356,84 @@ describe('NetworkManager', () => {
     });
   });
 
+  // ---- Resync message handling ----
+
+  describe('resync message handling', () => {
+    it('fires onResyncRequest callback', () => {
+      const nm = makeManager();
+      const received = [];
+      nm.onResyncRequest((msg) => received.push(msg));
+
+      nm._handleMessage({ type: 'resync_request', frame: 30 });
+
+      expect(received).toEqual([{ type: 'resync_request', frame: 30 }]);
+    });
+
+    it('fires onResync callback with snapshot', () => {
+      const nm = makeManager();
+      const received = [];
+      nm.onResync((msg) => received.push(msg));
+
+      const snapshot = { frame: 30, p1: { hp: 100 }, p2: { hp: 80 }, combat: { timer: 55 } };
+      nm._handleMessage({ type: 'resync', snapshot });
+
+      expect(received.length).toBe(1);
+      expect(received[0].snapshot.frame).toBe(30);
+    });
+
+    it('does not throw without callbacks registered', () => {
+      const nm = makeManager();
+      expect(() => nm._handleMessage({ type: 'resync_request', frame: 30 })).not.toThrow();
+      expect(() => nm._handleMessage({ type: 'resync', snapshot: {} })).not.toThrow();
+    });
+
+    it('clears resync callbacks on destroy', () => {
+      const nm = makeManager();
+      nm.onResyncRequest(() => {});
+      nm.onResync(() => {});
+
+      nm.destroy();
+
+      expect(nm._onResyncRequest).toBeNull();
+      expect(nm._onResync).toBeNull();
+    });
+
+    it('clears resync callbacks on resetForReselect', () => {
+      const nm = makeManager();
+      nm.onResyncRequest(() => {});
+      nm.onResync(() => {});
+
+      nm.resetForReselect();
+
+      expect(nm._onResyncRequest).toBeNull();
+      expect(nm._onResync).toBeNull();
+    });
+
+    it('sendResyncRequest sends correct message', () => {
+      const nm = makeManager();
+      nm.connected = true;
+      const sendSpy = vi.spyOn(nm.socket, 'send');
+
+      nm.sendResyncRequest(42);
+
+      const sent = JSON.parse(sendSpy.mock.calls[0][0]);
+      expect(sent).toEqual({ type: 'resync_request', frame: 42 });
+    });
+
+    it('sendResync sends snapshot message', () => {
+      const nm = makeManager();
+      nm.connected = true;
+      const sendSpy = vi.spyOn(nm.socket, 'send');
+
+      const snapshot = { frame: 30, p1: {}, p2: {}, combat: {} };
+      nm.sendResync(snapshot);
+
+      const sent = JSON.parse(sendSpy.mock.calls[0][0]);
+      expect(sent.type).toBe('resync');
+      expect(sent.snapshot.frame).toBe(30);
+    });
+  });
+
   // ---- Input redundancy (receive side) ----
 
   describe('input history processing', () => {

--- a/tests/systems/network-manager.test.js
+++ b/tests/systems/network-manager.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { encodeInput } from '../../src/systems/InputBuffer.js';
 
 // Mock PartySocket before importing NetworkManager
 vi.mock('partysocket', () => {
@@ -437,10 +438,34 @@ describe('NetworkManager', () => {
   // ---- Input redundancy (receive side) ----
 
   describe('input history processing', () => {
-    it('fills gaps in remoteInputBuffer from history entries', () => {
+    it('fills gaps in remoteInputBuffer from history entries (encoded integers)', () => {
       const nm = makeManager();
 
-      // Simulate receiving frame 3 with history for frames 1 and 2
+      // History arrives as encoded integers (from RollbackManager.localInputHistory)
+      const hist1 = encodeInput({
+        left: false,
+        right: true,
+        up: false,
+        down: false,
+        lp: true,
+        hp: false,
+        lk: false,
+        hk: false,
+        sp: false,
+      });
+      const hist2 = encodeInput({
+        left: false,
+        right: false,
+        up: true,
+        down: false,
+        lp: false,
+        hp: false,
+        lk: false,
+        hk: false,
+        sp: false,
+      });
+
+      // Simulate receiving frame 3 with encoded history for frames 1 and 2
       nm._handleMessage({
         type: 'input',
         frame: 3,
@@ -456,46 +481,22 @@ describe('NetworkManager', () => {
           sp: false,
         },
         history: [
-          [
-            1,
-            {
-              left: false,
-              right: true,
-              up: false,
-              down: false,
-              lp: true,
-              hp: false,
-              lk: false,
-              hk: false,
-              sp: false,
-            },
-          ],
-          [
-            2,
-            {
-              left: false,
-              right: false,
-              up: true,
-              down: false,
-              lp: false,
-              hp: false,
-              lk: false,
-              hk: false,
-              sp: false,
-            },
-          ],
+          [1, hist1],
+          [2, hist2],
         ],
       });
 
-      // Primary input stored
+      // Primary input stored as object
       expect(nm.remoteInputBuffer[3]).toBeDefined();
       expect(nm.remoteInputBuffer[3].left).toBe(true);
 
-      // History entries filled gaps
+      // History entries decoded from integers to objects
       expect(nm.remoteInputBuffer[1]).toBeDefined();
+      expect(typeof nm.remoteInputBuffer[1]).toBe('object');
       expect(nm.remoteInputBuffer[1].right).toBe(true);
       expect(nm.remoteInputBuffer[1].lp).toBe(true);
       expect(nm.remoteInputBuffer[2]).toBeDefined();
+      expect(typeof nm.remoteInputBuffer[2]).toBe('object');
       expect(nm.remoteInputBuffer[2].up).toBe(true);
     });
 
@@ -515,7 +516,18 @@ describe('NetworkManager', () => {
         sp: false,
       };
 
-      // Receive frame 3 with history that includes frame 2 with different data
+      // Receive frame 3 with encoded history that includes frame 2 with different data
+      const hist2 = encodeInput({
+        left: true,
+        right: false,
+        up: false,
+        down: false,
+        lp: false,
+        hp: false,
+        lk: false,
+        hk: false,
+        sp: false,
+      });
       nm._handleMessage({
         type: 'input',
         frame: 3,
@@ -530,22 +542,7 @@ describe('NetworkManager', () => {
           hk: false,
           sp: false,
         },
-        history: [
-          [
-            2,
-            {
-              left: true,
-              right: false,
-              up: false,
-              down: false,
-              lp: false,
-              hp: false,
-              lk: false,
-              hk: false,
-              sp: false,
-            },
-          ],
-        ],
+        history: [[2, hist2]],
       });
 
       // Frame 2 should retain its original data (hp: true), not be overwritten
@@ -582,6 +579,17 @@ describe('NetworkManager', () => {
       const nm = makeManager();
       nm.isSpectator = true;
 
+      const hist1 = encodeInput({
+        left: false,
+        right: true,
+        up: false,
+        down: false,
+        lp: false,
+        hp: false,
+        lk: false,
+        hk: false,
+        sp: false,
+      });
       nm._handleMessage({
         type: 'input',
         frame: 3,
@@ -597,22 +605,7 @@ describe('NetworkManager', () => {
           hk: false,
           sp: false,
         },
-        history: [
-          [
-            1,
-            {
-              left: false,
-              right: true,
-              up: false,
-              down: false,
-              lp: false,
-              hp: false,
-              lk: false,
-              hk: false,
-              sp: false,
-            },
-          ],
-        ],
+        history: [[1, hist1]],
       });
 
       // Spectator buffer gets the primary input

--- a/tests/systems/network-manager.test.js
+++ b/tests/systems/network-manager.test.js
@@ -319,6 +319,307 @@ describe('NetworkManager', () => {
     });
   });
 
+  // ---- Checksum callback ----
+
+  describe('checksum message handling', () => {
+    it('fires onChecksum callback with frame and hash', () => {
+      const nm = makeManager();
+      const received = [];
+      nm.onChecksum((frame, hash) => received.push({ frame, hash }));
+
+      nm._handleMessage({ type: 'checksum', frame: 30, hash: 12345 });
+
+      expect(received).toEqual([{ frame: 30, hash: 12345 }]);
+    });
+
+    it('does not throw when no checksum callback is registered', () => {
+      const nm = makeManager();
+      expect(() => nm._handleMessage({ type: 'checksum', frame: 30, hash: 12345 })).not.toThrow();
+    });
+
+    it('clears checksum callback on destroy', () => {
+      const nm = makeManager();
+      nm.onChecksum(() => {});
+      expect(nm._onChecksum).not.toBeNull();
+
+      nm.destroy();
+      expect(nm._onChecksum).toBeNull();
+    });
+
+    it('clears checksum callback on resetForReselect', () => {
+      const nm = makeManager();
+      nm.onChecksum(() => {});
+      expect(nm._onChecksum).not.toBeNull();
+
+      nm.resetForReselect();
+      expect(nm._onChecksum).toBeNull();
+    });
+  });
+
+  // ---- Input redundancy (receive side) ----
+
+  describe('input history processing', () => {
+    it('fills gaps in remoteInputBuffer from history entries', () => {
+      const nm = makeManager();
+
+      // Simulate receiving frame 3 with history for frames 1 and 2
+      nm._handleMessage({
+        type: 'input',
+        frame: 3,
+        state: {
+          left: true,
+          right: false,
+          up: false,
+          down: false,
+          lp: false,
+          hp: false,
+          lk: false,
+          hk: false,
+          sp: false,
+        },
+        history: [
+          [
+            1,
+            {
+              left: false,
+              right: true,
+              up: false,
+              down: false,
+              lp: true,
+              hp: false,
+              lk: false,
+              hk: false,
+              sp: false,
+            },
+          ],
+          [
+            2,
+            {
+              left: false,
+              right: false,
+              up: true,
+              down: false,
+              lp: false,
+              hp: false,
+              lk: false,
+              hk: false,
+              sp: false,
+            },
+          ],
+        ],
+      });
+
+      // Primary input stored
+      expect(nm.remoteInputBuffer[3]).toBeDefined();
+      expect(nm.remoteInputBuffer[3].left).toBe(true);
+
+      // History entries filled gaps
+      expect(nm.remoteInputBuffer[1]).toBeDefined();
+      expect(nm.remoteInputBuffer[1].right).toBe(true);
+      expect(nm.remoteInputBuffer[1].lp).toBe(true);
+      expect(nm.remoteInputBuffer[2]).toBeDefined();
+      expect(nm.remoteInputBuffer[2].up).toBe(true);
+    });
+
+    it('does not overwrite existing confirmed inputs with history', () => {
+      const nm = makeManager();
+
+      // Frame 2 already confirmed
+      nm.remoteInputBuffer[2] = {
+        left: false,
+        right: false,
+        up: false,
+        down: false,
+        lp: false,
+        hp: true,
+        lk: false,
+        hk: false,
+        sp: false,
+      };
+
+      // Receive frame 3 with history that includes frame 2 with different data
+      nm._handleMessage({
+        type: 'input',
+        frame: 3,
+        state: {
+          left: false,
+          right: false,
+          up: false,
+          down: false,
+          lp: false,
+          hp: false,
+          lk: false,
+          hk: false,
+          sp: false,
+        },
+        history: [
+          [
+            2,
+            {
+              left: true,
+              right: false,
+              up: false,
+              down: false,
+              lp: false,
+              hp: false,
+              lk: false,
+              hk: false,
+              sp: false,
+            },
+          ],
+        ],
+      });
+
+      // Frame 2 should retain its original data (hp: true), not be overwritten
+      expect(nm.remoteInputBuffer[2].hp).toBe(true);
+      expect(nm.remoteInputBuffer[2].left).toBe(false);
+    });
+
+    it('works when history is absent (backwards compatible)', () => {
+      const nm = makeManager();
+
+      nm._handleMessage({
+        type: 'input',
+        frame: 5,
+        state: {
+          left: false,
+          right: false,
+          up: false,
+          down: false,
+          lp: true,
+          hp: false,
+          lk: false,
+          hk: false,
+          sp: false,
+        },
+      });
+
+      expect(nm.remoteInputBuffer[5]).toBeDefined();
+      expect(nm.remoteInputBuffer[5].lp).toBe(true);
+      // No other frames should exist
+      expect(Object.keys(nm.remoteInputBuffer)).toEqual(['5']);
+    });
+
+    it('does not process history for spectator inputs', () => {
+      const nm = makeManager();
+      nm.isSpectator = true;
+
+      nm._handleMessage({
+        type: 'input',
+        frame: 3,
+        slot: 0,
+        state: {
+          left: true,
+          right: false,
+          up: false,
+          down: false,
+          lp: false,
+          hp: false,
+          lk: false,
+          hk: false,
+          sp: false,
+        },
+        history: [
+          [
+            1,
+            {
+              left: false,
+              right: true,
+              up: false,
+              down: false,
+              lp: false,
+              hp: false,
+              lk: false,
+              hk: false,
+              sp: false,
+            },
+          ],
+        ],
+      });
+
+      // Spectator buffer gets the primary input
+      expect(nm.remoteInputBufferP1[3]).toBeDefined();
+      // History should NOT be processed for spectators
+      expect(nm.remoteInputBuffer[1]).toBeUndefined();
+      expect(nm.remoteInputBufferP1[1]).toBeUndefined();
+    });
+  });
+
+  // ---- sendChecksum ----
+
+  describe('sendChecksum', () => {
+    it('sends checksum message with frame and hash', () => {
+      const nm = makeManager();
+      nm.connected = true;
+      const sendSpy = vi.spyOn(nm.socket, 'send');
+
+      nm.sendChecksum(30, 12345);
+
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const sent = JSON.parse(sendSpy.mock.calls[0][0]);
+      expect(sent).toEqual({ type: 'checksum', frame: 30, hash: 12345 });
+    });
+  });
+
+  // ---- sendInput with history ----
+
+  describe('sendInput with history', () => {
+    it('includes history in message when provided', () => {
+      const nm = makeManager();
+      nm.connected = true;
+      const sendSpy = vi.spyOn(nm.socket, 'send');
+
+      const input = {
+        left: true,
+        right: false,
+        up: false,
+        down: false,
+        lp: false,
+        hp: false,
+        lk: false,
+        hk: false,
+        sp: false,
+      };
+      const history = [
+        [1, 5],
+        [2, 3],
+      ];
+
+      nm.sendInput(3, input, history);
+
+      const sent = JSON.parse(sendSpy.mock.calls[0][0]);
+      expect(sent.type).toBe('input');
+      expect(sent.frame).toBe(3);
+      expect(sent.history).toEqual([
+        [1, 5],
+        [2, 3],
+      ]);
+    });
+
+    it('omits history key when history is empty', () => {
+      const nm = makeManager();
+      nm.connected = true;
+      const sendSpy = vi.spyOn(nm.socket, 'send');
+
+      const input = {
+        left: false,
+        right: false,
+        up: false,
+        down: false,
+        lp: false,
+        hp: false,
+        lk: false,
+        hk: false,
+        sp: false,
+      };
+
+      nm.sendInput(1, input, []);
+
+      const sent = JSON.parse(sendSpy.mock.calls[0][0]);
+      expect(sent.history).toBeUndefined();
+    });
+  });
+
   // ---- B5: Callback buffering ----
 
   describe('B5: buffers messages for unregistered callbacks', () => {

--- a/tests/systems/rollback-manager.test.js
+++ b/tests/systems/rollback-manager.test.js
@@ -131,7 +131,8 @@ describe('RollbackManager', () => {
 
     it('sends local input to network with inputDelay offset', () => {
       rm.advance(noInput, scene, p1, p2, combat);
-      expect(nm.sendInput).toHaveBeenCalledWith(2, noInput);
+      // 3rd arg is redundant history (empty on first frame)
+      expect(nm.sendInput).toHaveBeenCalledWith(2, noInput, []);
     });
 
     it('stores local input at delayed frame', () => {


### PR DESCRIPTION
## Summary

- **Block damage determinism**: Replace `Math.floor(damage * 0.2)` with `Math.trunc(damage / 5)` — eliminates the only floating-point operation in the simulation path, ensuring 100% integer math determinism
- **Desync detection**: Peers exchange state checksums every 30 frames (XOR-rotate hash over key fields including positions, velocities, HP, stamina, cooldowns). On mismatch, a DESYNC warning appears in the HUD
- **Desync recovery**: P1-authoritative resync — on desync detection, P1 sends an authoritative state snapshot. P2 applies it and resets rollback state. Cooldown prevents resync flooding
- **Input redundancy**: Each packet includes 2 frames of input history so a single lost WebSocket message doesn't drop an attack. Receiver decodes encoded integers back to input objects before storing in the buffer
- **Adaptive input delay**: Recalculates every 3s based on RTT, clamped 1-5 frames with gradual increases. Scales rollback window to support up to ~166ms RTT
- **Constant cleanup**: Removes dead \`INPUT_DELAY\` and \`getInputDelay()\` from NetworkManager; single source of truth via \`ONLINE_INPUT_DELAY\` in FixedPoint.js
- **Hash completeness**: Added \`simVX\`/\`simVY\` (fighter velocities) to \`hashGameState\` — previously velocity desyncs were invisible to checksum detection

### Bug fix: input redundancy history decoding

History entries from \`RollbackManager.localInputHistory\` are encoded integers, but were stored directly in \`remoteInputBuffer\` which expects input state objects. When \`drainConfirmedInputs()\` fed them to \`encodeInput()\`, it returned 0 (all undefined keys = falsy), making every history-recovered frame an empty input and causing desync. Fixed by calling \`decodeInput()\` on history entries in \`NetworkManager._handleMessage\`.

## Test plan

- [x] All 304 tests pass (includes new tests for desync detection, resync, input history decoding, velocity hashing)
- [x] Lint clean
- [ ] Two-window local test: verify fight completes without desync warnings
- [ ] Deliberate desync injection: modify HP in one tab's console, verify DESYNC warning appears and resync corrects it
- [ ] Network throttle test: Chrome DevTools → add latency, verify adaptive delay adjusts
- [ ] Verify input redundancy: browser Network throttling with packet delay, attacks still register

🤖 Generated with [Claude Code](https://claude.com/claude-code)