### PR TITLE
Add dual license (MIT + CC BY-SA 4.0) and contribution framework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to A Los Traques
+
+Welcome! A Los Traques is a collaborative art experiment — a hobby fighting
+game built by friends. Contributions of all kinds are welcome: code, art,
+audio, ideas, bug reports, and more.
+
+The project is maintained by **Simon Soriano**, who has final creative
+and technical authority over all decisions. This isn't a democracy, but it is
+a friendly and open workshop.
+
+## How to contribute
+
+1. **Fork** the repository.
+2. **Create a branch** for your changes.
+3. **Submit a pull request** with a clear description of what you've done and
+   why.
+
+That's it. Keep it simple.
+
+If you're not sure whether a contribution would be welcome, open an issue
+first to discuss it. No contribution is too small — a typo fix is just as
+valued as a new feature.
+
+## Licensing of contributions
+
+This project uses a dual-license model (see the [LICENSE](LICENSE) file for
+full details):
+
+- **Code** is licensed under the **MIT License**.
+- **Assets** (art, audio, text, design docs, and other creative content) are
+  licensed under **Creative Commons Attribution-ShareAlike 4.0 International
+  (CC BY-SA 4.0)**.
+
+**By submitting a pull request or otherwise contributing to this project, you
+agree to license your contribution under the applicable license above.** You
+must have the right to make this grant — don't submit work you don't have
+permission to share.
+
+There is no CLA (Contributor License Agreement) to sign. Submitting your work
+to the repo is your agreement.
+
+## What happens to contributions
+
+The maintainer may accept, reject, request changes to, or modify any
+contribution. Merging a contribution does not guarantee it will remain in the
+project permanently — things get refactored, redesigned, or removed as the
+project evolves. That's normal and not a reflection on the quality of your
+work.
+
+## Credit
+
+All contributors are acknowledged in [CONTRIBUTORS.md](CONTRIBUTORS.md). If
+your PR is merged, you'll be added there (or you can add yourself as part of
+your PR).
+
+Contributors may also be credited in-game at the maintainer's discretion.
+
+## Third-party content
+
+If your contribution includes any content you did not create yourself — a
+sound effect from a sample library, a font, a code snippet from another
+project, etc. — you **must**:
+
+1. **Clearly identify** the third-party content in your PR description.
+2. **State its license** and confirm it is compatible with this project's
+   licenses (MIT for code, CC BY-SA 4.0 for assets).
+3. **Include attribution** as required by the original license.
+
+When in doubt, ask before submitting.
+
+## Code of conduct
+
+Be respectful, constructive, and collaborative. We're friends making a game
+together. Specifically:
+
+- **Be kind.** Assume good intentions. Give helpful feedback, not harsh
+  criticism.
+- **Be inclusive.** Everyone is welcome regardless of skill level or
+  background.
+- **Be constructive.** If you disagree with a decision, explain your
+  reasoning. The maintainer will listen, but the final call is theirs.
+
+That's the whole policy. If someone is making the project an unpleasant place
+to be, the maintainer will handle it.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,13 @@
+# Contributors
+
+Thanks to everyone who has contributed to A Los Traques. This file credits
+all contributors to the project — whether through code, art, audio, ideas, or
+anything else.
+
+If your contribution has been merged, feel free to add yourself here as part
+of your PR.
+
+| Name | Contributions | Date of first contribution |
+| --- | --- | --- |
+| Simon Soriano | Creator and maintainer | 2026-03-16 |
+| Felipe Suarez | Dynamic stage backgrounds, touch controls, UI fixes | 2026-03-22 |

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,87 @@
+# A Los Traques — Dual License
+
+This project uses a dual-license model. Different parts of the project are
+covered by different licenses, as described below.
+
+## Which license applies to what?
+
+### MIT License — Code
+
+All source code and configuration files are licensed under the MIT License.
+This includes (but is not limited to) files with the following extensions:
+
+`.js`, `.ts`, `.py`, `.gd`, `.cs`, `.rs`, `.lua`, `.sh`, `.json`, `.yaml`,
+`.yml`, `.toml`, `.html`, `.css`, `.scss`, `.vue`, `.jsx`, `.tsx`, `.mjs`,
+`.cjs`
+
+It also includes build scripts, CI/CD configuration, test files, and any
+other files whose primary purpose is to be executed or interpreted by a
+computer.
+
+### Creative Commons Attribution-ShareAlike 4.0 — Assets
+
+All artwork, sprites, 3D models, audio, music, sound effects, video, fonts,
+story/narrative text, design documents, and any other non-code creative
+content are licensed under the Creative Commons Attribution-ShareAlike 4.0
+International License (CC BY-SA 4.0).
+
+This includes (but is not limited to) files with the following extensions:
+
+`.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`, `.webp`, `.bmp`, `.psd`, `.aseprite`,
+`.blend`, `.fbx`, `.obj`, `.glb`, `.gltf`, `.mp3`, `.wav`, `.ogg`, `.flac`,
+`.mp4`, `.webm`, `.ttf`, `.otf`, `.woff`, `.woff2`, `.md` files in `docs/`
+
+### When in doubt
+
+If a file doesn't clearly fall into one category, it is licensed under the
+MIT License. If you're unsure, open an issue and ask.
+
+---
+
+## MIT License
+
+Copyright (c) 2026 Simon Soriano
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+
+All non-code creative content in this project is licensed under the Creative
+Commons Attribution-ShareAlike 4.0 International License.
+
+### You are free to:
+
+- **Share** — copy and redistribute the material in any medium or format.
+- **Adapt** — remix, transform, and build upon the material for any purpose,
+  even commercially.
+
+### Under the following terms:
+
+- **Attribution** — You must give appropriate credit, provide a link to the
+  license, and indicate if changes were made. You may do so in any reasonable
+  manner, but not in any way that suggests the licensor endorses you or your
+  use.
+- **ShareAlike** — If you remix, transform, or build upon the material, you
+  must distribute your contributions under the same license as the original.
+
+### Full license text:
+
+https://creativecommons.org/licenses/by-sa/4.0/legalcode


### PR DESCRIPTION
## Summary
- **LICENSE**: Dual-license structure — MIT for code, CC BY-SA 4.0 for assets, with clear file-type mapping
- **CONTRIBUTING.md**: Contributor guide covering philosophy, process, licensing of contributions, credit, third-party content, and code of conduct
- **CONTRIBUTORS.md**: Credits file listing Simon Soriano and Felipe Suarez

## Test plan
- [ ] Review LICENSE for accuracy and completeness
- [ ] Review CONTRIBUTING.md for tone and clarity
- [ ] Verify CONTRIBUTORS.md entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)