### PR TITLE
Fix RTCPeerConnection crash from non-array iceServers

### DIFF
--- a/party/server.js
+++ b/party/server.js
@@ -90,7 +90,8 @@ export default class FightRoom {
       }
 
       const data = await response.json();
-      return Response.json({ iceServers: data.iceServers });
+      const iceServers = Array.isArray(data.iceServers) ? data.iceServers : [data.iceServers];
+      return Response.json({ iceServers });
     } catch (err) {
       console.log('TURN credential fetch error:', err.message);
       return Response.json(

--- a/tests/party/server.test.js
+++ b/tests/party/server.test.js
@@ -992,14 +992,12 @@ describe('FightRoom', () => {
       };
       const room2 = new FightRoom(party);
 
-      const mockIceServers = [
-        { urls: 'stun:stun.cloudflare.com:3478' },
-        {
-          urls: 'turn:turn.cloudflare.com:3478?transport=udp',
-          username: 'user',
-          credential: 'pass',
-        },
-      ];
+      // Cloudflare TURN API returns iceServers as a single object, not an array
+      const mockIceServers = {
+        urls: ['stun:stun.cloudflare.com:3478', 'turn:turn.cloudflare.com:3478?transport=udp'],
+        username: 'user',
+        credential: 'pass',
+      };
 
       globalThis.fetch = vi.fn().mockResolvedValue({
         ok: true,
@@ -1012,7 +1010,9 @@ describe('FightRoom', () => {
 
       expect(response.status).toBe(200);
       const data = await response.json();
-      expect(data.iceServers).toEqual(mockIceServers);
+      // Server should wrap the single object in an array
+      expect(Array.isArray(data.iceServers)).toBe(true);
+      expect(data.iceServers).toEqual([mockIceServers]);
 
       // Verify Cloudflare API was called correctly
       expect(globalThis.fetch).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- Cloudflare TURN API returns `iceServers` as a single object, not an array
- `RTCPeerConnection` requires `iceServers` to be iterable, causing: `TypeError: Failed to read the 'iceServers' property from 'RTCConfiguration': The object must have a callable @@iterator property`
- Wrap the response with `Array.isArray` check in `party/server.js`

## Test plan
- [x] Updated test mock to match real Cloudflare API response format (object, not array)
- [x] All 501 tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)