### PR TITLE
Add dynamic controls based on device and fix scroll in LearningScene

### DIFF
--- a/src/scenes/LearningScene.js
+++ b/src/scenes/LearningScene.js
@@ -176,7 +176,7 @@ export class LearningScene extends Phaser.Scene {
   // Cards to load
   _buildCardsForActiveTab() {
     if (this.activeTab === 'basico') {
-      let cardsToShow = [...BASICO_CARDS];
+      const cardsToShow = [...BASICO_CARDS];
 
       if (this.isMobile) {
         cardsToShow.unshift(CONTROLES_MOVIL);
@@ -250,7 +250,6 @@ export class LearningScene extends Phaser.Scene {
     });
 
     this.tabObjects.push(bBg, bText, aBg, aText);
-
   }
 
   _buildCards(cards) {

--- a/src/scenes/LearningScene.js
+++ b/src/scenes/LearningScene.js
@@ -1,14 +1,38 @@
 import Phaser from 'phaser';
 import { GAME_HEIGHT, GAME_WIDTH } from '../config.js';
 
+const CONTROLES_ORDENADOR = {
+  title: 'CONTROLES (ORDENADOR)',
+  body:
+    'Mover: Flechas [←] [→]\n' +
+    'Saltar: [↑] / Bloquear: [↓]\n\n' +
+    'Ataques:\n' +
+    '[Z] Puno Liviano (PL)\n' +
+    '[X] Patada Liviana (PaL)\n' +
+    '[A] Puno Pesado (PP)\n' +
+    '[S] Patada Pesada (PaP)\n' +
+    '[D] Especial (ES)\n\n' +
+    'Pausa: [ESC]',
+};
+
+const CONTROLES_MOVIL = {
+  title: 'CONTROLES (PANTALLA TÁCTIL)',
+  body:
+    'Lado izquierdo:\n' +
+    'Joystick virtual para movimiento.\n\n' +
+    'Lado derecho (5 botones):\n' +
+    'PL (Puno Liviano)\n' +
+    'PaL (Patada Liviana)\n' +
+    'PP (Puno Pesado)\n' +
+    'PaP (Patada Pesada)\n' +
+    'ES (Especial)\n\n' +
+    'Soporta Multi-touch (mover y atacar).',
+};
+
 const BASICO_CARDS = [
   {
-    title: 'CONTROLES',
-    body: 'Joystick izquierdo para moverte.\n5 botones a la derecha:\nPL (puno liviano), PaL (patada liviana),\nPP (puno pesado), PaP (patada pesada),\nES (especial).',
-  },
-  {
     title: 'BLOQUEAR',
-    body: 'Mantene abajo en el joystick para\nbloquear. Reduce el dano un 80% y\nachica tu hitbox. Ideal contra ataques\npesados.',
+    body: 'Mantene abajo en el joystick o [↓]\npara bloquear. Reduce el dano un 80% y\nachica tu hitbox. Ideal contra ataques\npesados.',
   },
   {
     title: 'GOLPES LIVIANOS',
@@ -66,6 +90,11 @@ export class LearningScene extends Phaser.Scene {
     super('LearningScene');
   }
 
+  init() {
+    // Device detection by touching support
+    this.isMobile = this.sys.game.device.input.touch;
+  }
+
   create() {
     this.cameras.main.fadeIn(300, 0, 0, 0);
 
@@ -93,8 +122,6 @@ export class LearningScene extends Phaser.Scene {
     maskShape.fillRect(0, CONTENT_TOP, GAME_WIDTH, CONTENT_HEIGHT);
     const mask = maskShape.createGeometryMask();
     this.contentContainer.setMask(mask);
-
-    this._buildCards(BASICO_CARDS);
 
     // Scroll state
     this.scrollY = 0;
@@ -145,6 +172,23 @@ export class LearningScene extends Phaser.Scene {
     this.transitioning = false;
   }
 
+  // Cards to load
+  _buildCardsForActiveTab() {
+    if (this.activeTab === 'basico') {
+      let cardsToShow = [...BASICO_CARDS];
+
+      if (this.isMobile) {
+        cardsToShow.unshift(CONTROLES_MOVIL);
+      } else {
+        cardsToShow.unshift(CONTROLES_ORDENADOR);
+      }
+
+      this._buildCards(cardsToShow);
+    } else {
+      this._buildCards(AVANZADO_CARDS);
+    }
+  }
+
   _createTabs() {
     const tabY = 36;
     const tabW = 80;
@@ -177,7 +221,7 @@ export class LearningScene extends Phaser.Scene {
       if (this.activeTab === 'basico') return;
       this.activeTab = 'basico';
       this._createTabs();
-      this._buildCards(BASICO_CARDS);
+      this._buildCardsForActiveTab();
       this.scrollY = 0;
       this._applyScroll();
     });
@@ -199,12 +243,17 @@ export class LearningScene extends Phaser.Scene {
       if (this.activeTab === 'avanzado') return;
       this.activeTab = 'avanzado';
       this._createTabs();
-      this._buildCards(AVANZADO_CARDS);
+      this._buildCardsForActiveTab();
       this.scrollY = 0;
       this._applyScroll();
     });
 
     this.tabObjects.push(bBg, bText, aBg, aText);
+
+    // Initial card loading
+    if(this.contentContainer) {
+        this._buildCardsForActiveTab();
+    }
   }
 
   _buildCards(cards) {

--- a/src/scenes/LearningScene.js
+++ b/src/scenes/LearningScene.js
@@ -126,6 +126,7 @@ export class LearningScene extends Phaser.Scene {
     // Tab buttons
     this.activeTab = 'basico';
     this._createTabs();
+    this._buildCardsForActiveTab();
 
     // Drag scrolling
     this.dragStartY = null;
@@ -250,10 +251,6 @@ export class LearningScene extends Phaser.Scene {
 
     this.tabObjects.push(bBg, bText, aBg, aText);
 
-    // Initial card loading
-    if(this.contentContainer) {
-        this._buildCardsForActiveTab();
-    }
   }
 
   _buildCards(cards) {
@@ -319,9 +316,9 @@ export class LearningScene extends Phaser.Scene {
   }
 
   _updateMaxScroll() {
-     if (!this.totalContentHeight) return;
-     this.maxScroll = Math.max(0, this.totalContentHeight - CONTENT_HEIGHT);
-     this._updateScrollIndicator();
+    if (this.totalContentHeight == null) return;
+    this.maxScroll = Math.max(0, this.totalContentHeight - CONTENT_HEIGHT);
+    this._updateScrollIndicator();
   }
 
   _setScroll(value) {

--- a/src/scenes/LearningScene.js
+++ b/src/scenes/LearningScene.js
@@ -112,10 +112,6 @@ export class LearningScene extends Phaser.Scene {
       })
       .setOrigin(0.5);
 
-    // Tab buttons
-    this.activeTab = 'basico';
-    this._createTabs();
-
     // Content container + mask
     this.contentContainer = this.add.container(0, 0);
     const maskShape = this.make.graphics();
@@ -126,6 +122,10 @@ export class LearningScene extends Phaser.Scene {
     // Scroll state
     this.scrollY = 0;
     this.maxScroll = 0;
+
+    // Tab buttons
+    this.activeTab = 'basico';
+    this._createTabs();
 
     // Drag scrolling
     this.dragStartY = null;
@@ -314,9 +314,14 @@ export class LearningScene extends Phaser.Scene {
       yOffset += cardHeight + CARD_GAP;
     }
 
-    const totalContentHeight = yOffset - CONTENT_TOP;
-    this.maxScroll = Math.max(0, totalContentHeight - CONTENT_HEIGHT);
-    this._updateScrollIndicator();
+    this.totalContentHeight = yOffset - CONTENT_TOP;
+    this._updateMaxScroll();
+  }
+
+  _updateMaxScroll() {
+     if (!this.totalContentHeight) return;
+     this.maxScroll = Math.max(0, this.totalContentHeight - CONTENT_HEIGHT);
+     this._updateScrollIndicator();
   }
 
   _setScroll(value) {


### PR DESCRIPTION
## Summary
This PR introduces platform detection to the LearningScene so players see the correct control scheme (keyboard vs. touch buttons) depending on their device, based on the Combat Guide. It also includes several critical bug fixes related to content rendering and scroll behavior.

- Dynamic platform detection added to LearningScene (init() checks for touch device support).

- Platform-specific control cards: Dynamically injects either CONTROLES_ORDENADOR (keyboard keys) or CONTROLES_MOVIL (virtual joystick and buttons) into the BASICO tab depending on the user's device.

- Fixed initial content loading by removing a hardcoded _buildCards call that was overriding the dynamic tab logic upon entering the scene.

- Fixed scroll boundaries and hidden content bugs by reordering scroll initialization (this.maxScroll = 0) to run before tab creation, and correcting the scope of this.totalContentHeight so the scroll math works correctly.

 ## Test plan

For each device (mobile and computer):
- [ ] Navigate to COMO JUGAR from title screen
- [ ] Verify BASICO tabs display correct cards by device
- [ ] Test scroll via drag or mouse wheel, verify content clips properly
- [ ] Press VOLVER to return to title screen

<img width="1693" height="961" alt="Captura desde 2026-03-20 15-37-01" src="https://github.com/user-attachments/assets/c51122e4-3496-4cea-a5b2-89afd0166c80" />