### PR TITLE
Phase 4: Hardened reconnection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - `docs/graceful-reconnection.md` — Reconnection state machine, grace period, module responsibilities
 - `docs/room-state-machine.md` — Server room state (`roomState` transitions, `return_to_select` vs `disconnect`)
 - `docs/e2e-testing.md` — E2E multiplayer testing framework (autoplay, FightRecorder, Playwright)
-- `docs/rfcs/0001-networking-redesign.md` — Full networking rewrite RFC (Phase 1 complete, Phases 2-5 planned)
+- `docs/rfcs/0001-networking-redesign.md` — Full networking rewrite RFC (Phases 1-4 complete, Phase 5 optional)
 
 ## Online Multiplayer
 

--- a/docs/graceful-reconnection.md
+++ b/docs/graceful-reconnection.md
@@ -86,7 +86,10 @@ flowchart TD
 
 ## WebRTC Re-negotiation on Reconnect
 
-When a player reconnects after a network drop, the WebRTC DataChannel is destroyed and re-negotiated. This happens automatically via `_initWebRTC()` triggered by `opponent_reconnected`.
+When a player reconnects after a network drop, the WebRTC DataChannel is destroyed and re-negotiated. The two peers follow different paths:
+
+- **Staying peer** (never disconnected): Receives `opponent_reconnected` from server → calls `initWebRTC()` immediately (their signaling is already stable).
+- **Reconnecting peer**: Sends `rejoin` → receives `rejoin_ack` from server → flushes queued `initWebRTC()`. The WebRTC init is deferred via `queueWebRTCInit()` until `rejoin_ack` confirms the signaling channel is stable, preventing lost WebRTC signaling messages during WebSocket flapping.
 
 ```mermaid
 flowchart TD
@@ -94,9 +97,10 @@ flowchart TD
     DCClose --> WSClose["WebSocket closes"]
     WSClose --> Grace["20s grace period"]
     Grace --> Reconn["PartySocket reconnects"]
-    Reconn --> Rejoin["sendRejoin(slot)"]
-    Rejoin --> OppReconn["opponent_reconnected received"]
-    OppReconn --> ReInit["_initWebRTC()\nNew WebRTC negotiation"]
+    Reconn --> Queue["queueWebRTCInit()"]
+    Queue --> Rejoin["sendRejoin(slot)"]
+    Rejoin --> Ack["rejoin_ack received"]
+    Ack --> ReInit["flushPendingWebRTCInit()\nNew WebRTC negotiation"]
     ReInit --> Success{"P2P succeeds?"}
     Success -- Yes --> P2P["Resume with P2P inputs"]
     Success -- No --> WS["Continue with WS relay\n(same as pre-WebRTC behavior)"]
@@ -112,7 +116,11 @@ Three mechanisms detect connection loss:
 2. **Pong timeout (active, ~9s)**: NetworkManager sends pings every 3s and tracks `_lastPongTime`. If no pong arrives for >6s (PONG_TIMEOUT_MS), it synthetically triggers `_onSocketClose()` to enter the reconnection flow. This fires ~9s after WiFi drops (2 missed pongs + next interval tick).
 3. **WebSocket close (passive, 30s+)**: The browser eventually fires the `close` event. On mobile Safari this can take 30+ seconds.
 
-The `ReconnectionManager.handleConnectionLost()` guard (`if (this._state !== 'connected') return`) ensures that if multiple mechanisms fire, only the first triggers the reconnection flow.
+The `ReconnectionManager.handleConnectionLost()` is re-entrant: if already in `reconnecting` state, it resets the grace timer without re-firing `onPause`. This handles simultaneous disconnects where both peers drop at the same time — the grace period restarts from the latest event.
+
+## Transport Degradation
+
+When the WebRTC DataChannel closes but the WebSocket stays open (asymmetric drop), gameplay continues via WS relay without pausing. `TransportManager` emits `transportDegraded` to update the HUD transport indicator to "WS" in yellow immediately. When the DataChannel is re-established, `transportRestored` fires and the HUD reverts on the next cycle.
 
 ## Key Files
 
@@ -120,6 +128,7 @@ The `ReconnectionManager.handleConnectionLost()` guard (`if (this._state !== 'co
 |------|------|
 | `ReconnectionManager.js` | Pure state machine: connected → reconnecting → connected/disconnected |
 | `party/server.js` | Grace timer, slot reservation, `roomState` + `_stateBeforeGrace`, `return_to_select` vs `disconnect` |
-| `NetworkManager.js` | Socket lifecycle hooks, `opponent_reconnecting`/`opponent_reconnected`/`return_to_select` handlers, `sendRejoin()`, WebRTC re-init on reconnect |
+| `NetworkFacade.js` | Socket lifecycle hooks, `opponent_reconnecting`/`opponent_reconnected`/`return_to_select` handlers, `sendRejoin()`, `queueWebRTCInit()`, `rejoin_ack` → flush WebRTC init |
+| `TransportManager.js` | WebRTC lifecycle, `queueWebRTCInit`/`flushPendingWebRTCInit`, `transportDegraded`/`transportRestored` events |
 | `WebRTCTransport.js` | DataChannel transport — destroyed on disconnect, re-negotiated after reconnect |
 | `FightScene.js` | Integration: wires NM events → RM, shows overlay, handles `return_to_select` transition to SelectScene |

--- a/docs/rfcs/0001-networking-redesign.md
+++ b/docs/rfcs/0001-networking-redesign.md
@@ -1,6 +1,6 @@
 # RFC 0001: Networking Redesign
 
-**Status:** In Progress — Phases 1, 2A, 2B, 3 complete. Phase 4 ready for implementation.
+**Status:** In Progress — Phases 1, 2A, 2B, 3, 4 complete. Phase 5 optional.
 **Date:** 2026-03-22
 **Author:** Architecture Team
 
@@ -581,7 +581,7 @@ The 762-line `NetworkManager` monolith was decomposed into 5 focused modules + a
 
 ---
 
-### Phase 4: Hardened Reconnection (Depends on Phase 3)
+### Phase 4: Hardened Reconnection (Depends on Phase 3) — COMPLETE ✓
 
 **Goal:** Fix race conditions in the reconnection flow so WiFi drops mid-fight recover cleanly.
 

--- a/party/server.js
+++ b/party/server.js
@@ -179,7 +179,12 @@ export default class FightRoom {
     if (data.type === 'rejoin') {
       const rejoinSlot = data.slot;
       if (rejoinSlot !== 0 && rejoinSlot !== 1) return;
-      if (!this._graceTimers[rejoinSlot]) return;
+      if (!this._graceTimers[rejoinSlot]) {
+        // No grace period active — connection restored before server saw disconnect.
+        // Acknowledge so client knows signaling is stable.
+        connection.send(JSON.stringify({ type: 'rejoin_ack', state: this.roomState }));
+        return;
+      }
       clearTimeout(this._graceTimers[rejoinSlot]);
       this._graceTimers[rejoinSlot] = null;
       this.players[rejoinSlot].id = connection.id;
@@ -209,6 +214,7 @@ export default class FightRoom {
         this._sendToOther(rejoinSlot, { type: 'opponent_reconnected' });
         this._broadcastToSpectators({ type: 'opponent_reconnected' });
       }
+      connection.send(JSON.stringify({ type: 'rejoin_ack', state: this.roomState }));
       return;
     }
 

--- a/party/server.js
+++ b/party/server.js
@@ -181,7 +181,11 @@ export default class FightRoom {
       if (rejoinSlot !== 0 && rejoinSlot !== 1) return;
       if (!this._graceTimers[rejoinSlot]) {
         // No grace period active — connection restored before server saw disconnect.
-        // Acknowledge so client knows signaling is stable.
+        // Update connection ID so stale onClose for the old connection won't
+        // match this slot and erroneously start a grace period.
+        if (this.players[rejoinSlot]) {
+          this.players[rejoinSlot].id = connection.id;
+        }
         connection.send(JSON.stringify({ type: 'rejoin_ack', state: this.roomState }));
         return;
       }

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -915,11 +915,20 @@ export class FightScene extends Phaser.Scene {
     nm.onSocketClose(() => this.reconnectionManager.handleConnectionLost());
     nm.onSocketOpen(() => {
       this.reconnectionManager.handleConnectionRestored();
+      nm.queueWebRTCInit(); // queue until rejoin_ack confirms signaling stable
       nm.sendRejoin(nm.getPlayerSlot());
     });
     nm.onOpponentReconnecting(() => this.reconnectionManager.handleOpponentReconnecting());
     nm.onOpponentReconnected(() => this.reconnectionManager.handleOpponentReconnected());
     nm.onDisconnect(() => this.reconnectionManager.handleOpponentDisconnected());
+
+    // Transport degradation: DataChannel dropped but WebSocket still works
+    nm.onTransportDegraded(() => {
+      if (this._transportText) {
+        this._transportText.setText('WS');
+        this._transportText.setColor('#ffcc00');
+      }
+    });
 
     // Grace expired during fight — return to fighter select
     nm.onReturnToSelect(() => {

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -893,16 +893,19 @@ export class FightScene extends Phaser.Scene {
     this.reconnectionManager.onPause(() => {
       this._reconnecting = true;
       this._showReconnectingOverlay();
+      this.recorder?.recordNetworkEvent('reconnection_pause', {});
     });
 
     this.reconnectionManager.onResume(() => {
       this._reconnecting = false;
       this._hideReconnectingOverlay();
+      this.recorder?.recordNetworkEvent('reconnection_resume', {});
     });
 
     this.reconnectionManager.onDisconnect(() => {
       this._reconnecting = false;
       this._hideReconnectingOverlay();
+      this.recorder?.recordNetworkEvent('reconnection_disconnect', {});
       this.combat.roundActive = false;
       this._onlineDisconnected = true;
       this.centerText.setText('DESCONECTADO');
@@ -912,11 +915,15 @@ export class FightScene extends Phaser.Scene {
     });
 
     // Wire NetworkManager socket events → ReconnectionManager
-    nm.onSocketClose(() => this.reconnectionManager.handleConnectionLost());
+    nm.onSocketClose(() => {
+      this.reconnectionManager.handleConnectionLost();
+      this.recorder?.recordNetworkEvent('socket_close', {});
+    });
     nm.onSocketOpen(() => {
       this.reconnectionManager.handleConnectionRestored();
       nm.queueWebRTCInit(); // queue until rejoin_ack confirms signaling stable
       nm.sendRejoin(nm.getPlayerSlot());
+      this.recorder?.recordNetworkEvent('socket_open', {});
     });
     nm.onOpponentReconnecting(() => this.reconnectionManager.handleOpponentReconnecting());
     nm.onOpponentReconnected(() => this.reconnectionManager.handleOpponentReconnected());
@@ -928,6 +935,7 @@ export class FightScene extends Phaser.Scene {
         this._transportText.setText('WS');
         this._transportText.setColor('#ffcc00');
       }
+      this.recorder?.recordNetworkEvent('transport_degraded', {});
     });
 
     // Grace expired during fight — return to fighter select

--- a/src/systems/ReconnectionManager.js
+++ b/src/systems/ReconnectionManager.js
@@ -38,7 +38,12 @@ export class ReconnectionManager {
 
   handleConnectionLost() {
     if (this._destroyed) return;
-    if (this._state !== 'connected') return;
+    if (this._state === 'disconnected') return;
+    if (this._state === 'reconnecting') {
+      // Re-entrant: reset timer without re-firing onPause
+      this._reconnectStartTime = this._now();
+      return;
+    }
     this._enterReconnecting();
   }
 
@@ -51,7 +56,12 @@ export class ReconnectionManager {
 
   handleOpponentReconnecting() {
     if (this._destroyed) return;
-    if (this._state !== 'connected') return;
+    if (this._state === 'disconnected') return;
+    if (this._state === 'reconnecting') {
+      // Re-entrant: reset timer without re-firing onPause
+      this._reconnectStartTime = this._now();
+      return;
+    }
     this._enterReconnecting();
   }
 

--- a/src/systems/net/NetworkFacade.js
+++ b/src/systems/net/NetworkFacade.js
@@ -92,6 +92,9 @@ export class NetworkFacade {
     this.signaling.on('rejoin_available', (msg) => {
       if (this._onRejoinAvailable) this._onRejoinAvailable(msg.slot);
     });
+    this.signaling.on('rejoin_ack', () => {
+      this.transport.flushPendingWebRTCInit();
+    });
 
     // Room lifecycle callbacks
     this._onOpponentReady = null;
@@ -250,6 +253,12 @@ export class NetworkFacade {
   onSocketOpen(cb) {
     this._onSocketOpen = cb;
   }
+  onTransportDegraded(cb) {
+    this.transport.onTransportDegraded(cb);
+  }
+  onTransportRestored(cb) {
+    this.transport.onTransportRestored(cb);
+  }
 
   // --- Public API: send messages ---
 
@@ -290,6 +299,13 @@ export class NetworkFacade {
     const msg = { type: 'rejoin', slot };
     if (reset) msg.reset = true;
     this.signaling.send(msg);
+  }
+  /**
+   * Queue WebRTC init for after signaling confirms stable (rejoin_ack).
+   * Called by the reconnecting peer before sendRejoin.
+   */
+  queueWebRTCInit() {
+    this.transport.queueWebRTCInit(this.signaling.playerSlot);
   }
   sendPing() {
     this.monitor.sendPing();
@@ -339,6 +355,8 @@ export class NetworkFacade {
       'return_to_select',
       'rejoin_available',
     ]);
+    // Cancel any pending WebRTC init from reconnection flow
+    this.transport.cancelPendingWebRTCInit();
     // Note: WebRTC is intentionally preserved across reselect
   }
 

--- a/src/systems/net/NetworkFacade.js
+++ b/src/systems/net/NetworkFacade.js
@@ -94,6 +94,10 @@ export class NetworkFacade {
     });
     this.signaling.on('rejoin_ack', () => {
       this.transport.flushPendingWebRTCInit();
+      // rejoin_ack confirms our rejoin succeeded. The server only sends
+      // opponent_reconnected to the OTHER peer, so we must resume our own
+      // ReconnectionManager here.
+      if (this._onOpponentReconnected) this._onOpponentReconnected();
     });
 
     // Room lifecycle callbacks

--- a/src/systems/net/TransportManager.js
+++ b/src/systems/net/TransportManager.js
@@ -27,6 +27,17 @@ export class TransportManager {
     /** @type {RTCIceServer[]|null} */
     this._iceServers = null;
 
+    /** @type {number|null} Pending WebRTC init slot (deferred until signaling stable) */
+    this._pendingWebRTCInit = null;
+
+    /** @type {boolean} True after DC was open then closed (degraded state) */
+    this._transportDegraded = false;
+
+    /** @type {Function|null} */
+    this._onTransportDegraded = null;
+    /** @type {Function|null} */
+    this._onTransportRestored = null;
+
     // Register signaling relay for WebRTC messages
     signaling.on('webrtc_offer', (msg) => this._handleSignal(msg));
     signaling.on('webrtc_answer', (msg) => this._handleSignal(msg));
@@ -66,10 +77,19 @@ export class TransportManager {
       onOpen: () => {
         this._transportMode = 'webrtc';
         this._webrtcReady = true;
+        if (this._transportDegraded) {
+          this._transportDegraded = false;
+          if (this._onTransportRestored) this._onTransportRestored();
+        }
       },
       onClose: () => {
+        const wasOpen = this._webrtcReady;
         this._transportMode = 'websocket';
         this._webrtcReady = false;
+        if (wasOpen) {
+          this._transportDegraded = true;
+          if (this._onTransportDegraded) this._onTransportDegraded();
+        }
       },
       onFailed: () => {
         this._transportMode = 'websocket';
@@ -93,6 +113,7 @@ export class TransportManager {
     }
     this._transportMode = 'websocket';
     this._webrtcReady = false;
+    this._pendingWebRTCInit = null;
   }
 
   /**
@@ -122,6 +143,48 @@ export class TransportManager {
       console.log('[TM] TURN credential fetch error:', err.message);
       // Non-fatal: fall back to STUN-only
     }
+  }
+
+  /**
+   * Queue WebRTC init for later (deferred until signaling confirms stable).
+   * @param {number} playerSlot
+   */
+  queueWebRTCInit(playerSlot) {
+    this._pendingWebRTCInit = playerSlot;
+  }
+
+  /**
+   * Flush pending WebRTC init if one is queued.
+   */
+  flushPendingWebRTCInit() {
+    if (this._pendingWebRTCInit !== null) {
+      const slot = this._pendingWebRTCInit;
+      this._pendingWebRTCInit = null;
+      this.initWebRTC(slot);
+    }
+  }
+
+  /**
+   * Cancel pending WebRTC init without executing it.
+   */
+  cancelPendingWebRTCInit() {
+    this._pendingWebRTCInit = null;
+  }
+
+  /**
+   * Register callback for when DataChannel drops mid-fight (WebSocket still works).
+   * @param {Function} cb
+   */
+  onTransportDegraded(cb) {
+    this._onTransportDegraded = cb;
+  }
+
+  /**
+   * Register callback for when DataChannel is re-established after degradation.
+   * @param {Function} cb
+   */
+  onTransportRestored(cb) {
+    this._onTransportRestored = cb;
   }
 
   /**
@@ -155,10 +218,13 @@ export class TransportManager {
 
   destroy() {
     this.destroyWebRTC();
+    this._transportDegraded = false;
     this.signaling.off('webrtc_offer');
     this.signaling.off('webrtc_answer');
     this.signaling.off('webrtc_ice');
     this._onP2PMessage = null;
+    this._onTransportDegraded = null;
+    this._onTransportRestored = null;
   }
 
   // --- Internal ---

--- a/tests/e2e/helpers/browser-helpers.js
+++ b/tests/e2e/helpers/browser-helpers.js
@@ -14,6 +14,16 @@ export async function waitForMatchComplete(page, timeout = 110_000) {
 }
 
 /**
+ * Wait until the fight is in progress (enough frames simulated).
+ * Used to ensure the fight is running before injecting network disruptions.
+ */
+export async function waitForFightInProgress(page, minFrames = 120, timeout = 60_000) {
+  await page.waitForFunction((min) => (window.__FIGHT_LOG?.totalFrames ?? 0) > min, minFrames, {
+    timeout,
+  });
+}
+
+/**
  * Extract the full fight log from a page.
  */
 export async function extractFightLog(page) {

--- a/tests/e2e/multiplayer-reconnection.spec.js
+++ b/tests/e2e/multiplayer-reconnection.spec.js
@@ -1,0 +1,137 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import {
+  extractFightLog,
+  p1Url,
+  p2Url,
+  waitForFightInProgress,
+  waitForMatchComplete,
+  waitForRoomId,
+} from './helpers/browser-helpers.js';
+import { generateBundle } from './helpers/bundle-generator.js';
+import { generateReport } from './helpers/report-generator.js';
+
+const BASE_URL = 'http://localhost:5173';
+const RESULTS_DIR = 'test-results';
+
+test.describe('Multiplayer reconnection', () => {
+  test('fight resumes after mid-fight disconnect', async ({ browser }, testInfo) => {
+    const ctx1 = await browser.newContext();
+    const ctx2 = await browser.newContext();
+    const pageP1 = await ctx1.newPage();
+    const pageP2 = await ctx2.newPage();
+
+    let logP1, logP2, usedP1Url, usedP2Url;
+
+    const p1Console = [];
+    const p2Console = [];
+    pageP1.on('console', (msg) => p1Console.push(`[${msg.type()}] ${msg.text()}`));
+    pageP2.on('console', (msg) => p2Console.push(`[${msg.type()}] ${msg.text()}`));
+
+    const testName = 'reconnection mid-fight';
+
+    try {
+      // P1 creates room
+      usedP1Url = p1Url(BASE_URL, { fighter: 'simon', seed: 42 });
+      await pageP1.goto(usedP1Url);
+
+      const roomId = await waitForRoomId(pageP1);
+      expect(roomId).toBeTruthy();
+
+      // P2 joins room
+      usedP2Url = p2Url(BASE_URL, roomId, { fighter: 'jeka', seed: 42 });
+      await pageP2.goto(usedP2Url);
+
+      // Wait for fight to be in progress (~2 seconds of gameplay)
+      await waitForFightInProgress(pageP1, 120);
+
+      // Simulate network drop:
+      // 1. Close PartySocket (prevents auto-reconnect)
+      // 2. Wait for server to process onClose and start grace period
+      // 3. Manually reconnect — server sees rejoin within grace → opponent_reconnected
+      await pageP2.evaluate(() => {
+        const scene = window.game.scene.getScene('FightScene');
+        scene.networkManager.signaling.socket.close();
+      });
+      await pageP2.waitForTimeout(1500);
+      await pageP2.evaluate(() => {
+        const scene = window.game.scene.getScene('FightScene');
+        scene.networkManager.signaling.socket.reconnect();
+      });
+
+      // Wait for both matches to complete after reconnection
+      await Promise.all([waitForMatchComplete(pageP1), waitForMatchComplete(pageP2)]);
+
+      [logP1, logP2] = await Promise.all([extractFightLog(pageP1), extractFightLog(pageP2)]);
+
+      // Both peers completed the match after reconnection
+      expect(logP1).toBeTruthy();
+      expect(logP2).toBeTruthy();
+      expect(logP1.matchComplete).toBe(true);
+      expect(logP2.matchComplete).toBe(true);
+
+      // P2 experienced a socket close + reopen
+      const p2Events = logP2.networkEvents.map((e) => e.type);
+      expect(p2Events).toContain('socket_close');
+      expect(p2Events).toContain('socket_open');
+
+      // Neither peer's grace period expired
+      const p1Events = logP1.networkEvents.map((e) => e.type);
+      expect(p1Events).not.toContain('reconnection_disconnect');
+      expect(p2Events).not.toContain('reconnection_disconnect');
+
+      // If P1 saw the disconnect, it must also have seen the recovery
+      if (p1Events.includes('reconnection_pause')) {
+        expect(p1Events).toContain('reconnection_resume');
+      }
+
+      // No desyncs after reconnection
+      expect(logP1.desyncCount).toBe(0);
+      expect(logP2.desyncCount).toBe(0);
+    } finally {
+      if (logP1 && logP2) {
+        const report = generateReport(logP1, logP2, testName);
+        const bundle = generateBundle(logP1, logP2, { p1: usedP1Url, p2: usedP2Url });
+
+        fs.mkdirSync(RESULTS_DIR, { recursive: true });
+        const slug = testName.replace(/\s+/g, '-').toLowerCase();
+        const reportPath = path.join(RESULTS_DIR, `${slug}-report.md`);
+        const bundlePath = path.join(RESULTS_DIR, `${slug}-bundle.json`);
+        fs.writeFileSync(reportPath, report);
+        fs.writeFileSync(bundlePath, JSON.stringify(bundle, null, 2));
+
+        const hashMatch = logP1.finalStateHash === logP2.finalStateHash;
+        const icon =
+          hashMatch && logP1.desyncCount === 0 && logP2.desyncCount === 0
+            ? ':white_check_mark:'
+            : ':x:';
+        const summaryLine =
+          `${icon} **${testName}** — ${logP1.fighterId} vs ${logP2.fighterId} | ` +
+          `hash: ${hashMatch ? 'match' : 'MISMATCH'} | ` +
+          `desyncs: ${logP1.desyncCount + logP2.desyncCount} | ` +
+          `winner: ${logP1.result?.winnerId || logP2.result?.winnerId || '?'}`;
+        const summaryPath = path.join(RESULTS_DIR, 'ci-summary.md');
+        fs.appendFileSync(summaryPath, `${summaryLine}\n`);
+
+        await testInfo.attach('report', { path: reportPath, contentType: 'text/markdown' });
+        await testInfo.attach('bundle', { path: bundlePath, contentType: 'application/json' });
+      }
+
+      if (p1Console.length > 0 || p2Console.length > 0) {
+        const consolePath = path.join(
+          RESULTS_DIR,
+          `${testName.replace(/\s+/g, '-').toLowerCase()}-console.log`,
+        );
+        const consoleContent =
+          `=== P1 Console (${p1Console.length} messages) ===\n${p1Console.join('\n')}\n\n` +
+          `=== P2 Console (${p2Console.length} messages) ===\n${p2Console.join('\n')}\n`;
+        fs.writeFileSync(consolePath, consoleContent);
+        await testInfo.attach('console-logs', { path: consolePath, contentType: 'text/plain' });
+      }
+
+      await ctx1.close();
+      await ctx2.close();
+    }
+  });
+});

--- a/tests/party/server.test.js
+++ b/tests/party/server.test.js
@@ -454,6 +454,22 @@ describe('FightRoom', () => {
       expect(c1bMsgs.some((m) => m.type === 'rejoin_ack' && m.state === room.roomState)).toBe(true);
     });
 
+    it('no-grace rejoin updates connection ID so stale onClose is ignored', () => {
+      const conn1b = makeConnection('c1b');
+      party.getConnections = () => [conn1b, conn2, conn3];
+
+      // Rejoin before server saw disconnect (no grace timer)
+      room.onMessage(JSON.stringify({ type: 'rejoin', slot: 0 }), conn1b);
+      expect(room.players[0].id).toBe('c1b');
+
+      // Stale onClose for OLD connection — should NOT start grace
+      conn2.send.mockClear();
+      room.onClose(conn1);
+      expect(room.roomState).not.toBe('reconnecting');
+      const c2Msgs = conn2.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c2Msgs.some((m) => m.type === 'opponent_reconnecting')).toBe(false);
+    });
+
     it('new connection during grace period receives rejoin_available', () => {
       room.onClose(conn1);
 

--- a/tests/party/server.test.js
+++ b/tests/party/server.test.js
@@ -438,15 +438,20 @@ describe('FightRoom', () => {
       expect(c2Msgs.some((m) => m.type === 'opponent_reconnected')).toBe(false);
     });
 
-    it('rejoin with no active timer is ignored', () => {
+    it('rejoin with no active timer sends rejoin_ack with current state', () => {
       // No disconnect happened
       const conn1b = makeConnection('c1b');
       conn2.send.mockClear();
 
       room.onMessage(JSON.stringify({ type: 'rejoin', slot: 0 }), conn1b);
 
+      // Should not notify opponent
       const c2Msgs = conn2.send.mock.calls.map((c) => JSON.parse(c[0]));
       expect(c2Msgs.some((m) => m.type === 'opponent_reconnected')).toBe(false);
+
+      // Should send rejoin_ack to the rejoining connection
+      const c1bMsgs = conn1b.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c1bMsgs.some((m) => m.type === 'rejoin_ack' && m.state === room.roomState)).toBe(true);
     });
 
     it('new connection during grace period receives rejoin_available', () => {
@@ -546,6 +551,39 @@ describe('FightRoom', () => {
       const c1Msgs = conn1.send.mock.calls.map((c) => JSON.parse(c[0]));
       expect(c1Msgs.some((m) => m.type === 'spectator_count')).toBe(true);
       expect(c1Msgs.some((m) => m.type === 'opponent_reconnecting')).toBe(false);
+    });
+
+    it('successful rejoin during grace sends rejoin_ack to rejoiner', () => {
+      room.onClose(conn1);
+
+      const conn1b = makeConnection('c1b');
+      party.getConnections = () => [conn1b, conn2, conn3];
+      room.onMessage(JSON.stringify({ type: 'rejoin', slot: 0 }), conn1b);
+
+      const c1bMsgs = conn1b.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c1bMsgs.some((m) => m.type === 'rejoin_ack')).toBe(true);
+    });
+
+    it('duplicate rejoin messages are idempotent', () => {
+      room.onClose(conn1);
+
+      const conn1b = makeConnection('c1b');
+      party.getConnections = () => [conn1b, conn2, conn3];
+
+      // First rejoin clears grace timer
+      room.onMessage(JSON.stringify({ type: 'rejoin', slot: 0 }), conn1b);
+      conn1b.send.mockClear();
+      conn2.send.mockClear();
+
+      // Second rejoin — no grace timer, gets rejoin_ack
+      room.onMessage(JSON.stringify({ type: 'rejoin', slot: 0 }), conn1b);
+
+      const c1bMsgs = conn1b.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c1bMsgs.some((m) => m.type === 'rejoin_ack')).toBe(true);
+
+      // Should not send opponent_reconnected again
+      const c2Msgs = conn2.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(c2Msgs.some((m) => m.type === 'opponent_reconnected')).toBe(false);
     });
 
     it('both players disconnect simultaneously: independent grace timers', () => {

--- a/tests/systems/net/network-facade.test.js
+++ b/tests/systems/net/network-facade.test.js
@@ -449,6 +449,16 @@ describe('NetworkFacade', () => {
       expect(nf.transport._webrtc).not.toBeNull();
     });
 
+    it('rejoin_ack fires onOpponentReconnected callback', () => {
+      const nf = makeFacade();
+      const reconnected = vi.fn();
+      nf.onOpponentReconnected(reconnected);
+
+      emitMsg(nf, { type: 'rejoin_ack', state: 'fighting' });
+
+      expect(reconnected).toHaveBeenCalledOnce();
+    });
+
     it('rejoin_ack without pending init is no-op', () => {
       globalThis.RTCPeerConnection = class {};
       const nf = makeFacade();

--- a/tests/systems/net/network-facade.test.js
+++ b/tests/systems/net/network-facade.test.js
@@ -436,6 +436,29 @@ describe('NetworkFacade', () => {
     });
   });
 
+  describe('rejoin_ack flushes pending WebRTC init', () => {
+    it('rejoin_ack flushes pending WebRTC init', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nf = makeFacade();
+      emitMsg(nf, { type: 'assign', player: 0 });
+
+      nf.queueWebRTCInit();
+      expect(nf.transport._webrtc).toBeNull();
+
+      emitMsg(nf, { type: 'rejoin_ack', state: 'fighting' });
+      expect(nf.transport._webrtc).not.toBeNull();
+    });
+
+    it('rejoin_ack without pending init is no-op', () => {
+      globalThis.RTCPeerConnection = class {};
+      const nf = makeFacade();
+      emitMsg(nf, { type: 'assign', player: 0 });
+
+      emitMsg(nf, { type: 'rejoin_ack', state: 'fighting' });
+      expect(nf.transport._webrtc).toBeNull();
+    });
+  });
+
   describe('B4: message queuing', () => {
     it('queues messages when disconnected, flushes on reconnect', () => {
       const nf = makeFacade();

--- a/tests/systems/net/transport-manager.test.js
+++ b/tests/systems/net/transport-manager.test.js
@@ -290,6 +290,112 @@ describe('TransportManager', () => {
     });
   });
 
+  describe('queueWebRTCInit / flushPendingWebRTCInit', () => {
+    it('queueWebRTCInit stores slot but does not init WebRTC', () => {
+      globalThis.RTCPeerConnection = class {};
+      const signaling = makeSignaling();
+      const tm = new TransportManager(signaling);
+
+      tm.queueWebRTCInit(0);
+
+      expect(tm._webrtc).toBeNull();
+      expect(tm._pendingWebRTCInit).toBe(0);
+    });
+
+    it('flushPendingWebRTCInit inits WebRTC with queued slot', () => {
+      globalThis.RTCPeerConnection = class {};
+      const signaling = makeSignaling();
+      const tm = new TransportManager(signaling);
+
+      tm.queueWebRTCInit(0);
+      tm.flushPendingWebRTCInit();
+
+      expect(tm._webrtc).not.toBeNull();
+      expect(tm._pendingWebRTCInit).toBeNull();
+    });
+
+    it('flushPendingWebRTCInit is no-op when nothing queued', () => {
+      globalThis.RTCPeerConnection = class {};
+      const signaling = makeSignaling();
+      const tm = new TransportManager(signaling);
+
+      tm.flushPendingWebRTCInit(); // should not throw
+
+      expect(tm._webrtc).toBeNull();
+    });
+
+    it('queueWebRTCInit overwrites previous pending slot', () => {
+      globalThis.RTCPeerConnection = class {};
+      const signaling = makeSignaling();
+      const tm = new TransportManager(signaling);
+
+      tm.queueWebRTCInit(0);
+      tm.queueWebRTCInit(1);
+      tm.flushPendingWebRTCInit();
+
+      // Should have used slot 1 (answerer, no startOffer)
+      expect(tm._webrtc).not.toBeNull();
+      expect(tm._webrtc.state).toBe('idle'); // P2 = answerer
+    });
+
+    it('destroyWebRTC clears pending init', () => {
+      const signaling = makeSignaling();
+      const tm = new TransportManager(signaling);
+
+      tm.queueWebRTCInit(0);
+      tm.destroyWebRTC();
+
+      expect(tm._pendingWebRTCInit).toBeNull();
+    });
+  });
+
+  describe('transport degraded / restored events', () => {
+    it('emits transportDegraded when open DataChannel closes', () => {
+      globalThis.RTCPeerConnection = class {};
+      const signaling = makeSignaling();
+      const tm = new TransportManager(signaling);
+      const degraded = vi.fn();
+      tm.onTransportDegraded(degraded);
+
+      tm.initWebRTC(0);
+      tm._webrtc._simulateOpen();
+      tm._webrtc._simulateClose();
+
+      expect(degraded).toHaveBeenCalledOnce();
+    });
+
+    it('does not emit transportDegraded when DC was never open', () => {
+      globalThis.RTCPeerConnection = class {};
+      const signaling = makeSignaling();
+      const tm = new TransportManager(signaling);
+      const degraded = vi.fn();
+      tm.onTransportDegraded(degraded);
+
+      tm.initWebRTC(0);
+      tm._webrtc._simulateFailed();
+
+      expect(degraded).not.toHaveBeenCalled();
+    });
+
+    it('emits transportRestored when DC reopens after degradation', () => {
+      globalThis.RTCPeerConnection = class {};
+      const signaling = makeSignaling();
+      const tm = new TransportManager(signaling);
+      const restored = vi.fn();
+      tm.onTransportRestored(restored);
+
+      tm.initWebRTC(0);
+      tm._webrtc._simulateOpen();
+      tm._webrtc._simulateClose(); // degraded
+
+      // Re-init and reopen
+      tm.initWebRTC(0);
+      tm._webrtc._simulateOpen();
+
+      expect(restored).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('destroy', () => {
     it('destroys WebRTC and unregisters signaling handlers', () => {
       globalThis.RTCPeerConnection = class {};

--- a/tests/systems/reconnection-manager.test.js
+++ b/tests/systems/reconnection-manager.test.js
@@ -33,14 +33,34 @@ describe('ReconnectionManager', () => {
       expect(onPause).toHaveBeenCalledOnce();
     });
 
-    it('is idempotent when already reconnecting', () => {
+    it('resets timer when already reconnecting without re-firing onPause', () => {
       const onPause = vi.fn();
       rm.onPause(onPause);
 
       rm.handleConnectionLost();
-      rm.handleConnectionLost();
+      clock.value = 3000; // 2000ms elapsed
+      rm.handleConnectionLost(); // re-entrant: resets timer
 
       expect(onPause).toHaveBeenCalledOnce();
+      expect(rm.elapsed()).toBe(0); // timer reset to current time
+    });
+
+    it('re-entrant timer reset extends grace period from latest event', () => {
+      const onDisconnect = vi.fn();
+      rm.onDisconnect(onDisconnect);
+
+      rm.handleConnectionLost(); // t=1000
+      clock.value = 4000; // 3000ms elapsed
+      rm.handleConnectionLost(); // reset timer to t=4000
+
+      clock.value = 8999; // 4999ms since reset (< 5000)
+      rm.tick();
+      expect(rm.state).toBe('reconnecting');
+
+      clock.value = 9000; // 5000ms since reset (= gracePeriodMs)
+      rm.tick();
+      expect(rm.state).toBe('disconnected');
+      expect(onDisconnect).toHaveBeenCalledOnce();
     });
   });
 
@@ -55,14 +75,33 @@ describe('ReconnectionManager', () => {
       expect(onPause).toHaveBeenCalledOnce();
     });
 
-    it('is idempotent when already reconnecting', () => {
+    it('resets timer when already reconnecting without re-firing onPause', () => {
       const onPause = vi.fn();
       rm.onPause(onPause);
 
       rm.handleOpponentReconnecting();
+      clock.value = 3000;
       rm.handleOpponentReconnecting();
 
       expect(onPause).toHaveBeenCalledOnce();
+      expect(rm.elapsed()).toBe(0);
+    });
+
+    it('simultaneous disconnect: grace period runs from latest event', () => {
+      const onDisconnect = vi.fn();
+      rm.onDisconnect(onDisconnect);
+
+      rm.handleConnectionLost(); // t=1000
+      clock.value = 3000;
+      rm.handleOpponentReconnecting(); // reset timer to t=3000
+
+      clock.value = 7999; // 4999ms since reset
+      rm.tick();
+      expect(rm.state).toBe('reconnecting');
+
+      clock.value = 8000; // 5000ms since reset
+      rm.tick();
+      expect(rm.state).toBe('disconnected');
     });
   });
 


### PR DESCRIPTION
## Summary

- **Race 4**: Server responds with `rejoin_ack` when rejoin arrives before grace period starts (fast PartySocket reconnect). Also updates connection ID in no-grace path so stale `onClose` events don't erroneously start grace.
- **Race 2**: `ReconnectionManager.handleConnectionLost()` is now re-entrant — resets grace timer when both peers disconnect simultaneously instead of ignoring the second event.
- **Race 1**: Reconnecting peer queues WebRTC init via `queueWebRTCInit()` until `rejoin_ack` confirms signaling is stable. Prevents lost WebRTC signaling messages during WebSocket flapping.
- **Race 3**: `TransportManager` emits `transportDegraded`/`transportRestored` when DataChannel drops while WebSocket stays open. FightScene updates HUD transport indicator immediately.
- **E2E**: New Playwright test simulates mid-fight WebSocket disconnect + reconnect. Verifies match completes after recovery, no desyncs.

## Test plan

- [x] All 516 unit tests pass (`bun run test:run`)
- [x] Lint clean (`bun run lint`)
- [x] All 3 E2E tests pass (`bun run test:e2e`) — including new reconnection test
- [ ] Manual: two browser tabs, start fight, kill WiFi on one — reconnection overlay appears, WebRTC renegotiates, HUD updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)