### PR TITLE
Fix E2E desync: deterministic frame-based round transitions

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,7 @@ export const GRAVITY = 800;
 // Combat
 export const ROUND_TIME = 60; // seconds
 export const ROUNDS_TO_WIN = 2;
+export const ROUND_TRANSITION_FRAMES = 300; // ~5s at 60fps — pause between rounds in online mode
 export const MAX_HP = 100;
 export const MAX_SPECIAL = 100;
 export const SPECIAL_COST = 50;

--- a/src/entities/Fighter.js
+++ b/src/entities/Fighter.js
@@ -459,6 +459,36 @@ export class Fighter {
     }
   }
 
+  /**
+   * Reset fighter state for a new round (simulation-safe, no sprite/animation calls).
+   * Used by deterministic frame-based round transitions in online mode.
+   */
+  resetForRound(x) {
+    this.simX = Math.trunc(x * FP_SCALE);
+    this.simY = GROUND_Y_FP;
+    this.simVX = 0;
+    this.simVY = 0;
+    this.hp = MAX_HP;
+    this.special = 0;
+    this.state = 'idle';
+    this.attackCooldown = 0;
+    this.attackFrameElapsed = 0;
+    this.comboCount = 0;
+    this.blockTimer = 0;
+    this.hurtTimer = 0;
+    this.currentAttack = null;
+    this.hitConnected = false;
+    this.hasDoubleJumped = false;
+    this._airborneTime = 0;
+    this.stamina = MAX_STAMINA_FP;
+    this._isTouchingWall = false;
+    this._wallDir = 0;
+    this._hasWallJumped = false;
+    this._specialTintTimer = 0;
+    this._prevAnimState = null;
+    this.facingRight = this.playerIndex === 0;
+  }
+
   get alive() {
     return this.hp > 0;
   }

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -249,6 +249,10 @@ export class FightScene extends Phaser.Scene {
       // Replay mode: don't bail out — the fixed-timestep loop handles round transitions
       if (this._replayP1 && this._replayP2) {
         // fall through to the fixed-timestep loop below
+      } else if (this.gameMode === 'online') {
+        // Online mode: keep simulation running during round transitions so both
+        // peers stay in lockstep. The frame-based transitionTimer in simulateFrame
+        // handles deterministic round reset.
       } else {
         // Allow restart after match over (Space key or tap)
         if (
@@ -864,15 +868,11 @@ export class FightScene extends Phaser.Scene {
       if (msg.matchOver && this._matchOverProcessed) return;
       if (!msg.matchOver && msg.roundNumber <= this._lastProcessedRound) return;
 
-      this.combat.stopRound();
-      this.combat.p1RoundsWon = msg.p1Rounds;
-      this.combat.p2RoundsWon = msg.p2Rounds;
-      this.combat.roundNumber = msg.roundNumber;
-
+      // Don't modify combat state here — simulateFrame handles it deterministically.
+      // Only fire visual/audio effects via onRoundOver/onMatchOver.
       if (msg.event === 'ko' || msg.event === 'timeup') {
         if (msg.matchOver) {
           this._matchOverProcessed = true;
-          this.combat.matchOver = true;
           this.onMatchOver(msg.winnerIndex);
         } else {
           this._lastProcessedRound = msg.roundNumber;
@@ -1101,6 +1101,7 @@ export class FightScene extends Phaser.Scene {
 
   _handleOnlineUpdate(time, delta) {
     this.frameCounter++;
+    const wasRoundActive = this.combat.roundActive;
 
     // Read local input: from AI in autoplay mode, from InputManager otherwise
     let localInput;
@@ -1153,6 +1154,28 @@ export class FightScene extends Phaser.Scene {
     if (roundEvent && this.isHost) {
       this.recorder?.recordRoundEvent(this.rollbackManager.currentFrame, roundEvent);
       this.combat.handleRoundEnd(roundEvent);
+    }
+
+    // Detect simulation-driven round reset (transitionTimer expired → roundActive became true)
+    if (!wasRoundActive && this.combat.roundActive) {
+      // Sync sprites to new positions after reset
+      this.p1Fighter.syncSprite();
+      this.p2Fighter.syncSprite();
+      if (this.p1Fighter.hasAnims) this.p1Fighter.sprite.play(`${this.p1Fighter.fighterId}_idle`);
+      if (this.p2Fighter.hasAnims) this.p2Fighter.sprite.play(`${this.p2Fighter.fighterId}_idle`);
+      this._updateHUD();
+      // Show round intro text (visual only)
+      this.centerText.setText(`ROUND ${this.combat.roundNumber - 1}`);
+      this.subtitleText.setText('');
+      this.game.audioManager.play('announce_round');
+      this.time.delayedCall(800, () => {
+        this.centerText.setText('A PELEAR!');
+        this.game.audioManager.play('announce_fight');
+        this.time.delayedCall(500, () => {
+          this.centerText.setText('');
+          this.subtitleText.setText('');
+        });
+      });
     }
 
     // P1 sends periodic state snapshots for spectators
@@ -1710,7 +1733,20 @@ export class FightScene extends Phaser.Scene {
       ease: 'Back.easeOut',
     });
 
-    // Stop AI movement
+    if (this.gameMode === 'online') {
+      // Online mode: simulation handles round reset via deterministic transitionTimer.
+      // Only show visual feedback here — don't modify fighter/combat state.
+      this.time.delayedCall(1500, () => {
+        this.centerText.setText(`${winnerName} GANA EL ROUND!`);
+        this.centerText.setScale(1).setAlpha(1);
+        this.subtitleText.setText(
+          `RONDAS: ${this.combat.p1RoundsWon} - ${this.combat.p2RoundsWon}`,
+        );
+      });
+      return;
+    }
+
+    // Local mode: manage round transition via Phaser timers
     this.p1Fighter.stop();
     this.p2Fighter.stop();
 
@@ -1754,8 +1790,11 @@ export class FightScene extends Phaser.Scene {
       this.aiController = null;
     }
 
-    this.p1Fighter.stop();
-    this.p2Fighter.stop();
+    // In online mode, don't modify simulation state — simulateFrame handles it
+    if (this.gameMode !== 'online') {
+      this.p1Fighter.stop();
+      this.p2Fighter.stop();
+    }
 
     this.centerText.setText('K.O.!');
     this.subtitleText.setText('');

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -200,6 +200,11 @@ export class FightScene extends Phaser.Scene {
       console.log(
         `[REPLAY] Starting replay: ${this.p1Data.id} vs ${this.p2Data.id}, totalFrames P1=${this._replayP1.totalFrames} P2=${this._replayP2.totalFrames}`,
       );
+    } else if (this.gameMode === 'online') {
+      // Online mode: start round immediately for determinism.
+      // The simulation must not depend on wall-clock Phaser timers.
+      this.combat.startRound();
+      this._showRoundIntroVisual();
     } else {
       this._showRoundIntro();
     }
@@ -1670,6 +1675,39 @@ export class FightScene extends Phaser.Scene {
   // =========================================================================
   // ROUND FLOW
   // =========================================================================
+  /** Visual-only round intro for online mode — doesn't touch roundActive or startRound. */
+  _showRoundIntroVisual() {
+    this.centerText.setText(`ROUND ${this.combat.roundNumber}`);
+    this.subtitleText.setText('');
+    this.game.audioManager.play('announce_round');
+    this.centerText.setScale(2.5).setAlpha(0);
+    this.tweens.add({
+      targets: this.centerText,
+      scaleX: 1,
+      scaleY: 1,
+      alpha: 1,
+      duration: 400,
+      ease: 'Back.easeOut',
+    });
+    this.time.delayedCall(1500, () => {
+      this.centerText.setText('A PELEAR!');
+      this.game.audioManager.play('announce_fight');
+      this.centerText.setScale(2).setAlpha(0);
+      this.tweens.add({
+        targets: this.centerText,
+        scaleX: 1,
+        scaleY: 1,
+        alpha: 1,
+        duration: 300,
+        ease: 'Back.easeOut',
+      });
+      this.time.delayedCall(800, () => {
+        this.centerText.setText('');
+        this.subtitleText.setText('');
+      });
+    });
+  }
+
   _showRoundIntro() {
     this.combat.roundActive = false;
 

--- a/src/systems/CombatSystem.js
+++ b/src/systems/CombatSystem.js
@@ -25,6 +25,7 @@ export class CombatSystem {
     this.timerEvent = null;
     this._timerAccumulator = 0;
     this.suppressRoundEvents = false;
+    this.transitionTimer = 0; // frame-based countdown between rounds (online mode)
   }
 
   startRound() {
@@ -308,6 +309,7 @@ export class CombatSystem {
     this.roundActive = false;
     this.matchOver = false;
     this._timerAccumulator = 0;
+    this.transitionTimer = 0;
     this.suppressRoundEvents = false;
     if (this.timerEvent) {
       this.timerEvent.remove();

--- a/src/systems/GameState.js
+++ b/src/systems/GameState.js
@@ -86,6 +86,7 @@ export function captureCombatState(combat) {
     roundActive: combat.roundActive,
     matchOver: combat.matchOver,
     _timerAccumulator: combat._timerAccumulator || 0,
+    transitionTimer: combat.transitionTimer || 0,
   };
 }
 
@@ -102,6 +103,7 @@ export function restoreCombatState(combat, state) {
   combat.roundActive = state.roundActive;
   combat.matchOver = state.matchOver;
   combat._timerAccumulator = state._timerAccumulator || 0;
+  combat.transitionTimer = state.transitionTimer || 0;
 }
 
 /**
@@ -150,6 +152,10 @@ export function hashGameState(snapshot) {
     snapshot.p2.hurtTimer,
     snapshot.combat.timer,
     snapshot.combat.roundNumber,
+    snapshot.combat.transitionTimer || 0,
+    snapshot.combat.roundActive ? 1 : 0,
+    snapshot.combat.p1RoundsWon,
+    snapshot.combat.p2RoundsWon,
   ];
   for (const v of vals) {
     h = ((h << 5) | (h >>> 27)) ^ (v | 0);

--- a/src/systems/SimulationStep.js
+++ b/src/systems/SimulationStep.js
@@ -4,9 +4,12 @@
  * Frame-based — no delta time needed.
  */
 
-import { ROUNDS_TO_WIN } from '../config.js';
+import { GAME_WIDTH, ROUND_TIME, ROUND_TRANSITION_FRAMES, ROUNDS_TO_WIN } from '../config.js';
 import { FP_SCALE } from './FixedPoint.js';
 import { decodeInput } from './InputBuffer.js';
+
+const P1_START_X = GAME_WIDTH * 0.3;
+const P2_START_X = GAME_WIDTH * 0.7;
 
 /**
  * Apply decoded input to a fighter.
@@ -108,6 +111,23 @@ export function simulateFrame(
       if (combat.p1RoundsWon >= ROUNDS_TO_WIN || combat.p2RoundsWon >= ROUNDS_TO_WIN) {
         combat.matchOver = true;
       }
+      // Start frame-based transition countdown (deterministic, both peers agree)
+      if (!combat.matchOver) {
+        combat.transitionTimer = ROUND_TRANSITION_FRAMES;
+      }
+    }
+  }
+
+  // 6b. Tick transition timer — deterministic round reset for online mode
+  if (!combat.roundActive && combat.transitionTimer > 0) {
+    combat.transitionTimer--;
+    if (combat.transitionTimer <= 0 && !combat.matchOver) {
+      // Reset fighters for next round (simulation-safe, no sprite/audio calls)
+      p1Fighter.resetForRound(P1_START_X);
+      p2Fighter.resetForRound(P2_START_X);
+      combat.timer = ROUND_TIME;
+      combat._timerAccumulator = 0;
+      combat.roundActive = true;
     }
   }
 

--- a/tests/helpers/sim-factory.js
+++ b/tests/helpers/sim-factory.js
@@ -311,6 +311,31 @@ export function createSimFighter(xPx, playerIndex, fighterData) {
       this.sprite.x = this.simX / FP_SCALE;
       this.sprite.y = this.simY / FP_SCALE;
     },
+    resetForRound(x) {
+      this.simX = Math.trunc(x * FP_SCALE);
+      this.simY = GROUND_Y_FP;
+      this.simVX = 0;
+      this.simVY = 0;
+      this.hp = MAX_HP;
+      this.special = 0;
+      this.state = 'idle';
+      this.attackCooldown = 0;
+      this.attackFrameElapsed = 0;
+      this.comboCount = 0;
+      this.blockTimer = 0;
+      this.hurtTimer = 0;
+      this.currentAttack = null;
+      this.hitConnected = false;
+      this.hasDoubleJumped = false;
+      this._airborneTime = 0;
+      this.stamina = MAX_STAMINA_FP;
+      this._isTouchingWall = false;
+      this._wallDir = 0;
+      this._hasWallJumped = false;
+      this._specialTintTimer = 0;
+      this._prevAnimState = null;
+      this.facingRight = this.playerIndex === 0;
+    },
   };
 }
 
@@ -328,6 +353,7 @@ export function createSimCombat({ suppressRoundEvents = true } = {}) {
     roundNumber: 1,
     p1RoundsWon: 0,
     p2RoundsWon: 0,
+    transitionTimer: 0,
     _lastEndReason: null,
     resolveBodyCollision(f1, f2) {
       const halfW = 18 * FP_SCALE;

--- a/tests/systems/desync-detection.test.js
+++ b/tests/systems/desync-detection.test.js
@@ -110,6 +110,7 @@ function mockCombat() {
     roundActive: true,
     matchOver: false,
     _timerAccumulator: 0,
+    transitionTimer: 0,
     resolveBodyCollision: vi.fn(),
     checkHit: vi.fn(),
     tickTimer: vi.fn(),

--- a/tests/systems/determinism.test.js
+++ b/tests/systems/determinism.test.js
@@ -348,6 +348,11 @@ function createSimCombat() {
     suppressRoundEvents: true,
     timer: 60,
     _timerAccumulator: 0,
+    transitionTimer: 0,
+    matchOver: false,
+    roundNumber: 1,
+    p1RoundsWon: 0,
+    p2RoundsWon: 0,
     resolveBodyCollision(f1, f2) {
       const halfW = 18 * FP_SCALE;
       const airThreshold = GROUND_Y_FP - 20 * FP_SCALE;

--- a/tests/systems/game-state.test.js
+++ b/tests/systems/game-state.test.js
@@ -49,6 +49,7 @@ function makeCombat(overrides = {}) {
     roundActive: true,
     matchOver: false,
     _timerAccumulator: 0,
+    transitionTimer: 0,
     ...overrides,
   };
 }

--- a/tests/systems/rollback-manager.test.js
+++ b/tests/systems/rollback-manager.test.js
@@ -89,6 +89,7 @@ function mockCombat() {
     roundActive: true,
     matchOver: false,
     _timerAccumulator: 0,
+    transitionTimer: 0,
     resolveBodyCollision: vi.fn(),
     checkHit: vi.fn(),
     tickTimer: vi.fn(),


### PR DESCRIPTION
## Summary

- **Fix checksum mismatch** at frame 855 after KO in E2E determinism test. Root cause: round transitions used wall-clock Phaser timers (`time.delayedCall`) which fired at different times on each peer, causing state divergence when the simulation resumed.
- **Add frame-based `transitionTimer`** to `CombatSystem` — counts down inside `simulateFrame()` so both peers reset fighters and start the next round at the exact same simulation frame.
- **Keep simulation running** during online round transitions instead of pausing (`update()` no longer returns early when `roundActive === false` in online mode), so the rollback/checksum system stays active.
- **Remove redundant combat state overwrites** from P2's `onRoundEvent` handler — `simulateFrame` already handles all state mutations deterministically.

## Test plan

- [x] `bun run test:run` — 501 unit tests pass
- [x] `bun run lint` — clean
- [x] `bun run test:e2e` — both determinism tests pass (previously the seeded test failed with checksum mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)