### PR TITLE
Fix simulation running at display refresh rate instead of fixed 60fps

### DIFF
--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -160,6 +160,9 @@ export class FightScene extends Phaser.Scene {
     this.escKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
     this.escKey.on('down', () => this._togglePause());
 
+    // -- Fixed-timestep accumulator for simulation --
+    this._simAccumulator = 0;
+
     // -- Start first round intro --
     this._showRoundIntro();
   }
@@ -181,14 +184,7 @@ export class FightScene extends Phaser.Scene {
       return;
     }
 
-    // Update fighters (frame-based FP physics).
-    // In online mode, simulateFrame() handles update() — skip here to avoid double-update.
-    if (this.gameMode !== 'online') {
-      this.p1Fighter.update();
-      this.p2Fighter.update();
-    }
-
-    // Update projectiles
+    // Update projectiles (delta-based, visual rate)
     for (let i = this.projectiles.length - 1; i >= 0; i--) {
       const proj = this.projectiles[i];
       proj.update(delta);
@@ -197,7 +193,7 @@ export class FightScene extends Phaser.Scene {
       }
     }
 
-    // Update touch controls each frame
+    // Update touch controls each frame (visual rate for responsive input)
     if (this.touchControls) this.touchControls.update();
 
     if (this.gameMode === 'spectator') {
@@ -219,38 +215,27 @@ export class FightScene extends Phaser.Scene {
       return;
     }
 
-    if (this.gameMode === 'online') {
-      // Online: _handleOnlineUpdate does facing, hit detection (host only),
-      // state sync, and HUD update internally
-      this._handleOnlineUpdate(time, delta);
-    } else {
-      // -- Handle P1 input --
-      this._handleP1Input();
-
-      // -- Handle P2 AI --
-      if (this.aiController) {
-        this.aiController.update(time, delta);
-        this.aiController.applyDecisions();
-      }
-
-      // -- Body collision (push-back) --
-      this.combat.resolveBodyCollision(this.p1Fighter, this.p2Fighter);
-
-      // -- Facing --
-      this.p1Fighter.faceOpponent(this.p2Fighter);
-      this.p2Fighter.faceOpponent(this.p1Fighter);
-
-      // -- Hit detection (both directions) --
-      this.combat.checkHit(this.p1Fighter, this.p2Fighter);
-      this.combat.checkHit(this.p2Fighter, this.p1Fighter);
-
-      // -- Sync sprites from simulation state --
-      this.p1Fighter.syncSprite();
-      this.p2Fighter.syncSprite();
-
-      // -- Update HUD --
-      this._updateHUD();
+    // Fixed-timestep accumulator: gate simulation to exactly 60fps
+    const FIXED_DELTA = 1000 / 60; // 16.667ms
+    this._simAccumulator += delta;
+    // Cap to prevent spiral of death (e.g. tab was backgrounded)
+    if (this._simAccumulator > FIXED_DELTA * 4) {
+      this._simAccumulator = FIXED_DELTA * 4;
     }
+
+    while (this._simAccumulator >= FIXED_DELTA) {
+      this._simAccumulator -= FIXED_DELTA;
+      if (this.gameMode === 'online') {
+        this._handleOnlineUpdate(time, delta);
+      } else {
+        this._handleLocalUpdate(time, delta);
+      }
+    }
+
+    // Sync sprites + HUD at visual rate (after all sim ticks)
+    this.p1Fighter.syncSprite();
+    this.p2Fighter.syncSprite();
+    this._updateHUD();
   }
 
   // =========================================================================
@@ -769,6 +754,26 @@ export class FightScene extends Phaser.Scene {
     }
   }
 
+  _handleLocalUpdate(time, delta) {
+    this.p1Fighter.update();
+    this.p2Fighter.update();
+
+    this._handleP1Input();
+
+    if (this.aiController) {
+      this.aiController.update(time, delta);
+      this.aiController.applyDecisions();
+    }
+
+    this.combat.resolveBodyCollision(this.p1Fighter, this.p2Fighter);
+
+    this.p1Fighter.faceOpponent(this.p2Fighter);
+    this.p2Fighter.faceOpponent(this.p1Fighter);
+
+    this.combat.checkHit(this.p1Fighter, this.p2Fighter);
+    this.combat.checkHit(this.p2Fighter, this.p1Fighter);
+  }
+
   _handleOnlineUpdate(_time, _delta) {
     this.frameCounter++;
     const input = this.inputManager;
@@ -804,8 +809,6 @@ export class FightScene extends Phaser.Scene {
         p2x: this.p2Fighter.simX / FP_SCALE,
       });
     }
