### PR TITLE
Add Claude Code project permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bun:*)",
+      "Bash(bunx:*)",
+      "Bash(node:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(npx:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(mkdir:*)",
+      "Bash(rm:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)",
+      "Bash(find:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(sort:*)",
+      "Bash(diff:*)",
+      "Bash(which:*)",
+      "Bash(echo:*)",
+      "Bash(true)",
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
+      "WebFetch(domain:registry.npmjs.org)",
+      "WebFetch(domain:docs.partykit.io)",
+      "WebFetch(domain:partykit.io)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:api.github.com)",
+      "WebFetch(domain:npm.im)",
+      "WebFetch(domain:www.npmjs.com)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with pre-approved permissions for common dev commands (bun, node, git, gh, shell utilities, file tools, WebFetch domains)
- Reduces permission prompts for contributors using Claude Code on this project

## Test plan
- [ ] Verify Claude Code picks up permissions without prompting for allowed commands
- [ ] Confirm sandbox still enforces boundaries for non-allowed operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)