### PR TITLE
Fix rollback-safe round events (RFC 0001 Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,17 +116,21 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - `docs/multiplayer-security.md` — Trust boundaries, server protections, known gaps
 - `docs/graceful-reconnection.md` — Reconnection state machine, grace period, module responsibilities
 - `docs/room-state-machine.md` — Server room state (`roomState` transitions, `return_to_select` vs `disconnect`)
+- `docs/rfcs/0001-networking-redesign.md` — Full networking rewrite RFC (Phase 1 complete, Phases 2-5 planned)
 
 ## Online Multiplayer
 
 - PartyKit server at `party/server.js`, max 2 players per room (pure relay, no game logic)
 - **Rollback netcode** (GGPO-style): both peers run identical simulations locally with zero perceived input lag
-- P1 authoritative for round events (KO/timeup) only — P2 sets `suppressRoundEvents=true` and receives `round_event` messages
+- **Deferred round events**: `simulateFrame()` returns `{ type, winnerIndex }` descriptors instead of firing side effects. Both P1 and P2 set `suppressRoundEvents=true`. P1 handles events from `advance()` return via `combat.handleRoundEnd()`. P2 receives via `onRoundEvent` network handler.
 - Input prediction: repeat last movement, zero attack buttons. Rollback + re-simulate on misprediction (max 7 frames)
 - Fixed timestep: `FIXED_DELTA = 16.667ms` for deterministic online simulation
 - Input encoding: 9 booleans packed as single integer (bits 0-8) via `InputBuffer.js`
 - Fighter timers are deterministic (no `scene.time.delayedCall` in simulation path)
-- `CombatSystem.tickTimer()` counts frames (60 frames = 1 second) instead of Phaser timer events
+- `CombatSystem.tickTimer({ muteEffects })` counts frames (60 frames = 1 second), returns `{ timeup: true }` instead of calling `timeUp()` directly
+- `CombatSystem.checkHit()` returns `{ hit, ko }` on hit instead of boolean
+- Checksum compares confirmed frames (`currentFrame - maxRollbackFrames - 1`) to avoid false positives from predicted inputs
+- WebSocket inputs always accepted regardless of DataChannel state (resilient to asymmetric WebRTC reconnection)
 - Audio/particles/camera shake suppressed during rollback re-simulation (`muteEffects`)
 - Spectators receive P1 sync snapshots (same as old model, no rollback)
 - URL join: `?room=XXXX` skips title, goes directly to LobbyScene

--- a/docs/rfcs/0001-networking-redesign.md
+++ b/docs/rfcs/0001-networking-redesign.md
@@ -1,0 +1,840 @@
+# RFC 0001: Networking Redesign
+
+**Status:** Draft
+**Date:** 2026-03-22
+**Author:** Architecture Team
+
+---
+
+## Summary
+
+Multiplayer in A Los Traques is broken. Testing on real phones shows: timers 3-4 seconds apart, one phone declares a winner while the other continues playing, and fighters keep moving after the match has ended on one side.
+
+Root cause analysis reveals bugs in **both** layers:
+
+1. **Simulation/Rollback bugs** — Round-ending events (`timeUp`, `handleKO`) fire during rollback re-simulation and on predicted (unconfirmed) inputs, corrupting game state and causing divergence between peers.
+2. **Transport bugs** — No TURN server means WebRTC fails behind symmetric NAT (every mobile carrier, most corporate WiFi). The 759-line `NetworkManager` monolith makes every fix a cross-cutting change.
+
+This RFC proposes a full networking rewrite that fixes the simulation determinism bugs, adds Cloudflare TURN for reliable connectivity, decomposes the network layer into focused modules, and introduces a headless testing harness to prevent regressions.
+
+---
+
+## Goals and Non-Goals
+
+### Goals
+
+- **Fix multiplayer so both phones see the same game** — timer sync, round results agree, fighters stop when a round ends
+- **Reliable P2P connectivity** — work across mobile carriers, corporate WiFi, symmetric NATs via TURN fallback
+- **Rollback-safe round events** — KO/timeup detection must never corrupt simulation state during rollback re-simulation
+- **Testable networking** — headless dual-simulation harness that can verify determinism and rollback correctness without a browser
+- **Clean module boundaries** — replace the NetworkManager monolith with focused, independently testable modules
+- **Connection quality visibility** — players know their connection quality before starting a match
+
+### Non-Goals
+
+- **Rust/Wasm rollback engine** — the current JS rollback math is sound; bugs are in event handling and transport, not in the rollback algorithm
+- **Server-authoritative simulation** — P2P with rollback is correct for 1v1 fighting games (lowest latency)
+- **Ranked matchmaking** — this is a friends game; room codes are sufficient
+- **Anti-cheat** — friends-only context; peers can inspect/modify local state
+- **Voice chat or video** — out of scope; game uses text shouts from spectators
+
+---
+
+## Requirements and Constraints
+
+| Requirement | Detail |
+|------------|--------|
+| Platform | iPhone 15 Safari landscape (primary), Chrome/Firefox desktop (secondary) |
+| Resolution | 480x270 internal, 60fps fixed timestep |
+| Players | Exactly 2 per match + spectators |
+| Perceived latency | < 100ms ("feels local") via input prediction |
+| Transport | WebRTC DataChannel (unreliable/unordered) primary, WebSocket relay fallback |
+| NAT traversal | Must work behind symmetric NAT (mobile carriers) |
+| Reconnection | 20-second grace period for dropped connections |
+| Language | All UI text in Spanish |
+| Stack | Phaser 3, Vite, Bun, PartyKit (Cloudflare Workers) |
+| Determinism | Fixed-point integer math (FP_SCALE=1000), frame-based timers, no floating-point in simulation path |
+
+---
+
+## Proposed Architecture
+
+### High-Level Overview
+
+```mermaid
+flowchart LR
+    subgraph Client["Browser Client"]
+        GL[Game Loop<br/>FightScene]
+        RM[RollbackManager]
+        SS[SimulationStep]
+        GS[GameState<br/>save/restore]
+        IS[InputSync]
+        TM[TransportManager]
+        SC[SignalingClient]
+        CM[ConnectionMonitor]
+        SR[SpectatorRelay]
+    end
+
+    subgraph Server["PartyKit Server"]
+        RS[Room State Machine]
+        SIG[Signaling Relay]
+        TURN_EP[TURN Credential<br/>Endpoint]
+    end
+
+    subgraph CF["Cloudflare"]
+        TURN[Cloudflare TURN<br/>Relay Service]
+    end
+
+    GL -->|local input| RM
+    RM -->|simulate frame| SS
+    RM -->|save/restore| GS
+    RM -->|send/receive inputs| IS
+    IS -->|route packets| TM
+    TM -->|P2P DataChannel| TM
+    TM -->|WebSocket fallback| SC
+    SC <-->|signaling + relay| SIG
+    TM -.->|TURN relay| TURN
+    SC -->|fetch credentials| TURN_EP
+    TURN_EP -->|generate| TURN
+    CM -->|monitor quality| TM
+    CM -->|monitor quality| SC
+    SR -->|spectator data| SC
+```
+
+### Rollback + Round Event Flow
+
+This is the critical fix. The current system fires `timeUp()`/`handleKO()` during rollback re-simulation, corrupting state. The new design **defers** round events and only fires them on confirmed inputs.
+
+```mermaid
+sequenceDiagram
+    participant GL as Game Loop
+    participant RM as RollbackManager
+    participant SIM as SimulationStep
+    participant CS as CombatSystem
+
+    Note over GL,CS: Per-frame advance (60fps)
+
+    GL->>RM: advance(localInput)
+    RM->>RM: Store local input at frame+delay
+    RM->>RM: Send input to peer via InputSync
+    RM->>RM: Drain confirmed remote inputs
+
+    alt Misprediction detected
+        Note over RM,CS: ROLLBACK (muteEffects=true)
+        RM->>SIM: restoreGameState(snapshot)
+        loop Re-simulate frames
+            RM->>SIM: simulateFrame(muteEffects=true)
+            SIM->>CS: tickTimer(muteEffects=true)
+            Note over CS: Timer ticks but timeUp() is SUPPRESSED
+            SIM->>CS: checkHit(muteEffects=true)
+            Note over CS: Hit resolves but handleKO() is SUPPRESSED
+        end
+    end
+
+    Note over RM,CS: CURRENT FRAME (normal advance)
+    RM->>SIM: simulateFrame(muteEffects=false)
+    SIM->>CS: tickTimer(muteEffects=false)
+    SIM->>CS: checkHit(muteEffects=false)
+
+    alt P1 (host) detects KO/timeup
+        CS-->>GL: Return roundEvent = {type, winner}
+        Note over GL: P1 fires side effects + sends to P2
+    end
+    alt P2 (guest) detects KO/timeup locally
+        Note over CS: suppressRoundEvents=true
+        Note over GL: P2 IGNORES local detection,<br/>waits for P1's network message
+    end
+```
+
+### Module Decomposition
+
+The 759-line `NetworkManager` is replaced by 5 focused modules:
+
+```mermaid
+flowchart TB
+    subgraph net["src/systems/net/"]
+        SC[SignalingClient<br/>~150 lines<br/>WebSocket lifecycle,<br/>room messages]
+        TM[TransportManager<br/>~200 lines<br/>WebRTC + WS routing,<br/>TURN credentials]
+        IS[InputSync<br/>~120 lines<br/>Frame-indexed input<br/>send/receive/drain]
+        CM[ConnectionMonitor<br/>~100 lines<br/>RTT, ping/pong,<br/>quality assessment]
+        SR[SpectatorRelay<br/>~80 lines<br/>Spectator buffers,<br/>sync, shout, potion]
+    end
+
+    NF[NetworkFacade<br/>~50 lines<br/>Composes all modules,<br/>exposes same public API]
+
+    SC --> TM
+    SC --> NF
+    TM --> NF
+    IS --> NF
+    CM --> NF
+    SR --> NF
+
+    IS --> TM
+    CM --> TM
+    CM --> SC
+    SR --> SC
+```
+
+---
+
+## Technology Choices
+
+| Component | Current | Proposed | Rationale |
+|-----------|---------|----------|-----------|
+| Rollback core | `RollbackManager.js` (JS) | Same (JS), with deferred round events | Architecture is sound; bugs are in event handling, not rollback math. GGRS/Wasm adds complexity without solving the actual problem. |
+| TURN server | None (STUN only) | **Cloudflare Realtime TURN** | 1,000 GB/month free tier. Anycast routing to nearest edge. $0.05/GB after free tier. |
+| STUN servers | `stun:stun.l.google.com:19302` (single) | Google STUN x2 + Cloudflare STUN | Redundancy. Multiple servers reduce single-point-of-failure risk. |
+| Signaling/relay | PartyKit | **PartyKit** (keep) | Already deployed, works well. Built on Cloudflare Workers. Add `onRequest` for TURN credential endpoint. |
+| Transport | `WebRTCTransport.js` + `NetworkManager.js` | `TransportManager.js` + `SignalingClient.js` | Clean separation of concerns. TURN credentials as constructor parameter. Transport-agnostic `send()` API. |
+| Input sync | Embedded in `NetworkManager` | `InputSync.js` (extracted) | Independently testable. Clear API: `sendInput()`, `drainConfirmedInputs()`. |
+| Monitoring | Ping/pong in `NetworkManager` | `ConnectionMonitor.js` (extracted) | Pre-match quality probing. Mid-match degradation detection. RTT on DataChannel (not just WebSocket). |
+| Infra provisioning | Manual | **Terraform** (Cloudflare provider) | DNS, Workers config. TURN Key ID via Cloudflare dashboard/API (no Terraform resource exists for TURN yet). |
+| Testing | Unit tests (Vitest) | + **Headless dual-simulation harness** | `NetworkSimulator` mock transport connecting two RollbackManagers. Configurable latency/loss/jitter. |
+
+### Cloudflare TURN Integration
+
+```
+┌─────────────┐     ┌──────────────────┐     ┌────────────────────┐
+│  Client A    │     │  PartyKit Server │     │  Cloudflare TURN   │
+│  (browser)   │     │  (onRequest)     │     │  Credential API    │
+└──────┬───────┘     └────────┬─────────┘     └─────────┬──────────┘
+       │  GET /turn-creds     │                         │
+       │─────────────────────>│  POST generate-ice-     │
+       │                      │  servers (ttl=86400)    │
+       │                      │────────────────────────>│
+       │                      │                         │
+       │                      │  { iceServers: [...] }  │
+       │                      │<────────────────────────│
+       │  { iceServers }      │                         │
+       │<─────────────────────│                         │
+       │                      │                         │
+       │  new RTCPeerConnection({ iceServers })         │
+       │                                                │
+```
+
+**TURN Key ID** is created once via Cloudflare dashboard and stored as a PartyKit environment variable (`CLOUDFLARE_TURN_KEY_ID`, `CLOUDFLARE_TURN_API_TOKEN`). No Terraform resource exists for Cloudflare TURN yet — the key is provisioned manually.
+
+**Terraform** manages: Cloudflare DNS records, Workers/PartyKit deployment configuration, environment variable bindings.
+
+---
+
+## Core API and Data Model
+
+### SimulationStep — Rollback-Safe Round Events
+
+The key change: `simulateFrame()` returns a round event descriptor instead of firing side effects directly. Side effects are deferred to the caller.
+
+```javascript
+// NEW: simulateFrame returns optional round event (no side effects)
+/**
+ * @returns {{ type: 'ko'|'timeup', winnerIndex: number } | null}
+ */
+export function simulateFrame(p1, p2, combat, p1Input, p2Input, { muteEffects = false } = {}) {
+  p1.update();
+  p2.update();
+  applyInputToFighter(p1, decodeInput(p1Input));
+  applyInputToFighter(p2, decodeInput(p2Input));
+  combat.resolveBodyCollision(p1, p2);
+  p1.faceOpponent(p2);
+  p2.faceOpponent(p1);
+
+  let roundEvent = null;
+  if (combat.roundActive) {
+    // checkHit returns KO info instead of calling handleKO()
+    const p1Hit = combat.checkHit(p1, p2, { muteEffects });
+    const p2Hit = combat.checkHit(p2, p1, { muteEffects });
+    if (p1Hit?.ko) roundEvent = { type: 'ko', winnerIndex: 0 };
+    else if (p2Hit?.ko) roundEvent = { type: 'ko', winnerIndex: 1 };
+
+    // tickTimer returns timeup info instead of calling timeUp()
+    const timerResult = combat.tickTimer({ muteEffects });
+    if (timerResult?.timeup) {
+      roundEvent = { type: 'timeup', winnerIndex: p1.hp >= p2.hp ? 0 : 1 };
+    }
+  }
+
+  p1.syncSprite();
+  p2.syncSprite();
+  return roundEvent;
+}
+```
+
+### RollbackManager — Deferred Event Handling
+
+```javascript
+// In RollbackManager.advance():
+
+// During rollback re-simulation: IGNORE round events
+for (let f = rollbackFrame; f < this.currentFrame; f++) {
+  simulateFrame(p1, p2, combat, p1Input, p2Input, { muteEffects: true });
+  // Return value (round event) is intentionally discarded
+}
+
+// During current frame: CAPTURE round event
+const roundEvent = simulateFrame(p1, p2, combat, p1Input, p2Input);
+// Return to caller (FightScene) for deferred handling
+return { roundEvent };
+```
+
+### FightScene — P1 Authority for Round Events
+
+```javascript
+// P1 (host): fires side effects and sends to P2
+const { roundEvent } = rollbackManager.advance(localInput, this, p1, p2, combat);
+if (roundEvent && this.isHost) {
+  combat.handleRoundEnd(roundEvent);  // Fire audio, camera, UI
+  networkManager.sendRoundEvent(roundEvent);
+}
+
+// P2 (guest): waits for P1's network message
+// combat.suppressRoundEvents = true (set in _setupOnlineMode)
+networkManager.onRoundEvent((event) => {
+  if (!this.isHost) {
+    combat.handleRoundEnd(event);  // Fire audio, camera, UI
+  }
+});
+```
+
+### NetworkFacade — Composed Public API
+
+The `NetworkFacade` composes all 5 modules and exposes the same API that `FightScene`, `LobbyScene`, and `SelectScene` currently use. This allows incremental migration.
+
+```javascript
+export class NetworkFacade {
+  constructor(roomId, host, options) {
+    this.signaling = new SignalingClient(roomId, host);
+    this.transport = new TransportManager(this.signaling);
+    this.inputSync = new InputSync(this.transport);
+    this.monitor = new ConnectionMonitor(this.signaling, this.transport);
+    this.spectator = options.spectator ? new SpectatorRelay(this.signaling) : null;
+  }
+
+  // Same public API as current NetworkManager:
+  sendInput(frame, inputState, history) { return this.inputSync.sendInput(frame, inputState, history); }
+  drainConfirmedInputs() { return this.inputSync.drainConfirmedInputs(); }
+  sendChecksum(frame, hash) { return this.inputSync.sendChecksum(frame, hash); }
+  sendReady(fighterId) { return this.signaling.sendReady(fighterId); }
+  onAssign(cb) { return this.signaling.on('assign', cb); }
+  onOpponentJoined(cb) { return this.signaling.on('opponent_joined', cb); }
+  getPlayerSlot() { return this.signaling.playerSlot; }
+  get rtt() { return this.monitor.rtt; }
+  // ... etc
+}
+```
+
+### InputSync — Clean Input Pipeline
+
+```javascript
+export class InputSync {
+  constructor(transport) {
+    this.transport = transport;
+    this.remoteInputBuffer = new Map();  // frame → encodedInput
+    this.lastRemoteInput = 0;
+  }
+
+  sendInput(frame, inputState, history) {
+    const msg = { type: 'input', frame, state: inputState, history };
+    this.transport.send(msg);
+  }
+
+  drainConfirmedInputs() {
+    const entries = [...this.remoteInputBuffer.entries()];
+    this.remoteInputBuffer.clear();
+    return entries;
+  }
+
+  handleRemoteInput(frame, inputState, history) {
+    this.remoteInputBuffer.set(frame, inputState);
+    // Backfill gaps from redundant history
+    for (const [hf, hs] of history) {
+      if (!this.remoteInputBuffer.has(hf)) {
+        this.remoteInputBuffer.set(hf, hs);
+      }
+    }
+  }
+}
+```
+
+### TransportManager — Dual Transport with TURN
+
+```javascript
+export class TransportManager {
+  constructor(signalingClient) {
+    this.signaling = signalingClient;
+    this.pc = null;           // RTCPeerConnection
+    this.dc = null;           // RTCDataChannel
+    this.iceServers = null;   // Fetched from server
+    this.state = 'idle';      // idle | connecting | webrtc | websocket
+  }
+
+  async fetchTurnCredentials() {
+    // Called on opponent_joined, before WebRTC negotiation
+    const creds = await this.signaling.fetchTurnCredentials();
+    this.iceServers = creds.iceServers;
+  }
+
+  async connect(isOfferer) {
+    await this.fetchTurnCredentials();
+    this.pc = new RTCPeerConnection({ iceServers: this.iceServers });
+    // ... DataChannel setup, offer/answer exchange via signaling
+  }
+
+  send(data) {
+    if (this.dc?.readyState === 'open') {
+      this.dc.send(JSON.stringify(data));
+      return 'webrtc';
+    }
+    this.signaling.send(data);
+    return 'websocket';
+  }
+
+  getConnectionInfo() {
+    return {
+      type: this.state,        // 'webrtc' | 'websocket'
+      iceType: this._iceType,  // 'host' | 'srflx' | 'relay'
+      rtt: this._dcRtt,
+    };
+  }
+}
+```
+
+### ConnectionMonitor — Pre-Match Quality Probing
+
+```javascript
+export class ConnectionMonitor {
+  constructor(signaling, transport) {
+    this.signaling = signaling;
+    this.transport = transport;
+    this.rtt = 0;
+    this.jitter = 0;
+  }
+
+  /**
+   * Run pre-match quality assessment (call during character select).
+   * Sends 10 pings over 2 seconds, measures RTT distribution.
+   * @returns {{ avgRtt, maxRtt, jitter, iceType, quality: 'good'|'fair'|'poor' }}
+   */
+  async assessQuality() {
+    const samples = [];
+    for (let i = 0; i < 10; i++) {
+      const rtt = await this._pingOnce();
+      samples.push(rtt);
+      await new Promise(r => setTimeout(r, 200));
+    }
+    const avgRtt = samples.reduce((a, b) => a + b, 0) / samples.length;
+    const maxRtt = Math.max(...samples);
+    const jitter = this._calculateJitter(samples);
+    const iceType = this.transport.getConnectionInfo().iceType;
+
+    let quality = 'good';
+    if (avgRtt > 150 || iceType === 'relay') quality = 'fair';
+    if (avgRtt > 250 || this.transport.state === 'websocket') quality = 'poor';
+
+    return { avgRtt, maxRtt, jitter, iceType, quality };
+  }
+}
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1: Fix Simulation Determinism (Critical Path)
+
+**Goal:** Both peers see the same game state. Timer synchronized. Rounds end at the same time on both phones.
+
+**Description:**
+- Make `tickTimer()` accept `{ muteEffects }` — suppress `timeUp()` during rollback re-simulation
+- Make `checkHit()` return KO info instead of calling `handleKO()` directly during simulation
+- `simulateFrame()` returns optional round event descriptor instead of firing side effects
+- `RollbackManager.advance()` captures round event from current frame, discards during re-simulation
+- P2 sets `combat.suppressRoundEvents = true` in `_setupOnlineMode()`
+- P1 sends round events to P2 via network; P2 waits for P1's message before firing UI
+
+**Deliverables:**
+- Modified `CombatSystem.js` — `tickTimer({ muteEffects })`, `checkHit()` returns KO info
+- Modified `SimulationStep.js` — returns round event, passes `muteEffects` to all combat methods
+- Modified `RollbackManager.js` — deferred round event handling
+- Modified `FightScene.js` — P1 authority, P2 `suppressRoundEvents = true`, deferred event wiring
+- New `tests/systems/rollback-round-events.test.js` — regression tests for all 3 root cause bugs
+
+**Risks:**
+- Changing `simulateFrame()` return value affects all callers (local mode, spectator mode). Mitigate: local mode ignores return value and handles events via existing `CombatSystem` callbacks.
+
+**Estimated effort:** 2-3 days
+
+---
+
+### Phase 2A: Headless Testing Harness (Parallelizable with 2B)
+
+**Goal:** Automated tests that catch desync, timer drift, and rollback corruption without needing a browser.
+
+**Description:**
+- Create `NetworkSimulator` mock transport with configurable: latency (ms), jitter (ms), packet loss (%), reordering probability, burst loss length
+- Create `HeadlessFight` test utility that wires two `RollbackManager` instances + `SimulationStep` + `CombatSystem` via `NetworkSimulator`
+- Uses mock fighters from existing `tests/systems/determinism.test.js` pattern (pure FP simulation, no Phaser)
+- Scripted input sequences drive both sides
+- Assertions: bit-exact state at every confirmed frame, timer values match, round events agree
+
+**Deliverables:**
+- `tests/harness/NetworkSimulator.js` — configurable mock transport
+- `tests/harness/HeadlessFight.js` — dual-simulation test utility
+- `tests/harness/MockFighter.js` — pure simulation fighter (extracted from `determinism.test.js`)
+- `tests/integration/dual-sim-determinism.test.js` — determinism under various network conditions
+- `tests/integration/dual-sim-round-events.test.js` — round event correctness under rollback
+
+**Test scenarios:**
+| Scenario | Latency | Loss | Expected |
+|----------|---------|------|----------|
+| Perfect LAN | 0ms | 0% | Bit-exact, no rollbacks |
+| Good WiFi | 30ms | 0% | Bit-exact at confirmation, rollbacks converge |
+| Mobile cellular | 80ms, 20ms jitter | 2% | State converges within rollback window |
+| Bad connection | 150ms, 50ms jitter | 10% | State converges, adaptive delay increases |
+| Burst loss | 50ms | 5 consecutive frames lost | Recovers via input redundancy |
+| Timer edge case | 50ms | timed to hit timer=0 during rollback | Timer identical on both sides |
+| KO during rollback | 50ms | timed to cause KO misprediction | Round event only fires on confirmed state |
+
+**Risks:**
+- Mock fighters may diverge from real Fighter.js behavior over time. Mitigate: share constants from `FixedPoint.js`, add snapshot comparison tests against real fighters in Playwright layer.
+
+**Estimated effort:** 3-4 days
+
+---
+
+### Phase 2B: Transport Layer + TURN (Parallelizable with 2A)
+
+**Goal:** Reliable P2P connectivity across all network types. Clean module boundaries.
+
+**Description:**
+
+**2B.1: Cloudflare TURN integration**
+- Create Cloudflare TURN key via dashboard, store as PartyKit env vars (`CLOUDFLARE_TURN_KEY_ID`, `CLOUDFLARE_TURN_API_TOKEN`)
+- Add `onRequest` handler to `party/server.js` to generate TURN credentials (REST call to `rtc.live.cloudflare.com`)
+- Client fetches credentials on `opponent_joined`, before WebRTC negotiation
+- ICE server list: Google STUN x2 + Cloudflare STUN + Cloudflare TURN (UDP + TCP)
+
+**2B.2: Module decomposition**
+- Extract `SignalingClient.js` from NetworkManager (WebSocket lifecycle, room messages, event emitter)
+- Extract `TransportManager.js` from NetworkManager + WebRTCTransport (WebRTC setup, TURN creds, transport routing)
+- Extract `InputSync.js` from NetworkManager (input buffer, send/receive, drain, checksum/resync relay)
+- Extract `ConnectionMonitor.js` from NetworkManager (ping/pong, RTT, pong timeout, quality assessment)
+- Extract `SpectatorRelay.js` from NetworkManager (spectator buffers, sync, shout, potion)
+- Create `NetworkFacade.js` that composes all 5 and exposes the same public API
+
+**2B.3: Terraform configuration**
+- Terraform config for Cloudflare DNS, PartyKit/Workers environment variables
+- TURN key ID as a Terraform variable (provisioned manually, referenced in config)
+
+**Deliverables:**
+- `src/systems/net/SignalingClient.js`
+- `src/systems/net/TransportManager.js`
+- `src/systems/net/InputSync.js`
+- `src/systems/net/ConnectionMonitor.js`
+- `src/systems/net/SpectatorRelay.js`
+- `src/systems/net/NetworkFacade.js`
+- Modified `party/server.js` — `onRequest` for TURN credential endpoint
+- `infra/main.tf` — Terraform configuration
+- `tests/systems/net/signaling-client.test.js`
+- `tests/systems/net/transport-manager.test.js`
+- `tests/systems/net/input-sync.test.js`
+- Delete: `src/systems/NetworkManager.js`, `src/systems/WebRTCTransport.js`
+
+**Risks:**
+- Decomposition may introduce subtle message ordering bugs. Mitigate: `NetworkFacade` exposes identical API, existing tests run against facade.
+- Cloudflare TURN credential API may have latency. Mitigate: fetch eagerly on `opponent_joined` (during character select), cache for 5 minutes.
+
+**Estimated effort:** 4-5 days
+
+---
+
+### Phase 3: Integration + Connection Quality (Depends on 2A + 2B)
+
+**Goal:** Wire fixed simulation to new transport. Pre-match quality indicator.
+
+**Description:**
+- Replace `NetworkManager` imports with `NetworkFacade` in all scenes (FightScene, LobbyScene, SelectScene, PreFightScene, VictoryScene)
+- Wire `ConnectionMonitor.assessQuality()` during character select
+- Show connection quality indicator in SelectScene UI:
+  - Green dot: P2P direct (`host`/`srflx`), RTT < 80ms — "Buena conexion"
+  - Yellow dot: TURN relay or RTT 80-150ms — "Conexion aceptable"
+  - Red dot: WebSocket fallback or RTT > 150ms — "Conexion lenta"
+- Players can always proceed regardless of quality (friends game, not ranked)
+- Exchange `connection_quality` message via server so both peers see the indicator
+
+**Deliverables:**
+- Updated scene imports (FightScene, LobbyScene, SelectScene, etc.)
+- Connection quality UI in SelectScene
+- New `connection_quality` message type in `party/server.js`
+- End-to-end test: two headless simulations through `NetworkFacade`
+
+**Risks:**
+- UI changes in SelectScene may conflict with ongoing work. Mitigate: quality indicator is a small overlay, minimal scene changes.
+
+**Estimated effort:** 2 days
+
+---
+
+### Phase 4: Hardened Reconnection (Depends on Phase 3)
+
+**Goal:** Fix race conditions in reconnection flow.
+
+**Description:**
+- `TransportManager` handles WebRTC renegotiation as a proper state machine (not `_initWebRTC()` called from multiple code paths)
+- On reconnect: `SignalingClient` reconnects WebSocket → sends `rejoin` → waits for server confirmation → `TransportManager` renegotiates WebRTC
+- Sequential, not concurrent: WebSocket must be stable before WebRTC renegotiation starts
+- `ReconnectionManager` (already solid) receives events from `SignalingClient` and `TransportManager` through clean callbacks
+- Add reconnection integration test in headless harness: simulate WebSocket drop, reconnect, verify state convergence
+
+**Deliverables:**
+- `TransportManager` reconnection state machine
+- `SignalingClient` rejoin flow (sequential)
+- `tests/integration/reconnection.test.js`
+
+**Risks:**
+- WebRTC renegotiation on Safari has known quirks (ICE restart behavior). Mitigate: on reconnect failure, fall back to WebSocket relay rather than retrying indefinitely.
+
+**Estimated effort:** 2 days
+
+---
+
+### Phase 5: Binary Input Protocol (Optional)
+
+**Goal:** Reduce per-packet overhead on DataChannel.
+
+**Description:**
+Currently inputs are JSON-encoded (~100 bytes per packet):
+```json
+{"type":"input","frame":1234,"state":{"left":true,"right":false,...},"history":[[1233,42],[1232,0]]}
+```
+
+Replace with binary encoding on DataChannel (keep JSON on WebSocket for debuggability):
+- 1 byte: message type (0x01 = input)
+- 2 bytes: frame number (uint16, wraps at 65535 = ~18 minutes at 60fps)
+- 2 bytes: encoded input (uint16, only 9 bits used)
+- N * 4 bytes: history entries (uint16 frame + uint16 input each)
+- Total: ~13 bytes vs ~100 bytes
+
+**Why optional:** At 60fps, even JSON is only ~6KB/s, well within any connection. But smaller packets reduce DataChannel per-packet overhead and are more resilient to congestion.
+
+**Deliverables:**
+- `src/systems/net/BinaryCodec.js` — encode/decode binary input packets
+- `tests/systems/net/binary-codec.test.js`
+- Updated `TransportManager.send()` to use binary on DataChannel
+
+**Risks:**
+- Binary debugging is harder. Mitigate: keep JSON on WebSocket path, add hex dump logging for binary path.
+
+**Estimated effort:** 0.5 days
+
+---
+
+## Phase Dependency Diagram
+
+```mermaid
+flowchart TB
+    P1[Phase 1<br/>Fix Simulation Determinism<br/>2-3 days]
+    P2A[Phase 2A<br/>Headless Testing Harness<br/>3-4 days]
+    P2B[Phase 2B<br/>Transport + TURN + Modules<br/>4-5 days]
+    P3[Phase 3<br/>Integration + Quality UI<br/>2 days]
+    P4[Phase 4<br/>Hardened Reconnection<br/>2 days]
+    P5[Phase 5<br/>Binary Protocol<br/>0.5 days]
+
+    P1 --> P2A
+    P1 --> P2B
+    P2A --> P3
+    P2B --> P3
+    P3 --> P4
+    P4 --> P5
+
+    style P2A fill:#e1f5fe
+    style P2B fill:#e1f5fe
+    style P5 fill:#fff3e0
+```
+
+**Phase 2A and 2B run in parallel** (blue). Phase 5 is optional (orange).
+
+**Total estimated effort:** 13-16 days (sequential), ~10-12 days (with parallelism).
+
+---
+
+## Migration and Rollout Strategy
+
+### Incremental Migration via NetworkFacade
+
+The `NetworkFacade` pattern allows zero-disruption migration:
+
+1. **Phase 1** modifies existing files in-place (SimulationStep, CombatSystem, RollbackManager, FightScene). No module boundary changes.
+
+2. **Phase 2B** creates new modules in `src/systems/net/` and a `NetworkFacade` that exposes the exact same public API as the current `NetworkManager`. Scenes continue to import and use the same interface.
+
+3. **Phase 3** swaps imports from `NetworkManager` to `NetworkFacade`. This is a mechanical find-and-replace with no behavioral changes.
+
+4. Once all scenes use `NetworkFacade`, delete `src/systems/NetworkManager.js` and `src/systems/WebRTCTransport.js`.
+
+### Rollout Steps
+
+1. **Local testing:** Fix simulation bugs (Phase 1), run headless harness (Phase 2A), verify determinism
+2. **Staging:** Deploy TURN-enabled PartyKit server, test on two iPhones over cellular
+3. **Canary:** Enable for a subset of rooms (e.g., rooms starting with "test-")
+4. **Full rollout:** Remove canary gate, update docs
+
+### Backward Compatibility
+
+- The PartyKit server changes are additive (new `onRequest` endpoint, new `connection_quality` message type). Old clients continue to work — they just won't use TURN or quality probing.
+- The `NetworkFacade` exposes the same API. No scene changes required during Phase 2B.
+
+---
+
+## Testing Strategy
+
+### Layer 1: Headless Dual-Simulation Harness (Phase 2A)
+
+Two `RollbackManager` instances connected via a `NetworkSimulator` mock transport. Uses real `SimulationStep`, `GameState`, `InputBuffer`, `CombatSystem` with mock fighters (existing pattern from `tests/systems/determinism.test.js`).
+
+`NetworkSimulator` is configurable:
+- **Latency**: one-way delay in ms (applied per-packet)
+- **Jitter**: random variation added to latency (uniform distribution)
+- **Packet loss**: probability of dropping a packet (0-1)
+- **Reordering**: probability of delivering packets out of order
+- **Burst loss**: consecutive frames dropped (simulates WiFi handoff)
+
+```javascript
+const sim = new NetworkSimulator({
+  latencyMs: 80,
+  jitterMs: 20,
+  packetLossRate: 0.02,
+  burstLossFrames: 0,
+});
+
+const fight = new HeadlessFight(sim, {
+  p1Inputs: generateInputSequence(600),  // 10 seconds
+  p2Inputs: generateInputSequence(600),
+});
+
+const result = fight.run();
+expect(result.p1FinalState).toEqual(result.p2FinalState);
+expect(result.p1Timer).toBe(result.p2Timer);
+expect(result.p1RoundEvents).toEqual(result.p2RoundEvents);
+```
+
+### Layer 2: Targeted Rollback Regression Tests
+
+```javascript
+// Test: timeUp during rollback re-simulation must NOT fire side effects
+test('timer reaching 0 during rollback does not corrupt state', () => {
+  // Set timer to 1 second remaining (60 frames)
+  // Run 59 frames normally
+  // Inject a misprediction at frame 55 that triggers rollback
+  // During re-simulation frames 55-59, timer hits 0
+  // Assert: roundActive is still true after rollback completes
+  // Assert: timeUp() was NOT called during re-simulation
+});
+
+// Test: KO on predicted input + rollback
+test('KO on predicted input is rolled back correctly', () => {
+  // Set defender HP to 1
+  // Predict an attack that would KO
+  // Confirmed input shows the attack was blocked
+  // Assert: defender HP is not 0, round continues
+  // Assert: handleKO() was NOT called
+});
+```
+
+### Layer 3: Transport Unit Tests
+
+- Mock `RTCPeerConnection` and `RTCDataChannel` for `TransportManager` tests
+- Mock `PartySocket` for `SignalingClient` tests
+- Test TURN credential fetching (mock HTTP response)
+- Test ICE candidate type reporting
+- Test transport fallback (DataChannel close → WebSocket)
+
+### Layer 4: Playwright E2E (CI-optional, Slow)
+
+- Two `browser.newContext()` instances connecting to local PartyKit server (`bun run party:dev`)
+- Scripted inputs via `page.evaluate(() => window.game.inputManager.injectInput({...}))`
+- Assert both tabs show same timer, HP, and round result after 30 seconds of play
+- Run as a separate CI job (not blocking, takes ~2 minutes)
+
+---
+
+## Open Questions and Alternatives
+
+### Open Questions
+
+| # | Question | Impact | Current Leaning |
+|---|----------|--------|-----------------|
+| 1 | Should P2 also detect round events locally (with delay tolerance) as a backup, or purely wait for P1's message? | If P1 disconnects mid-round-event, P2 might hang. | P2 detects locally with a 30-frame delay as a fallback. If P1's message hasn't arrived within 30 frames of local detection, P2 fires locally. |
+| 2 | Should the binary protocol (Phase 5) be prioritized? | Smaller packets are more resilient to congestion on constrained mobile connections. | Keep optional. JSON at 6KB/s is fine for DataChannel. Revisit if testing shows packet loss issues at scale. |
+| 3 | Should we add a TURN-only mode for debugging? | Useful for testing TURN path specifically. | Yes — add a `?forceTurn=1` URL parameter that sets `iceTransportPolicy: 'relay'` on RTCPeerConnection. |
+| 4 | Should spectator sync use the rollback system or stay as P1-broadcasted snapshots? | Current approach (P1 broadcasts every 3 frames) is simple and works. Rollback for spectators adds complexity. | Keep current approach. Spectators don't need frame-perfect accuracy. |
+| 5 | How should we handle TURN credential expiry during very long sessions? | TURN credentials have max 48h TTL. Matches are typically < 10 minutes. | No action needed. If a match somehow lasts > 48h, TURN fallback stops working but WebSocket relay continues. |
+
+### Alternatives Considered
+
+**GGRS (Rust/Wasm)**
+- Pros: Battle-tested rollback library, handles spectator delay, input delay calculation
+- Cons: Wasm bridging overhead (copy 30 state fields across JS/Wasm boundary 60x/sec), Rust toolchain maintenance, Safari Wasm debugging is painful
+- Verdict: **Rejected.** The rollback math is 324 lines of JS and works correctly. The bugs are in event handling and transport, not rollback scheduling.
+
+**geckos.io**
+- Pros: WebRTC DataChannel library with server-side Node component, handles connection management
+- Cons: Designed for client-server topology (not P2P), adds a server hop, unmaintained (last release 2023)
+- Verdict: **Rejected.** P2P is correct for 1v1 fighting games. Adding a server hop increases latency.
+
+**Cloudflare Durable Objects (replace PartyKit)**
+- Pros: More control, no PartyKit dependency
+- Cons: Would reimplement WebSocket management that PartyKit provides for free. PartyKit IS built on Durable Objects.
+- Verdict: **Rejected.** PartyKit works and is deployed. The server code is 362 lines and well-understood.
+
+**Client-Server Architecture (server runs simulation)**
+- Pros: No desync possible (single source of truth), easier anti-cheat
+- Cons: Adds ~50-100ms latency per input (server round-trip), requires beefy server, overkill for friends game
+- Verdict: **Rejected.** For a 1v1 fighting game where every frame matters, P2P with rollback is the correct architecture.
+
+**Metered.ca (alternative TURN provider)**
+- Pros: Simple REST API, free tier (50 GB/month)
+- Cons: Smaller free tier than Cloudflare (50 GB vs 1,000 GB), separate infrastructure from the rest of the stack
+- Verdict: **Rejected in favor of Cloudflare TURN.** Same cloud provider as PartyKit, 20x larger free tier.
+
+---
+
+## Appendix: Files Modified/Created
+
+### Modified
+
+| File | Change |
+|------|--------|
+| `src/systems/CombatSystem.js` | `tickTimer({ muteEffects })`, `checkHit()` returns KO info |
+| `src/systems/SimulationStep.js` | Returns round event, passes `muteEffects` to all combat methods |
+| `src/systems/RollbackManager.js` | Deferred round event in `advance()`, discard during re-simulation |
+| `src/scenes/FightScene.js` | P1 authority wiring, P2 `suppressRoundEvents`, deferred events, quality UI |
+| `party/server.js` | `onRequest` TURN credential endpoint, `connection_quality` message |
+
+### Created
+
+| File | Purpose |
+|------|---------|
+| `src/systems/net/SignalingClient.js` | WebSocket lifecycle, room messages |
+| `src/systems/net/TransportManager.js` | WebRTC + WS routing, TURN credentials |
+| `src/systems/net/InputSync.js` | Frame-indexed input send/receive/drain |
+| `src/systems/net/ConnectionMonitor.js` | RTT, ping/pong, quality assessment |
+| `src/systems/net/SpectatorRelay.js` | Spectator buffers, sync, shout, potion |
+| `src/systems/net/NetworkFacade.js` | Composes all modules, same public API |
+| `infra/main.tf` | Terraform config for Cloudflare DNS + env vars |
+| `tests/harness/NetworkSimulator.js` | Mock transport with configurable conditions |
+| `tests/harness/HeadlessFight.js` | Dual-simulation test utility |
+| `tests/harness/MockFighter.js` | Pure simulation fighter (no Phaser) |
+| `tests/integration/dual-sim-determinism.test.js` | Determinism under network conditions |
+| `tests/integration/dual-sim-round-events.test.js` | Round event correctness |
+| `tests/integration/reconnection.test.js` | Reconnection flow |
+| `tests/systems/net/signaling-client.test.js` | SignalingClient unit tests |
+| `tests/systems/net/transport-manager.test.js` | TransportManager unit tests |
+| `tests/systems/net/input-sync.test.js` | InputSync unit tests |
+| `src/systems/net/BinaryCodec.js` | Binary input encoding (Phase 5, optional) |
+
+### Deleted
+
+| File | Reason |
+|------|--------|
+| `src/systems/NetworkManager.js` | Replaced by `net/` modules + `NetworkFacade` |
+| `src/systems/WebRTCTransport.js` | Absorbed into `TransportManager` |

--- a/docs/rfcs/0001-networking-redesign.md
+++ b/docs/rfcs/0001-networking-redesign.md
@@ -1,6 +1,6 @@
 # RFC 0001: Networking Redesign
 
-**Status:** Draft
+**Status:** In Progress — Phase 1 complete
 **Date:** 2026-03-22
 **Author:** Architecture Team
 
@@ -439,7 +439,7 @@ export class ConnectionMonitor {
 
 ## Implementation Plan
 
-### Phase 1: Fix Simulation Determinism (Critical Path)
+### Phase 1: Fix Simulation Determinism (Critical Path) — COMPLETE ✓
 
 **Goal:** Both peers see the same game state. Timer synchronized. Rounds end at the same time on both phones.
 
@@ -448,18 +448,21 @@ export class ConnectionMonitor {
 - Make `checkHit()` return KO info instead of calling `handleKO()` directly during simulation
 - `simulateFrame()` returns optional round event descriptor instead of firing side effects
 - `RollbackManager.advance()` captures round event from current frame, discards during re-simulation
-- P2 sets `combat.suppressRoundEvents = true` in `_setupOnlineMode()`
-- P1 sends round events to P2 via network; P2 waits for P1's message before firing UI
+- Both P1 and P2 set `combat.suppressRoundEvents = true` in `_setupOnlineMode()`
+- P1 captures round events from `advance()` return value, fires via `combat.handleRoundEnd()`
+- P2 receives round events from P1 via `onRoundEvent` network handler
 
 **Deliverables:**
-- Modified `CombatSystem.js` — `tickTimer({ muteEffects })`, `checkHit()` returns KO info
-- Modified `SimulationStep.js` — returns round event, passes `muteEffects` to all combat methods
-- Modified `RollbackManager.js` — deferred round event handling
-- Modified `FightScene.js` — P1 authority, P2 `suppressRoundEvents = true`, deferred event wiring
-- New `tests/systems/rollback-round-events.test.js` — regression tests for all 3 root cause bugs
+- Modified `CombatSystem.js` — `tickTimer({ muteEffects })`, `checkHit()` returns `{ hit, ko }`, new `handleRoundEnd(roundEvent)` method
+- Modified `SimulationStep.js` — returns round event descriptor, passes `muteEffects` to all combat methods
+- Modified `RollbackManager.js` — deferred round event handling, checksum on confirmed frames
+- Modified `FightScene.js` — P1 authority, both players `suppressRoundEvents = true`, P2 `onRoundEvent` handler
+- Modified `NetworkManager.js` — always accept WS inputs regardless of DataChannel state
+- New `tests/systems/rollback-round-events.test.js` — 13 regression tests for rollback round events
 
-**Risks:**
-- Changing `simulateFrame()` return value affects all callers (local mode, spectator mode). Mitigate: local mode ignores return value and handles events via existing `CombatSystem` callbacks.
+**Additional fixes discovered during testing:**
+- **False desync alerts:** Checksum was comparing predicted (unconfirmed) state at `currentFrame - 1`. Changed to `currentFrame - maxRollbackFrames - 1` so both peers compare confirmed state only. False desyncs triggered harmful resyncs that cleared input history.
+- **Asymmetric WebRTC reconnection:** When P1's DataChannel reconnected, it ignored all WebSocket inputs. P2 might still be sending via WebSocket if P2's DataChannel wasn't ready. Removed the WS input ignore — `spectatorOnly` flag already prevents duplication.
 
 **Estimated effort:** 2-3 days
 

--- a/docs/rollback-netcode.md
+++ b/docs/rollback-netcode.md
@@ -49,27 +49,33 @@ The rollback system is transport-agnostic — `RollbackManager` reads from `remo
 - **Packet loss** on the unreliable DataChannel is handled the same as late TCP delivery — prediction + rollback
 - **Mid-fight transport switch** (P2P drops → WS fallback) is invisible to the simulation layer
 
-## Peer-Equal Model
+## Peer-Equal Model with Deferred Round Events
 
-Both peers are equal in the simulation. There is no host/guest distinction for gameplay — both independently detect KO, timeup, round transitions, and match over. Deterministic fixed-point math guarantees bit-for-bit agreement.
+Both peers run identical deterministic simulations with zero perceived input lag. Round-ending events (KO/timeup) are **deferred** — `simulateFrame()` returns a round event descriptor instead of firing side effects directly. This prevents corruption during rollback re-simulation.
+
+Both P1 and P2 set `combat.suppressRoundEvents = true` in online mode:
+- **P1 (host):** Captures round events from `advance()` return value, fires side effects via `combat.handleRoundEnd(roundEvent)`, and sends the event to P2 + spectators
+- **P2 (guest):** Ignores local round event detection; receives authoritative round events from P1 via `onRoundEvent` network handler
 
 P1 has additional **non-gameplay** responsibilities:
 - Sends sync snapshots to spectators (every 3 frames)
-- Sends `round_event` messages for spectators (3x with 200ms spacing)
+- Sends `round_event` messages to P2 + spectators (3x with 200ms spacing)
 - Handles potion requests from spectators
 - Sends authoritative resync snapshots on desync detection
 
 ## Simulation Step
 
-Each frame, `simulateFrame()` runs these steps in order using fixed-point integer math (no floats):
+Each frame, `simulateFrame()` runs these steps in order using fixed-point integer math (no floats) and returns an optional round event descriptor (`{ type: 'ko'|'timeup', winnerIndex }` or `null`):
 
 1. `fighter.update()` — FP gravity, cooldown frame timers
 2. `applyInput()` — FP velocities, attack triggers
 3. `resolveBodyCollision()` — FP coordinate push-back
 4. `faceOpponent()` — simX comparison
-5. `checkHit()` — `fpRectsOverlap()` hitbox detection
-6. `tickTimer()` — frame-counted (60 frames = 1 second)
+5. `checkHit()` — `fpRectsOverlap()` hitbox detection; returns `{ hit, ko }` on hit
+6. `tickTimer({ muteEffects })` — frame-counted (60 frames = 1 second); returns `{ timeup: true }` when timer reaches 0
 7. `syncSprite()` — render positions from sim state
+
+KO takes priority over timeup if both occur on the same frame. The return value is used by `RollbackManager.advance()` to defer round event handling.
 
 ## RollbackManager.advance() — Per Frame
 
@@ -83,9 +89,13 @@ flowchart TD
     D -- No --> F["6. Predict remote input\n(repeat movement,\nzero attacks)"]
     F --> G["7. Save snapshot via\ncaptureGameState"]
     G --> H["8. Simulate frame\ncurrentFrame++"]
-    H --> I["9. Prune old snapshots\nbeyond rollback window"]
+    H --> RE{"Round event\nreturned?"}
+    RE -- Yes --> RE_P1["P1: handleRoundEnd()\n+ send to P2"]
+    RE -- No --> I
+    RE_P1 --> I
+    I["9. Prune old snapshots\nbeyond rollback window"]
     I --> J{"10. Frame %\n30 == 0?"}
-    J -- Yes --> K["Send checksum\nvia hashGameState"]
+    J -- Yes --> K["Send checksum for\nconfirmed frame\n(current - maxRollback - 1)"]
     J -- No --> L{"11. Frame %\n180 == 0?"}
     K --> L
     L -- Yes --> M["Recalculate\ninputDelay from RTT"]
@@ -154,7 +164,7 @@ flowchart LR
 
 ## Desync Detection & Recovery
 
-Both peers exchange state checksums every 30 frames. On mismatch, P1 sends an authoritative state snapshot to resync P2.
+Both peers exchange state checksums every 30 frames. Checksums compare **confirmed** frames (`currentFrame - maxRollbackFrames - 1`) to avoid false positives from predicted inputs. On mismatch, P1 sends an authoritative state snapshot to resync P2.
 
 ### Detection
 

--- a/docs/webrtc-transport.md
+++ b/docs/webrtc-transport.md
@@ -114,7 +114,7 @@ flowchart TD
     end
 ```
 
-When both transports are active, the receiving peer ignores WebSocket `input` messages (dedup guard) since they arrive via DataChannel.
+WebSocket `input` messages are always accepted regardless of local DataChannel state. This prevents input loss during asymmetric reconnection (where one peer has DataChannel open but the other is still sending via WebSocket). No duplication risk: when a peer sends via DataChannel, its WebSocket copy uses `spectatorOnly` so the server won't forward it to the opponent.
 
 ## Fallback Scenarios
 

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -682,6 +682,11 @@ export class FightScene extends Phaser.Scene {
     this.isHost = slot === 0;
     this._muteEffects = false;
 
+    // Suppress direct round event firing inside simulation for both P1 and P2.
+    // P1 handles round events from advance() return value.
+    // P2 waits for P1's network message.
+    this.combat.suppressRoundEvents = true;
+
     // Determine which fighter is local vs remote
     this.localFighter = slot === 0 ? this.p1Fighter : this.p2Fighter;
     this.remoteFighter = slot === 0 ? this.p2Fighter : this.p1Fighter;
@@ -872,7 +877,18 @@ export class FightScene extends Phaser.Scene {
     input.consumeTouch();
 
     // Run rollback advance (handles input sending, prediction, rollback, simulation)
-    this.rollbackManager.advance(localInput, this, this.p1Fighter, this.p2Fighter, this.combat);
+    const { roundEvent } = this.rollbackManager.advance(
+      localInput,
+      this,
+      this.p1Fighter,
+      this.p2Fighter,
+      this.combat,
+    );
+
+    // P1 (host) handles round events: fire side effects + send to P2
+    if (roundEvent && this.isHost) {
+      this.combat.handleRoundEnd(roundEvent);
+    }
 
     // P1 sends periodic state snapshots for spectators
     if (this.isHost && this.frameCounter % this._syncInterval === 0) {

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -747,6 +747,31 @@ export class FightScene extends Phaser.Scene {
     this._lastProcessedRound = 0;
     this._matchOverProcessed = false;
 
+    // P2 (guest) receives round events from P1 via network.
+    // P1 detects round events locally from advance() return value;
+    // P2 suppresses local detection and waits for P1's authoritative message.
+    nm.onRoundEvent((msg) => {
+      if (this.isHost) return; // P1 already handled locally
+      if (msg.matchOver && this._matchOverProcessed) return;
+      if (!msg.matchOver && msg.roundNumber <= this._lastProcessedRound) return;
+
+      this.combat.stopRound();
+      this.combat.p1RoundsWon = msg.p1Rounds;
+      this.combat.p2RoundsWon = msg.p2Rounds;
+      this.combat.roundNumber = msg.roundNumber;
+
+      if (msg.event === 'ko' || msg.event === 'timeup') {
+        if (msg.matchOver) {
+          this._matchOverProcessed = true;
+          this.combat.matchOver = true;
+          this.onMatchOver(msg.winnerIndex);
+        } else {
+          this._lastProcessedRound = msg.roundNumber;
+          this.onRoundOver(msg.winnerIndex);
+        }
+      }
+    });
+
     // --- Graceful reconnection ---
     this.reconnectionManager = new ReconnectionManager({ gracePeriodMs: 20000 });
     this._reconnecting = false;

--- a/src/systems/CombatSystem.js
+++ b/src/systems/CombatSystem.js
@@ -58,16 +58,29 @@ export class CombatSystem {
   /**
    * Frame-counted timer tick for deterministic simulation.
    * Called once per simulation frame. Decrements timer every 60 frames.
+   * Returns { timeup: true } when timer reaches 0, null otherwise.
+   * In local mode (!suppressRoundEvents), also fires timeUp() directly.
+   * @param {{ muteEffects?: boolean }} [options]
+   * @returns {{ timeup: true } | null}
    */
-  tickTimer() {
+  tickTimer({ muteEffects = false } = {}) {
     this._timerAccumulator++;
     if (this._timerAccumulator >= 60) {
       this._timerAccumulator = 0;
       this.timer--;
-      if (this.timer <= 0 && !this.suppressRoundEvents) this.timeUp();
+      if (this.timer <= 0) {
+        if (!muteEffects && !this.suppressRoundEvents) this.timeUp();
+        return { timeup: true };
+      }
     }
+    return null;
   }
 
+  /**
+   * Check if attacker's hitbox overlaps defender's hurtbox and apply damage.
+   * Returns { hit: true, ko: boolean } on hit, false on miss.
+   * @returns {{ hit: true, ko: boolean } | false}
+   */
   checkHit(attacker, defender, { muteEffects = false } = {}) {
     if (!attacker.currentAttack || attacker.state !== 'attacking') return false;
     if (attacker.hitConnected) return false;
@@ -81,9 +94,9 @@ export class CombatSystem {
     const hw = Math.abs(hitbox.w);
 
     if (fpRectsOverlap(hx, hitbox.y, hw, hitbox.h, hurtbox.x, hurtbox.y, hurtbox.w, hurtbox.h)) {
-      this.applyDamage(attacker, defender, { muteEffects });
+      const ko = this.applyDamage(attacker, defender, { muteEffects });
       attacker.hitConnected = true;
-      return true;
+      return { hit: true, ko: !!ko };
     }
     return false;
   }
@@ -169,6 +182,8 @@ export class CombatSystem {
     if (ko && !muteEffects && !this.suppressRoundEvents) {
       this.handleKO(attacker, defender);
     }
+
+    return ko;
   }
 
   timeUp() {
@@ -195,6 +210,27 @@ export class CombatSystem {
       this.scene.flashScreen();
     }
     this.roundWin(winnerIndex);
+  }
+
+  /**
+   * Handle a round-ending event from deferred round event detection.
+   * Used by online mode where round events are captured from simulateFrame()
+   * return values instead of firing directly inside the simulation.
+   * @param {{ type: 'ko'|'timeup', winnerIndex: number }} roundEvent
+   */
+  handleRoundEnd(roundEvent) {
+    this.stopRound();
+    if (roundEvent.type === 'ko') {
+      this.scene.game.audioManager.play('ko');
+      this.scene.cameras.main.shake(300, 0.015);
+      if (this.scene.flashScreen) {
+        this.scene.flashScreen();
+      }
+    } else if (roundEvent.type === 'timeup') {
+      this.scene.game.audioManager.play('announce_timeup');
+      this._lastEndReason = 'timeup';
+    }
+    this.roundWin(roundEvent.winnerIndex);
   }
 
   roundWin(playerIndex) {

--- a/src/systems/NetworkManager.js
+++ b/src/systems/NetworkManager.js
@@ -213,8 +213,11 @@ export class NetworkManager {
         if (this._webrtc) this._webrtc.handleSignal(msg);
         break;
       case 'input':
-        // When WebRTC is active, ignore WS inputs for non-spectators (inputs arrive via DataChannel)
-        if (this._webrtcReady && !this.isSpectator) break;
+        // Always accept WS inputs even when DataChannel is open.
+        // The remote peer may still be sending via WS if their DataChannel
+        // isn't ready yet (asymmetric reconnection). No duplication risk:
+        // when a peer sends via DataChannel, its WS copy uses spectatorOnly
+        // so the server won't forward it to the opponent.
         if (this.isSpectator && msg.slot != null) {
           // Spectator: route input to correct player buffer
           const buf = msg.slot === 0 ? 'remoteInputBufferP1' : 'remoteInputBufferP2';

--- a/src/systems/RollbackManager.js
+++ b/src/systems/RollbackManager.js
@@ -164,11 +164,14 @@ export class RollbackManager {
     this._pruneOldData();
 
     // 11. Periodic checksum exchange for desync detection
+    // Compare a frame that is maxRollbackFrames behind current, where all inputs
+    // should be confirmed on both peers. Comparing recent frames produces false
+    // positives because predicted (unconfirmed) remote inputs may differ.
     if (this.currentFrame > 0 && this.currentFrame % CHECKSUM_INTERVAL === 0) {
-      const snapshot = this.stateSnapshots.get(this.currentFrame - 1);
-      if (snapshot) {
+      const checksumFrame = this.currentFrame - this.maxRollbackFrames - 1;
+      const snapshot = this.stateSnapshots.get(checksumFrame);
+      if (snapshot && checksumFrame >= 0) {
         const hash = hashGameState(snapshot);
-        const checksumFrame = this.currentFrame - 1;
         this._localChecksums.set(checksumFrame, hash);
         this.nm.sendChecksum(checksumFrame, hash);
       }

--- a/src/systems/RollbackManager.js
+++ b/src/systems/RollbackManager.js
@@ -68,11 +68,15 @@ export class RollbackManager {
 
   /**
    * Main rollback loop — call once per visual frame.
+   * Returns { roundEvent } where roundEvent is a deferred round event
+   * descriptor from the current frame's simulation, or null.
+   * Round events during rollback re-simulation are intentionally discarded.
    * @param {object} rawLocalInput - { left, right, up, down, lp, hp, lk, hk, sp }
    * @param {object} scene - FightScene (for _muteEffects flag)
    * @param {import('../entities/Fighter.js').Fighter} p1
    * @param {import('../entities/Fighter.js').Fighter} p2
    * @param {import('./CombatSystem.js').CombatSystem} combat
+   * @returns {{ roundEvent: { type: 'ko'|'timeup', winnerIndex: number } | null }}
    */
   advance(rawLocalInput, scene, p1, p2, combat) {
     const encodedLocal = encodeInput(rawLocalInput);
@@ -148,10 +152,10 @@ export class RollbackManager {
     // 7. Save snapshot for currentFrame (before simulating)
     this.stateSnapshots.set(this.currentFrame, captureGameState(this.currentFrame, p1, p2, combat));
 
-    // 8. Simulate currentFrame
+    // 8. Simulate currentFrame — capture round event from current frame
     const p1Input = this._getInputForFrame(this.currentFrame, true);
     const p2Input = this._getInputForFrame(this.currentFrame, false);
-    simulateFrame(p1, p2, combat, p1Input, p2Input);
+    const roundEvent = simulateFrame(p1, p2, combat, p1Input, p2Input);
 
     // 9. Advance frame
     this.currentFrame++;
@@ -178,6 +182,9 @@ export class RollbackManager {
     ) {
       this._recalculateInputDelay();
     }
+
+    // 13. Return deferred round event for caller to handle
+    return { roundEvent };
   }
 
   /**

--- a/src/systems/SimulationStep.js
+++ b/src/systems/SimulationStep.js
@@ -39,12 +39,14 @@ export function applyInputToFighter(fighter, inputState) {
 /**
  * Run one deterministic simulation frame.
  * No delta parameter — all physics is frame-based integer math.
+ * Returns an optional round event descriptor when KO or timeup is detected.
  * @param {import('../entities/Fighter.js').Fighter} p1Fighter
  * @param {import('../entities/Fighter.js').Fighter} p2Fighter
  * @param {import('./CombatSystem.js').CombatSystem} combat
  * @param {number} p1Input - Encoded input for P1
  * @param {number} p2Input - Encoded input for P2
  * @param {{ muteEffects?: boolean }} [options]
+ * @returns {{ type: 'ko'|'timeup', winnerIndex: number } | null}
  */
 export function simulateFrame(
   p1Fighter,
@@ -71,16 +73,28 @@ export function simulateFrame(
   p1Fighter.faceOpponent(p2Fighter);
   p2Fighter.faceOpponent(p1Fighter);
 
-  // 5. Hit detection (both directions)
+  // 5. Hit detection + timer tick → capture round events
+  let roundEvent = null;
   if (combat.roundActive) {
-    combat.checkHit(p1Fighter, p2Fighter, { muteEffects });
-    combat.checkHit(p2Fighter, p1Fighter, { muteEffects });
+    const p1Hit = combat.checkHit(p1Fighter, p2Fighter, { muteEffects });
+    const p2Hit = combat.checkHit(p2Fighter, p1Fighter, { muteEffects });
+
+    if (p1Hit?.ko) roundEvent = { type: 'ko', winnerIndex: 0 };
+    else if (p2Hit?.ko) roundEvent = { type: 'ko', winnerIndex: 1 };
 
     // 6. Tick timer
-    combat.tickTimer();
+    const timerResult = combat.tickTimer({ muteEffects });
+    if (!roundEvent && timerResult?.timeup) {
+      roundEvent = {
+        type: 'timeup',
+        winnerIndex: p1Fighter.hp >= p2Fighter.hp ? 0 : 1,
+      };
+    }
   }
 
   // 7. Sync sprites (rendering only)
   p1Fighter.syncSprite();
   p2Fighter.syncSprite();
+
+  return roundEvent;
 }

--- a/tests/systems/desync-detection.test.js
+++ b/tests/systems/desync-detection.test.js
@@ -190,14 +190,15 @@ describe('RollbackManager checksum exchange', () => {
     rm = new RollbackManager(nm, 0, { inputDelay: 2, maxRollbackFrames: 7 });
   });
 
-  it('sends checksum every 30 frames', () => {
+  it('sends checksum every 30 frames for confirmed frames', () => {
     for (let i = 0; i < 31; i++) {
       rm.advance(noInput, scene, p1, p2, combat);
     }
     // At frame 30 (after advancing 30 times, currentFrame becomes 30)
     expect(nm.sendChecksum).toHaveBeenCalledTimes(1);
     const [frame, hash] = nm.sendChecksum.mock.calls[0];
-    expect(frame).toBe(29); // snapshot of frame 29 (currentFrame - 1 at step 11)
+    // Checksum frame is maxRollbackFrames+1 behind current: 30 - 7 - 1 = 22
+    expect(frame).toBe(22);
     expect(typeof hash).toBe('number');
   });
 

--- a/tests/systems/network-manager.test.js
+++ b/tests/systems/network-manager.test.js
@@ -807,7 +807,7 @@ describe('NetworkManager', () => {
       expect(wsMsg.spectatorOnly).toBeUndefined();
     });
 
-    it('ignores WS input messages when WebRTC is active (non-spectator)', () => {
+    it('accepts WS input messages even when WebRTC is active (asymmetric reconnection)', () => {
       globalThis.RTCPeerConnection = class {};
       const nm = makeManager();
       nm.playerSlot = 0;
@@ -815,9 +815,10 @@ describe('NetworkManager', () => {
       nm._handleMessage({ type: 'opponent_joined' });
       nm._webrtc._simulateOpen();
 
-      // WS input should be ignored
+      // WS input should be accepted — remote peer may still be sending via WS
+      // if their DataChannel isn't ready yet (no duplication: sender uses spectatorOnly)
       nm._handleMessage({ type: 'input', frame: 1, state: { left: true } });
-      expect(Object.keys(nm.remoteInputBuffer).length).toBe(0);
+      expect(Object.keys(nm.remoteInputBuffer).length).toBe(1);
     });
 
     it('still processes WS input when spectator even with WebRTC active', () => {

--- a/tests/systems/rollback-round-events.test.js
+++ b/tests/systems/rollback-round-events.test.js
@@ -1,0 +1,832 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MAX_HP, ROUNDS_TO_WIN, STAMINA_COSTS } from '../../src/config.js';
+import { calculateBlockDamage } from '../../src/entities/combat-block.js';
+import { calculateDamage } from '../../src/systems/combat-math.js';
+import {
+  DOUBLE_JUMP_AIRBORNE_THRESHOLD,
+  FP_SCALE,
+  fpClamp,
+  fpRectsOverlap,
+  GRAVITY_PER_FRAME_FP,
+  GROUND_Y_FP,
+  HURT_TIMER_KNOCKDOWN,
+  HURT_TIMER_LIGHT,
+  JUMP_VY_FP,
+  KNOCKBACK_VX_FP,
+  KNOCKBACK_VY_FP,
+  MAX_SPECIAL_FP,
+  MAX_STAMINA_FP,
+  SPECIAL_COST_FP,
+  SPECIAL_TINT_MAX_FRAMES,
+  STAGE_LEFT_FP,
+  STAGE_RIGHT_FP,
+  STAMINA_REGEN_ATTACKING_PER_FRAME_FP,
+  STAMINA_REGEN_BLOCKING_PER_FRAME_FP,
+  STAMINA_REGEN_IDLE_PER_FRAME_FP,
+  WALL_DETECT_THRESHOLD_FP,
+  WALL_JUMP_X_FP,
+  WALL_JUMP_Y_FP,
+  WALL_SLIDE_SPEED_FP,
+} from '../../src/systems/FixedPoint.js';
+import {
+  captureCombatState,
+  captureFighterState,
+  captureGameState,
+  restoreCombatState,
+  restoreFighterState,
+  restoreGameState,
+} from '../../src/systems/GameState.js';
+import { encodeInput } from '../../src/systems/InputBuffer.js';
+import { simulateFrame } from '../../src/systems/SimulationStep.js';
+
+/**
+ * Create a pure simulation fighter (no Phaser dependency).
+ * Identical to determinism.test.js version.
+ */
+function createSimFighter(xPx, playerIndex, stats = { speed: 3, power: 3, defense: 3 }) {
+  const moves = {
+    lightPunch: {
+      type: 'lightPunch',
+      damage: 8,
+      startup: 3,
+      active: 2,
+      recovery: 5,
+      hitstun: 12,
+      blockstun: 8,
+    },
+    heavyPunch: {
+      type: 'heavyPunch',
+      damage: 14,
+      startup: 5,
+      active: 3,
+      recovery: 8,
+      hitstun: 20,
+      blockstun: 14,
+    },
+    lightKick: {
+      type: 'lightKick',
+      damage: 8,
+      startup: 3,
+      active: 2,
+      recovery: 5,
+      hitstun: 14,
+      blockstun: 9,
+    },
+    heavyKick: {
+      type: 'heavyKick',
+      damage: 14,
+      startup: 5,
+      active: 3,
+      recovery: 8,
+      hitstun: 22,
+      blockstun: 15,
+    },
+    special: {
+      type: 'special',
+      damage: 25,
+      startup: 8,
+      active: 4,
+      recovery: 10,
+      hitstun: 30,
+      blockstun: 20,
+    },
+  };
+
+  return {
+    simX: xPx * FP_SCALE,
+    simY: GROUND_Y_FP,
+    simVX: 0,
+    simVY: 0,
+    hp: MAX_HP,
+    special: 0,
+    stamina: MAX_STAMINA_FP,
+    state: 'idle',
+    attackCooldown: 0,
+    hurtTimer: 0,
+    hitConnected: false,
+    attackFrameElapsed: 0,
+    comboCount: 0,
+    blockTimer: 0,
+    currentAttack: null,
+    isOnGround: true,
+    _airborneTime: 0,
+    hasDoubleJumped: false,
+    facingRight: playerIndex === 0,
+    _isTouchingWall: false,
+    _wallDir: 0,
+    _hasWallJumped: false,
+    _prevAnimState: null,
+    _specialTintTimer: 0,
+    playerIndex,
+    data: { stats, moves },
+    sprite: { x: xPx, y: 220, setFlipX() {}, clearTint() {}, setTint() {} },
+    scene: { _muteEffects: true, game: { audioManager: { play() {} } } },
+    hasAnims: false,
+
+    update() {
+      if (this.attackCooldown > 0) {
+        this.attackCooldown--;
+        this.attackFrameElapsed++;
+      }
+      if (this.attackCooldown <= 0 && this.state === 'attacking') {
+        this.state = 'idle';
+        this.currentAttack = null;
+      }
+      if (this._specialTintTimer > 0) this._specialTintTimer--;
+      if (this.blockTimer > 0) this.blockTimer--;
+      if (this.hurtTimer > 0) {
+        this.hurtTimer--;
+        if (this.hurtTimer <= 0) this.state = 'idle';
+      }
+      let regenRate = STAMINA_REGEN_IDLE_PER_FRAME_FP;
+      if (this.state === 'attacking') regenRate = STAMINA_REGEN_ATTACKING_PER_FRAME_FP;
+      else if (this.state === 'blocking') regenRate = STAMINA_REGEN_BLOCKING_PER_FRAME_FP;
+      this.stamina = Math.min(MAX_STAMINA_FP, this.stamina + regenRate);
+
+      this.simVY += GRAVITY_PER_FRAME_FP;
+      this.simY += Math.trunc(this.simVY / 60);
+      this.simX += Math.trunc(this.simVX / 60);
+
+      const wasAirborne = !this.isOnGround;
+      this.isOnGround = this.simY >= GROUND_Y_FP;
+      if (this.isOnGround && wasAirborne) {
+        this.hasDoubleJumped = false;
+        this._hasWallJumped = false;
+        this._airborneTime = 0;
+      }
+      if (!this.isOnGround) this._airborneTime++;
+
+      this.simX = fpClamp(this.simX, STAGE_LEFT_FP, STAGE_RIGHT_FP);
+
+      this._isTouchingWall = false;
+      this._wallDir = 0;
+      if (!this.isOnGround) {
+        if (this.simX <= STAGE_LEFT_FP + WALL_DETECT_THRESHOLD_FP) {
+          this._isTouchingWall = true;
+          this._wallDir = -1;
+        } else if (this.simX >= STAGE_RIGHT_FP - WALL_DETECT_THRESHOLD_FP) {
+          this._isTouchingWall = true;
+          this._wallDir = 1;
+        }
+        if (this._isTouchingWall && this.simVY > WALL_SLIDE_SPEED_FP) {
+          this.simVY = WALL_SLIDE_SPEED_FP;
+        }
+      }
+      if (this.simY > GROUND_Y_FP) {
+        this.simY = GROUND_Y_FP;
+        this.simVY = 0;
+      }
+    },
+
+    moveLeft(speed) {
+      if (this.state === 'attacking' || this.state === 'hurt' || this.state === 'knockdown') return;
+      if (this.state === 'blocking' && this.blockTimer > 0) return;
+      this.simVX = -speed;
+      this.state = 'walking';
+    },
+    moveRight(speed) {
+      if (this.state === 'attacking' || this.state === 'hurt' || this.state === 'knockdown') return;
+      if (this.state === 'blocking' && this.blockTimer > 0) return;
+      this.simVX = speed;
+      this.state = 'walking';
+    },
+    stop() {
+      if (this.state === 'attacking' || this.state === 'hurt' || this.state === 'knockdown') return;
+      if (this.state === 'blocking' && this.blockTimer > 0) return;
+      this.simVX = 0;
+      if (this.isOnGround) this.state = 'idle';
+    },
+    jump() {
+      if (this.state === 'attacking' || this.state === 'hurt' || this.state === 'knockdown') return;
+      if (this.isOnGround) {
+        this.simVY = JUMP_VY_FP;
+        this.state = 'jumping';
+        this.isOnGround = false;
+      } else if (this._isTouchingWall && !this._hasWallJumped) {
+        this._hasWallJumped = true;
+        this.hasDoubleJumped = false;
+        this.simVY = WALL_JUMP_Y_FP;
+        this.simVX = -this._wallDir * WALL_JUMP_X_FP;
+        this.state = 'jumping';
+      } else if (!this.hasDoubleJumped && this._airborneTime > DOUBLE_JUMP_AIRBORNE_THRESHOLD) {
+        this.hasDoubleJumped = true;
+        this.simVY = -380 * FP_SCALE;
+      }
+    },
+    block() {
+      if (this.state === 'attacking' || this.state === 'hurt' || this.state === 'knockdown') return;
+      if (this.state !== 'blocking') this.blockTimer = 3;
+      this.state = 'blocking';
+      this.simVX = 0;
+    },
+    attack(type) {
+      if (this.attackCooldown > 0 || this.state === 'hurt' || this.state === 'knockdown') {
+        return false;
+      }
+      if (type === 'special' && this.special < SPECIAL_COST_FP) return false;
+      const staCost = (STAMINA_COSTS[type] || 15) * FP_SCALE;
+      if (this.stamina < staCost) return false;
+      this.stamina -= staCost;
+      const moveData = this.data.moves[type];
+      if (!moveData) return false;
+      this.state = 'attacking';
+      this.hitConnected = false;
+      this.attackFrameElapsed = 0;
+      this.currentAttack = { type, ...moveData };
+      this.attackCooldown = moveData.startup + moveData.active + moveData.recovery;
+      if (type === 'special') {
+        this.special -= SPECIAL_COST_FP;
+        this._specialTintTimer = Math.min(this.attackCooldown, SPECIAL_TINT_MAX_FRAMES);
+      }
+      return true;
+    },
+    faceOpponent(opponent) {
+      this.facingRight = this.simX < opponent.simX;
+    },
+    getAttackHitbox() {
+      if (this.state !== 'attacking' || !this.currentAttack) return null;
+      const move = this.currentAttack;
+      if (
+        this.attackFrameElapsed < move.startup ||
+        this.attackFrameElapsed >= move.startup + move.active
+      ) {
+        return null;
+      }
+      const defaultReach = this.currentAttack.type.includes('Kick') ? 55 : 45;
+      const reach = (this.currentAttack.reach || defaultReach) * FP_SCALE;
+      const h = (this.currentAttack.height || 40) * FP_SCALE;
+      const dir = this.facingRight ? 1 : -1;
+      return {
+        x: this.simX + dir * 10 * FP_SCALE,
+        y: this.simY - 50 * FP_SCALE,
+        w: reach * dir,
+        h,
+      };
+    },
+    getHurtbox() {
+      let w = 36,
+        h = 60,
+        offsetY = 60;
+      if (this.state === 'blocking') {
+        h = 40;
+        offsetY = 40;
+      } else if (!this.isOnGround) {
+        w = 28;
+        h = 50;
+        offsetY = 50;
+      } else if (this.state === 'attacking') {
+        w = 40;
+      }
+      return {
+        x: this.simX - Math.trunc(w / 2) * FP_SCALE,
+        y: this.simY - offsetY * FP_SCALE,
+        w: w * FP_SCALE,
+        h: h * FP_SCALE,
+      };
+    },
+    takeDamage(amount, attackerSimX, stunFrames) {
+      if (this.state === 'blocking') amount = calculateBlockDamage(amount);
+      this.hp = Math.max(0, this.hp - amount);
+      this.special = Math.min(MAX_SPECIAL_FP, this.special + amount * 800);
+      const knockDir = this.simX > attackerSimX ? 1 : -1;
+      this.simVX = knockDir * KNOCKBACK_VX_FP;
+      if (stunFrames != null) {
+        if (amount >= 15) {
+          this.state = 'knockdown';
+          this.hurtTimer = stunFrames;
+          this.simVY = KNOCKBACK_VY_FP;
+        } else {
+          this.state = 'hurt';
+          this.hurtTimer = stunFrames;
+        }
+      } else if (amount >= 15) {
+        this.state = 'knockdown';
+        this.hurtTimer = HURT_TIMER_KNOCKDOWN;
+        this.simVY = KNOCKBACK_VY_FP;
+      } else {
+        this.state = 'hurt';
+        this.hurtTimer = HURT_TIMER_LIGHT;
+      }
+      return this.hp <= 0;
+    },
+    syncSprite() {
+      this.sprite.x = this.simX / FP_SCALE;
+      this.sprite.y = this.simY / FP_SCALE;
+    },
+  };
+}
+
+/**
+ * Create a sim combat system that mirrors CombatSystem behavior
+ * but with suppressRoundEvents=true (online mode).
+ */
+function createSimCombat({ suppressRoundEvents = true } = {}) {
+  return {
+    roundActive: true,
+    suppressRoundEvents,
+    timer: 60,
+    _timerAccumulator: 0,
+    matchOver: false,
+    roundNumber: 1,
+    p1RoundsWon: 0,
+    p2RoundsWon: 0,
+    _lastEndReason: null,
+    resolveBodyCollision(f1, f2) {
+      const halfW = 18 * FP_SCALE;
+      const airThreshold = GROUND_Y_FP - 20 * FP_SCALE;
+      if (f1.simY < airThreshold || f2.simY < airThreshold) return;
+      const overlap = halfW + halfW - Math.abs(f1.simX - f2.simX);
+      if (overlap <= 0) return;
+      const pushEach = Math.trunc(overlap / 2);
+      const sign = f1.simX < f2.simX ? -1 : 1;
+      f1.simX += sign * pushEach;
+      f2.simX -= sign * pushEach;
+      f1.simX = fpClamp(f1.simX, STAGE_LEFT_FP, STAGE_RIGHT_FP);
+      f2.simX = fpClamp(f2.simX, STAGE_LEFT_FP, STAGE_RIGHT_FP);
+    },
+    checkHit(attacker, defender, { muteEffects = false } = {}) {
+      if (!attacker.currentAttack || attacker.state !== 'attacking') return false;
+      if (attacker.hitConnected) return false;
+      const hitbox = attacker.getAttackHitbox();
+      const hurtbox = defender.getHurtbox();
+      if (!hitbox || !hurtbox) return false;
+      const hx = hitbox.w < 0 ? hitbox.x + hitbox.w : hitbox.x;
+      const hw = Math.abs(hitbox.w);
+      if (fpRectsOverlap(hx, hitbox.y, hw, hitbox.h, hurtbox.x, hurtbox.y, hurtbox.w, hurtbox.h)) {
+        const move = attacker.currentAttack;
+        const damage = calculateDamage(
+          move.damage,
+          attacker.data.stats.power,
+          defender.data.stats.defense,
+        );
+        attacker.special = Math.min(MAX_SPECIAL_FP, attacker.special + damage * 200);
+        const stunFrames =
+          defender.state === 'blocking' ? move.blockstun || undefined : move.hitstun || undefined;
+        const ko = defender.takeDamage(damage, attacker.simX, stunFrames);
+        attacker.hitConnected = true;
+        return { hit: true, ko };
+      }
+      return false;
+    },
+    tickTimer({ muteEffects = false } = {}) {
+      this._timerAccumulator++;
+      if (this._timerAccumulator >= 60) {
+        this._timerAccumulator = 0;
+        this.timer--;
+        if (this.timer <= 0) {
+          return { timeup: true };
+        }
+      }
+      return null;
+    },
+    stopRound() {
+      this.roundActive = false;
+    },
+  };
+}
+
+const EMPTY = encodeInput({
+  left: false,
+  right: false,
+  up: false,
+  down: false,
+  lp: false,
+  hp: false,
+  lk: false,
+  hk: false,
+  sp: false,
+});
+
+describe('rollback-safe round events', () => {
+  describe('tickTimer returns timeup instead of firing side effects', () => {
+    it('tickTimer returns { timeup: true } when timer reaches 0', () => {
+      const combat = createSimCombat();
+      combat.timer = 1;
+      combat._timerAccumulator = 59;
+
+      const result = combat.tickTimer();
+      expect(result).toEqual({ timeup: true });
+      expect(combat.timer).toBe(0);
+    });
+
+    it('tickTimer returns null when timer has not reached 0', () => {
+      const combat = createSimCombat();
+      combat.timer = 10;
+      combat._timerAccumulator = 0;
+
+      const result = combat.tickTimer();
+      expect(result).toBeNull();
+    });
+
+    it('tickTimer with muteEffects still ticks the timer (deterministic)', () => {
+      const combat = createSimCombat();
+      combat.timer = 1;
+      combat._timerAccumulator = 59;
+
+      const result = combat.tickTimer({ muteEffects: true });
+      expect(result).toEqual({ timeup: true });
+      expect(combat.timer).toBe(0);
+    });
+  });
+
+  describe('checkHit returns KO info instead of calling handleKO', () => {
+    it('checkHit returns { hit: true, ko: true } when hit causes KO', () => {
+      const p1 = createSimFighter(100, 0);
+      const p2 = createSimFighter(130, 1);
+      const combat = createSimCombat();
+
+      // Set up P1 mid-attack in active frames, P2 at 1 HP
+      p1.state = 'attacking';
+      p1.currentAttack = { type: 'heavyPunch', damage: 14, startup: 3, active: 3, recovery: 8, hitstun: 20, blockstun: 14 };
+      p1.attackFrameElapsed = 4; // in active frames (startup=3, active=3 → 3,4,5 are active)
+      p1.attackCooldown = 10;
+      p1.hitConnected = false;
+      p1.facingRight = true;
+
+      p2.hp = 1; // Will be KO'd by any hit
+
+      const result = combat.checkHit(p1, p2);
+      expect(result).toEqual({ hit: true, ko: true });
+      expect(p2.hp).toBe(0);
+    });
+
+    it('checkHit returns { hit: true, ko: false } when hit does not KO', () => {
+      const p1 = createSimFighter(100, 0);
+      const p2 = createSimFighter(130, 1);
+      const combat = createSimCombat();
+
+      p1.state = 'attacking';
+      p1.currentAttack = { type: 'lightPunch', damage: 8, startup: 3, active: 2, recovery: 5, hitstun: 12, blockstun: 8 };
+      p1.attackFrameElapsed = 3; // in active frames
+      p1.attackCooldown = 7;
+      p1.hitConnected = false;
+      p1.facingRight = true;
+
+      p2.hp = MAX_HP; // Will survive
+
+      const result = combat.checkHit(p1, p2);
+      expect(result).toEqual({ hit: true, ko: false });
+      expect(p2.hp).toBeGreaterThan(0);
+    });
+
+    it('checkHit returns false on miss', () => {
+      const p1 = createSimFighter(100, 0);
+      const p2 = createSimFighter(400, 1); // Far apart — no hit
+      const combat = createSimCombat();
+
+      p1.state = 'attacking';
+      p1.currentAttack = { type: 'lightPunch', damage: 8, startup: 3, active: 2, recovery: 5, hitstun: 12, blockstun: 8 };
+      p1.attackFrameElapsed = 3;
+      p1.attackCooldown = 7;
+      p1.hitConnected = false;
+      p1.facingRight = true;
+
+      const result = combat.checkHit(p1, p2);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('simulateFrame returns round event descriptors', () => {
+    it('returns null when no round event occurs', () => {
+      const p1 = createSimFighter(144, 0);
+      const p2 = createSimFighter(336, 1);
+      const combat = createSimCombat();
+
+      const result = simulateFrame(p1, p2, combat, EMPTY, EMPTY);
+      expect(result).toBeNull();
+    });
+
+    it('returns KO event when a fighter is knocked out', () => {
+      const p1 = createSimFighter(100, 0);
+      const p2 = createSimFighter(130, 1);
+      const combat = createSimCombat();
+
+      // Set P2 to 1 HP and P1 mid-attack at startup frame
+      // We need to advance enough frames for the attack to reach active frames
+      p2.hp = 1;
+
+      // Start P1 attacking
+      const attackInput = encodeInput({
+        left: false, right: false, up: false, down: false,
+        lp: false, hp: true, lk: false, hk: false, sp: false,
+      });
+
+      // Run through startup frames until active frames connect
+      let roundEvent = null;
+      for (let f = 0; f < 20 && !roundEvent; f++) {
+        const input = f === 0 ? attackInput : EMPTY;
+        roundEvent = simulateFrame(p1, p2, combat, input, EMPTY);
+      }
+
+      expect(roundEvent).toEqual({ type: 'ko', winnerIndex: 0 });
+    });
+
+    it('returns timeup event when timer reaches 0', () => {
+      const p1 = createSimFighter(144, 0);
+      const p2 = createSimFighter(336, 1);
+      const combat = createSimCombat();
+
+      // Set timer to expire in 1 tick
+      combat.timer = 1;
+      combat._timerAccumulator = 59;
+
+      // Give P1 more HP so P1 wins on timeup
+      p1.hp = 80;
+      p2.hp = 50;
+
+      const result = simulateFrame(p1, p2, combat, EMPTY, EMPTY);
+      expect(result).toEqual({ type: 'timeup', winnerIndex: 0 });
+    });
+
+    it('returns timeup with P2 winner when P2 has more HP', () => {
+      const p1 = createSimFighter(144, 0);
+      const p2 = createSimFighter(336, 1);
+      const combat = createSimCombat();
+
+      combat.timer = 1;
+      combat._timerAccumulator = 59;
+
+      p1.hp = 30;
+      p2.hp = 70;
+
+      const result = simulateFrame(p1, p2, combat, EMPTY, EMPTY);
+      expect(result).toEqual({ type: 'timeup', winnerIndex: 1 });
+    });
+
+    it('KO takes priority over timeup when both happen on same frame', () => {
+      const p1 = createSimFighter(100, 0);
+      const p2 = createSimFighter(130, 1);
+      const combat = createSimCombat();
+
+      // Set up so both KO and timeup could happen
+      combat.timer = 1;
+      combat._timerAccumulator = 59;
+      p2.hp = 1;
+
+      // P1 attacks (heavy punch)
+      p1.state = 'attacking';
+      p1.currentAttack = { type: 'heavyPunch', damage: 14, startup: 3, active: 3, recovery: 8, hitstun: 20, blockstun: 14 };
+      p1.attackFrameElapsed = 3; // just before active frame after update()
+      p1.attackCooldown = 10;
+      p1.hitConnected = false;
+      p1.facingRight = true;
+
+      const result = simulateFrame(p1, p2, combat, EMPTY, EMPTY);
+      // KO should take priority
+      if (result) {
+        expect(result.type).toBe('ko');
+        expect(result.winnerIndex).toBe(0);
+      }
+    });
+  });
+
+  describe('timer reaching 0 during rollback does not corrupt state', () => {
+    it('round event is discarded during rollback re-simulation', () => {
+      const p1 = createSimFighter(144, 0);
+      const p2 = createSimFighter(336, 1);
+      const combat = createSimCombat();
+
+      // Set timer to 2 seconds (120 frames)
+      combat.timer = 2;
+      combat._timerAccumulator = 0;
+
+      // Run 59 frames (timer still at 2)
+      for (let f = 0; f < 59; f++) {
+        simulateFrame(p1, p2, combat, EMPTY, EMPTY, { muteEffects: true });
+      }
+      expect(combat.timer).toBe(2);
+
+      // Frame 60: timer decrements to 1
+      simulateFrame(p1, p2, combat, EMPTY, EMPTY, { muteEffects: true });
+      expect(combat.timer).toBe(1);
+
+      // Snapshot state at this point
+      const snapshot = captureGameState(60, p1, p2, combat);
+
+      // Run 59 more frames
+      for (let f = 0; f < 59; f++) {
+        simulateFrame(p1, p2, combat, EMPTY, EMPTY, { muteEffects: true });
+      }
+      expect(combat.timer).toBe(1);
+
+      // Frame 120: timer decrements to 0 → timeup detected
+      const event = simulateFrame(p1, p2, combat, EMPTY, EMPTY, { muteEffects: true });
+
+      // Event is returned even with muteEffects (caller decides what to do)
+      expect(event).toEqual({ type: 'timeup', winnerIndex: expect.any(Number) });
+
+      // Critically: roundActive should still be true (not corrupted by timeUp side effects)
+      // because suppressRoundEvents=true prevents timeUp() from being called
+      expect(combat.roundActive).toBe(true);
+
+      // Restore snapshot and verify state is clean
+      restoreGameState(snapshot, p1, p2, combat);
+      expect(combat.timer).toBe(1);
+      expect(combat.roundActive).toBe(true);
+    });
+  });
+
+  describe('KO on predicted input is rolled back correctly', () => {
+    it('KO from predicted attack is undone after rollback', () => {
+      const p1 = createSimFighter(100, 0);
+      const p2 = createSimFighter(130, 1);
+      const combat = createSimCombat();
+
+      // Set P2 to low HP
+      p2.hp = 1;
+
+      // Run some idle frames to establish state
+      for (let f = 0; f < 10; f++) {
+        simulateFrame(p1, p2, combat, EMPTY, EMPTY);
+      }
+
+      // Snapshot before the predicted attack
+      const snapshot = captureGameState(10, p1, p2, combat);
+      const snapshotP2Hp = p2.hp;
+
+      // Simulate with a predicted attack (P1 heavy punch)
+      const attackInput = encodeInput({
+        left: false, right: false, up: false, down: false,
+        lp: false, hp: true, lk: false, hk: false, sp: false,
+      });
+
+      // Run through attack frames — might KO
+      let koDetected = false;
+      for (let f = 0; f < 15; f++) {
+        const input = f === 0 ? attackInput : EMPTY;
+        const event = simulateFrame(p1, p2, combat, input, EMPTY, { muteEffects: true });
+        if (event?.type === 'ko') koDetected = true;
+      }
+
+      // KO should have been detected in the simulation
+      expect(koDetected).toBe(true);
+      expect(p2.hp).toBe(0);
+
+      // But roundActive is still true because we're in rollback (suppressRoundEvents=true)
+      expect(combat.roundActive).toBe(true);
+
+      // Now rollback: restore snapshot
+      restoreGameState(snapshot, p1, p2, combat);
+
+      // Confirmed input shows P1 was NOT attacking (misprediction)
+      // Re-simulate with the correct input (idle)
+      for (let f = 0; f < 15; f++) {
+        simulateFrame(p1, p2, combat, EMPTY, EMPTY);
+      }
+
+      // P2 should still be alive — the KO was on a mispredicted input
+      expect(p2.hp).toBe(snapshotP2Hp);
+      expect(combat.roundActive).toBe(true);
+    });
+  });
+
+  describe('P1 and P2 agree on round events', () => {
+    it('both peers produce identical round event from identical simulation', () => {
+      // Simulate the same inputs on two independent instances (P1 and P2 views)
+      const p1a = createSimFighter(100, 0);
+      const p2a = createSimFighter(130, 1);
+      const combatA = createSimCombat();
+
+      const p1b = createSimFighter(100, 0);
+      const p2b = createSimFighter(130, 1);
+      const combatB = createSimCombat();
+
+      // Set both P2 fighters to low HP
+      p2a.hp = 1;
+      p2b.hp = 1;
+
+      const attackInput = encodeInput({
+        left: false, right: false, up: false, down: false,
+        lp: false, hp: true, lk: false, hk: false, sp: false,
+      });
+
+      const eventsA = [];
+      const eventsB = [];
+
+      for (let f = 0; f < 20; f++) {
+        const input = f === 0 ? attackInput : EMPTY;
+        const eventA = simulateFrame(p1a, p2a, combatA, input, EMPTY);
+        const eventB = simulateFrame(p1b, p2b, combatB, input, EMPTY);
+        if (eventA) eventsA.push({ frame: f, ...eventA });
+        if (eventB) eventsB.push({ frame: f, ...eventB });
+      }
+
+      // Both sides detect the same round event at the same frame
+      expect(eventsA).toEqual(eventsB);
+      expect(eventsA.length).toBeGreaterThan(0);
+      expect(eventsA[0].type).toBe('ko');
+      expect(eventsA[0].winnerIndex).toBe(0);
+    });
+
+    it('timeup event agrees on winner based on HP', () => {
+      const p1a = createSimFighter(144, 0);
+      const p2a = createSimFighter(336, 1);
+      const combatA = createSimCombat();
+      combatA.timer = 1;
+      combatA._timerAccumulator = 59;
+
+      const p1b = createSimFighter(144, 0);
+      const p2b = createSimFighter(336, 1);
+      const combatB = createSimCombat();
+      combatB.timer = 1;
+      combatB._timerAccumulator = 59;
+
+      // Different HP values
+      p1a.hp = 40;
+      p2a.hp = 60;
+      p1b.hp = 40;
+      p2b.hp = 60;
+
+      const eventA = simulateFrame(p1a, p2a, combatA, EMPTY, EMPTY);
+      const eventB = simulateFrame(p1b, p2b, combatB, EMPTY, EMPTY);
+
+      expect(eventA).toEqual({ type: 'timeup', winnerIndex: 1 });
+      expect(eventB).toEqual({ type: 'timeup', winnerIndex: 1 });
+    });
+  });
+
+  describe('round event not returned when roundActive is false', () => {
+    it('simulateFrame returns null when round is not active', () => {
+      const p1 = createSimFighter(100, 0);
+      const p2 = createSimFighter(130, 1);
+      const combat = createSimCombat();
+      combat.roundActive = false;
+
+      p2.hp = 1;
+
+      const attackInput = encodeInput({
+        left: false, right: false, up: false, down: false,
+        lp: false, hp: true, lk: false, hk: false, sp: false,
+      });
+
+      // Even with an attack that would KO, no event when round is inactive
+      for (let f = 0; f < 20; f++) {
+        const input = f === 0 ? attackInput : EMPTY;
+        const result = simulateFrame(p1, p2, combat, input, EMPTY);
+        expect(result).toBeNull();
+      }
+    });
+  });
+
+  describe('snapshot/restore preserves round event determinism', () => {
+    it('restore + re-simulate produces same round event as straight-through', () => {
+      const p1ref = createSimFighter(100, 0);
+      const p2ref = createSimFighter(130, 1);
+      const combatRef = createSimCombat();
+      p2ref.hp = 30;
+
+      // Reference: straight-through with attack at frame 20
+      const attackInput = encodeInput({
+        left: false, right: false, up: false, down: false,
+        lp: false, hp: true, lk: false, hk: false, sp: false,
+      });
+
+      let refEvent = null;
+      let refEventFrame = -1;
+      for (let f = 0; f < 60; f++) {
+        const input = f === 20 ? attackInput : EMPTY;
+        const event = simulateFrame(p1ref, p2ref, combatRef, input, EMPTY);
+        if (event && !refEvent) {
+          refEvent = event;
+          refEventFrame = f;
+        }
+      }
+
+      // Rollback path: run to frame 15, snapshot, continue with wrong inputs, rollback, re-simulate
+      const p1 = createSimFighter(100, 0);
+      const p2 = createSimFighter(130, 1);
+      const combat = createSimCombat();
+      p2.hp = 30;
+
+      for (let f = 0; f < 15; f++) {
+        simulateFrame(p1, p2, combat, EMPTY, EMPTY);
+      }
+      const snapshot = captureGameState(15, p1, p2, combat);
+
+      // Wrong inputs: attack at frame 15 instead of 20
+      for (let f = 15; f < 30; f++) {
+        const input = f === 15 ? attackInput : EMPTY;
+        simulateFrame(p1, p2, combat, input, EMPTY, { muteEffects: true });
+      }
+
+      // Rollback to frame 15
+      restoreGameState(snapshot, p1, p2, combat);
+
+      // Re-simulate with correct inputs (attack at frame 20)
+      let rollbackEvent = null;
+      let rollbackEventFrame = -1;
+      for (let f = 15; f < 60; f++) {
+        const input = f === 20 ? attackInput : EMPTY;
+        const event = simulateFrame(p1, p2, combat, input, EMPTY);
+        if (event && !rollbackEvent) {
+          rollbackEvent = event;
+          rollbackEventFrame = f;
+        }
+      }
+
+      // Same event at same frame
+      expect(rollbackEvent).toEqual(refEvent);
+      expect(rollbackEventFrame).toBe(refEventFrame);
+    });
+  });
+});

--- a/tests/systems/rollback-round-events.test.js
+++ b/tests/systems/rollback-round-events.test.js
@@ -437,7 +437,15 @@ describe('rollback-safe round events', () => {
 
       // Set up P1 mid-attack in active frames, P2 at 1 HP
       p1.state = 'attacking';
-      p1.currentAttack = { type: 'heavyPunch', damage: 14, startup: 3, active: 3, recovery: 8, hitstun: 20, blockstun: 14 };
+      p1.currentAttack = {
+        type: 'heavyPunch',
+        damage: 14,
+        startup: 3,
+        active: 3,
+        recovery: 8,
+        hitstun: 20,
+        blockstun: 14,
+      };
       p1.attackFrameElapsed = 4; // in active frames (startup=3, active=3 → 3,4,5 are active)
       p1.attackCooldown = 10;
       p1.hitConnected = false;
@@ -456,7 +464,15 @@ describe('rollback-safe round events', () => {
       const combat = createSimCombat();
 
       p1.state = 'attacking';
-      p1.currentAttack = { type: 'lightPunch', damage: 8, startup: 3, active: 2, recovery: 5, hitstun: 12, blockstun: 8 };
+      p1.currentAttack = {
+        type: 'lightPunch',
+        damage: 8,
+        startup: 3,
+        active: 2,
+        recovery: 5,
+        hitstun: 12,
+        blockstun: 8,
+      };
       p1.attackFrameElapsed = 3; // in active frames
       p1.attackCooldown = 7;
       p1.hitConnected = false;
@@ -475,7 +491,15 @@ describe('rollback-safe round events', () => {
       const combat = createSimCombat();
 
       p1.state = 'attacking';
-      p1.currentAttack = { type: 'lightPunch', damage: 8, startup: 3, active: 2, recovery: 5, hitstun: 12, blockstun: 8 };
+      p1.currentAttack = {
+        type: 'lightPunch',
+        damage: 8,
+        startup: 3,
+        active: 2,
+        recovery: 5,
+        hitstun: 12,
+        blockstun: 8,
+      };
       p1.attackFrameElapsed = 3;
       p1.attackCooldown = 7;
       p1.hitConnected = false;
@@ -507,8 +531,15 @@ describe('rollback-safe round events', () => {
 
       // Start P1 attacking
       const attackInput = encodeInput({
-        left: false, right: false, up: false, down: false,
-        lp: false, hp: true, lk: false, hk: false, sp: false,
+        left: false,
+        right: false,
+        up: false,
+        down: false,
+        lp: false,
+        hp: true,
+        lk: false,
+        hk: false,
+        sp: false,
       });
 
       // Run through startup frames until active frames connect
@@ -565,7 +596,15 @@ describe('rollback-safe round events', () => {
 
       // P1 attacks (heavy punch)
       p1.state = 'attacking';
-      p1.currentAttack = { type: 'heavyPunch', damage: 14, startup: 3, active: 3, recovery: 8, hitstun: 20, blockstun: 14 };
+      p1.currentAttack = {
+        type: 'heavyPunch',
+        damage: 14,
+        startup: 3,
+        active: 3,
+        recovery: 8,
+        hitstun: 20,
+        blockstun: 14,
+      };
       p1.attackFrameElapsed = 3; // just before active frame after update()
       p1.attackCooldown = 10;
       p1.hitConnected = false;
@@ -646,8 +685,15 @@ describe('rollback-safe round events', () => {
 
       // Simulate with a predicted attack (P1 heavy punch)
       const attackInput = encodeInput({
-        left: false, right: false, up: false, down: false,
-        lp: false, hp: true, lk: false, hk: false, sp: false,
+        left: false,
+        right: false,
+        up: false,
+        down: false,
+        lp: false,
+        hp: true,
+        lk: false,
+        hk: false,
+        sp: false,
       });
 
       // Run through attack frames — might KO
@@ -696,8 +742,15 @@ describe('rollback-safe round events', () => {
       p2b.hp = 1;
 
       const attackInput = encodeInput({
-        left: false, right: false, up: false, down: false,
-        lp: false, hp: true, lk: false, hk: false, sp: false,
+        left: false,
+        right: false,
+        up: false,
+        down: false,
+        lp: false,
+        hp: true,
+        lk: false,
+        hk: false,
+        sp: false,
       });
 
       const eventsA = [];
@@ -755,8 +808,15 @@ describe('rollback-safe round events', () => {
       p2.hp = 1;
 
       const attackInput = encodeInput({
-        left: false, right: false, up: false, down: false,
-        lp: false, hp: true, lk: false, hk: false, sp: false,
+        left: false,
+        right: false,
+        up: false,
+        down: false,
+        lp: false,
+        hp: true,
+        lk: false,
+        hk: false,
+        sp: false,
       });
 
       // Even with an attack that would KO, no event when round is inactive
@@ -777,8 +837,15 @@ describe('rollback-safe round events', () => {
 
       // Reference: straight-through with attack at frame 20
       const attackInput = encodeInput({
-        left: false, right: false, up: false, down: false,
-        lp: false, hp: true, lk: false, hk: false, sp: false,
+        left: false,
+        right: false,
+        up: false,
+        down: false,
+        lp: false,
+        hp: true,
+        lk: false,
+        hk: false,
+        sp: false,
       });
 
       let refEvent = null;


### PR DESCRIPTION
## Summary

- **Fix multiplayer desync**: Round-ending events (KO/timeup) were firing during rollback re-simulation and on predicted inputs, corrupting game state and causing peers to diverge (timers 3-4s apart, different round winners on each phone)
- **Deferred round events**: `simulateFrame()` now returns round event descriptors instead of firing side effects directly. `RollbackManager.advance()` captures events from the current frame and discards them during re-simulation
- **P1 authority**: Both peers suppress direct round event firing in online mode. P1 handles deferred events from `advance()` return value and sends to P2 via existing network path. Local mode is unchanged

### Files changed
| File | Change |
|------|--------|
| `src/systems/CombatSystem.js` | `tickTimer({ muteEffects })` returns timeup info, `checkHit()` returns `{ hit, ko }`, new `handleRoundEnd()` |
| `src/systems/SimulationStep.js` | `simulateFrame()` returns `{ type, winnerIndex }` round event descriptor |
| `src/systems/RollbackManager.js` | `advance()` captures + returns `{ roundEvent }`, discards during re-sim |
| `src/scenes/FightScene.js` | `suppressRoundEvents=true` for both players, P1 handles deferred events |
| `tests/systems/rollback-round-events.test.js` | 13 regression tests for all 3 root cause bugs |
| `docs/rfcs/0001-networking-redesign.md` | RFC for the full networking redesign (Phase 1 implemented here) |

## Test plan

- [x] All 371 existing tests pass (no regressions)
- [x] Timer reaching 0 during rollback re-simulation does not corrupt roundActive
- [x] KO on predicted input is correctly rolled back when misprediction is detected
- [x] Both peers produce identical round events from identical simulation
- [x] Snapshot/restore preserves round event determinism
- [x] simulateFrame returns null when roundActive is false
- [ ] Manual test: two phones over cellular - verify timer sync and round results agree

Generated with Claude Code