-
-    this._updateHUD();
   }
 
   /** Send round event to guest + spectators (3x with 200ms spacing for reliability) */

--- a/tests/systems/fixed-timestep.test.js
+++ b/tests/systems/fixed-timestep.test.js
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+
+const FIXED_DELTA = 1000 / 60; // 16.667ms
+
+/**
+ * Pure function that mimics the fixed-timestep accumulator logic
+ * from FightScene.update(). Returns the new accumulator value and
+ * how many simulation ticks should run this frame.
+ */
+function runAccumulator(accumulator, delta, fixedDelta = FIXED_DELTA) {
+  accumulator += delta;
+  // Spiral-of-death cap: never accumulate more than 4 ticks worth
+  if (accumulator > fixedDelta * 4) {
+    accumulator = fixedDelta * 4;
+  }
+  let ticks = 0;
+  while (accumulator >= fixedDelta) {
+    accumulator -= fixedDelta;
+    ticks++;
+  }
+  return { accumulator, ticks };
+}
+
+describe('fixed-timestep accumulator', () => {
+  describe('60Hz display', () => {
+    it('produces exactly 1 tick per frame', () => {
+      const { accumulator, ticks } = runAccumulator(0, FIXED_DELTA);
+      expect(ticks).toBe(1);
+      expect(accumulator).toBeCloseTo(0, 10);
+    });
+  });
+
+  describe('120Hz display', () => {
+    const halfDelta = FIXED_DELTA / 2; // ~8.333ms
+
+    it('alternates between 0 and 1 tick per frame', () => {
+      // First frame: 8.333ms accumulated, not enough for a tick
+      const frame1 = runAccumulator(0, halfDelta);
+      expect(frame1.ticks).toBe(0);
+      expect(frame1.accumulator).toBeCloseTo(halfDelta, 10);
+
+      // Second frame: 8.333 + 8.333 = 16.667ms, exactly 1 tick
+      const frame2 = runAccumulator(frame1.accumulator, halfDelta);
+      expect(frame2.ticks).toBe(1);
+      expect(frame2.accumulator).toBeCloseTo(0, 10);
+    });
+  });
+
+  describe('30Hz display', () => {
+    it('produces exactly 2 ticks per frame', () => {
+      const doubleDelta = FIXED_DELTA * 2; // ~33.333ms
+      const { accumulator, ticks } = runAccumulator(0, doubleDelta);
+      expect(ticks).toBe(2);
+      expect(accumulator).toBeCloseTo(0, 10);
+    });
+  });
+
+  describe('spiral of death cap', () => {
+    it('limits ticks when delta is very large (backgrounded tab)', () => {
+      const { ticks } = runAccumulator(0, 1000); // 1 second gap
+      // Cap clamps accumulator to fixedDelta*4 (~66.67ms). Due to floating
+      // point, repeated subtraction of fixedDelta only fits 3 full ticks,
+      // leaving ~1 tick of remainder. The key invariant: ticks are bounded
+      // to a small number, not 60.
+      expect(ticks).toBeLessThanOrEqual(4);
+      expect(ticks).toBeGreaterThanOrEqual(3);
+    });
+
+    it('limits ticks even with pre-existing accumulator', () => {
+      const { ticks } = runAccumulator(FIXED_DELTA * 2, 500);
+      expect(ticks).toBeLessThanOrEqual(4);
+      expect(ticks).toBeGreaterThanOrEqual(3);
+    });
+
+    it('would produce many more ticks without the cap', () => {
+      // Without cap, 1000ms / 16.667ms = 60 ticks
+      const uncapped = runAccumulator(0, 1000, FIXED_DELTA);
+      // With a hypothetical no-cap version:
+      let acc = 1000;
+      let uncappedTicks = 0;
+      while (acc >= FIXED_DELTA) {
+        acc -= FIXED_DELTA;
+        uncappedTicks++;
+      }
+      expect(uncappedTicks).toBe(60); // would be 60 ticks
+      expect(uncapped.ticks).toBeLessThanOrEqual(4); // capped to ~4
+    });
+
+    it('discards excess accumulated time beyond the cap', () => {
+      const { accumulator } = runAccumulator(0, 1000);
+      // After consuming ticks, remainder should be less than 1 tick
+      expect(accumulator).toBeLessThan(FIXED_DELTA);
+      expect(accumulator).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('consistent tick count over 1 second', () => {
+    function simulateOneSecond(frameDelta) {
+      let acc = 0;
+      let totalTicks = 0;
+      const frames = Math.round(1000 / frameDelta);
+      for (let i = 0; i < frames; i++) {
+        const result = runAccumulator(acc, frameDelta);
+        acc = result.accumulator;
+        totalTicks += result.ticks;
+      }
+      return totalTicks;
+    }
+
+    it('60Hz produces 60 ticks per second', () => {
+      expect(simulateOneSecond(FIXED_DELTA)).toBe(60);
+    });
+
+    it('120Hz produces 60 ticks per second', () => {
+      expect(simulateOneSecond(FIXED_DELTA / 2)).toBe(60);
+    });
+
+    it('144Hz produces ~60 ticks per second', () => {
+      // 144Hz frame delta does not divide evenly into the fixed timestep,
+      // so floating point rounding may cause +/-1 tick drift per second.
+      // The key property: it stays very close to 60.
+      const delta144 = 1000 / 144;
+      const ticks = simulateOneSecond(delta144);
+      expect(ticks).toBeGreaterThanOrEqual(59);
+      expect(ticks).toBeLessThanOrEqual(61);
+    });
+
+    it('all display rates stay within 1 tick of 60 per second', () => {
+      const rates = [30, 48, 50, 60, 72, 90, 120, 144, 240];
+      for (const hz of rates) {
+        const delta = 1000 / hz;
+        const ticks = simulateOneSecond(delta);
+        expect(ticks).toBeGreaterThanOrEqual(59);
+        expect(ticks).toBeLessThanOrEqual(61);
+      }
+    });
+  });
+
+  describe('sub-frame remainder', () => {
+    it('carries fractional remainder between frames', () => {
+      // 144Hz: ~6.944ms per frame, less than one tick
+      const delta144 = 1000 / 144;
+      const frame1 = runAccumulator(0, delta144);
+      expect(frame1.ticks).toBe(0);
+      expect(frame1.accumulator).toBeCloseTo(delta144, 10);
+
+      // After enough frames, the remainder triggers a tick
+      let acc = 0;
+      let firstTickFrame = -1;
+      for (let i = 0; i < 10; i++) {
+        const result = runAccumulator(acc, delta144);
+        acc = result.accumulator;
+        if (result.ticks > 0 && firstTickFrame === -1) {
+          firstTickFrame = i;
+        }
+      }
+      // At 144Hz, a tick fires after ~2.4 frames, so frame index 2 (third frame)
+      expect(firstTickFrame).toBe(2);
+    });
+
+    it('remainder is always less than one fixed tick', () => {
+      const deltas = [10, 12.5, 15, 20, 25, 33.333];
+      for (const delta of deltas) {
+        const { accumulator } = runAccumulator(0, delta);
+        expect(accumulator).toBeLessThan(FIXED_DELTA);
+        expect(accumulator).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add fixed-timestep accumulator to `FightScene.update()` that gates simulation ticks to exactly 60fps regardless of display refresh rate (60/90/120/144Hz)
- Extract `_handleLocalUpdate()` method for local mode simulation, mirroring `_handleOnlineUpdate()` structure
- Move `syncSprite()` and `_updateHUD()` outside the accumulator loop so they run at visual rate
- Cap accumulator at 4 ticks (67ms) to prevent spiral of death when returning from a backgrounded tab

Closes #30

## Test plan
- [x] `bun run test:run` — all 254 tests pass (13 new fixed-timestep accumulator tests)
- [x] `bun run lint` — clean
- [ ] Open fight on 120Hz laptop + 60Hz phone in online mode — timer should count at same rate
- [ ] Local fight on 120Hz display — timer should take 60 seconds from 60→0, not 30
- [ ] Background a tab for 3s, return — game should not fast-forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)