### PR TITLE
WebRTC P2P transport for game inputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ CI runs via GitHub Actions (`.github/workflows/test.yml`) on PRs and pushes to m
 Markdown docs with Mermaid diagrams in `docs/`. When making significant changes to a documented system, update the relevant doc to stay in sync.
 
 - `docs/rollback-netcode.md` — Rollback netcode architecture (GGPO-style, peer-equal)
+- `docs/webrtc-transport.md` — WebRTC P2P transport (DataChannel, signaling, fallback)
 - `docs/multiplayer-security.md` — Trust boundaries, server protections, known gaps
 - `docs/graceful-reconnection.md` — Reconnection state machine, grace period, module responsibilities
 - `docs/room-state-machine.md` — Server room state (`roomState` transitions, `return_to_select` vs `disconnect`)

--- a/docs/graceful-reconnection.md
+++ b/docs/graceful-reconnection.md
@@ -84,14 +84,35 @@ flowchart TD
     RM -- "callbacks" --> FS
 ```
 
+## WebRTC Re-negotiation on Reconnect
+
+When a player reconnects after a network drop, the WebRTC DataChannel is destroyed and re-negotiated. This happens automatically via `_initWebRTC()` triggered by `opponent_reconnected`.
+
+```mermaid
+flowchart TD
+    Drop["Network drop"] --> DCClose["WebRTC DC closes\n_webrtcReady = false"]
+    DCClose --> WSClose["WebSocket closes"]
+    WSClose --> Grace["20s grace period"]
+    Grace --> Reconn["PartySocket reconnects"]
+    Reconn --> Rejoin["sendRejoin(slot)"]
+    Rejoin --> OppReconn["opponent_reconnected received"]
+    OppReconn --> ReInit["_initWebRTC()\nNew WebRTC negotiation"]
+    ReInit --> Success{"P2P succeeds?"}
+    Success -- Yes --> P2P["Resume with P2P inputs"]
+    Success -- No --> WS["Continue with WS relay\n(same as pre-WebRTC behavior)"]
+```
+
+During the grace period, if WebRTC was active before the drop, both peers fall back to WebSocket. Inputs can still flow via WS during the reconnection window (the pause overlay is driven by the ReconnectionManager, not the transport layer).
+
 ## Connection Loss Detection
 
-Two mechanisms detect connection loss:
+Three mechanisms detect connection loss:
 
-1. **Pong timeout (active, ~9s)**: NetworkManager sends pings every 3s and tracks `_lastPongTime`. If no pong arrives for >6s (PONG_TIMEOUT_MS), it synthetically triggers `_onSocketClose()` to enter the reconnection flow. This fires ~9s after WiFi drops (2 missed pongs + next interval tick).
-2. **WebSocket close (passive, 30s+)**: The browser eventually fires the `close` event. On mobile Safari this can take 30+ seconds.
+1. **WebRTC DataChannel close (fastest, <1s)**: The DataChannel `onclose` fires almost immediately when the peer's network drops. This triggers `_webrtcReady = false` and falls back to WebSocket, but does not by itself trigger the reconnection overlay — that's driven by the WebSocket layer.
+2. **Pong timeout (active, ~9s)**: NetworkManager sends pings every 3s and tracks `_lastPongTime`. If no pong arrives for >6s (PONG_TIMEOUT_MS), it synthetically triggers `_onSocketClose()` to enter the reconnection flow. This fires ~9s after WiFi drops (2 missed pongs + next interval tick).
+3. **WebSocket close (passive, 30s+)**: The browser eventually fires the `close` event. On mobile Safari this can take 30+ seconds.
 
-The `ReconnectionManager.handleConnectionLost()` guard (`if (this._state !== 'connected') return`) ensures that if both fire, the second is a no-op.
+The `ReconnectionManager.handleConnectionLost()` guard (`if (this._state !== 'connected') return`) ensures that if multiple mechanisms fire, only the first triggers the reconnection flow.
 
 ## Key Files
 
@@ -99,5 +120,6 @@ The `ReconnectionManager.handleConnectionLost()` guard (`if (this._state !== 'co
 |------|------|
 | `ReconnectionManager.js` | Pure state machine: connected → reconnecting → connected/disconnected |
 | `party/server.js` | Grace timer, slot reservation, `roomState` + `_stateBeforeGrace`, `return_to_select` vs `disconnect` |
-| `NetworkManager.js` | Socket lifecycle hooks, `opponent_reconnecting`/`opponent_reconnected`/`return_to_select` handlers, `sendRejoin()` |
+| `NetworkManager.js` | Socket lifecycle hooks, `opponent_reconnecting`/`opponent_reconnected`/`return_to_select` handlers, `sendRejoin()`, WebRTC re-init on reconnect |
+| `WebRTCTransport.js` | DataChannel transport — destroyed on disconnect, re-negotiated after reconnect |
 | `FightScene.js` | Integration: wires NM events → RM, shows overlay, handles `return_to_select` transition to SelectScene |

--- a/docs/multiplayer-security.md
+++ b/docs/multiplayer-security.md
@@ -11,7 +11,7 @@ flowchart LR
     end
 
     subgraph Enforce["Server — RELAY + ENFORCE"]
-        S["Slot assignment\nRate limiting\nMessage routing\nInput coercion\nCapacity enforcement\nStale cleanup\nGrace period management"]
+        S["Slot assignment\nRate limiting\nMessage routing\nInput coercion\nCapacity enforcement\nStale cleanup\nGrace period management\nSignaling relay"]
     end
 
     subgraph Untrusted
@@ -22,8 +22,9 @@ flowchart LR
         Spec["SPECTATOR\n\nCan only: shout, potion\n(both rate-limited)"]
     end
 
-    P1 <-- "sync, input" --> S
-    S <-- "input" --> P2
+    P1 <-. "inputs (WebRTC P2P)" .-> P2
+    P1 <-- "sync, signaling, spectatorOnly" --> S
+    S <-- "signaling, spectatorOnly" --> P2
     S <-- "shout, potion" --> Spec
 ```
 
@@ -77,6 +78,28 @@ flowchart TD
 
 Only P1 (slot 0) can send authoritative state messages (`sync`, `round_event`, `resync`). The server drops these from slot 1, preventing P2 from injecting false game state.
 
+### WebRTC Signaling Relay
+- Server relays `webrtc_offer`, `webrtc_answer`, `webrtc_ice` via `_sendToOther()` — only to the opponent, never to spectators
+- Signaling messages are not validated (SDP/ICE payloads passed through). This is acceptable: malformed SDP only affects the recipient's RTCPeerConnection, which handles it gracefully
+- No TURN server configured — only STUN (`stun.l.google.com`). If STUN fails (symmetric NAT), connection times out and falls back to WebSocket
+
+### P2P Data Path
+
+```mermaid
+flowchart TD
+    subgraph Bypass["P2P — Bypasses Server"]
+        DC["WebRTC DataChannel\nDTLS encrypted\nOnly carries input messages"]
+    end
+
+    subgraph Through["Via Server — All Other Messages"]
+        WS["sync, round_event, ready, start\nrematch, leave, shout, potion\nreconnection, signaling"]
+    end
+```
+
+- DataChannel traffic is **DTLS encrypted** by the browser — no plaintext on the wire
+- Only `input` messages flow over the DataChannel; all other message types remain on WebSocket through the server
+- The `spectatorOnly` flag on WebSocket inputs prevents the server from double-relaying to the opponent when P2P is active. A malicious client could omit this flag to cause duplicate inputs, but the receiving peer's dedup guard (`if (this._webrtcReady && !this.isSpectator) break`) drops WebSocket inputs when DataChannel is active
+
 ## Client-Side Guards
 
 - `PartySocket` maxRetries: 3
@@ -95,6 +118,7 @@ flowchart LR
         C["No message\nsize limits\n\nNo payload size\nvalidation"]
         D["No auth /\nidentity\n\nAnyone with room\ncode can join"]
         E["Peer can cheat\n\nModify local HP,\nfake inputs, etc.\nAcceptable for\nfriends-only P2P"]
+        F["No TURN\nserver\n\nP2P fails behind\nsymmetric NAT\n(fallback to WS)"]
     end
 ```
 
@@ -105,3 +129,6 @@ flowchart LR
 | No message size limits | Large payloads possible | PartyKit has upstream limits |
 | No auth/identity | Anyone with room code joins | Acceptable for friend groups |
 | Peer can cheat locally | Can modify HP, fake inputs | Inherent to P2P; acceptable tradeoff |
+| No TURN server | P2P fails behind symmetric NAT | Automatic fallback to WebSocket relay |
+| SDP/ICE not validated by server | Malformed signaling passed through | Browser handles gracefully; worst case is P2P fails → WS fallback |
+| P2P input not authenticated | Peer could send fake P2P inputs | Same risk as WS inputs — friends-only context |

--- a/docs/rollback-netcode.md
+++ b/docs/rollback-netcode.md
@@ -20,10 +20,10 @@ flowchart TB
         P2Sim["simulateFrame()\nIdentical FP integer math"]
     end
 
-    P1Enc -- "input + frame + history" --> Server
-    Server -- "input + frame + history" --> P2Sim
-    P2Enc -- "input + frame + history" --> Server
-    Server -- "input + frame + history" --> P1Sim
+    P1Enc -. "input + history (WebRTC P2P)" .-> P2Sim
+    P2Enc -. "input + history (WebRTC P2P)" .-> P1Sim
+    P1Enc -- "spectatorOnly input + history (WS)" --> Server
+    P2Enc -- "spectatorOnly input + history (WS)" --> Server
 
     subgraph Spectators
         Spec["Receive P1 sync snapshots\nNo rollback — passive display"]
@@ -31,6 +31,8 @@ flowchart TB
 
     Server --> Spectators
 ```
+
+> **Transport:** Game inputs use WebRTC DataChannels (P2P, unreliable/unordered) when available, with automatic fallback to WebSocket relay via the PartyKit server. The rollback system handles packet loss natively.
 
 ## Peer-Equal Model
 
@@ -211,7 +213,8 @@ stateDiagram-v2
 | `InputBuffer.js` | 9-bit input encoding/decoding |
 | `SimulationStep.js` | Single-frame deterministic advance |
 | `RollbackManager.js` | Orchestration: predict, rollback, re-simulate, checksum, adaptive delay, resync |
-| `NetworkManager.js` | Network layer: send/receive input, checksum, resync messages |
+| `WebRTCTransport.js` | P2P DataChannel transport (unreliable/unordered) |
+| `NetworkManager.js` | Dual transport: WebRTC primary, WebSocket fallback; send/receive input, checksum, resync |
 | `Fighter.js` | FP physics + frame-based timers |
 | `CombatSystem.js` | FP collision + hit detection |
 | `FightScene.js` | Integration: wires rollback + desync + resync + HUD |

--- a/docs/rollback-netcode.md
+++ b/docs/rollback-netcode.md
@@ -32,7 +32,22 @@ flowchart TB
     Server --> Spectators
 ```
 
-> **Transport:** Game inputs use WebRTC DataChannels (P2P, unreliable/unordered) when available, with automatic fallback to WebSocket relay via the PartyKit server. The rollback system handles packet loss natively.
+> **Transport:** Game inputs use WebRTC DataChannels (P2P, unreliable/unordered) when available, with automatic fallback to WebSocket relay via the PartyKit server. The rollback system handles packet loss natively. See [webrtc-transport.md](webrtc-transport.md) for full details.
+
+## Transport Layer
+
+```mermaid
+flowchart LR
+    NM["NetworkManager\nsendInput()"] --> Check{WebRTC open?}
+    Check -- Yes --> DC["DataChannel (P2P)\n→ opponent direct"]
+    Check -- Yes --> WS_S["WebSocket + spectatorOnly\n→ server → spectators"]
+    Check -- No --> WS_F["WebSocket (fallback)\n→ server → opponent + spectators"]
+```
+
+The rollback system is transport-agnostic — `RollbackManager` reads from `remoteInputBuffer` regardless of whether inputs arrived via DataChannel or WebSocket. This means:
+- **No code changes** in RollbackManager, GameState, SimulationStep, or InputBuffer
+- **Packet loss** on the unreliable DataChannel is handled the same as late TCP delivery — prediction + rollback
+- **Mid-fight transport switch** (P2P drops → WS fallback) is invisible to the simulation layer
 
 ## Peer-Equal Model
 

--- a/docs/room-state-machine.md
+++ b/docs/room-state-machine.md
@@ -49,13 +49,35 @@ flowchart TD
 - **`return_to_select`**: Grace expired during a fight. The room is still viable — the remaining player transitions back to `SelectScene` while keeping their `NetworkManager` connection alive. A new opponent can join and both re-select fighters.
 - **`disconnect`**: Grace expired during fighter select. The remaining player goes to `TitleScene` and the `NetworkManager` is destroyed.
 
+## Server Message Routing
+
+```mermaid
+flowchart TD
+    Msg["Incoming message"] --> Type{Message type?}
+
+    Type -- "ready" --> Ready["Validate roomState=selecting\nStore fighterId\nRelay opponent_ready\nIf both ready → start"]
+    Type -- "input" --> Input{"spectatorOnly?"}
+    Input -- No --> Relay["Relay to opponent\n+ broadcast to spectators"]
+    Input -- Yes --> SpecOnly["Skip opponent relay\nBroadcast to spectators only"]
+    Type -- "webrtc_offer\nwebrtc_answer\nwebrtc_ice" --> Signaling["Relay to opponent only\n(not spectators)"]
+    Type -- "sync\nround_event" --> HostOnly{"From slot 0?"}
+    HostOnly -- Yes --> RelayHost["Relay to opponent\n+ spectators"]
+    HostOnly -- No --> Drop["Drop (non-host)"]
+    Type -- "ping" --> Pong["Echo pong to sender"]
+    Type -- "rematch" --> Rematch["Relay to opponent only"]
+    Type -- "leave" --> Leave["Reset ready state\nRelay to opponent"]
+    Type -- "rejoin" --> Rejoin["Reclaim slot\nCancel grace timer"]
+```
+
 ## Client Handling
 
 The client's current Phaser scene is its implicit state. It reacts to server messages:
 
 | Message | SelectScene | FightScene |
 |---------|------------|------------|
+| `opponent_joined` | Init WebRTC negotiation | — |
 | `opponent_reconnecting` | — | Show "RECONECTANDO..." overlay |
-| `opponent_reconnected` | — | Hide overlay, resume |
+| `opponent_reconnected` | — | Hide overlay, resume, re-init WebRTC |
 | `disconnect` | Go to TitleScene | Show "DESCONECTADO" (frozen) |
 | `return_to_select` | — | Show "DESCONECTADO" for 2s, fade to SelectScene |
+| `webrtc_offer/answer/ice` | Forward to WebRTCTransport | Forward to WebRTCTransport |

--- a/docs/webrtc-transport.md
+++ b/docs/webrtc-transport.md
@@ -1,0 +1,195 @@
+# WebRTC P2P Transport
+
+WebRTC DataChannels provide direct peer-to-peer communication for game inputs, eliminating the server round-trip. The existing GGPO-style rollback system already handles packet loss and out-of-order delivery, making unreliable DataChannels a natural fit.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph P1["Player 1 (Browser)"]
+        NM1["NetworkManager"] --> WRT1["WebRTCTransport"]
+        NM1 --> WS1["WebSocket"]
+    end
+
+    subgraph Server["PartyKit Server"]
+        Sig["Signaling Relay\nwebrtc_offer/answer/ice"]
+        Spec["Spectator Relay\nspectatorOnly inputs"]
+    end
+
+    subgraph P2["Player 2 (Browser)"]
+        WRT2["WebRTCTransport"] --> NM2["NetworkManager"]
+        WS2["WebSocket"] --> NM2
+    end
+
+    WRT1 -. "DataChannel\n(P2P, UDP-like)" .-> WRT2
+    WS1 -- "signaling + spectatorOnly" --> Sig
+    Sig -- "signaling" --> WS2
+    Spec -- "inputs" --> Spectators
+```
+
+## Transport Negotiation Timeline
+
+```mermaid
+sequenceDiagram
+    participant P1 as P1 (Offerer)
+    participant S as Server
+    participant P2 as P2 (Answerer)
+
+    Note over P1,P2: Both connect via WebSocket
+    S->>P1: assign (slot 0)
+    S->>P2: assign (slot 1)
+    S->>P1: opponent_joined
+    S->>P2: opponent_joined
+
+    Note over P1: _initWebRTC()<br/>isOfferer = true
+
+    P1->>P1: createDataChannel("inputs")<br/>ordered: false, maxRetransmits: 0
+    P1->>P1: createOffer()
+    P1->>S: webrtc_offer (SDP)
+    S->>P2: webrtc_offer (SDP)
+
+    Note over P2: _initWebRTC()<br/>handleSignal(offer)
+
+    P2->>P2: setRemoteDescription(offer)
+    P2->>P2: createAnswer()
+    P2->>S: webrtc_answer (SDP)
+    S->>P1: webrtc_answer (SDP)
+    P1->>P1: setRemoteDescription(answer)
+
+    par ICE Candidates
+        P1->>S: webrtc_ice
+        S->>P2: webrtc_ice
+    and
+        P2->>S: webrtc_ice
+        S->>P1: webrtc_ice
+    end
+
+    Note over P1,P2: DataChannel opens (P2P established)
+
+    rect rgb(200, 255, 200)
+        Note over P1,P2: Game inputs flow P2P<br/>spectatorOnly copies via WS
+    end
+```
+
+## WebRTCTransport State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> idle
+    idle --> signaling : startOffer() / handleSignal(offer)
+    signaling --> connecting : DataChannel setup
+    connecting --> open : DC.onopen
+    open --> closed : DC.onclose / PC disconnected
+    signaling --> failed : 5s timeout
+    connecting --> failed : 5s timeout / PC failed
+    failed --> [*]
+    closed --> [*]
+
+    note right of open
+        P2P active
+        _webrtcReady = true
+    end note
+    note right of failed
+        Silent fallback to WS
+        _webrtc = null
+    end note
+```
+
+## Dual-Send Input Flow
+
+When WebRTC is active, `sendInput()` sends each input twice via different paths:
+
+```mermaid
+flowchart TD
+    SI["sendInput(frame, state)"] --> Check{_webrtcReady?}
+
+    Check -- Yes --> P2P["WebRTC DataChannel\n→ opponent (P2P)"]
+    Check -- Yes --> WS_Spec["WebSocket + spectatorOnly flag\n→ server → spectators only"]
+    Check -- No --> WS_Full["WebSocket (no flag)\n→ server → opponent + spectators"]
+
+    subgraph Receiving Side
+        P2P --> DC_Recv["DC.onmessage\n→ remoteInputBuffer"]
+        WS_Spec --> Srv_Spec["Server skips opponent\n→ broadcastToSpectators"]
+        WS_Full --> Srv_Full["Server relays to opponent\n+ broadcastToSpectators"]
+    end
+```
+
+When both transports are active, the receiving peer ignores WebSocket `input` messages (dedup guard) since they arrive via DataChannel.
+
+## Fallback Scenarios
+
+```mermaid
+flowchart TD
+    Start["_initWebRTC()"] --> STUN{"STUN succeeds?"}
+    STUN -- Yes --> DC{"DataChannel opens\nwithin 5s?"}
+    STUN -- No --> Timeout["5s timeout → onFailed"]
+    DC -- Yes --> P2P["P2P active ✓"]
+    DC -- No --> Timeout
+
+    Timeout --> Fallback["_webrtcReady = false\n_webrtc = null\nWebSocket relay (transparent)"]
+
+    P2P --> MidDrop{"DC drops mid-fight?"}
+    MidDrop -- Yes --> WSFallback["onClose → _transportMode = 'websocket'\nNext sendInput uses WS"]
+    MidDrop -- No --> Continue["Continue P2P"]
+```
+
+| Scenario | What Happens | User Impact |
+|----------|-------------|-------------|
+| Symmetric NAT (mobile carrier) | STUN fails → 5s timeout → WS fallback | None — same as before WebRTC |
+| Corporate firewall blocks UDP | Same as above | None |
+| WebRTC opens then drops mid-fight | `onClose` → fall back to WS | Brief latency increase, no disruption |
+| Browser lacks WebRTC API | `typeof RTCPeerConnection === 'undefined'` → skip init | None |
+| Both WS and WebRTC drop | Existing ReconnectionManager handles it (20s grace) | Pause overlay |
+
+## Reconnection
+
+```mermaid
+sequenceDiagram
+    participant P1 as P1
+    participant S as Server
+    participant P2 as P2
+
+    Note over P1: WiFi drops
+    Note over P1: WebRTC DC closes
+    Note over P1: WebSocket closes
+
+    S->>P2: opponent_reconnecting
+    Note over P2: Pause overlay
+
+    P1->>S: ws reconnect (PartySocket)
+    P1->>S: rejoin
+    S->>P2: opponent_reconnected
+
+    Note over P2: _initWebRTC() again
+    Note over P1: _initWebRTC() on opponent_reconnected
+
+    P1->>S: webrtc_offer (new negotiation)
+    S->>P2: webrtc_offer
+    P2->>S: webrtc_answer
+    S->>P1: webrtc_answer
+
+    alt P2P succeeds
+        Note over P1,P2: DataChannel reopens
+    else P2P fails
+        Note over P1,P2: Stay on WebSocket relay
+    end
+```
+
+## Configuration
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| DataChannel `ordered` | `false` | Rollback handles reordering |
+| DataChannel `maxRetransmits` | `0` | Rollback handles loss; retransmits add latency |
+| STUN server | `stun:stun.l.google.com:19302` | Free, widely available |
+| Connection timeout | 5000ms | Enough for STUN + ICE; fails fast for blocked UDP |
+| Offerer | Always P1 (slot 0) | Deterministic role assignment |
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/systems/WebRTCTransport.js` | RTCPeerConnection + DataChannel state machine |
+| `src/systems/NetworkManager.js` | Dual transport orchestration, signaling relay, fallback |
+| `party/server.js` | Signaling message relay (`webrtc_offer/answer/ice`), `spectatorOnly` input filter |
+| `src/scenes/FightScene.js` | Transport indicator (P2P/WS) in bottom-left corner |

--- a/party/server.js
+++ b/party/server.js
@@ -190,7 +190,9 @@ export default class FightRoom {
         break;
       }
       case 'input':
-        this._sendToOther(slot, data);
+        if (!data.spectatorOnly) {
+          this._sendToOther(slot, data);
+        }
         this._broadcastToSpectators({ ...data, slot });
         break;
       case 'checksum':
@@ -200,6 +202,11 @@ export default class FightRoom {
       case 'resync':
         // Only P1 (slot 0) can send authoritative resync snapshots
         if (slot !== 0) break;
+        this._sendToOther(slot, data);
+        break;
+      case 'webrtc_offer':
+      case 'webrtc_answer':
+      case 'webrtc_ice':
         this._sendToOther(slot, data);
         break;
       case 'sync':

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -615,12 +615,19 @@ export class FightScene extends Phaser.Scene {
         else this._pingText.setColor('#44ff44');
 
         if (this._transportText) {
-          if (this.networkManager._webrtcReady) {
+          const ready = this.networkManager._webrtcReady;
+          const mode = this.networkManager._transportMode;
+          const hasWrtc = !!this.networkManager._webrtc;
+          if (ready) {
             this._transportText.setText('P2P');
             this._transportText.setColor('#44ff44');
           } else {
             this._transportText.setText('WS');
             this._transportText.setColor('#666666');
+          }
+          // Temporary debug — remove after confirming
+          if (this._pingUpdateCounter === 0) {
+            console.log(`[HUD] transport: ready=${ready} mode=${mode} hasWebrtc=${hasWrtc}`);
           }
         }
       }

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -511,6 +511,18 @@ export class FightScene extends Phaser.Scene {
           .setOrigin(0.5, 1)
           .setDepth(depth + 3);
         this._pingUpdateCounter = 0;
+
+        // Transport indicator (bottom-left corner)
+        this._transportText = this.add
+          .text(4, infoY, 'WS', {
+            fontSize: '6px',
+            fontFamily: 'monospace',
+            color: '#666666',
+            stroke: '#000000',
+            strokeThickness: 2,
+          })
+          .setOrigin(0, 1)
+          .setDepth(depth + 3);
       }
     }
 
@@ -591,7 +603,7 @@ export class FightScene extends Phaser.Scene {
       this.roundDotsP2[i].setFillStyle(i < this.combat.p2RoundsWon ? 0xcc2200 : 0x333333);
     }
 
-    // Ping indicator (update ~1x per second)
+    // Ping + transport indicator (update ~1x per second)
     if (this._pingText && this.networkManager) {
       this._pingUpdateCounter = (this._pingUpdateCounter || 0) + 1;
       if (this._pingUpdateCounter >= 60) {
@@ -601,6 +613,16 @@ export class FightScene extends Phaser.Scene {
         if (ms > 150) this._pingText.setColor('#ff4444');
         else if (ms > 80) this._pingText.setColor('#ffcc00');
         else this._pingText.setColor('#44ff44');
+
+        if (this._transportText) {
+          if (this.networkManager._webrtcReady) {
+            this._transportText.setText('P2P');
+            this._transportText.setColor('#44ff44');
+          } else {
+            this._transportText.setText('WS');
+            this._transportText.setColor('#666666');
+          }
+        }
       }
     }
   }

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -615,19 +615,12 @@ export class FightScene extends Phaser.Scene {
         else this._pingText.setColor('#44ff44');
 
         if (this._transportText) {
-          const ready = this.networkManager._webrtcReady;
-          const mode = this.networkManager._transportMode;
-          const hasWrtc = !!this.networkManager._webrtc;
-          if (ready) {
+          if (this.networkManager._webrtcReady) {
             this._transportText.setText('P2P');
             this._transportText.setColor('#44ff44');
           } else {
             this._transportText.setText('WS');
             this._transportText.setColor('#666666');
-          }
-          // Temporary debug — remove after confirming
-          if (this._pingUpdateCounter === 0) {
-            console.log(`[HUD] transport: ready=${ready} mode=${mode} hasWebrtc=${hasWrtc}`);
           }
         }
       }

--- a/src/systems/NetworkManager.js
+++ b/src/systems/NetworkManager.js
@@ -601,7 +601,9 @@ export class NetworkManager {
   }
 
   resetForReselect() {
-    this._destroyWebRTC();
+    // Note: WebRTC is intentionally preserved across reselect — the P2P
+    // connection established during selection should persist into the fight.
+    // Only destroy/leave/reconnection should tear it down.
     this.remoteInputBuffer = {};
     this.lastRemoteInput = null;
     this.remoteInputBufferP1 = {};

--- a/src/systems/NetworkManager.js
+++ b/src/systems/NetworkManager.js
@@ -1,5 +1,6 @@
 import PartySocket from 'partysocket';
 import { decodeInput } from './InputBuffer.js';
+import { WebRTCTransport } from './WebRTCTransport.js';
 
 const PONG_TIMEOUT_MS = 6000;
 
@@ -56,6 +57,11 @@ export class NetworkManager {
     this._onChecksum = null;
     this._onResyncRequest = null;
     this._onResync = null;
+
+    // WebRTC P2P transport state
+    this._webrtc = null;
+    this._transportMode = 'websocket'; // 'websocket' | 'webrtc'
+    this._webrtcReady = false;
 
     // B5: Pending callback messages queue
     this._pendingCallbackMessages = {
@@ -188,6 +194,7 @@ export class NetworkManager {
         if (this._onAssign) this._onAssign(msg.player);
         break;
       case 'opponent_joined':
+        this._initWebRTC();
         if (this._onOpponentJoined) this._onOpponentJoined();
         break;
       case 'opponent_ready':
@@ -200,7 +207,14 @@ export class NetworkManager {
           this._pendingCallbackMessages.start.push(msg);
         }
         break;
+      case 'webrtc_offer':
+      case 'webrtc_answer':
+      case 'webrtc_ice':
+        if (this._webrtc) this._webrtc.handleSignal(msg);
+        break;
       case 'input':
+        // When WebRTC is active, ignore WS inputs for non-spectators (inputs arrive via DataChannel)
+        if (this._webrtcReady && !this.isSpectator) break;
         if (this.isSpectator && msg.slot != null) {
           // Spectator: route input to correct player buffer
           const buf = msg.slot === 0 ? 'remoteInputBufferP1' : 'remoteInputBufferP2';
@@ -279,6 +293,7 @@ export class NetworkManager {
         if (this._onOpponentReconnecting) this._onOpponentReconnecting();
         break;
       case 'opponent_reconnected':
+        this._initWebRTC();
         if (this._onOpponentReconnected) this._onOpponentReconnected();
         break;
       case 'return_to_select':
@@ -384,7 +399,15 @@ export class NetworkManager {
     if (history && history.length > 0) {
       msg.history = history;
     }
-    this._send(msg);
+    if (this._webrtcReady) {
+      // P2P: fast path for opponent (includes history for unreliable channel)
+      this._webrtc.send(JSON.stringify(msg));
+      // Server: spectator relay only (server won't forward to opponent)
+      this._send({ ...msg, spectatorOnly: true });
+    } else {
+      // Fallback: server relays to opponent + spectators
+      this._send(msg);
+    }
   }
 
   sendChecksum(frame, hash) {
@@ -578,6 +601,7 @@ export class NetworkManager {
   }
 
   resetForReselect() {
+    this._destroyWebRTC();
     this.remoteInputBuffer = {};
     this.lastRemoteInput = null;
     this.remoteInputBufferP1 = {};
@@ -604,6 +628,7 @@ export class NetworkManager {
   }
 
   destroy() {
+    this._destroyWebRTC();
     if (this._pingInterval) {
       clearInterval(this._pingInterval);
       this._pingInterval = null;
@@ -652,6 +677,61 @@ export class NetworkManager {
     this._boundOnOpen = null;
     this._boundOnClose = null;
     this._boundOnError = null;
+  }
+
+  _initWebRTC() {
+    // Don't init for spectators or if WebRTC APIs aren't available
+    if (this.isSpectator) return;
+    if (typeof RTCPeerConnection === 'undefined') return;
+
+    // Clean up any existing WebRTC connection
+    this._destroyWebRTC();
+
+    const isOfferer = this.playerSlot === 0;
+
+    this._webrtc = new WebRTCTransport({
+      isOfferer,
+      onSignal: (msg) => this._send(msg),
+      onMessage: (data) => {
+        try {
+          const msg = JSON.parse(data);
+          if (msg.type === 'input') {
+            this.remoteInputBuffer[msg.frame] = msg.state;
+            this.lastRemoteInput = msg.state;
+            if (this._onRemoteInput) this._onRemoteInput(msg.frame, msg.state);
+          }
+        } catch (_) {
+          // ignore malformed P2P messages
+        }
+      },
+      onOpen: () => {
+        this._transportMode = 'webrtc';
+        this._webrtcReady = true;
+      },
+      onClose: () => {
+        this._transportMode = 'websocket';
+        this._webrtcReady = false;
+      },
+      onFailed: () => {
+        // Silent fallback — stay on WebSocket
+        this._transportMode = 'websocket';
+        this._webrtcReady = false;
+        this._webrtc = null;
+      },
+    });
+
+    if (isOfferer) {
+      this._webrtc.startOffer();
+    }
+  }
+
+  _destroyWebRTC() {
+    if (this._webrtc) {
+      this._webrtc.destroy();
+      this._webrtc = null;
+    }
+    this._transportMode = 'websocket';
+    this._webrtcReady = false;
   }
 
   _send(msg) {

--- a/src/systems/NetworkManager.js
+++ b/src/systems/NetworkManager.js
@@ -704,6 +704,14 @@ export class NetworkManager {
           if (msg.type === 'input') {
             this.remoteInputBuffer[msg.frame] = msg.state;
             this.lastRemoteInput = msg.state;
+            // Process redundant input history — fill gaps from P2P packet loss
+            if (msg.history) {
+              for (const [hFrame, encodedInput] of msg.history) {
+                if (!(hFrame in this.remoteInputBuffer)) {
+                  this.remoteInputBuffer[hFrame] = decodeInput(encodedInput);
+                }
+              }
+            }
             if (this._onRemoteInput) this._onRemoteInput(msg.frame, msg.state);
           }
         } catch (_) {

--- a/src/systems/NetworkManager.js
+++ b/src/systems/NetworkManager.js
@@ -682,12 +682,16 @@ export class NetworkManager {
   _initWebRTC() {
     // Don't init for spectators or if WebRTC APIs aren't available
     if (this.isSpectator) return;
-    if (typeof RTCPeerConnection === 'undefined') return;
+    if (typeof RTCPeerConnection === 'undefined') {
+      console.log('[NM] WebRTC unavailable (no RTCPeerConnection)');
+      return;
+    }
 
     // Clean up any existing WebRTC connection
     this._destroyWebRTC();
 
     const isOfferer = this.playerSlot === 0;
+    console.log(`[NM] _initWebRTC slot=${this.playerSlot} offerer=${isOfferer}`);
 
     this._webrtc = new WebRTCTransport({
       isOfferer,

--- a/src/systems/WebRTCTransport.js
+++ b/src/systems/WebRTCTransport.js
@@ -1,0 +1,234 @@
+/**
+ * WebRTC DataChannel transport for P2P game inputs.
+ * Uses unreliable/unordered mode (UDP-like) — the rollback system handles loss natively.
+ *
+ * State machine: idle → signaling → connecting → open → closed|failed
+ */
+
+const ICE_SERVERS = [{ urls: 'stun:stun.l.google.com:19302' }];
+const DEFAULT_TIMEOUT_MS = 5000;
+
+export class WebRTCTransport {
+  /**
+   * @param {object} opts
+   * @param {boolean} opts.isOfferer - true for P1 (slot 0), false for P2
+   * @param {(msg: object) => void} opts.onSignal - send signaling message via WebSocket
+   * @param {(data: string) => void} opts.onMessage - incoming DataChannel message
+   * @param {() => void} opts.onOpen - DataChannel opened
+   * @param {() => void} opts.onClose - DataChannel closed after being open
+   * @param {() => void} opts.onFailed - connection failed or timed out
+   * @param {number} [opts.timeoutMs=5000] - max time to establish connection
+   */
+  constructor({
+    isOfferer,
+    onSignal,
+    onMessage,
+    onOpen,
+    onClose,
+    onFailed,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  }) {
+    this._isOfferer = isOfferer;
+    this._onSignal = onSignal;
+    this._onMessage = onMessage;
+    this._onOpen = onOpen;
+    this._onClose = onClose;
+    this._onFailed = onFailed;
+    this._timeoutMs = timeoutMs;
+
+    /** @type {'idle'|'signaling'|'connecting'|'open'|'closed'|'failed'} */
+    this.state = 'idle';
+
+    /** @type {RTCPeerConnection|null} */
+    this._pc = null;
+    /** @type {RTCDataChannel|null} */
+    this._dc = null;
+    /** @type {ReturnType<typeof setTimeout>|null} */
+    this._timeout = null;
+  }
+
+  /** P1 calls this to create an offer and DataChannel. */
+  async startOffer() {
+    if (this.state !== 'idle') return;
+    this.state = 'signaling';
+
+    this._startTimeout();
+    this._createPeerConnection();
+
+    // Offerer creates the DataChannel
+    this._dc = this._pc.createDataChannel('inputs', {
+      ordered: false,
+      maxRetransmits: 0,
+    });
+    this._setupDataChannel(this._dc);
+
+    const offer = await this._pc.createOffer();
+    await this._pc.setLocalDescription(offer);
+    this._onSignal({ type: 'webrtc_offer', sdp: offer.sdp });
+  }
+
+  /**
+   * Handle an incoming signaling message (offer, answer, or ICE candidate).
+   * @param {object} msg
+   */
+  async handleSignal(msg) {
+    switch (msg.type) {
+      case 'webrtc_offer': {
+        if (this._isOfferer) return; // offerer shouldn't receive offers
+        if (this.state !== 'idle') return;
+        this.state = 'signaling';
+
+        this._startTimeout();
+        this._createPeerConnection();
+
+        await this._pc.setRemoteDescription(
+          new RTCSessionDescription({ type: 'offer', sdp: msg.sdp }),
+        );
+        const answer = await this._pc.createAnswer();
+        await this._pc.setLocalDescription(answer);
+        this._onSignal({ type: 'webrtc_answer', sdp: answer.sdp });
+        break;
+      }
+      case 'webrtc_answer': {
+        if (!this._isOfferer) return; // answerer shouldn't receive answers
+        if (!this._pc) return;
+        await this._pc.setRemoteDescription(
+          new RTCSessionDescription({ type: 'answer', sdp: msg.sdp }),
+        );
+        break;
+      }
+      case 'webrtc_ice': {
+        if (!this._pc) return;
+        if (msg.candidate) {
+          await this._pc.addIceCandidate(new RTCIceCandidate(msg.candidate));
+        }
+        break;
+      }
+    }
+  }
+
+  /**
+   * Send data on the DataChannel.
+   * @param {string} data
+   * @returns {boolean} true if sent, false if channel not open
+   */
+  send(data) {
+    if (this._dc && this._dc.readyState === 'open') {
+      this._dc.send(data);
+      return true;
+    }
+    return false;
+  }
+
+  /** @returns {boolean} */
+  isOpen() {
+    return this._dc != null && this._dc.readyState === 'open';
+  }
+
+  /** Tear down everything. */
+  destroy() {
+    this._clearTimeout();
+    if (this._dc) {
+      this._dc.onopen = null;
+      this._dc.onclose = null;
+      this._dc.onmessage = null;
+      try {
+        this._dc.close();
+      } catch (_) {
+        /* ignore */
+      }
+      this._dc = null;
+    }
+    if (this._pc) {
+      this._pc.onicecandidate = null;
+      this._pc.ondatachannel = null;
+      this._pc.onconnectionstatechange = null;
+      try {
+        this._pc.close();
+      } catch (_) {
+        /* ignore */
+      }
+      this._pc = null;
+    }
+    if (this.state !== 'closed' && this.state !== 'failed') {
+      this.state = 'closed';
+    }
+  }
+
+  // --- Private ---
+
+  _createPeerConnection() {
+    this._pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+
+    this._pc.onicecandidate = (event) => {
+      if (event.candidate) {
+        this._onSignal({ type: 'webrtc_ice', candidate: event.candidate.toJSON() });
+      }
+    };
+
+    // Answerer receives the DataChannel here
+    this._pc.ondatachannel = (event) => {
+      this._dc = event.channel;
+      this._setupDataChannel(this._dc);
+    };
+
+    this._pc.onconnectionstatechange = () => {
+      const connState = this._pc?.connectionState;
+      if (connState === 'failed' || connState === 'disconnected') {
+        if (this.state === 'open') {
+          this.state = 'closed';
+          this._clearTimeout();
+          this._onClose();
+        } else if (this.state !== 'closed' && this.state !== 'failed') {
+          this._fail();
+        }
+      }
+    };
+  }
+
+  _setupDataChannel(dc) {
+    dc.onopen = () => {
+      this.state = 'open';
+      this._clearTimeout();
+      this._onOpen();
+    };
+
+    dc.onclose = () => {
+      if (this.state === 'open') {
+        this.state = 'closed';
+        this._onClose();
+      }
+    };
+
+    dc.onmessage = (event) => {
+      this._onMessage(event.data);
+    };
+
+    if (this.state === 'signaling') {
+      this.state = 'connecting';
+    }
+  }
+
+  _startTimeout() {
+    this._timeout = setTimeout(() => {
+      this._timeout = null;
+      if (this.state !== 'open') {
+        this._fail();
+      }
+    }, this._timeoutMs);
+  }
+
+  _clearTimeout() {
+    if (this._timeout) {
+      clearTimeout(this._timeout);
+      this._timeout = null;
+    }
+  }
+
+  _fail() {
+    this.state = 'failed';
+    this._clearTimeout();
+    this.destroy();
+    this._onFailed();
+  }
+}

--- a/src/systems/WebRTCTransport.js
+++ b/src/systems/WebRTCTransport.js
@@ -62,9 +62,15 @@ export class WebRTCTransport {
     });
     this._setupDataChannel(this._dc);
 
-    const offer = await this._pc.createOffer();
-    await this._pc.setLocalDescription(offer);
-    this._onSignal({ type: 'webrtc_offer', sdp: offer.sdp });
+    try {
+      const offer = await this._pc.createOffer();
+      await this._pc.setLocalDescription(offer);
+      this._log('offer created');
+      this._onSignal({ type: 'webrtc_offer', sdp: offer.sdp });
+    } catch (err) {
+      this._log('startOffer error', err);
+      this._fail();
+    }
   }
 
   /**
@@ -72,38 +78,45 @@ export class WebRTCTransport {
    * @param {object} msg
    */
   async handleSignal(msg) {
-    switch (msg.type) {
-      case 'webrtc_offer': {
-        if (this._isOfferer) return; // offerer shouldn't receive offers
-        if (this.state !== 'idle') return;
-        this.state = 'signaling';
+    try {
+      switch (msg.type) {
+        case 'webrtc_offer': {
+          if (this._isOfferer) return; // offerer shouldn't receive offers
+          if (this.state !== 'idle') return;
+          this.state = 'signaling';
 
-        this._startTimeout();
-        this._createPeerConnection();
+          this._startTimeout();
+          this._createPeerConnection();
 
-        await this._pc.setRemoteDescription(
-          new RTCSessionDescription({ type: 'offer', sdp: msg.sdp }),
-        );
-        const answer = await this._pc.createAnswer();
-        await this._pc.setLocalDescription(answer);
-        this._onSignal({ type: 'webrtc_answer', sdp: answer.sdp });
-        break;
-      }
-      case 'webrtc_answer': {
-        if (!this._isOfferer) return; // answerer shouldn't receive answers
-        if (!this._pc) return;
-        await this._pc.setRemoteDescription(
-          new RTCSessionDescription({ type: 'answer', sdp: msg.sdp }),
-        );
-        break;
-      }
-      case 'webrtc_ice': {
-        if (!this._pc) return;
-        if (msg.candidate) {
-          await this._pc.addIceCandidate(new RTCIceCandidate(msg.candidate));
+          await this._pc.setRemoteDescription(
+            new RTCSessionDescription({ type: 'offer', sdp: msg.sdp }),
+          );
+          const answer = await this._pc.createAnswer();
+          await this._pc.setLocalDescription(answer);
+          this._log('answer created');
+          this._onSignal({ type: 'webrtc_answer', sdp: answer.sdp });
+          break;
         }
-        break;
+        case 'webrtc_answer': {
+          if (!this._isOfferer) return; // answerer shouldn't receive answers
+          if (!this._pc) return;
+          await this._pc.setRemoteDescription(
+            new RTCSessionDescription({ type: 'answer', sdp: msg.sdp }),
+          );
+          this._log('answer received');
+          break;
+        }
+        case 'webrtc_ice': {
+          if (!this._pc) return;
+          if (msg.candidate) {
+            await this._pc.addIceCandidate(new RTCIceCandidate(msg.candidate));
+          }
+          break;
+        }
       }
+    } catch (err) {
+      this._log('handleSignal error', err);
+      this._fail();
     }
   }
 
@@ -168,12 +181,14 @@ export class WebRTCTransport {
 
     // Answerer receives the DataChannel here
     this._pc.ondatachannel = (event) => {
+      this._log('remote DataChannel received');
       this._dc = event.channel;
       this._setupDataChannel(this._dc);
     };
 
     this._pc.onconnectionstatechange = () => {
       const connState = this._pc?.connectionState;
+      this._log('PC state:', connState);
       if (connState === 'failed' || connState === 'disconnected') {
         if (this.state === 'open') {
           this.state = 'closed';
@@ -188,12 +203,14 @@ export class WebRTCTransport {
 
   _setupDataChannel(dc) {
     dc.onopen = () => {
+      this._log('DataChannel open');
       this.state = 'open';
       this._clearTimeout();
       this._onOpen();
     };
 
     dc.onclose = () => {
+      this._log('DataChannel closed');
       if (this.state === 'open') {
         this.state = 'closed';
         this._onClose();
@@ -226,9 +243,14 @@ export class WebRTCTransport {
   }
 
   _fail() {
+    this._log(`failed (was ${this.state})`);
     this.state = 'failed';
     this._clearTimeout();
     this.destroy();
     this._onFailed();
+  }
+
+  _log(...args) {
+    console.log(`[WebRTC ${this._isOfferer ? 'P1' : 'P2'}]`, ...args);
   }
 }

--- a/tests/party/server.test.js
+++ b/tests/party/server.test.js
@@ -837,6 +837,61 @@ describe('FightRoom', () => {
       expect(c3Msgs.some((m) => m.type === 'round_event')).toBe(true);
     });
 
+    it('webrtc_offer relayed to opponent only', () => {
+      room.onMessage(JSON.stringify({ type: 'webrtc_offer', sdp: 'offer-sdp' }), conn1);
+
+      const c2Msgs = conn2.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c2Msgs.some((m) => m.type === 'webrtc_offer' && m.sdp === 'offer-sdp')).toBe(true);
+
+      expect(conn3.send).not.toHaveBeenCalled();
+    });
+
+    it('webrtc_answer relayed to opponent only', () => {
+      room.onMessage(JSON.stringify({ type: 'webrtc_answer', sdp: 'answer-sdp' }), conn2);
+
+      const c1Msgs = conn1.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c1Msgs.some((m) => m.type === 'webrtc_answer' && m.sdp === 'answer-sdp')).toBe(true);
+
+      expect(conn3.send).not.toHaveBeenCalled();
+    });
+
+    it('webrtc_ice relayed to opponent only', () => {
+      room.onMessage(
+        JSON.stringify({ type: 'webrtc_ice', candidate: { candidate: 'test' } }),
+        conn1,
+      );
+
+      const c2Msgs = conn2.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c2Msgs.some((m) => m.type === 'webrtc_ice')).toBe(true);
+
+      expect(conn3.send).not.toHaveBeenCalled();
+    });
+
+    it('input with spectatorOnly NOT relayed to opponent, IS broadcast to spectators', () => {
+      room.onMessage(
+        JSON.stringify({ type: 'input', frame: 1, state: 7, spectatorOnly: true }),
+        conn1,
+      );
+
+      // Opponent should NOT receive it
+      const c2Msgs = conn2.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c2Msgs.some((m) => m.type === 'input')).toBe(false);
+
+      // Spectator SHOULD receive it (with slot added)
+      const c3Msgs = conn3.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c3Msgs.some((m) => m.type === 'input' && m.slot === 0)).toBe(true);
+    });
+
+    it('input without spectatorOnly relayed to opponent AND spectators (fallback)', () => {
+      room.onMessage(JSON.stringify({ type: 'input', frame: 1, state: 7 }), conn1);
+
+      const c2Msgs = conn2.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c2Msgs.some((m) => m.type === 'input')).toBe(true);
+
+      const c3Msgs = conn3.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c3Msgs.some((m) => m.type === 'input')).toBe(true);
+    });
+
     it('rematch relayed only to opponent, not spectators', () => {
       room.onMessage(JSON.stringify({ type: 'rematch' }), conn1);
 

--- a/tests/systems/network-manager.test.js
+++ b/tests/systems/network-manager.test.js
@@ -1,6 +1,48 @@
 import { describe, expect, it, vi } from 'vitest';
 import { encodeInput } from '../../src/systems/InputBuffer.js';
 
+// Mock WebRTCTransport before importing NetworkManager
+vi.mock('../../src/systems/WebRTCTransport.js', () => {
+  class MockWebRTCTransport {
+    constructor(opts) {
+      this._opts = opts;
+      this._sent = [];
+      this.state = 'idle';
+    }
+    async startOffer() {
+      this.state = 'signaling';
+    }
+    async handleSignal(_msg) {}
+    send(data) {
+      this._sent.push(data);
+      return true;
+    }
+    isOpen() {
+      return this.state === 'open';
+    }
+    destroy() {
+      this.state = 'closed';
+    }
+    // Test helper: simulate open
+    _simulateOpen() {
+      this.state = 'open';
+      if (this._opts.onOpen) this._opts.onOpen();
+    }
+    _simulateClose() {
+      this.state = 'closed';
+      if (this._opts.onClose) this._opts.onClose();
+    }
+    _simulateFailed() {
+      this.state = 'failed';
+      if (this._opts.onFailed) this._opts.onFailed();
+    }
+    _simulateMessage(data) {
+      if (this._opts.onMessage) this._opts.onMessage(data);
+    }
+  }
+  return { WebRTCTransport: MockWebRTCTransport };
+});
+
 // Mock PartySocket before importing NetworkManager
 vi.mock('partysocket', () => {
   class MockPartySocket {
@@ -688,6 +730,229 @@ describe('NetworkManager', () => {
 
       const sent = JSON.parse(sendSpy.mock.calls[0][0]);
       expect(sent.history).toBeUndefined();
+    });
+  });
+
+  // ---- WebRTC integration ----
+
+  describe('WebRTC P2P transport', () => {
+    it('inits WebRTC on opponent_joined (P1 as offerer)', () => {
+      const nm = makeManager();
+      nm.playerSlot = 0;
+      // Ensure RTCPeerConnection is available
+      globalThis.RTCPeerConnection = class {};
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      expect(nm._webrtc).not.toBeNull();
+    });
+
+    it('does not init WebRTC for spectators', () => {
+      const nm = makeManager();
+      nm.isSpectator = true;
+      globalThis.RTCPeerConnection = class {};
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      expect(nm._webrtc).toBeNull();
+    });
+
+    it('P1 (slot 0) calls startOffer, P2 does not', () => {
+      globalThis.RTCPeerConnection = class {};
+
+      const nm1 = makeManager();
+      nm1.playerSlot = 0;
+      nm1._handleMessage({ type: 'opponent_joined' });
+      expect(nm1._webrtc.state).toBe('signaling'); // mock startOffer sets signaling
+
+      const nm2 = makeManager();
+      nm2.playerSlot = 1;
+      nm2._handleMessage({ type: 'opponent_joined' });
+      expect(nm2._webrtc.state).toBe('idle'); // waiting for offer
+    });
+
+    it('sets _webrtcReady on open, sends inputs via WebRTC', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 0;
+      nm.connected = true;
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      nm._webrtc._simulateOpen();
+
+      expect(nm._webrtcReady).toBe(true);
+      expect(nm._transportMode).toBe('webrtc');
+
+      const sendSpy = vi.spyOn(nm.socket, 'send');
+      nm.sendInput(5, { left: true });
+
+      // WebRTC should have received the input
+      expect(nm._webrtc._sent.length).toBe(1);
+      const p2pMsg = JSON.parse(nm._webrtc._sent[0]);
+      expect(p2pMsg).toMatchObject({ type: 'input', frame: 5, state: { left: true } });
+
+      // WebSocket should also have received input with spectatorOnly flag
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const wsMsg = JSON.parse(sendSpy.mock.calls[0][0]);
+      expect(wsMsg.spectatorOnly).toBe(true);
+    });
+
+    it('falls back to WebSocket when WebRTC not ready', () => {
+      const nm = makeManager();
+      nm.connected = true;
+
+      const sendSpy = vi.spyOn(nm.socket, 'send');
+      nm.sendInput(5, { left: true });
+
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const wsMsg = JSON.parse(sendSpy.mock.calls[0][0]);
+      expect(wsMsg.spectatorOnly).toBeUndefined();
+    });
+
+    it('ignores WS input messages when WebRTC is active (non-spectator)', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 0;
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      nm._webrtc._simulateOpen();
+
+      // WS input should be ignored
+      nm._handleMessage({ type: 'input', frame: 1, state: { left: true } });
+      expect(Object.keys(nm.remoteInputBuffer).length).toBe(0);
+    });
+
+    it('still processes WS input when spectator even with WebRTC active', () => {
+      const nm = makeManager();
+      nm.isSpectator = true;
+      nm._webrtcReady = true; // hypothetical edge case
+
+      nm._handleMessage({ type: 'input', frame: 1, state: { left: true }, slot: 0 });
+      expect(nm.remoteInputBufferP1[1]).toMatchObject({ left: true });
+    });
+
+    it('falls back to WS on DataChannel close', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 0;
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      nm._webrtc._simulateOpen();
+      expect(nm._webrtcReady).toBe(true);
+
+      nm._webrtc._simulateClose();
+      expect(nm._webrtcReady).toBe(false);
+      expect(nm._transportMode).toBe('websocket');
+    });
+
+    it('stays on WS when WebRTC fails silently', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 0;
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      nm._webrtc._simulateFailed();
+
+      expect(nm._webrtcReady).toBe(false);
+      expect(nm._webrtc).toBeNull();
+    });
+
+    it('forwards signaling messages to WebRTC transport', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 1;
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      const handleSpy = vi.spyOn(nm._webrtc, 'handleSignal');
+
+      nm._handleMessage({ type: 'webrtc_offer', sdp: 'test-sdp' });
+      expect(handleSpy).toHaveBeenCalledWith({ type: 'webrtc_offer', sdp: 'test-sdp' });
+
+      nm._handleMessage({ type: 'webrtc_ice', candidate: { candidate: 'test' } });
+      expect(handleSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores signaling messages when no WebRTC transport', () => {
+      const nm = makeManager();
+      // No WebRTC initialized
+      expect(() => {
+        nm._handleMessage({ type: 'webrtc_offer', sdp: 'test' });
+        nm._handleMessage({ type: 'webrtc_answer', sdp: 'test' });
+        nm._handleMessage({ type: 'webrtc_ice', candidate: {} });
+      }).not.toThrow();
+    });
+
+    it('receives P2P input messages via DataChannel', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 0;
+      const received = [];
+      nm.onRemoteInput((frame, state) => received.push({ frame, state }));
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      nm._webrtc._simulateOpen();
+
+      // Simulate P2P message
+      nm._webrtc._simulateMessage(
+        JSON.stringify({ type: 'input', frame: 10, state: { right: true } }),
+      );
+
+      expect(nm.remoteInputBuffer[10]).toMatchObject({ right: true });
+      expect(nm.lastRemoteInput).toMatchObject({ right: true });
+      expect(received.length).toBe(1);
+    });
+
+    it('resetForReselect destroys WebRTC and resets state', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 0;
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      nm._webrtc._simulateOpen();
+
+      nm.resetForReselect();
+      expect(nm._webrtc).toBeNull();
+      expect(nm._webrtcReady).toBe(false);
+      expect(nm._transportMode).toBe('websocket');
+    });
+
+    it('destroy() cleans up WebRTC', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 0;
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      const webrtc = nm._webrtc;
+      const destroySpy = vi.spyOn(webrtc, 'destroy');
+
+      nm.destroy();
+      expect(destroySpy).toHaveBeenCalled();
+      expect(nm._webrtc).toBeNull();
+    });
+
+    it('re-inits WebRTC on opponent_reconnected', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 0;
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      const firstWebrtc = nm._webrtc;
+
+      nm._handleMessage({ type: 'opponent_reconnected' });
+      // Should have destroyed old and created new
+      expect(firstWebrtc.state).toBe('closed');
+      expect(nm._webrtc).not.toBe(firstWebrtc);
+    });
+
+    it('handles malformed P2P messages gracefully', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 0;
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      nm._webrtc._simulateOpen();
+
+      expect(() => {
+        nm._webrtc._simulateMessage('not json{{{');
+      }).not.toThrow();
     });
   });
 

--- a/tests/systems/network-manager.test.js
+++ b/tests/systems/network-manager.test.js
@@ -900,6 +900,80 @@ describe('NetworkManager', () => {
       expect(received.length).toBe(1);
     });
 
+    it('processes input history from P2P messages to fill gaps', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 0;
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      nm._webrtc._simulateOpen();
+
+      const hist1 = encodeInput({
+        left: false,
+        right: true,
+        up: false,
+        down: false,
+        lp: false,
+        hp: false,
+        lk: false,
+        hk: false,
+        sp: false,
+      });
+
+      // Simulate P2P message with history (frame 1 was lost, arrives as history in frame 3)
+      nm._webrtc._simulateMessage(
+        JSON.stringify({
+          type: 'input',
+          frame: 3,
+          state: { left: true },
+          history: [[1, hist1]],
+        }),
+      );
+
+      // Primary input stored
+      expect(nm.remoteInputBuffer[3]).toMatchObject({ left: true });
+      // History entry decoded and filled gap
+      expect(nm.remoteInputBuffer[1]).toBeDefined();
+      expect(nm.remoteInputBuffer[1].right).toBe(true);
+    });
+
+    it('P2P history does not overwrite existing confirmed inputs', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nm = makeManager();
+      nm.playerSlot = 0;
+
+      nm._handleMessage({ type: 'opponent_joined' });
+      nm._webrtc._simulateOpen();
+
+      // Frame 1 already confirmed
+      nm.remoteInputBuffer[1] = { left: true, right: false, up: false, down: false, lp: false, hp: false, lk: false, hk: false, sp: false };
+
+      const hist1 = encodeInput({
+        left: false,
+        right: true,
+        up: false,
+        down: false,
+        lp: false,
+        hp: false,
+        lk: false,
+        hk: false,
+        sp: false,
+      });
+
+      nm._webrtc._simulateMessage(
+        JSON.stringify({
+          type: 'input',
+          frame: 3,
+          state: { down: true },
+          history: [[1, hist1]],
+        }),
+      );
+
+      // Frame 1 should retain original data, not be overwritten by history
+      expect(nm.remoteInputBuffer[1].left).toBe(true);
+      expect(nm.remoteInputBuffer[1].right).toBe(false);
+    });
+
     it('resetForReselect preserves WebRTC connection', () => {
       globalThis.RTCPeerConnection = class {};
       const nm = makeManager();

--- a/tests/systems/network-manager.test.js
+++ b/tests/systems/network-manager.test.js
@@ -900,7 +900,7 @@ describe('NetworkManager', () => {
       expect(received.length).toBe(1);
     });
 
-    it('resetForReselect destroys WebRTC and resets state', () => {
+    it('resetForReselect preserves WebRTC connection', () => {
       globalThis.RTCPeerConnection = class {};
       const nm = makeManager();
       nm.playerSlot = 0;
@@ -909,9 +909,10 @@ describe('NetworkManager', () => {
       nm._webrtc._simulateOpen();
 
       nm.resetForReselect();
-      expect(nm._webrtc).toBeNull();
-      expect(nm._webrtcReady).toBe(false);
-      expect(nm._transportMode).toBe('websocket');
+      // WebRTC should survive reselect — it persists across scene transitions
+      expect(nm._webrtc).not.toBeNull();
+      expect(nm._webrtcReady).toBe(true);
+      expect(nm._transportMode).toBe('webrtc');
     });
 
     it('destroy() cleans up WebRTC', () => {

--- a/tests/systems/network-manager.test.js
+++ b/tests/systems/network-manager.test.js
@@ -946,7 +946,17 @@ describe('NetworkManager', () => {
       nm._webrtc._simulateOpen();
 
       // Frame 1 already confirmed
-      nm.remoteInputBuffer[1] = { left: true, right: false, up: false, down: false, lp: false, hp: false, lk: false, hk: false, sp: false };
+      nm.remoteInputBuffer[1] = {
+        left: true,
+        right: false,
+        up: false,
+        down: false,
+        lp: false,
+        hp: false,
+        lk: false,
+        hk: false,
+        sp: false,
+      };
 
       const hist1 = encodeInput({
         left: false,

--- a/tests/systems/webrtc-transport.test.js
+++ b/tests/systems/webrtc-transport.test.js
@@ -1,0 +1,456 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mock WebRTC browser APIs ---
+
+class MockRTCSessionDescription {
+  constructor({ type, sdp }) {
+    this.type = type;
+    this.sdp = sdp;
+  }
+}
+
+class MockRTCIceCandidate {
+  constructor(candidate) {
+    Object.assign(this, candidate);
+  }
+  toJSON() {
+    return { candidate: this.candidate, sdpMid: this.sdpMid };
+  }
+}
+
+class MockDataChannel {
+  constructor(label, opts) {
+    this.label = label;
+    this.ordered = opts?.ordered ?? true;
+    this.maxRetransmits = opts?.maxRetransmits;
+    this.readyState = 'connecting';
+    this.onopen = null;
+    this.onclose = null;
+    this.onmessage = null;
+    this._sent = [];
+  }
+  send(data) {
+    this._sent.push(data);
+  }
+  close() {
+    this.readyState = 'closed';
+  }
+  // Test helper: simulate open
+  _open() {
+    this.readyState = 'open';
+    if (this.onopen) this.onopen();
+  }
+  _close() {
+    this.readyState = 'closed';
+    if (this.onclose) this.onclose();
+  }
+  _receiveMessage(data) {
+    if (this.onmessage) this.onmessage({ data });
+  }
+}
+
+class MockRTCPeerConnection {
+  constructor(config) {
+    this.config = config;
+    this.onicecandidate = null;
+    this.ondatachannel = null;
+    this.onconnectionstatechange = null;
+    this.connectionState = 'new';
+    this.localDescription = null;
+    this.remoteDescription = null;
+    this._dc = null;
+  }
+  createDataChannel(label, opts) {
+    this._dc = new MockDataChannel(label, opts);
+    return this._dc;
+  }
+  async createOffer() {
+    return { type: 'offer', sdp: 'mock-offer-sdp' };
+  }
+  async createAnswer() {
+    return { type: 'answer', sdp: 'mock-answer-sdp' };
+  }
+  async setLocalDescription(desc) {
+    this.localDescription = desc;
+  }
+  async setRemoteDescription(desc) {
+    this.remoteDescription = desc;
+  }
+  async addIceCandidate(_candidate) {}
+  close() {
+    this.connectionState = 'closed';
+  }
+  // Test helper: simulate ICE candidate
+  _emitIceCandidate(candidate) {
+    if (this.onicecandidate) {
+      this.onicecandidate({
+        candidate: candidate
+          ? { candidate: candidate.candidate, sdpMid: candidate.sdpMid, toJSON: () => candidate }
+          : null,
+      });
+    }
+  }
+  // Test helper: simulate connection state change
+  _setConnectionState(state) {
+    this.connectionState = state;
+    if (this.onconnectionstatechange) this.onconnectionstatechange();
+  }
+}
+
+// Install globals
+globalThis.RTCPeerConnection = MockRTCPeerConnection;
+globalThis.RTCSessionDescription = MockRTCSessionDescription;
+globalThis.RTCIceCandidate = MockRTCIceCandidate;
+
+const { WebRTCTransport } = await import('../../src/systems/WebRTCTransport.js');
+
+describe('WebRTCTransport', () => {
+  let signals, messages, events;
+
+  function makeCallbacks(overrides = {}) {
+    signals = [];
+    messages = [];
+    events = { open: 0, close: 0, failed: 0 };
+    return {
+      onSignal: (msg) => signals.push(msg),
+      onMessage: (data) => messages.push(data),
+      onOpen: () => events.open++,
+      onClose: () => events.close++,
+      onFailed: () => events.failed++,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- State transitions ---
+
+  describe('offerer flow (P1)', () => {
+    it('transitions idle → connecting on startOffer', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      expect(transport.state).toBe('idle');
+
+      await transport.startOffer();
+      // State goes through signaling → connecting (DC setup happens immediately)
+      expect(transport.state).toBe('connecting');
+    });
+
+    it('sends webrtc_offer signal on startOffer', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+
+      expect(signals.length).toBeGreaterThanOrEqual(1);
+      const offer = signals.find((s) => s.type === 'webrtc_offer');
+      expect(offer).toBeDefined();
+      expect(offer.sdp).toBe('mock-offer-sdp');
+    });
+
+    it('creates DataChannel with unreliable/unordered config', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+
+      const dc = transport._dc;
+      expect(dc.label).toBe('inputs');
+      expect(dc.ordered).toBe(false);
+      expect(dc.maxRetransmits).toBe(0);
+    });
+
+    it('transitions to connecting then open when DataChannel opens', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+
+      expect(transport.state).toBe('connecting');
+
+      transport._dc._open();
+      expect(transport.state).toBe('open');
+      expect(events.open).toBe(1);
+    });
+  });
+
+  describe('answerer flow (P2)', () => {
+    it('handles offer and sends answer', async () => {
+      const transport = new WebRTCTransport({ isOfferer: false, ...makeCallbacks() });
+      expect(transport.state).toBe('idle');
+
+      await transport.handleSignal({ type: 'webrtc_offer', sdp: 'remote-offer-sdp' });
+
+      expect(transport.state).toBe('signaling');
+      const answer = signals.find((s) => s.type === 'webrtc_answer');
+      expect(answer).toBeDefined();
+      expect(answer.sdp).toBe('mock-answer-sdp');
+    });
+
+    it('receives DataChannel via ondatachannel event', async () => {
+      const transport = new WebRTCTransport({ isOfferer: false, ...makeCallbacks() });
+      await transport.handleSignal({ type: 'webrtc_offer', sdp: 'remote-offer-sdp' });
+
+      // Simulate remote DataChannel creation
+      const remoteDC = new MockDataChannel('inputs', { ordered: false, maxRetransmits: 0 });
+      transport._pc.ondatachannel({ channel: remoteDC });
+
+      expect(transport._dc).toBe(remoteDC);
+      expect(transport.state).toBe('connecting');
+
+      remoteDC._open();
+      expect(transport.state).toBe('open');
+      expect(events.open).toBe(1);
+    });
+  });
+
+  // --- ICE candidates ---
+
+  describe('ICE candidate exchange', () => {
+    it('emits webrtc_ice signal on local ICE candidate', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+
+      transport._pc._emitIceCandidate({ candidate: 'candidate:1', sdpMid: '0' });
+
+      const ice = signals.find((s) => s.type === 'webrtc_ice');
+      expect(ice).toBeDefined();
+      expect(ice.candidate).toEqual({ candidate: 'candidate:1', sdpMid: '0' });
+    });
+
+    it('adds remote ICE candidate', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+
+      const addSpy = vi.spyOn(transport._pc, 'addIceCandidate');
+      await transport.handleSignal({ type: 'webrtc_ice', candidate: { candidate: 'remote:1' } });
+
+      expect(addSpy).toHaveBeenCalled();
+    });
+  });
+
+  // --- Sending / receiving data ---
+
+  describe('data transfer', () => {
+    it('send() returns false when not open', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      expect(transport.send('test')).toBe(false);
+
+      await transport.startOffer();
+      expect(transport.send('test')).toBe(false); // DC exists but not open
+    });
+
+    it('send() returns true and sends when open', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+      transport._dc._open();
+
+      expect(transport.send('hello')).toBe(true);
+      expect(transport._dc._sent).toEqual(['hello']);
+    });
+
+    it('receives messages via onMessage callback', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+      transport._dc._open();
+
+      transport._dc._receiveMessage('{"frame":1}');
+      expect(messages).toEqual(['{"frame":1}']);
+    });
+  });
+
+  // --- isOpen ---
+
+  describe('isOpen()', () => {
+    it('returns false when no DataChannel', () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      expect(transport.isOpen()).toBe(false);
+    });
+
+    it('returns true when DataChannel is open', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+      transport._dc._open();
+      expect(transport.isOpen()).toBe(true);
+    });
+  });
+
+  // --- Timeout ---
+
+  describe('timeout', () => {
+    it('fires onFailed after timeout if not open', async () => {
+      const transport = new WebRTCTransport({
+        isOfferer: true,
+        ...makeCallbacks(),
+        timeoutMs: 5000,
+      });
+      await transport.startOffer();
+
+      vi.advanceTimersByTime(5000);
+
+      expect(events.failed).toBe(1);
+      expect(transport.state).toBe('failed');
+    });
+
+    it('does not fire onFailed if opened before timeout', async () => {
+      const transport = new WebRTCTransport({
+        isOfferer: true,
+        ...makeCallbacks(),
+        timeoutMs: 5000,
+      });
+      await transport.startOffer();
+      transport._dc._open();
+
+      vi.advanceTimersByTime(10000);
+      expect(events.failed).toBe(0);
+      expect(transport.state).toBe('open');
+    });
+
+    it('uses default 5s timeout', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+
+      vi.advanceTimersByTime(4999);
+      expect(events.failed).toBe(0);
+
+      vi.advanceTimersByTime(1);
+      expect(events.failed).toBe(1);
+    });
+  });
+
+  // --- Connection state changes ---
+
+  describe('connection state changes', () => {
+    it('fires onClose when connection fails while open', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+      transport._dc._open();
+
+      transport._pc._setConnectionState('failed');
+      expect(events.close).toBe(1);
+      expect(transport.state).toBe('closed');
+    });
+
+    it('fires onFailed when connection fails during setup', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+
+      transport._pc._setConnectionState('failed');
+      expect(events.failed).toBe(1);
+      expect(transport.state).toBe('failed');
+    });
+  });
+
+  // --- DataChannel close ---
+
+  describe('DataChannel close', () => {
+    it('fires onClose when DataChannel closes while open', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+      transport._dc._open();
+
+      transport._dc._close();
+      expect(events.close).toBe(1);
+      expect(transport.state).toBe('closed');
+    });
+
+    it('does not fire onClose when DataChannel closes before open', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+
+      transport._dc._close();
+      expect(events.close).toBe(0);
+    });
+  });
+
+  // --- destroy ---
+
+  describe('destroy()', () => {
+    it('closes PC and DC, clears timeout', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+
+      const pc = transport._pc;
+      const dc = transport._dc;
+      const closePCSpy = vi.spyOn(pc, 'close');
+      const closeDCSpy = vi.spyOn(dc, 'close');
+
+      transport.destroy();
+
+      expect(closePCSpy).toHaveBeenCalled();
+      expect(closeDCSpy).toHaveBeenCalled();
+      expect(transport._pc).toBeNull();
+      expect(transport._dc).toBeNull();
+      expect(transport.state).toBe('closed');
+    });
+
+    it('is safe to call multiple times', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+
+      transport.destroy();
+      expect(() => transport.destroy()).not.toThrow();
+    });
+
+    it('does not fire timeout after destroy', async () => {
+      const transport = new WebRTCTransport({
+        isOfferer: true,
+        ...makeCallbacks(),
+        timeoutMs: 5000,
+      });
+      await transport.startOffer();
+      transport.destroy();
+
+      vi.advanceTimersByTime(10000);
+      expect(events.failed).toBe(0);
+    });
+  });
+
+  // --- Guards ---
+
+  describe('signal guards', () => {
+    it('offerer ignores incoming offer', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+
+      const signalCount = signals.length;
+      await transport.handleSignal({ type: 'webrtc_offer', sdp: 'rogue-offer' });
+      // No new signals should have been generated
+      expect(signals.length).toBe(signalCount);
+    });
+
+    it('answerer ignores incoming answer', async () => {
+      const transport = new WebRTCTransport({ isOfferer: false, ...makeCallbacks() });
+      await transport.handleSignal({ type: 'webrtc_offer', sdp: 'offer-sdp' });
+
+      const signalCount = signals.length;
+      await transport.handleSignal({ type: 'webrtc_answer', sdp: 'rogue-answer' });
+      expect(signals.length).toBe(signalCount);
+    });
+
+    it('startOffer is no-op if not idle', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      await transport.startOffer();
+      const signalCount = signals.length;
+
+      await transport.startOffer(); // second call
+      expect(signals.length).toBe(signalCount);
+    });
+
+    it('handleSignal(offer) is no-op if answerer not idle', async () => {
+      const transport = new WebRTCTransport({ isOfferer: false, ...makeCallbacks() });
+      await transport.handleSignal({ type: 'webrtc_offer', sdp: 'first-offer' });
+      const signalCount = signals.length;
+
+      await transport.handleSignal({ type: 'webrtc_offer', sdp: 'second-offer' });
+      expect(signals.length).toBe(signalCount);
+    });
+
+    it('ICE candidate ignored when no PC exists', async () => {
+      const transport = new WebRTCTransport({ isOfferer: true, ...makeCallbacks() });
+      // No startOffer called, _pc is null
+      await expect(
+        transport.handleSignal({ type: 'webrtc_ice', candidate: { candidate: 'test' } }),
+      ).resolves.not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **WebRTC DataChannel (P2P, unreliable/unordered)** as primary transport for game inputs between players, eliminating the server round-trip (−20-80ms RTT)
- **Automatic fallback** to existing WebSocket relay when P2P fails (symmetric NAT, corporate firewalls) — transparent to the rollback layer
- **Server signaling relay** for SDP/ICE negotiation + `spectatorOnly` flag so spectators still receive inputs via WebSocket
- **Transport indicator** in bottom-left corner during online fights: green "P2P" or dim "WS"

## Architecture

```
              WebSocket (signaling + lobby + spectators)
 ┌────────┐  ←────────────────────────────────────────→  ┌────────┐
 │ Player 1│              PartyKit Server                │ Player 2│
 └────────┘  ←─ ─ ─ WebRTC DataChannel (P2P) ─ ─ ─ ─→  └────────┘
                    (inputs, unreliable/unordered)
```

## Changes

| Commit | Files | Description |
|--------|-------|-------------|
| 1 | `WebRTCTransport.js` + tests | New transport with state machine, 5s timeout, STUN |
| 2 | `server.js` + tests | Signaling relay + spectatorOnly input flag |
| 3 | `NetworkManager.js` + tests | Dual transport integration, dedup, fallback |
| 4 | `FightScene.js` + docs | UI indicator + updated architecture diagram |

## Test plan

- [ ] `bun run test:run` — 290 tests pass (49 new: 28 WebRTC, 16 NM, 5 server)
- [ ] `bun run lint` — clean
- [ ] Two-tab same browser: WebRTC connects via loopback, indicator shows "P2P"
- [ ] Force fallback: set `timeoutMs: 1` in WebRTCTransport, verify game plays normally with "WS" indicator
- [ ] Spectator: verify inputs visible in both P2P and fallback modes
- [ ] Reconnection: kill WiFi → pause overlay → reconnect → resume (WebRTC re-negotiates or falls back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)