### PR TITLE
feat: implement multiplayer debuggability (RFC 0004)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - `docs/e2e-testing.md` — E2E multiplayer testing framework (autoplay, FightRecorder, Playwright)
 - `docs/rfcs/0001-networking-redesign.md` — Full networking rewrite RFC (Phases 1-4 complete, Phase 5 optional)
 - `docs/rfcs/0002-multiplayer-redesign.md` — Multiplayer architecture redesign (Phases 1, 2A, 2B, 3 complete, Phase 4 next)
+- `docs/rfcs/0004-multiplayer-debuggability.md` — Multiplayer debuggability (Phases 1-4 complete)
 
 ## Online Multiplayer
 
@@ -183,6 +184,18 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - Spectators receive P1 sync snapshots (same as old model, no rollback)
 - URL join: `?room=XXXX` skips title, goes directly to LobbyScene
 - `bun run party:dev` for local dev, `bun run party:deploy` to deploy
+
+## Multiplayer Debuggability (RFC 0004)
+
+- **Logger** (`src/systems/Logger.js`): Static singleton with levels OFF/ERROR/WARN/INFO/DEBUG/TRACE, per-module tags, 256-entry ring buffer. Zero overhead when OFF. All net modules instrumented.
+- **MatchTelemetry** (`src/systems/MatchTelemetry.js`): Always-on counters (rollbacks, desyncs, RTT samples, transport changes). Wired in `_setupOnlineMode()`.
+- **Debug mode**: `?debug=1` URL param or triple-tap top-right corner. Activates FightRecorder for real matches, verbose logging, debug overlay.
+- **DebugOverlay** (`src/systems/DebugOverlay.js`): Bottom-left HUD showing RTT, transport mode, rollback stats, match state. Tap to expand. Spanish labels.
+- **DebugBundleExporter** (`src/systems/DebugBundleExporter.js`): Generates v2 bundles with FightRecorder data + Logger ring buffer + MatchTelemetry + environment info. Supports clipboard copy and file download.
+- **1-click bundle collection**: "Exportar Todo" collects bundles from both peers + server `/diagnostics` endpoint. Uses `debug_request`/`debug_response` message relay.
+- **Session ID**: Generated in SignalingClient, passed as PartySocket query param, included in all server logs and debug bundles for client-server correlation.
+- **Server logging**: `party/server.js` uses structured JSON logging (`_log()` method) with ring buffer. State transitions, connect/disconnect, rejoin, rate limits all logged.
+- **Server diagnostics**: `GET /parties/main/{roomId}/diagnostics` returns room state, players, event log. Token-protected via `DIAG_TOKEN` env var.
 
 ## CRITICAL: Keep this file updated
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ tests/
 - `matchContext`: payload containing competition logic (e.g. tournament state).
 - Scenes pass data via `scene.start('SceneName', { p1Id, p2Id, stageId, gameMode, networkManager, matchContext })`
 - FightScene uses `MatchStateMachine` for flow control: `isPaused` is a getter on SM state, `_reconnecting`/`_onlineDisconnected` eliminated, update loop guards on `matchState.state` instead of `combat.roundActive`
+- **Logging**: Use `Logger.create('ModuleName')` from `src/systems/Logger.js` instead of `console.log/warn/error`. Zero overhead when level is OFF (default). See RFC 0005.
 - **Before every commit**: run `bun run lint:fix` to auto-fix formatting/lint issues, then verify with `bun run lint`. CI runs Biome lint and will fail on any error.
 - **Atomic commits**: make a separate commit for each logical change. Don't bundle unrelated changes into one commit.
 
@@ -162,7 +163,8 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - `docs/e2e-testing.md` — E2E multiplayer testing framework (autoplay, FightRecorder, Playwright)
 - `docs/rfcs/0001-networking-redesign.md` — Full networking rewrite RFC (Phases 1-4 complete, Phase 5 optional)
 - `docs/rfcs/0002-multiplayer-redesign.md` — Multiplayer architecture redesign (Phases 1, 2A, 2B, 3 complete, Phase 4 next)
-- `docs/rfcs/0004-multiplayer-debuggability.md` — Multiplayer debuggability (Phases 1-4 complete)
+- `docs/rfcs/0004-authentication-redesign-vercel.md` — Authentication & persistence (Supabase + Vercel)
+- `docs/rfcs/0005-multiplayer-debuggability.md` — Multiplayer debuggability (Phases 1-4 complete)
 
 ## Online Multiplayer
 
@@ -185,7 +187,7 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - URL join: `?room=XXXX` skips title, goes directly to LobbyScene
 - `bun run party:dev` for local dev, `bun run party:deploy` to deploy
 
-## Multiplayer Debuggability (RFC 0004)
+## Multiplayer Debuggability (RFC 0005)
 
 - **Logger** (`src/systems/Logger.js`): Static singleton with levels OFF/ERROR/WARN/INFO/DEBUG/TRACE, per-module tags, 256-entry ring buffer. Zero overhead when OFF. All net modules instrumented.
 - **MatchTelemetry** (`src/systems/MatchTelemetry.js`): Always-on counters (rollbacks, desyncs, RTT samples, transport changes). Wired in `_setupOnlineMode()`.

--- a/docs/rfcs/0004-multiplayer-debuggability.md
+++ b/docs/rfcs/0004-multiplayer-debuggability.md
@@ -369,6 +369,52 @@ Expanded (tap):
 
 PartyKit runs on Cloudflare Workers. `console.log` in Workers goes to the real-time log stream (via `wrangler tail` or dashboard). The server gets structured JSON logging at key decision points -- always on since Workers logs are ephemeral and cost nothing.
 
+### 7. Client-Server Log Correlation
+
+Client and server logs are independent systems with different clocks and no shared identifiers beyond `roomId` and `playerSlot`. To correlate them during incident analysis, we introduce a **session ID**.
+
+**How it works:**
+
+1. Client generates a short random session ID on connection (e.g. `crypto.randomUUID().slice(0, 8)` → `"a3f7b2c1"`)
+2. Session ID is passed as a query parameter on the PartySocket connection: `new PartySocket({ query: { sessionId } })`
+3. Server extracts `sessionId` from the connection URL and stores it alongside `connection.id`
+4. All server logs include `{ roomId, slot, sessionId }` — all client logs include `{ roomId, slot, sessionId }`
+5. Debug bundles include the `sessionId` in their metadata
+
+**Correlation flow:**
+
+```mermaid
+sequenceDiagram
+    participant C as Client (sessionId: a3f7b2c1)
+    participant S as Server (wrangler tail)
+
+    C->>S: PartySocket connect ?sessionId=a3f7b2c1
+    S->>S: Log: {type: "connect", roomId: "ABCD", slot: 0, sessionId: "a3f7b2c1"}
+
+    Note over C: Client logs: [SignalingClient] {sessionId: "a3f7b2c1", ...}
+    Note over S: Server logs: {sessionId: "a3f7b2c1", ...}
+
+    C->>S: input message
+    S->>S: Log: {type: "relay", msgType: "input", sessionId: "a3f7b2c1"}
+
+    Note over C,S: To correlate: filter server logs by sessionId, <br/>match against client debug bundle by same sessionId
+```
+
+**What you can correlate:**
+
+| Scenario | Client-side evidence | Server-side evidence | Correlation key |
+|----------|---------------------|---------------------|-----------------|
+| Transport degradation | Logger: `[TransportManager] DataChannel closed` | Log: `{type: "relay", transport: "ws"}` (inputs now via WS) | `sessionId` + timestamp window |
+| Reconnection | Logger: `[SignalingClient] Socket close` → `Socket open` | Log: `{type: "disconnect"}` → `{type: "rejoin", sessionId}` | `sessionId` (new connection, same session ID) |
+| Grace period expiry | Logger: `[FightScene] Reconnection disconnect` | Log: `{type: "grace_expired", slot, sessionId}` | `sessionId` + `slot` |
+| Desync | Debug bundle: checksum mismatch at frame N | Log: `{type: "relay", msgType: "resync_request"}` | `roomId` + timestamp window |
+
+**Key properties:**
+- `sessionId` survives reconnections — client reuses the same ID across PartySocket auto-reconnects
+- Both peers in a room have different session IDs, so you can distinguish P1 vs P2 in server logs
+- The `sessionId` is not sensitive (short random string, no PII)
+- Correlation is manual (grep server logs by sessionId, compare with client bundle) — no automated join needed
+
 ---
 
 ## Module Instrumentation Plan
@@ -443,7 +489,8 @@ PartyKit runs on Cloudflare Workers. `console.log` in Workers goes to the real-t
 | 1.7 | Instrument `SpectatorRelay.js` | Add DEBUG log for buffer flush, sync sent. |
 | 1.8 | Instrument `NetworkFacade.js` | Add INFO/DEBUG logs for TURN fetch, WebRTC init, reconnect flow. |
 | 1.9 | Replace FightScene console calls | Replace `console.warn`/`console.log` calls in FightScene.js online multiplayer paths with structured `log.*()` calls. Keep replay-specific `[REPLAY]` logs as-is (different concern). |
-| 1.10 | Unit tests | Test Logger: level filtering, ring buffer overflow, per-module override, fast bail. Test MatchTelemetry: counter increments, RTT sampling. |
+| 1.10 | Generate session ID in `SignalingClient` | Generate `sessionId` via `crypto.randomUUID().slice(0, 8)` on construction. Pass as PartySocket query param. Include in all Logger entries as context. Persist in debug bundles. |
+| 1.11 | Unit tests | Test Logger: level filtering, ring buffer overflow, per-module override, fast bail. Test MatchTelemetry: counter increments, RTT sampling. |
 
 **Verification:**
 - All existing tests pass (no behavioral changes)
@@ -509,7 +556,7 @@ PartyKit runs on Cloudflare Workers. `console.log` in Workers goes to the real-t
 
 | # | Task | Details |
 |---|------|---------|
-| 4.1 | Structured logging in `party/server.js` | Log state transitions in `_transition()`. Log connect/disconnect in `onConnect()`/`onClose()`. Log rejoin flow in `_handleRejoin()`. Log rate limit triggers. Use `console.log(JSON.stringify({...}))` for structured output compatible with `wrangler tail`. |
+| 4.1 | Structured logging in `party/server.js` | Log state transitions in `_transition()`. Log connect/disconnect in `onConnect()`/`onClose()`. Log rejoin flow in `_handleRejoin()`. Log rate limit triggers. Use `console.log(JSON.stringify({...}))` for structured output compatible with `wrangler tail`. Extract `sessionId` from connection query params and include in all log entries for client-server correlation. |
 | 4.2 | Room diagnostic HTTP endpoint | `GET /parties/main/{roomId}/diagnostics` returns JSON: `{ roomState, players, spectatorCount, graceTimers, fightInfo }`. Protected by bearer token from env var (`DIAG_TOKEN`). |
 | 4.3 | Server-side ring buffer | In-memory array of last 50 server events (state transitions, connects, disconnects, errors). Included in diagnostic endpoint response. |
 | 4.4 | Replace existing server console.log | Replace 2 existing `console.log` calls at lines 131 and 147 with structured JSON format. |

--- a/docs/rfcs/0004-multiplayer-debuggability.md
+++ b/docs/rfcs/0004-multiplayer-debuggability.md
@@ -1,0 +1,644 @@
+# RFC 0004: Multiplayer Debuggability
+
+**Status:** Proposed
+**Date:** 2026-03-30
+**Author:** Architecture Team
+**Predecessor:** [RFC 0002: Multiplayer Architecture Redesign](0002-multiplayer-redesign.md) (Phases 1–3 complete)
+
+---
+
+## Summary
+
+When a player reports "multiplayer is broken", the team has zero data: no logs from either peer, no network health metrics, no input/rollback/desync timeline, no way to reproduce the issue. The existing debugging infrastructure -- FightRecorder, E2E bundle format, comparison reports -- is excellent but gated behind `?autoplay=1`. Real players never see it.
+
+This RFC proposes a four-phase system that bridges the gap between the E2E test infrastructure and real-world debugging:
+
+1. A structured, leveled, per-module **Logger** with an in-memory ring buffer
+2. A **debug mode** that activates FightRecorder for real matches (decoupled from autoplay)
+3. Exportable **debug bundles** in the same format the E2E framework already consumes
+4. **Server-side** structured logging and room diagnostics
+
+The system adds zero overhead when debug mode is off (always-on telemetry uses fewer than 200 bytes per match), and under 1KB/second of memory when debug mode is active.
+
+---
+
+## Goals and Non-Goals
+
+### Goals
+
+| Priority | Goal |
+|----------|------|
+| **P0** | **Field debugging** -- when a player reports a problem, the team can ask them to reproduce with `?debug=1` and export a bundle that contains everything needed to diagnose the issue |
+| **P0** | **Always-on metrics** -- every match produces a lightweight summary (rollback count, max depth, desync count, transport mode, RTT samples) stored in memory, exportable on demand |
+| **P0** | **Structured logging** -- replace scattered `console.log` with a tagged, leveled logger. Every networking module gets instrumented. Logs can be enabled per-module at runtime |
+| **P1** | **Network health visibility** -- optional HUD overlay showing RTT, transport mode, rollback count, input buffer depth, desync count |
+| **P1** | **Reuse existing infrastructure** -- FightRecorder and bundle-generator already capture the right data. The gap is activation, not implementation |
+| **P2** | **Server-side observability** -- PartyKit server logs state transitions, message routing decisions, grace period events |
+
+### Non-Goals
+
+| Non-Goal | Rationale |
+|----------|-----------|
+| External analytics/crash reporting | No Sentry, no analytics SDK. Zero external dependencies. Friends-only game. |
+| Persistent storage of debug bundles | Bundles are ephemeral (copy-to-clipboard or download). No backend storage needed. |
+| Automated desync reporting | Requires server-side storage and a reporting UI. Players manually share bundles. |
+| Performance profiling overlay | FPS counter exists in DevConsole. Frame timing profiling is a different concern. |
+| Replay from debug bundles | Already works via `?replay=1` + `window.__REPLAY_BUNDLE`. Not new work. |
+
+---
+
+## High-Level Requirements
+
+| # | Requirement | Detail |
+|---|------------|--------|
+| R1 | Structured logger | `Logger` module with levels (ERROR, WARN, INFO, DEBUG, TRACE), per-module tags, ring buffer storage, zero overhead when level is OFF |
+| R2 | Always-on telemetry | Lightweight in-memory counters updated every match: rollback count, max depth, desync count, transport mode, RTT min/avg/max. Under 200 bytes. |
+| R3 | Debug mode activation | URL param `?debug=1` or triple-tap top-right corner enables: verbose logging, FightRecorder, network health overlay |
+| R4 | FightRecorder decoupled from autoplay | `FightRecorder` instantiation controlled by debug mode flag, not `game.autoplay?.enabled` |
+| R5 | Debug bundle export | Same JSON format as E2E bundles (`generateBundle()`), augmented with logger ring buffer and network health samples. Downloadable or copy-to-clipboard. |
+| R6 | Network health overlay | Optional HUD showing RTT, transport mode (P2P/WS), rollback count, input buffer depth, desync count, match state. Spanish labels. |
+| R7 | Per-module instrumentation | All 6 networking modules (NetworkFacade, SignalingClient, TransportManager, InputSync, ConnectionMonitor, SpectatorRelay) plus FightScene and party/server.js get structured log calls at key decision points |
+| R8 | Server-side logging | party/server.js logs state transitions, message routing, rejoin flow, grace period events, rate limit triggers |
+| R9 | Zero performance impact when off | Logger level OFF = no string formatting, no object allocation, no function calls beyond a single branch check |
+
+---
+
+## Architecture
+
+### Logger Module
+
+```mermaid
+flowchart TB
+    subgraph Logger["Logger (src/systems/Logger.js)"]
+        direction TB
+        API["Logger.create('TransportManager')"]
+        Levels["Levels: OFF < ERROR < WARN < INFO < DEBUG < TRACE"]
+        RB["Ring Buffer (256 entries)"]
+        Output["Output: console + ring buffer"]
+    end
+
+    subgraph Consumers["Per-Module Loggers"]
+        L_TM["log.debug('WebRTC init', &#123;slot, offerer&#125;)"]
+        L_SC["log.info('Handler registered', &#123;type&#125;)"]
+        L_IS["log.trace('Input buffered', &#123;frame, depth&#125;)"]
+        L_CM["log.debug('Pong received', &#123;rtt&#125;)"]
+        L_NF["log.info('TURN fetch', &#123;servers&#125;)"]
+        L_FS["log.warn('Desync detected', &#123;frame&#125;)"]
+    end
+
+    subgraph Config["Runtime Configuration"]
+        Global["Global level (default: OFF)"]
+        PerMod["Per-module override map"]
+        Debug["?debug=1 sets Global=DEBUG"]
+    end
+
+    Consumers --> API
+    API --> Levels
+    Levels --> |"level >= threshold"| RB
+    Levels --> |"level >= threshold"| Output
+    Config --> Levels
+```
+
+### Data Flow: Debug Bundle Generation
+
+```mermaid
+flowchart LR
+    subgraph AlwaysOn["Always On"]
+        Telemetry["MatchTelemetry\n(lightweight counters)"]
+    end
+
+    subgraph DebugMode["Debug Mode Only"]
+        FR["FightRecorder\n(inputs, checksums,\nrollbacks, desyncs)"]
+        LRB["Logger Ring Buffer\n(256 structured entries)"]
+        NHS["Network Health Samples\n(RTT every 3s)"]
+    end
+
+    subgraph Export["Bundle Export"]
+        BG["DebugBundleExporter\n(extends E2E format)"]
+        JSON["JSON Bundle\n~50-200KB"]
+    end
+
+    subgraph Delivery["Delivery"]
+        Clip["Copy to Clipboard"]
+        DL["Download .json"]
+    end
+
+    Telemetry --> BG
+    FR --> BG
+    LRB --> BG
+    NHS --> BG
+    BG --> JSON
+    JSON --> Clip
+    JSON --> DL
+```
+
+### Debug Mode Activation Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Boot as BootScene
+    participant Logger
+    participant FS as FightScene
+    participant FR as FightRecorder
+    participant HUD as Debug Overlay
+
+    alt URL param ?debug=1
+        Boot->>Boot: Parse URL params
+        Boot->>Boot: game.debugMode = true
+        Boot->>Logger: setGlobalLevel(DEBUG)
+    else Triple-tap gesture
+        User->>FS: Triple-tap top-right corner
+        FS->>FS: game.debugMode = true
+        FS->>Logger: setGlobalLevel(DEBUG)
+    end
+
+    FS->>FS: _setupOnlineMode()
+    FS->>FS: Check game.debugMode
+
+    alt debugMode is true
+        FS->>FR: new FightRecorder(...)
+        FS->>HUD: Create debug overlay
+    else debugMode is false
+        Note over FS: Skip FightRecorder + overlay
+        Note over Logger: Global level remains OFF
+    end
+```
+
+### Integration with Existing Systems
+
+```mermaid
+flowchart TB
+    subgraph Existing["Existing (Unchanged)"]
+        AP["AutoplayController\n?autoplay=1"]
+        E2E["E2E Tests\n(Playwright)"]
+        BH["browser-helpers.js\nextractFightLog()"]
+        BGen["bundle-generator.js\ngenerateBundle()"]
+        RGen["report-generator.js\ngenerateReport()"]
+    end
+
+    subgraph New["New"]
+        DM["Debug Mode\n?debug=1 / gesture"]
+        Log["Logger module"]
+        MT["MatchTelemetry"]
+        DO["Debug Overlay (HUD)"]
+        DBG["DebugBundleExporter"]
+    end
+
+    subgraph Shared["Shared (Decoupled)"]
+        FR["FightRecorder\n(activated by autoplay OR debug)"]
+        WFL["window.__FIGHT_LOG\n(populated by either mode)"]
+    end
+
+    AP -->|"autoplay=true"| FR
+    DM -->|"debugMode=true"| FR
+    FR --> WFL
+    WFL --> BH
+    BH --> BGen
+    BH --> RGen
+    E2E --> BH
+
+    DM --> Log
+    DM --> DO
+    Log --> DBG
+    MT --> DBG
+    FR --> DBG
+    DBG -->|"extends"| BGen
+```
+
+---
+
+## Detailed Design
+
+### 1. Logger Module (`src/systems/Logger.js`)
+
+A minimal structured logger. No external dependencies. Static singleton -- modules get lightweight wrappers via `Logger.create('ModuleName')`.
+
+```javascript
+// API sketch -- not final implementation
+export const LogLevel = { OFF: 0, ERROR: 1, WARN: 2, INFO: 3, DEBUG: 4, TRACE: 5 };
+
+class Logger {
+  static _globalLevel = LogLevel.OFF;
+  static _moduleOverrides = new Map();  // module -> level
+  static _ringBuffer = [];              // { ts, module, level, msg, data }
+  static _ringBufferMax = 256;
+
+  static create(module) {
+    return {
+      error: (msg, data) => Logger._log(module, LogLevel.ERROR, msg, data),
+      warn:  (msg, data) => Logger._log(module, LogLevel.WARN,  msg, data),
+      info:  (msg, data) => Logger._log(module, LogLevel.INFO,  msg, data),
+      debug: (msg, data) => Logger._log(module, LogLevel.DEBUG, msg, data),
+      trace: (msg, data) => Logger._log(module, LogLevel.TRACE, msg, data),
+    };
+  }
+
+  static _log(module, level, msg, data) {
+    const threshold = Logger._moduleOverrides.get(module) ?? Logger._globalLevel;
+    if (level > threshold) return;  // fast bail -- zero overhead when OFF
+    const entry = { ts: Date.now(), module, level, msg, data };
+    Logger._ringBuffer.push(entry);
+    if (Logger._ringBuffer.length > Logger._ringBufferMax) Logger._ringBuffer.shift();
+    // Console output: WARN/ERROR always, others only when enabled
+    const prefix = `[${module}]`;
+    if (level <= LogLevel.WARN) console.warn(prefix, msg, data ?? '');
+    else console.log(prefix, msg, data ?? '');
+  }
+}
+```
+
+Key design decisions:
+
+- **Fast bail.** When level is OFF, `_log()` returns after a single integer comparison. No string formatting, no object allocation.
+- **Ring buffer.** Fixed-size (256 entries). Old entries dropped silently. Included in debug bundles. Not written to disk.
+- **Console output.** WARN and ERROR always go to console when level is active. DEBUG/TRACE only when explicitly enabled. Production users see zero console noise when level is OFF.
+
+### 2. MatchTelemetry (`src/systems/MatchTelemetry.js`)
+
+Always-on lightweight counters. Updated in the RollbackManager advance loop. Zero allocation -- just integer increments.
+
+```javascript
+// Data shape -- plain object, not a class
+{
+  matchId: string,           // roomId or 'local'
+  startedAt: number,         // Date.now()
+  transportMode: string,     // 'webrtc' | 'websocket'
+  transportChanges: number,
+  rollbackCount: number,
+  maxRollbackDepth: number,
+  desyncCount: number,
+  resyncCount: number,
+  rttSamples: number[],      // sampled every 3s, max 60 entries (~3 min match)
+  rttMin: number,
+  rttMax: number,
+  rttAvg: number,
+  disconnectionCount: number,
+  reconnectionCount: number,
+  matchDurationMs: number,
+}
+```
+
+Total memory: under 200 bytes (excluding `rttSamples` array which caps at ~480 bytes for a full match).
+
+### 3. FightRecorder Decoupling
+
+The critical change is at `src/scenes/FightScene.js:770`. Currently:
+
+```javascript
+// Current: only in autoplay
+if (this.game.autoplay?.enabled) {
+  this.recorder = new FightRecorder({ ... });
+}
+```
+
+Proposed:
+
+```javascript
+// New: autoplay OR debug mode
+if (this.game.autoplay?.enabled || this.game.debugMode) {
+  this.recorder = new FightRecorder({ ... });
+}
+```
+
+This single conditional change unlocks the entire FightRecorder data pipeline for real matches.
+
+### 4. Debug Bundle Format
+
+Extends the existing E2E bundle format (from `tests/e2e/helpers/bundle-generator.js`) with diagnostic data:
+
+```javascript
+{
+  version: 2,
+  generatedAt: '<ISO string>',
+  source: 'debug' | 'e2e',            // distinguishes origin
+
+  // Existing fields (same as E2E bundle)
+  config: { p1FighterId, p2FighterId, stageId, ... },
+  confirmedInputs: [...],
+  p1: { playerSlot, inputs, checksums, roundEvents, networkEvents, finalState, ... },
+  p2: null,                            // single-peer debug bundles only have local data
+
+  // NEW: diagnostic data
+  diagnostics: {
+    telemetry: { /* MatchTelemetry counters */ },
+    logBuffer: [{ ts, module, level, msg, data }],   // logger ring buffer
+    networkHealth: {
+      samples: [{ ts, rtt, transport, bufferDepth }],
+      transportChanges: [{ ts, from, to }],
+    },
+    matchState: {
+      transitions: [{ ts, from, to, event }],
+      finalState: '<string>',
+    },
+    environment: {
+      userAgent: '<string>',
+      platform: '<string>',
+      connection: { type, downlink, rtt },            // Navigator.connection
+    },
+  },
+}
+```
+
+### 5. Debug Overlay (Network Health HUD)
+
+Positioned bottom-left, below the existing transport indicator. All text in Spanish. Collapsed by default -- tap to expand.
+
+```
+Collapsed:
+┌────────────────────┐
+│  RTT: 45ms  P2P    │
+└────────────────────┘
+
+Expanded (tap):
+┌──────────────────────────┐
+│  RTT: 45ms    P2P        │
+│  Rollbacks: 12  Max: 3   │
+│  Desyncs: 0   Buf: 2     │
+│  Estado: ROUND_ACTIVE     │
+│  [Exportar Debug]         │
+└──────────────────────────┘
+```
+
+- Updates once per second (same cadence as existing ping timer)
+- Semi-transparent black background, monospace, depth 200
+- Only visible when `game.debugMode` is true
+- Reads from: `RollbackManager`, `ConnectionMonitor`, `TransportManager`, `InputSync`, `MatchStateMachine`
+
+### 6. Server-Side Logging
+
+PartyKit runs on Cloudflare Workers. `console.log` in Workers goes to the real-time log stream (via `wrangler tail` or dashboard). The server gets structured JSON logging at key decision points -- always on since Workers logs are ephemeral and cost nothing.
+
+---
+
+## Module Instrumentation Plan
+
+### What Gets Logged Per Module
+
+**NetworkFacade** (`src/systems/net/NetworkFacade.js`):
+- INFO: TURN fetch result (server count or failure)
+- DEBUG: WebRTC init trigger (slot, offerer flag)
+- DEBUG: Reconnect flow events (opponent_joined, opponent_reconnected, rejoin_ack)
+
+**SignalingClient** (`src/systems/net/SignalingClient.js`):
+- INFO: Socket open/close events
+- DEBUG: Handler registration (`on()` calls with type)
+- DEBUG: Pending queue flush (B4: count on reconnect)
+- DEBUG: Callback buffer flush (B5: type, count)
+- WARN: JSON parse errors (currently silently caught)
+- TRACE: Message dispatch (type, has handler)
+
+**TransportManager** (`src/systems/net/TransportManager.js`):
+- INFO: WebRTC init (slot, offerer, ICE server count) -- replaces `console.log` at line 61
+- INFO: TURN credentials fetched (server count) -- replaces `console.log` at line 140
+- WARN: WebRTC unavailable -- replaces `console.log` at line 54
+- WARN: TURN fetch failure -- replaces `console.log` at lines 133, 143
+- DEBUG: Transport mode change (websocket to webrtc, degradation)
+- DEBUG: DataChannel open/close events
+
+**InputSync** (`src/systems/net/InputSync.js`):
+- DEBUG: Input arrival (frame, buffer depth, source: p2p or ws)
+- DEBUG: Redundant history applied (frame, gap count)
+- TRACE: Input send (frame, transport used, history length)
+
+**ConnectionMonitor** (`src/systems/net/ConnectionMonitor.js`):
+- DEBUG: Pong received (RTT value)
+- WARN: Pong timeout fired (last pong time, elapsed)
+
+**SpectatorRelay** (`src/systems/net/SpectatorRelay.js`):
+- DEBUG: Callback buffer flush (type, message count)
+- DEBUG: Sync sent (frame number)
+
+**FightScene** (`src/scenes/FightScene.js`):
+- INFO: Online mode setup (slot, room, fighters, stage)
+- WARN: Desync detected -- replaces `console.warn` at line 798
+- WARN: Resync applied -- replaces `console.warn` at line 831
+- DEBUG: Frame-0 sync result -- replaces `console.log` at lines 1850-1901
+- DEBUG: Round event (type, winner, frame)
+- DEBUG: Reconnection events (pause, resume, disconnect)
+
+**party/server.js**:
+- INFO: All state transitions (`_transition()`)
+- INFO: Connect/disconnect events with slot and room state
+- INFO: Rejoin flow (slot, grace active, reset flag)
+- WARN: Rate limit triggers (type, connection ID, cooldown remaining)
+- WARN: Out-of-state message rejections
+
+---
+
+## Implementation Plan
+
+### Phase 1: Structured Logger + Always-On Telemetry
+
+**Objective:** Create the Logger module and MatchTelemetry. Instrument all networking modules. Replace existing `console.log` calls with structured logger calls.
+
+| # | Task | Details |
+|---|------|---------|
+| 1.1 | Create `src/systems/Logger.js` | Static singleton. Levels: OFF, ERROR, WARN, INFO, DEBUG, TRACE. Per-module tag. Ring buffer (256 entries). `Logger.create(module)` returns lightweight wrapper. Fast bail when level is OFF. |
+| 1.2 | Create `src/systems/MatchTelemetry.js` | Always-on counters. Hooks into RollbackManager callbacks (`_onRollback`, `_onDesync`). Samples RTT from ConnectionMonitor every 3 seconds. Records transport changes. |
+| 1.3 | Instrument `TransportManager.js` | Replace 5 existing `console.log` calls (lines 54, 61, 133, 140, 143) with logger calls. Add DEBUG logs for DataChannel state changes. |
+| 1.4 | Instrument `SignalingClient.js` | Add log calls for socket lifecycle, handler registration, pending queue flush, B5 buffer flush. Replace silent catch with `log.warn()`. |
+| 1.5 | Instrument `InputSync.js` | Add DEBUG log for input arrival (frame, buffer depth). Add TRACE log for input send. |
+| 1.6 | Instrument `ConnectionMonitor.js` | Add DEBUG log for pong received (RTT). Add WARN log for timeout. |
+| 1.7 | Instrument `SpectatorRelay.js` | Add DEBUG log for buffer flush, sync sent. |
+| 1.8 | Instrument `NetworkFacade.js` | Add INFO/DEBUG logs for TURN fetch, WebRTC init, reconnect flow. |
+| 1.9 | Replace FightScene console calls | Replace `console.warn`/`console.log` calls in FightScene.js online multiplayer paths with structured `log.*()` calls. Keep replay-specific `[REPLAY]` logs as-is (different concern). |
+| 1.10 | Unit tests | Test Logger: level filtering, ring buffer overflow, per-module override, fast bail. Test MatchTelemetry: counter increments, RTT sampling. |
+
+**Verification:**
+- All existing tests pass (no behavioral changes)
+- `Logger.create('test').debug('msg')` with global level OFF produces zero side effects
+- Ring buffer correctly caps at 256 entries
+- No new `console.log` calls in `src/systems/net/` -- all replaced by Logger
+
+---
+
+### Phase 2: Debug Mode + FightRecorder for Real Matches
+
+**Objective:** Activate FightRecorder and verbose logging for real matches via URL param or in-game gesture. Add network health overlay.
+
+| # | Task | Details |
+|---|------|---------|
+| 2.1 | Parse `?debug=1` URL param | In BootScene alongside existing autoplay param parsing. Set `game.debugMode = true`. Call `Logger.setGlobalLevel(LogLevel.DEBUG)`. |
+| 2.2 | Decouple FightRecorder from autoplay | Change guard at FightScene.js line 770 from `game.autoplay?.enabled` to `game.autoplay?.enabled \|\| game.debugMode`. Same for recorder hook wiring at lines 786-793. |
+| 2.3 | Triple-tap gesture activation | In FightScene `create()`: register touch listener on top-right 60x40 region. Three taps within 1 second toggles `game.debugMode`. On activation: set Logger level, instantiate FightRecorder if not already active, show overlay. |
+| 2.4 | Create `src/systems/DebugOverlay.js` | Phaser text container at bottom-left. Collapsed: RTT + transport mode. Tap to expand: rollback count, max depth, desync count, buffer depth, match state. Updates 1x/second. Spanish labels. Semi-transparent background. Depth 200. |
+| 2.5 | Wire MatchTelemetry to FightScene | Create MatchTelemetry instance in `_setupOnlineMode()`. Wire to RollbackManager hooks. Feed data to debug overlay. |
+| 2.6 | Integration test | Playwright test: load with `?debug=1`, verify FightRecorder is active (`window.__FIGHT_LOG` populated), verify Logger ring buffer has entries. |
+
+**Verification:**
+- `?debug=1` activates FightRecorder for a real online match (not autoplay)
+- `window.__FIGHT_LOG` is populated with inputs, checksums, rollbacks, desyncs
+- Logger ring buffer contains entries from networking modules
+- Debug overlay shows live RTT, transport mode, rollback stats
+- With `?debug=1` OFF, no FightRecorder, no overlay, no DEBUG-level logs (zero overhead)
+- All existing E2E tests pass unchanged (autoplay path unaffected)
+
+---
+
+### Phase 3: Debug Bundle Export
+
+**Objective:** Enable players to export a JSON debug bundle containing FightRecorder data, logger ring buffer, network health samples, and environment info.
+
+| # | Task | Details |
+|---|------|---------|
+| 3.1 | Create `src/systems/DebugBundleExporter.js` | Generates JSON bundle from FightRecorder log, Logger ring buffer, MatchTelemetry, MatchStateMachine transition history, `Navigator.connection` info. Extends E2E `generateBundle()` format with `diagnostics` section. Sets `version: 2` and `source: 'debug'`. |
+| 3.2 | Add "Exportar Debug" button | Visible only when `game.debugMode` is true. Placed in expanded debug overlay. Spanish label: "Exportar Debug". |
+| 3.3 | Implement copy-to-clipboard | Primary export method for mobile. Uses `navigator.clipboard.writeText(JSON.stringify(bundle))`. Shows "Copiado!" confirmation toast. Falls back to download if clipboard API unavailable. |
+| 3.4 | Implement file download | Secondary export method. Creates Blob + temporary `<a>` element, triggers download. Filename: `debug-{roomId}-{timestamp}.json`. |
+| 3.5 | Add MatchStateMachine transition logging | Record all transitions in an array: `{ ts, from, to, event }`. Capped at 100 entries. Feed into debug bundle. |
+| 3.6 | Collect environment info | `navigator.userAgent`, `navigator.platform`, `navigator.connection` (if available: `type`, `downlink`, `rtt`). Include in `diagnostics.environment`. |
+| 3.7 | E2E bundle backward compatibility | Ensure existing `generateBundle()` in `tests/e2e/helpers/bundle-generator.js` still works. New bundles are a superset. `generateReport()` handles both v1 and v2 bundles. |
+
+**Verification:**
+- Exported bundle is valid JSON
+- Bundle contains all FightRecorder data (inputs, checksums, rollbacks, desyncs)
+- Bundle contains Logger ring buffer entries
+- Bundle contains MatchTelemetry counters
+- Bundle contains environment info (userAgent, connection type)
+- Bundle is loadable by existing `generateReport()` (backward compatible)
+- Copy-to-clipboard works on Mobile Safari iPhone 15
+- File download works as fallback
+- Bundle size is reasonable (50-200KB for a typical match)
+
+---
+
+### Phase 4: Server-Side Logging + Room Diagnostics
+
+**Objective:** Add structured logging to `party/server.js`. Add an HTTP diagnostic endpoint for inspecting live room state.
+
+| # | Task | Details |
+|---|------|---------|
+| 4.1 | Structured logging in `party/server.js` | Log state transitions in `_transition()`. Log connect/disconnect in `onConnect()`/`onClose()`. Log rejoin flow in `_handleRejoin()`. Log rate limit triggers. Use `console.log(JSON.stringify({...}))` for structured output compatible with `wrangler tail`. |
+| 4.2 | Room diagnostic HTTP endpoint | `GET /parties/main/{roomId}/diagnostics` returns JSON: `{ roomState, players, spectatorCount, graceTimers, fightInfo }`. Protected by bearer token from env var (`DIAG_TOKEN`). |
+| 4.3 | Server-side ring buffer | In-memory array of last 50 server events (state transitions, connects, disconnects, errors). Included in diagnostic endpoint response. |
+| 4.4 | Replace existing server console.log | Replace 2 existing `console.log` calls at lines 131 and 147 with structured JSON format. |
+| 4.5 | Server test updates | Update `tests/party/server.test.js` to verify: diagnostic endpoint returns correct data, ring buffer caps at 50 entries. |
+
+**Verification:**
+- `wrangler tail` shows structured JSON logs for state transitions during a real match
+- `GET /diagnostics` with valid token returns room state JSON
+- `GET /diagnostics` without token returns 401
+- Existing server tests pass
+
+---
+
+### Phase Dependencies
+
+```mermaid
+flowchart LR
+    P1["Phase 1\nLogger +\nTelemetry"]
+    P2["Phase 2\nDebug Mode +\nFightRecorder"]
+    P3["Phase 3\nBundle Export"]
+    P4["Phase 4\nServer Logging"]
+
+    P1 --> P2
+    P2 --> P3
+    P1 -.-> P4
+
+    style P1 fill:#4a9,stroke:#333,color:#000
+    style P4 fill:#49a,stroke:#333,color:#000
+```
+
+Phase 4 (server-side) only depends on Phase 1 for the logging pattern -- it can proceed in parallel with Phases 2-3.
+
+---
+
+## Decision Matrices
+
+### Debug Mode Activation Method
+
+| Method | Discoverability | Mobile Friendly | Accidental Activation Risk | Recommendation |
+|--------|----------------|-----------------|---------------------------|----------------|
+| URL param `?debug=1` | Low (team shares URL) | Yes | None | **Primary** |
+| Triple-tap corner | Medium | Yes | Low (3 taps in 1s on small region) | **Secondary** |
+| Long-press logo | Medium | Yes | Medium (accidental long press) | Reject |
+| Shake gesture | Low | Yes | High (natural phone movement) | Reject |
+
+**Decision:** URL param as primary, triple-tap as secondary (mobile). Both activate the same `game.debugMode` flag.
+
+### Debug Bundle Delivery
+
+| Method | Mobile Safari Support | User Effort | Size Limit | Recommendation |
+|--------|----------------------|-------------|-----------|----------------|
+| Copy to clipboard | Yes (Clipboard API) | Low (paste into chat) | ~1MB practical | **Primary** |
+| File download | Yes (Blob + `<a>`) | Medium (find file, share) | Unlimited | **Fallback** |
+| Upload to server | N/A | Lowest | Unlimited | Reject (no backend) |
+| QR code | Limited | Medium | ~3KB max | Reject (too large) |
+
+**Decision:** Copy-to-clipboard as primary (mobile-first, player pastes into Discord/WhatsApp). File download as fallback when clipboard API is unavailable.
+
+### Logger Ring Buffer Size
+
+| Size | Memory | Coverage at DEBUG level | Recommendation |
+|------|--------|------------------------|----------------|
+| 64 entries | ~16KB | ~10 seconds | Too short |
+| 256 entries | ~64KB | ~40 seconds | **Selected** |
+| 1024 entries | ~256KB | ~3 minutes | Excessive for mobile |
+
+**Decision:** 256 entries. A typical desync investigation needs the 20-30 seconds before the event.
+
+---
+
+## Open Questions
+
+| # | Question | Options | Recommendation |
+|---|----------|---------|----------------|
+| Q1 | Should MatchTelemetry persist across rematches? | A) Reset per match B) Accumulate across session | A -- reset per match. Each match should have independent metrics. |
+| Q2 | Should the debug overlay be interactive (tap to expand)? | A) Static, always full B) Collapsed by default, tap to expand | B -- collapsed by default. Show only RTT and transport mode in collapsed state. |
+| Q3 | Should Logger support remote log shipping? | A) Local only (ring buffer + console) B) Optional WebSocket shipping | A for now. Bundle export is sufficient. Revisit if manual sharing proves insufficient. |
+| Q4 | Should the server diagnostic endpoint be available in production? | A) Always (token-protected) B) Dev only C) Feature-flagged | A -- always available. Token-protected is sufficient for a friends-only game. |
+| Q5 | Should debug bundles include raw input data? | A) Full inputs (replayable) B) Stats only (smaller) | A -- full inputs. FightRecorder already captures sparse inputs efficiently. Enables replay for reproduction. |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|-----------|------------|
+| Logger overhead in hot path | Frame drops during rollback resimulation | Low | Fast bail: single integer comparison when OFF. Never log inside `tick()` -- only in the networking layer around it. |
+| Ring buffer memory on mobile | Memory pressure on iPhone | Low | Cap individual entry `data` at 500 chars. Total buffer under 128KB worst case. |
+| Clipboard API failure on Mobile Safari | Can't export bundle | Medium | Always call from button click handler (satisfies user gesture requirement). HTTPS already required. Fall back to file download. |
+| Debug mode left on by accident | UI clutter, minor perf impact | Low | Visible "DEBUG" badge in overlay. "Desactivar" button to turn off. |
+| Breaking autoplay/E2E path | CI tests fail | Low | Change is additive (OR condition). Autoplay path identical. Add regression test. |
+| Bundle size exceeds clipboard limit | Long matches produce large bundles | Low | Sparse input recording keeps size manageable. Fall back to file download. Show size in toast. |
+
+---
+
+## Replacing Existing Console Logs
+
+The following existing `console.log`/`console.warn` calls get replaced by Logger calls. Non-breaking -- Logger emits to console at the same levels.
+
+| File | Line(s) | Current | Replacement |
+|------|---------|---------|-------------|
+| `TransportManager.js` | 54 | `console.log('[TM] WebRTC unavailable')` | `log.warn('WebRTC unavailable')` |
+| `TransportManager.js` | 61 | `console.log('[TM] initWebRTC ...')` | `log.info('WebRTC init', {slot, offerer})` |
+| `TransportManager.js` | 133 | `console.log('[TM] TURN ... failed')` | `log.warn('TURN fetch failed', {status})` |
+| `TransportManager.js` | 140 | `console.log('[TM] TURN ... fetched')` | `log.info('TURN fetched', {count})` |
+| `TransportManager.js` | 143 | `console.log('[TM] TURN ... error')` | `log.warn('TURN fetch error', {err})` |
+| `FightScene.js` | 798 | `console.warn('[DESYNC] ...')` | `log.warn('Desync', {frame, local, remote})` |
+| `FightScene.js` | 831 | `console.warn('[RESYNC] ...')` | `log.warn('Resync applied', {frame})` |
+| `FightScene.js` | 1850-1901 | `console.log('[SYNC] ...')` | `log.debug('Frame-0 sync', {...})` |
+| `party/server.js` | 131 | `console.log('TURN ... error')` | `console.log(JSON.stringify({type: 'turn_error', ...}))` |
+| `party/server.js` | 147 | `console.log('TURN ... error')` | `console.log(JSON.stringify({type: 'turn_error', ...}))` |
+
+---
+
+## Appendix: Example Debug Session
+
+A player reports "the game froze and then desynced" on their iPhone.
+
+1. Team asks player to reload with `?debug=1` appended to URL
+2. Player reproduces the issue
+3. Player taps the collapsed overlay, taps "Exportar Debug"
+4. Player pastes the JSON bundle into Discord/WhatsApp
+5. Team runs `generateReport()` on the bundle -- sees:
+   - RTT spike from 40ms to 800ms at frame 340
+   - Transport degraded from P2P to WS at frame 342
+   - 6-frame rollback at frame 345 (normal max is 3)
+   - Desync detected at frame 360 (checksum mismatch)
+   - Resync applied at frame 362
+   - Logger shows: `[TransportManager] DataChannel closed` at the exact timestamp
+   - Logger shows: `[InputSync] Buffer depth 0 for 4 consecutive frames` preceding the desync
+6. Team identifies root cause: network handoff caused ICE failure, WebSocket fallback introduced enough latency to exceed rollback window
+7. Fix: increase max rollback window when transport degrades, or add proactive resync on transport degradation

--- a/docs/rfcs/0004-multiplayer-debuggability.md
+++ b/docs/rfcs/0004-multiplayer-debuggability.md
@@ -1,6 +1,6 @@
 # RFC 0004: Multiplayer Debuggability
 
-**Status:** Proposed
+**Status:** Implemented
 **Date:** 2026-03-30
 **Author:** Architecture Team
 **Predecessor:** [RFC 0002: Multiplayer Architecture Redesign](0002-multiplayer-redesign.md) (Phases 1–3 complete)

--- a/docs/rfcs/0004-multiplayer-debuggability.md
+++ b/docs/rfcs/0004-multiplayer-debuggability.md
@@ -22,6 +22,60 @@ The system adds zero overhead when debug mode is off (always-on telemetry uses f
 
 ---
 
+## Debug Flow: How It Works in Practice
+
+### Manual testing (developer workflow)
+
+You're testing multiplayer: P1 on your laptop, P2 on your phone over 5G.
+
+**Today (no debug tools):**
+
+1. Open the game on both devices, create a room, play
+2. Something breaks -- freeze, desync, disconnect
+3. You have nothing. Maybe a `[DESYNC]` in the laptop's DevTools console if you had it open. The phone has no DevTools. You're guessing.
+
+**With this RFC:**
+
+1. Append `?debug=1` to both URLs:
+   - Laptop: `https://your-game.com/?debug=1&createRoom=1`
+   - Phone: `https://your-game.com/?debug=1&room=ABCD`
+2. Both show a small collapsed overlay at bottom-left: `RTT: 45ms P2P`
+3. Play the match. You can watch RTT and transport mode change in real time.
+4. Something breaks. Tap the overlay on the phone to expand:
+   ```
+   RTT: 820ms   WS
+   Rollbacks: 47  Max: 7
+   Desyncs: 2   Buf: 0
+   Estado: RECONNECTING
+   [Exportar Debug] [Exportar Todo]
+   ```
+   You already know: transport degraded from P2P to WebSocket, RTT spiked, rollbacks went deep, 2 desyncs, input buffer is empty (starved).
+5. Tap "Exportar Todo" on either device -- this collects debug bundles from **both peers and the server** into a single combined bundle, then copies it to clipboard.
+6. Paste the combined bundle into Slack/Discord. It contains:
+   - Both peers' Logger ring buffers (last ~40s of structured logs from every networking module)
+   - Both peers' FightRecorder data (inputs, checksums, rollback events, desync frames)
+   - Both peers' RTT samples, transport mode changes, match state transitions
+   - Server ring buffer (state transitions, message routing, grace period events)
+   - Device/connection info from both peers (`Navigator.connection` shows "5G, 30Mbps downlink" for the phone)
+   - Shared `sessionId` linking client logs to server logs
+7. Run `generateReport()` on the bundle or read the JSON directly. You can see:
+   - "RTT spiked from 40ms to 800ms at frame 340 on P2"
+   - "Transport degraded P2P→WS at frame 342"
+   - "`[TransportManager] DataChannel closed` at that exact timestamp"
+   - "`[InputSync] Buffer depth 0 for 4 frames` right before the desync"
+   - "Desync at frame 360, resync applied at frame 362"
+   - Server log: `{type: "relay", msgType: "input", transport: "ws"}` confirming WS fallback
+
+### When a player reports an issue
+
+1. Ask them to reload with `?debug=1` appended to the URL
+2. They reproduce the issue
+3. They tap the overlay → "Exportar Todo" (or "Exportar Debug" for just their own data)
+4. They paste the JSON into your chat
+5. You have everything you need to diagnose -- from both sides of the connection
+
+---
+
 ## Goals and Non-Goals
 
 ### Goals
@@ -356,7 +410,7 @@ Expanded (tap):
 │  Rollbacks: 12  Max: 3   │
 │  Desyncs: 0   Buf: 2     │
 │  Estado: ROUND_ACTIVE     │
-│  [Exportar Debug]         │
+│  [Exportar Debug] [Todo]  │
 └──────────────────────────┘
 ```
 
@@ -364,6 +418,8 @@ Expanded (tap):
 - Semi-transparent black background, monospace, depth 200
 - Only visible when `game.debugMode` is true
 - Reads from: `RollbackManager`, `ConnectionMonitor`, `TransportManager`, `InputSync`, `MatchStateMachine`
+- "Exportar Debug" exports only the local peer's bundle
+- "Todo" collects bundles from both peers + server (see section 8)
 
 ### 6. Server-Side Logging
 
@@ -414,6 +470,70 @@ sequenceDiagram
 - Both peers in a room have different session IDs, so you can distinguish P1 vs P2 in server logs
 - The `sessionId` is not sensitive (short random string, no PII)
 - Correlation is manual (grep server logs by sessionId, compare with client bundle) — no automated join needed
+
+### 8. 1-Click Bundle Collection ("Exportar Todo")
+
+Instead of asking both players to export bundles separately, either peer can collect **all debug data from both peers and the server** in one action.
+
+**Flow:**
+
+```mermaid
+sequenceDiagram
+    participant P1 as P1 (collector)
+    participant S as Server (PartyKit)
+    participant P2 as P2 (remote peer)
+
+    P1->>P1: Generate own debug bundle
+    par Collect remote data
+        P1->>S: send({type: 'debug_request'})
+        S->>P2: relay debug_request
+        P2->>P2: Generate own debug bundle
+        P2->>S: send({type: 'debug_response', bundle: {...}})
+        S->>P1: relay debug_response
+    and Collect server data
+        P1->>S: GET /diagnostics (HTTP)
+        S->>P1: {roomState, players, eventLog}
+    end
+    P1->>P1: Merge into combined bundle
+    P1->>P1: Copy to clipboard / download
+```
+
+**Server changes (`party/server.js`):**
+
+Two new message types in the `onMessage` switch — simple relay, same pattern as `checksum`/`resync_request`:
+
+```javascript
+case 'debug_request':
+case 'debug_response':
+  this._sendToOther(slot, data);
+  break;
+```
+
+**Client changes:**
+
+- `NetworkFacade` gets four new methods: `sendDebugRequest()`, `onDebugRequest(cb)`, `sendDebugResponse(bundle)`, `onDebugResponse(cb)`
+- `DebugBundleExporter.collectAll()` orchestrates the flow: generate local bundle, send request to peer, fetch `/diagnostics`, wait for response (3s timeout), merge
+
+**Combined bundle format:**
+
+```javascript
+{
+  version: 2,
+  source: 'debug-combined',
+  collectedBy: 'p1',                    // which peer initiated collection
+  local: { /* collector's full debug data */ },
+  remote: { /* other peer's debug data */ },  // null if peer unavailable
+  remoteError: null | 'timeout' | 'not_in_debug_mode',
+  server: { /* /diagnostics response */ },    // null if endpoint unavailable
+  serverError: null | 'fetch_failed' | 'unauthorized',
+}
+```
+
+**Edge cases:**
+- P2 not in debug mode → P2 receives `debug_request` but has no FightRecorder. Responds with a minimal bundle (environment info only, `debugMode: false`). Collector sees `remote.debugMode: false`.
+- P2 disconnected → `debug_response` never arrives. 3-second timeout, combined bundle has `remote: null, remoteError: 'timeout'`.
+- Server `/diagnostics` unavailable → `server: null, serverError: 'fetch_failed'`. Collection still succeeds with client-side data.
+- Both peers in debug mode → either can be the collector. The "Todo" button is available on both.
 
 ---
 
@@ -536,6 +656,10 @@ sequenceDiagram
 | 3.5 | Add MatchStateMachine transition logging | Record all transitions in an array: `{ ts, from, to, event }`. Capped at 100 entries. Feed into debug bundle. |
 | 3.6 | Collect environment info | `navigator.userAgent`, `navigator.platform`, `navigator.connection` (if available: `type`, `downlink`, `rtt`). Include in `diagnostics.environment`. |
 | 3.7 | E2E bundle backward compatibility | Ensure existing `generateBundle()` in `tests/e2e/helpers/bundle-generator.js` still works. New bundles are a superset. `generateReport()` handles both v1 and v2 bundles. |
+| 3.8 | Add `debug_request`/`debug_response` relay to server | Add both message types to `onMessage` switch in `party/server.js` — simple `_sendToOther(slot, data)` relay, same pattern as `checksum`. |
+| 3.9 | Add debug request/response to `NetworkFacade` | `sendDebugRequest()`, `onDebugRequest(cb)`, `sendDebugResponse(bundle)`, `onDebugResponse(cb)`. Wire `onDebugRequest` to auto-respond with local bundle. |
+| 3.10 | Add `collectAll()` to `DebugBundleExporter` | Orchestrates: generate local bundle → send `debug_request` to peer → fetch `GET /diagnostics` → wait for `debug_response` (3s timeout) → merge into combined bundle with `source: 'debug-combined'`. |
+| 3.11 | Add "Todo" button to debug overlay | "Exportar Todo" alongside "Exportar Debug". Calls `collectAll()`, shows "Recopilando..." while waiting, then "Copiado!" on success. |
 
 **Verification:**
 - Exported bundle is valid JSON
@@ -547,6 +671,9 @@ sequenceDiagram
 - Copy-to-clipboard works on Mobile Safari iPhone 15
 - File download works as fallback
 - Bundle size is reasonable (50-200KB for a typical match)
+- "Exportar Todo" collects data from both peers when both are connected and in debug mode
+- "Exportar Todo" gracefully handles P2 disconnected (combined bundle with `remote: null`)
+- "Exportar Todo" gracefully handles `/diagnostics` unavailable (combined bundle with `server: null`)
 
 ---
 
@@ -671,21 +798,38 @@ The following existing `console.log`/`console.warn` calls get replaced by Logger
 
 ---
 
-## Appendix: Example Debug Session
+## Appendix: Example Analysis of a Combined Debug Bundle
 
-A player reports "the game froze and then desynced" on their iPhone.
+A developer tests with laptop (P1) + phone on 5G (P2). The match desyncs. They tap "Todo" on the laptop to collect everything, paste the combined bundle, and open it:
 
-1. Team asks player to reload with `?debug=1` appended to URL
-2. Player reproduces the issue
-3. Player taps the collapsed overlay, taps "Exportar Debug"
-4. Player pastes the JSON bundle into Discord/WhatsApp
-5. Team runs `generateReport()` on the bundle -- sees:
-   - RTT spike from 40ms to 800ms at frame 340
-   - Transport degraded from P2P to WS at frame 342
-   - 6-frame rollback at frame 345 (normal max is 3)
-   - Desync detected at frame 360 (checksum mismatch)
-   - Resync applied at frame 362
-   - Logger shows: `[TransportManager] DataChannel closed` at the exact timestamp
-   - Logger shows: `[InputSync] Buffer depth 0 for 4 consecutive frames` preceding the desync
-6. Team identifies root cause: network handoff caused ICE failure, WebSocket fallback introduced enough latency to exceed rollback window
-7. Fix: increase max rollback window when transport degrades, or add proactive resync on transport degradation
+```
+combined.local (P1 - laptop):
+  RTT samples: [38, 42, 40, 45, 41, 820, 790, 650]   ← spike at sample 6
+  Transport: webrtc → websocket at frame 342
+  Rollbacks: 47 total, max depth 7
+  Desyncs: 2 (frames 360, 385)
+  Logger:
+    [TransportManager] DataChannel closed                 @ 1711814422340
+    [InputSync] Buffer depth 0, 4 consecutive frames      @ 1711814422400
+    [ConnectionMonitor] Pong RTT=820ms                    @ 1711814422500
+
+combined.remote (P2 - phone 5G):
+  Environment: iPhone, Safari 18.2, connection: { type: 'cellular', downlink: 30 }
+  RTT samples: [40, 38, 42, 800, 750, 680]              ← spike earlier on P2 side
+  Transport: webrtc → websocket at frame 340              ← P2 lost P2P first
+  Rollbacks: 52 total, max depth 7
+  Logger:
+    [TransportManager] DataChannel closed (ICE failed)    @ 1711814422100
+    [SignalingClient] Socket close                        @ 1711814422200
+    [SignalingClient] Socket open (reconnect)             @ 1711814422800
+
+combined.server:
+  Event log:
+    {type: "state_transition", from: "fighting", to: "reconnecting"} @ 1711814422250
+    {type: "relay", msgType: "input", slot: 1, transport: "ws"}      @ 1711814422900
+    {type: "state_transition", from: "reconnecting", to: "fighting"} @ 1711814422850
+```
+
+**Root cause:** 5G handoff on P2's phone caused ICE failure at frame 340. P2 lost DataChannel first, then WebSocket briefly. Server went to `reconnecting` state. After reconnect, all traffic on WebSocket relay added ~800ms latency, exceeding the rollback window and causing desyncs.
+
+**Fix direction:** Increase max rollback window when transport degrades, or proactively resync on transport degradation.

--- a/docs/rfcs/0005-multiplayer-debuggability.md
+++ b/docs/rfcs/0005-multiplayer-debuggability.md
@@ -1,4 +1,4 @@
-# RFC 0004: Multiplayer Debuggability
+# RFC 0005: Multiplayer Debuggability
 
 **Status:** Implemented
 **Date:** 2026-03-30

--- a/party/server.js
+++ b/party/server.js
@@ -64,6 +64,23 @@ export default class FightRoom {
     this._potionCooldowns = new Map();
     /** @type {(ReturnType<typeof setTimeout>|null)[]} grace period timers per slot */
     this._graceTimers = [null, null];
+    /** @type {Map<string, string>} connectionId -> sessionId for log correlation */
+    this._sessionIds = new Map();
+    /** @type {Array<object>} Ring buffer of last 50 server events */
+    this._eventLog = [];
+    this._eventLogMax = 50;
+  }
+
+  /**
+   * Structured log: writes JSON to console (for wrangler tail) and ring buffer.
+   */
+  _log(entry) {
+    const full = { ts: Date.now(), roomId: this.party.id, ...entry };
+    console.log(JSON.stringify(full));
+    this._eventLog.push(full);
+    if (this._eventLog.length > this._eventLogMax) {
+      this._eventLog.shift();
+    }
   }
 
   /**
@@ -72,7 +89,9 @@ export default class FightRoom {
   _transition(event) {
     const transitions = ROOM_TRANSITIONS[this.roomState];
     if (!transitions || !transitions[event]) return false;
+    const from = this.roomState;
     this.roomState = transitions[event];
+    this._log({ type: 'state_transition', from, to: this.roomState, event });
     return true;
   }
 
@@ -98,6 +117,22 @@ export default class FightRoom {
       }
       return response;
     }
+
+    if (url.pathname.endsWith('/diagnostics') && request.method === 'GET') {
+      const diagToken = this.party.env?.DIAG_TOKEN;
+      if (diagToken) {
+        const auth = request.headers.get('Authorization');
+        if (auth !== `Bearer ${diagToken}`) {
+          return new Response('Unauthorized', { status: 401, headers: corsHeaders });
+        }
+      }
+      const response = Response.json(this._getDiagnostics());
+      for (const [key, value] of Object.entries(corsHeaders)) {
+        response.headers.set(key, value);
+      }
+      return response;
+    }
+
     return new Response('Not Found', { status: 404, headers: corsHeaders });
   }
 
@@ -128,7 +163,7 @@ export default class FightRoom {
       );
 
       if (!response.ok) {
-        console.log(`TURN credential API error: ${response.status}`);
+        this._log({ type: 'turn_error', reason: 'api_error', status: response.status });
         return Response.json(
           {
             iceServers: [
@@ -144,7 +179,7 @@ export default class FightRoom {
       const iceServers = Array.isArray(data.iceServers) ? data.iceServers : [data.iceServers];
       return Response.json({ iceServers });
     } catch (err) {
-      console.log('TURN credential fetch error:', err.message);
+      this._log({ type: 'turn_error', reason: 'fetch_error', error: err.message });
       return Response.json(
         {
           iceServers: [
@@ -160,6 +195,10 @@ export default class FightRoom {
   onConnect(connection, ctx) {
     const url = new URL(ctx.request.url);
     const isSpectator = url.searchParams.get('spectate') === '1';
+    const sessionId = url.searchParams.get('sessionId') || null;
+    if (sessionId) {
+      this._sessionIds.set(connection.id, sessionId);
+    }
 
     if (isSpectator) {
       this.spectators.add(connection.id);
@@ -199,6 +238,7 @@ export default class FightRoom {
     }
 
     this.players[slot] = { id: connection.id, fighterId: null, ready: false };
+    this._log({ type: 'connect', slot, sessionId, roomState: this.roomState });
     connection.send(JSON.stringify({ type: 'assign', player: slot }));
 
     if (this.spectators.size > 0) {
@@ -276,6 +316,10 @@ export default class FightRoom {
       case 'rematch':
         this._sendToOther(slot, data);
         break;
+      case 'debug_request':
+      case 'debug_response':
+        this._sendToOther(slot, data);
+        break;
       case 'leave':
         this._handleLeave(slot);
         break;
@@ -334,6 +378,15 @@ export default class FightRoom {
     const rejoinSlot = data.slot;
     if (rejoinSlot !== 0 && rejoinSlot !== 1) return;
 
+    const sessionId = this._sessionIds.get(connection.id) || null;
+    this._log({
+      type: 'rejoin',
+      slot: rejoinSlot,
+      sessionId,
+      graceActive: !!this._graceTimers[rejoinSlot],
+      reset: !!data.reset,
+    });
+
     if (!this._graceTimers[rejoinSlot]) {
       // No grace period active — connection restored before server saw disconnect.
       // Update connection ID so stale onClose won't match this slot.
@@ -388,7 +441,15 @@ export default class FightRoom {
       case 'shout': {
         const now = Date.now();
         const last = this._shoutCooldowns.get(connection.id) || 0;
-        if (now - last < 2000) return;
+        if (now - last < 2000) {
+          this._log({
+            type: 'rate_limit',
+            msgType: 'shout',
+            connId: connection.id,
+            cooldownRemaining: 2000 - (now - last),
+          });
+          return;
+        }
         this._shoutCooldowns.set(connection.id, now);
         this._broadcast({ type: 'shout', text: String(data.text).slice(0, 20) });
         break;
@@ -396,7 +457,15 @@ export default class FightRoom {
       case 'potion': {
         const now = Date.now();
         const last = this._potionCooldowns.get(connection.id) || 0;
-        if (now - last < 15000) return;
+        if (now - last < 15000) {
+          this._log({
+            type: 'rate_limit',
+            msgType: 'potion',
+            connId: connection.id,
+            cooldownRemaining: 15000 - (now - last),
+          });
+          return;
+        }
         this._potionCooldowns.set(connection.id, now);
         const target = data.target === 0 ? 0 : 1;
         const potionType = data.potionType === 'special' ? 'special' : 'hp';
@@ -419,6 +488,10 @@ export default class FightRoom {
     const slot = this._slotOf(connection.id);
     if (slot === -1) return;
 
+    const sessionId = this._sessionIds.get(connection.id) || null;
+    this._log({ type: 'disconnect', slot, sessionId, roomState: this.roomState });
+    this._sessionIds.delete(connection.id);
+
     this._stateBeforeGrace = this.roomState;
     this._transition('ws_close');
     this._sendToOther(slot, { type: 'opponent_reconnecting' });
@@ -431,6 +504,7 @@ export default class FightRoom {
   }
 
   _finalizeDisconnect(slot) {
+    this._log({ type: 'grace_expired', slot, stateBeforeGrace: this._stateBeforeGrace });
     const wasFighting = this._stateBeforeGrace === RoomState.FIGHTING;
     this.players[slot] = null;
 
@@ -516,5 +590,26 @@ export default class FightRoom {
     for (const conn of this.party.getConnections()) {
       conn.send(json);
     }
+  }
+
+  _getDiagnostics() {
+    return {
+      roomId: this.party.id,
+      roomState: this.roomState,
+      players: this.players.map((p, i) => {
+        if (!p) return null;
+        return {
+          slot: i,
+          ready: p.ready,
+          fighterId: p.fighterId,
+          sessionId: this._sessionIds.get(p.id) || null,
+        };
+      }),
+      spectatorCount: this.spectators.size,
+      graceTimers: [!!this._graceTimers[0], !!this._graceTimers[1]],
+      fightInfo: this.fightInfo,
+      stateBeforeGrace: this._stateBeforeGrace,
+      eventLog: this._eventLog.slice(),
+    };
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,9 @@
 import Phaser from 'phaser';
 import { GAME_HEIGHT, GAME_WIDTH } from './config.js';
+import { Logger } from './systems/Logger.js';
+
+const log = Logger.create('Main');
+
 import { BootScene } from './scenes/BootScene.js';
 import { BracketScene } from './scenes/BracketScene.js';
 import { FightScene } from './scenes/FightScene.js';
@@ -67,6 +71,6 @@ new AudioManager(window.game);
 
 // Initialize Auth State
 onAuthStateChange((event, session) => {
-  console.log(`Auth event: ${event}`);
+  log.info('Auth state change', { event });
   window.game.registry.set('user', session?.user || null);
 });

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -144,8 +144,17 @@ export class BootScene extends Phaser.Scene {
     this.generateRect('special_bar_bg', 100, 8, 0x333333);
     this.generateRect('special_bar_fill', 100, 8, 0xffcc00);
 
-    // If URL has ?room=, go directly to lobby as joiner or spectator
+    // Parse debug mode URL param
     const params = new URLSearchParams(window.location.search);
+    if (params.get('debug') === '1') {
+      this.game.debugMode = true;
+      // Import Logger dynamically to avoid circular deps in BootScene
+      import('../systems/Logger.js').then(({ Logger, LogLevel }) => {
+        Logger.setGlobalLevel(LogLevel.DEBUG);
+      });
+    }
+
+    // If URL has ?room=, go directly to lobby as joiner or spectator
     const roomId = params.get('room');
     // Replay mode: load bundle from window global or sessionStorage
     if (this.game.autoplay?.replay) {

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -25,7 +25,9 @@ import {
 } from '../systems/FixedPoint.js';
 import { encodeInput } from '../systems/InputBuffer.js';
 import { InputManager } from '../systems/InputManager.js';
+import { Logger, LogLevel } from '../systems/Logger.js';
 import { MatchEvent, MatchState, MatchStateMachine } from '../systems/MatchStateMachine.js';
+import { MatchTelemetry } from '../systems/MatchTelemetry.js';
 import { ReconnectionManager } from '../systems/ReconnectionManager.js';
 import { ReplayInputSource } from '../systems/ReplayInputSource.js';
 import { RollbackManager } from '../systems/RollbackManager.js';
@@ -36,6 +38,8 @@ import { VFXBridge } from '../systems/VFXBridge.js';
 // ---------------------------------------------------------------------------
 // HUD layout constants
 // ---------------------------------------------------------------------------
+const log = Logger.create('FightScene');
+
 const BAR_W = 160;
 const BAR_H = 10;
 const BAR_Y = 12;
@@ -226,6 +230,117 @@ export class FightScene extends Phaser.Scene {
       this._startFrameZeroSync();
     } else {
       this._showRoundIntro();
+    }
+
+    // Triple-tap gesture to activate debug mode (top-right 60x40 region)
+    if (this.gameMode === 'online' && !this.game.debugMode) {
+      this._tripleTapTimes = [];
+      this.input.on('pointerdown', (pointer) => {
+        if (pointer.x > GAME_WIDTH - 60 && pointer.y < 40) {
+          const now = Date.now();
+          this._tripleTapTimes.push(now);
+          // Keep only taps within the last 1 second
+          this._tripleTapTimes = this._tripleTapTimes.filter((t) => now - t < 1000);
+          if (this._tripleTapTimes.length >= 3) {
+            this._tripleTapTimes = [];
+            this._activateDebugMode();
+          }
+        }
+      });
+    }
+  }
+
+  _activateDebugMode() {
+    if (this.game.debugMode) return;
+    this.game.debugMode = true;
+    Logger.setGlobalLevel(LogLevel.DEBUG);
+    log.info('Debug mode activated via triple-tap');
+
+    // Activate FightRecorder if not already running
+    if (!this.recorder && this.networkManager) {
+      const nm = this.networkManager;
+      const slot = nm.getPlayerSlot();
+      this.recorder = new FightRecorder({
+        roomId: nm.roomId,
+        playerSlot: slot,
+        fighterId: slot === 0 ? this.p1Id : this.p2Id,
+        opponentId: slot === 0 ? this.p2Id : this.p1Id,
+        stageId: this.stageId,
+        config: {},
+      });
+      // Wire recorder to rollback manager
+      const origRollback = this.rollbackManager._onRollback;
+      this.rollbackManager._onRollback = (frame, depth) => {
+        this.recorder.recordRollback(frame, depth);
+        if (origRollback) origRollback(frame, depth);
+      };
+      this.rollbackManager._onLocalChecksum = (frame, hash) =>
+        this.recorder.recordChecksum(frame, hash);
+      this.rollbackManager._onConfirmedInputs = (frame, p1, p2) =>
+        this.recorder.recordConfirmedInputs(frame, p1, p2);
+    }
+
+    // Create debug overlay
+    import('../systems/DebugOverlay.js').then(({ DebugOverlay }) => {
+      const nm = this.networkManager;
+      this.debugOverlay = new DebugOverlay(this, {
+        getTelemetry: () => this.telemetry,
+        getConnectionMonitor: () => nm.monitor,
+        getTransportManager: () => nm.transport,
+        getInputSync: () => nm.inputSync,
+        getMatchState: () => this.matchState,
+        onExportDebug: () => this._exportDebugBundle(),
+        onExportAll: () => this._exportAllBundles(),
+      });
+    });
+  }
+
+  async _exportDebugBundle() {
+    const { DebugBundleExporter } = await import('../systems/DebugBundleExporter.js');
+    const bundle = DebugBundleExporter.generateBundle({
+      recorder: this.recorder,
+      telemetry: this.telemetry,
+      matchState: this.matchState,
+      sessionId: this.networkManager?.sessionId,
+      debugMode: !!this.game.debugMode,
+    });
+    const copied = await DebugBundleExporter.copyToClipboard(bundle);
+    if (this.debugOverlay) {
+      this.debugOverlay.showToast(copied ? 'Copiado!' : 'Descargado!');
+    }
+  }
+
+  async _exportAllBundles() {
+    if (this.debugOverlay) this.debugOverlay.showToast('Recopilando...');
+    const { DebugBundleExporter } = await import('../systems/DebugBundleExporter.js');
+
+    // Auto-respond to debug requests from the other peer
+    const nm = this.networkManager;
+    nm.onDebugRequest(() => {
+      const localBundle = DebugBundleExporter.generateBundle({
+        recorder: this.recorder,
+        telemetry: this.telemetry,
+        matchState: this.matchState,
+        sessionId: nm.sessionId,
+        debugMode: !!this.game.debugMode,
+      });
+      nm.sendDebugResponse(localBundle);
+    });
+
+    const combined = await DebugBundleExporter.collectAll({
+      generateLocalBundle: () =>
+        DebugBundleExporter.generateBundle({
+          recorder: this.recorder,
+          telemetry: this.telemetry,
+          matchState: this.matchState,
+          sessionId: nm.sessionId,
+          debugMode: !!this.game.debugMode,
+        }),
+      networkManager: nm,
+    });
+    const copied = await DebugBundleExporter.copyToClipboard(combined);
+    if (this.debugOverlay) {
+      this.debugOverlay.showToast(copied ? 'Copiado!' : 'Descargado!');
     }
   }
 
@@ -731,6 +846,13 @@ export class FightScene extends Phaser.Scene {
   _setupOnlineMode() {
     const nm = this.networkManager;
     const slot = nm.getPlayerSlot();
+    log.info('Online mode setup', {
+      slot,
+      room: nm.roomId,
+      p1: this.p1Id,
+      p2: this.p2Id,
+      stage: this.stageId,
+    });
 
     // Both peers are equal in rollback netcode (no host/guest distinction for gameplay)
     this.isHost = slot === 0;
@@ -766,8 +888,8 @@ export class FightScene extends Phaser.Scene {
       }
     }
 
-    // Fight recorder for E2E testing
-    if (this.game.autoplay?.enabled) {
+    // Fight recorder for E2E testing and debug mode
+    if (this.game.autoplay?.enabled || this.game.debugMode) {
       this.recorder = new FightRecorder({
         roomId: nm.roomId,
         playerSlot: slot,
@@ -775,12 +897,16 @@ export class FightScene extends Phaser.Scene {
         opponentId: slot === 0 ? this.p2Id : this.p1Id,
         stageId: this.stageId,
         config: {
-          seed: this.game.autoplay.seed,
-          speed: this.game.autoplay.speed,
-          aiDifficulty: this.game.autoplay.aiDifficulty,
+          seed: this.game.autoplay?.seed,
+          speed: this.game.autoplay?.speed,
+          aiDifficulty: this.game.autoplay?.aiDifficulty,
         },
       });
     }
+
+    // Always-on telemetry
+    this.telemetry = new MatchTelemetry(nm.roomId);
+    this.telemetry.wireConnectionMonitor(nm.monitor);
 
     // Wire recorder hooks into rollback manager
     if (this.recorder) {
@@ -792,10 +918,51 @@ export class FightScene extends Phaser.Scene {
         this.recorder.recordConfirmedInputs(frame, p1, p2);
     }
 
+    // Wire telemetry to rollback manager (augment existing callbacks)
+    const origRollback = this.rollbackManager._onRollback;
+    this.rollbackManager._onRollback = (frame, depth) => {
+      this.telemetry.recordRollback(frame, depth);
+      if (origRollback) origRollback(frame, depth);
+    };
+
+    // Wire transport changes to telemetry
+    nm.onTransportDegraded(() => this.telemetry.recordTransportChange('websocket'));
+    nm.onTransportRestored(() => this.telemetry.recordTransportChange('webrtc'));
+
+    // Debug overlay (only in debug mode)
+    if (this.game.debugMode) {
+      import('../systems/DebugOverlay.js').then(({ DebugOverlay }) => {
+        this.debugOverlay = new DebugOverlay(this, {
+          getTelemetry: () => this.telemetry,
+          getConnectionMonitor: () => nm.monitor,
+          getTransportManager: () => nm.transport,
+          getInputSync: () => nm.inputSync,
+          getMatchState: () => this.matchState,
+          onExportDebug: () => this._exportDebugBundle(),
+          onExportAll: () => this._exportAllBundles(),
+        });
+      });
+    }
+
+    // Auto-respond to debug_request from peer (always wired, even without debug mode)
+    nm.onDebugRequest(() => {
+      import('../systems/DebugBundleExporter.js').then(({ DebugBundleExporter }) => {
+        const bundle = DebugBundleExporter.generateBundle({
+          recorder: this.recorder,
+          telemetry: this.telemetry,
+          matchState: this.matchState,
+          sessionId: nm.sessionId,
+          debugMode: !!this.game.debugMode,
+        });
+        nm.sendDebugResponse(bundle);
+      });
+    });
+
     // Wire desync detection + resync
     nm.onChecksum((frame, hash) => this.rollbackManager.handleRemoteChecksum(frame, hash));
     this.rollbackManager._onDesync = (frame, localHash, remoteHash) => {
-      console.warn(`[DESYNC] frame=${frame} local=${localHash} remote=${remoteHash}`);
+      log.warn('Desync detected', { frame, local: localHash, remote: remoteHash });
+      this.telemetry.recordDesync();
       this.recorder?.recordDesync(frame, localHash, remoteHash);
       this._showDesyncWarning();
 
@@ -828,7 +995,8 @@ export class FightScene extends Phaser.Scene {
     // P2 applies resync snapshots from P1
     nm.onResync((msg) => {
       if (this.isHost) return;
-      console.warn(`[RESYNC] Applying P1 snapshot at frame ${msg.snapshot.frame}`);
+      log.warn('Resync applied', { frame: msg.snapshot.frame });
+      this.telemetry.recordResync();
       this.rollbackManager.applyResync(msg.snapshot, this.p1Fighter, this.p2Fighter, this.combat);
       if (this._desyncWarning) {
         this._desyncWarning.destroy();
@@ -849,19 +1017,24 @@ export class FightScene extends Phaser.Scene {
     nm.onRoundEvent((msg) => {
       if (this.isHost) return; // P1 already handled locally
       if (msg.matchOver && this._matchOverProcessed) {
-        console.log(`[FightScene] P2 onRoundEvent ignored: matchOver already processed`);
+        log.debug('P2 onRoundEvent ignored: matchOver already processed');
         return;
       }
       if (!msg.matchOver && msg.roundNumber <= this._lastProcessedRound) {
-        console.log(
-          `[FightScene] P2 onRoundEvent ignored: round ${msg.roundNumber} already processed (last=${this._lastProcessedRound})`,
-        );
+        log.debug('P2 onRoundEvent ignored: round already processed', {
+          round: msg.roundNumber,
+          last: this._lastProcessedRound,
+        });
         return;
       }
 
-      console.log(
-        `[FightScene] P2 onRoundEvent: event=${msg.event} winner=P${msg.winnerIndex + 1} matchOver=${msg.matchOver} round=${msg.roundNumber} state=${this.matchState.state}`,
-      );
+      log.debug('P2 onRoundEvent', {
+        event: msg.event,
+        winner: msg.winnerIndex,
+        matchOver: msg.matchOver,
+        round: msg.roundNumber,
+        state: this.matchState.state,
+      });
 
       // Don't modify combat state here — simulateFrame handles it deterministically.
       // Fire round-end audio/VFX via bridges, then UI transitions.
@@ -1154,9 +1327,13 @@ export class FightScene extends Phaser.Scene {
 
     // Handle round events (same flow as online P1/host)
     if (roundEvent) {
-      console.log(
-        `[FightScene] Local roundEvent: type=${roundEvent.type} winner=P${roundEvent.winnerIndex + 1} matchOver=${this.combat.matchOver} frame=${this._localFrame} state=${this.matchState.state}`,
-      );
+      log.debug('Local roundEvent', {
+        type: roundEvent.type,
+        winner: roundEvent.winnerIndex,
+        matchOver: this.combat.matchOver,
+        frame: this._localFrame,
+        state: this.matchState.state,
+      });
       this.combat.stopRound();
       if (this.combat.matchOver) {
         this.onMatchOver(roundEvent.winnerIndex);
@@ -1278,9 +1455,13 @@ export class FightScene extends Phaser.Scene {
     // P1 (host) handles round events: stop round timer + UI transitions
     // Audio/VFX already handled by bridges above via round_ko/round_timeup events
     if (roundEvent && this.isHost) {
-      console.log(
-        `[FightScene] P1 roundEvent: type=${roundEvent.type} winner=P${roundEvent.winnerIndex + 1} matchOver=${this.combat.matchOver} frame=${this.rollbackManager.currentFrame} state=${this.matchState.state}`,
-      );
+      log.debug('P1 roundEvent', {
+        type: roundEvent.type,
+        winner: roundEvent.winnerIndex,
+        matchOver: this.combat.matchOver,
+        frame: this.rollbackManager.currentFrame,
+        state: this.matchState.state,
+      });
       this.combat.stopRound();
       if (this.combat.matchOver) {
         this.onMatchOver(roundEvent.winnerIndex);
@@ -1847,13 +2028,13 @@ export class FightScene extends Phaser.Scene {
 
     // Listen for peer's hash
     nm.onFrameZeroSync((msg) => {
-      console.log(`[SYNC] Received peer hash: ${msg.hash}`);
+      log.debug('Frame-0 sync: received peer hash', { hash: msg.hash });
       this._syncRemoteHash = msg.hash;
       this._checkFrameZeroSync();
     });
 
     // Send our hash immediately and retry every 500ms until confirmed
-    console.log(`[SYNC] Sending frame-0 hash: ${localHash}`);
+    log.debug('Frame-0 sync: sending hash', { hash: localHash });
     nm.sendFrameZeroSync(localHash);
     this._syncRetryTimer = this.time.addEvent({
       delay: 500,
@@ -1868,7 +2049,7 @@ export class FightScene extends Phaser.Scene {
     // Timeout: 5 seconds
     this._syncTimeout = this.time.delayedCall(5000, () => {
       if (this.matchState.state === MatchState.SYNCHRONIZING) {
-        console.warn('[SYNC] Frame-0 sync timed out');
+        log.warn('Frame-0 sync timed out');
         this._cleanupSyncTimers();
         this.matchState.transition(MatchEvent.SYNC_TIMEOUT);
         this.centerText.setText('DESCONECTADO');
@@ -1896,11 +2077,12 @@ export class FightScene extends Phaser.Scene {
     this._cleanupSyncTimers();
 
     if (this._syncLocalHash === this._syncRemoteHash) {
-      console.log('[SYNC] Frame-0 sync confirmed');
+      log.debug('Frame-0 sync confirmed', { hash: this._syncLocalHash });
     } else {
-      console.warn(
-        `[SYNC] Frame-0 hash mismatch: local=${this._syncLocalHash}, remote=${this._syncRemoteHash}. Proceeding anyway.`,
-      );
+      log.warn('Frame-0 hash mismatch', {
+        local: this._syncLocalHash,
+        remote: this._syncRemoteHash,
+      });
     }
 
     this.matchState.transition(MatchEvent.SYNC_CONFIRMED);
@@ -1985,14 +2167,14 @@ export class FightScene extends Phaser.Scene {
    */
   onRoundOver(winnerIndex) {
     if (!this.matchState.canTransition(MatchEvent.ROUND_OVER)) {
-      console.warn(
-        `[FightScene] onRoundOver ignored: cannot transition ROUND_OVER from state=${this.matchState.state}`,
-      );
+      log.warn('onRoundOver ignored: invalid state', { state: this.matchState.state });
       return;
     }
-    console.log(
-      `[FightScene] onRoundOver winner=P${winnerIndex + 1} state=${this.matchState.state} rounds=${this.combat.p1RoundsWon}-${this.combat.p2RoundsWon}`,
-    );
+    log.debug('Round over', {
+      winner: winnerIndex,
+      state: this.matchState.state,
+      rounds: `${this.combat.p1RoundsWon}-${this.combat.p2RoundsWon}`,
+    });
     this.matchState.transition(MatchEvent.ROUND_OVER);
 
     // Host sends round event to guest
@@ -2034,15 +2216,15 @@ export class FightScene extends Phaser.Scene {
       if (this.matchState.canTransition(MatchEvent.ROUND_OVER)) {
         // Still in ROUND_ACTIVE — need ROUND_OVER first, then check again
       } else {
-        console.warn(
-          `[FightScene] onMatchOver ignored: cannot transition MATCH_OVER from state=${this.matchState.state}`,
-        );
+        log.warn('onMatchOver ignored: invalid state', { state: this.matchState.state });
         return;
       }
     }
-    console.log(
-      `[FightScene] onMatchOver winner=P${winnerIndex + 1} state=${this.matchState.state} rounds=${this.combat.p1RoundsWon}-${this.combat.p2RoundsWon}`,
-    );
+    log.debug('Match over', {
+      winner: winnerIndex,
+      state: this.matchState.state,
+      rounds: `${this.combat.p1RoundsWon}-${this.combat.p2RoundsWon}`,
+    });
     if (this.matchState.canTransition(MatchEvent.ROUND_OVER)) {
       this.matchState.transition(MatchEvent.ROUND_OVER);
     }
@@ -2163,6 +2345,8 @@ export class FightScene extends Phaser.Scene {
     if (this.aiController) this.aiController.destroy();
     if (this.touchControls) this.touchControls.destroy();
     if (this.reconnectionManager) this.reconnectionManager.destroy();
+    if (this.telemetry) this.telemetry.destroy();
+    if (this.debugOverlay) this.debugOverlay.destroy();
     this._cleanupSyncTimers();
     this.matchState = null;
     // Destroy projectiles

--- a/src/scenes/LoginScene.js
+++ b/src/scenes/LoginScene.js
@@ -2,6 +2,9 @@ import Phaser from 'phaser';
 import { GAME_HEIGHT, GAME_WIDTH } from '../config.js';
 import { syncProfile } from '../services/api.js';
 import { getSession, logIn, signUp } from '../services/supabase.js';
+import { Logger } from '../systems/Logger.js';
+
+const log = Logger.create('LoginScene');
 
 export class LoginScene extends Phaser.Scene {
   constructor() {
@@ -41,14 +44,14 @@ export class LoginScene extends Phaser.Scene {
         try {
           await syncProfile(session.user.user_metadata?.nickname);
         } catch (e) {
-          console.error('Profile sync failed', e);
+          log.warn('Profile sync failed', { err: e.message });
         }
 
         this.time.delayedCall(1000, () => this.scene.start('TitleScene'));
         return;
       }
     } catch (e) {
-      console.error('Session check failed', e);
+      log.warn('Session check failed', { err: e.message });
     }
 
     this.statusText.setText('Inicia sesión para guardar tus estadísticas');

--- a/src/scenes/TitleScene.js
+++ b/src/scenes/TitleScene.js
@@ -3,6 +3,9 @@ import { GAME_HEIGHT, GAME_WIDTH } from '../config.js';
 import { getProfile } from '../services/api.js';
 import { logOut } from '../services/supabase.js';
 import { createButton } from '../services/UIService.js';
+import { Logger } from '../systems/Logger.js';
+
+const log = Logger.create('TitleScene');
 
 export class TitleScene extends Phaser.Scene {
   constructor() {
@@ -102,7 +105,7 @@ export class TitleScene extends Phaser.Scene {
           await logOut();
           this.scene.start('LoginScene');
         } catch (e) {
-          console.error('Logout failed', e);
+          log.warn('Logout failed', { err: e.message });
         }
       });
 
@@ -116,7 +119,7 @@ export class TitleScene extends Phaser.Scene {
           }
         })
         .catch((e) => {
-          console.warn('Could not fetch profile', e);
+          log.warn('Profile fetch failed', { err: e.message });
           statsText.setText('Estadísticas no disponibles');
         });
     } else {

--- a/src/scenes/VictoryScene.js
+++ b/src/scenes/VictoryScene.js
@@ -4,6 +4,9 @@ import fightersData from '../data/fighters.json';
 import { updateStats } from '../services/api.js';
 import { TournamentManager } from '../services/TournamentManager.js';
 import { createButton } from '../services/UIService.js';
+import { Logger } from '../systems/Logger.js';
+
+const log = Logger.create('VictoryScene');
 
 export class VictoryScene extends Phaser.Scene {
   constructor() {
@@ -313,7 +316,7 @@ export class VictoryScene extends Phaser.Scene {
         onComplete: () => feedback.destroy(),
       });
     } catch (e) {
-      console.error('Failed to update stats', e);
+      log.warn('Stats update failed', { err: e.message });
     }
   }
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,4 +1,7 @@
+import { Logger } from '../systems/Logger.js';
 import { getSession } from './supabase.js';
+
+const log = Logger.create('API');
 
 const API_BASE = '/api';
 
@@ -35,7 +38,7 @@ async function apiFetch(endpoint, options = {}) {
     try {
       data = await response.json();
     } catch (e) {
-      console.error('Failed to parse JSON response', e);
+      log.warn('JSON parse error', { endpoint, err: e.message });
     }
   } else {
     // Handle non-JSON or empty responses

--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -1,4 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
+import { Logger } from '../systems/Logger.js';
+
+const log = Logger.create('Supabase');
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -6,7 +9,7 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 export const authEnabled = !!(supabaseUrl && supabaseAnonKey);
 
 if (!authEnabled) {
-  console.warn('Supabase credentials missing. Auth features will be disabled.');
+  log.warn('Auth disabled: credentials missing');
 }
 
 export const supabase = authEnabled ? createClient(supabaseUrl, supabaseAnonKey) : null;

--- a/src/systems/DebugBundleExporter.js
+++ b/src/systems/DebugBundleExporter.js
@@ -1,0 +1,215 @@
+import { Logger } from './Logger.js';
+
+const log = Logger.create('DebugBundleExporter');
+
+/**
+ * Generates debug bundles from FightRecorder, Logger ring buffer,
+ * MatchTelemetry, and MatchStateMachine transition history.
+ *
+ * Extends the E2E bundle format (v1) with a diagnostics section (v2).
+ */
+export class DebugBundleExporter {
+  /**
+   * Generate a local debug bundle from the current scene state.
+   * @param {object} options
+   * @param {import('./FightRecorder.js').FightRecorder} [options.recorder]
+   * @param {import('./MatchTelemetry.js').MatchTelemetry} [options.telemetry]
+   * @param {import('./MatchStateMachine.js').MatchStateMachine} [options.matchState]
+   * @param {string} [options.sessionId]
+   * @param {boolean} [options.debugMode]
+   * @returns {object} Debug bundle JSON
+   */
+  static generateBundle({ recorder, telemetry, matchState, sessionId, debugMode = false }) {
+    const fightLog = recorder ? window.__FIGHT_LOG : null;
+
+    const bundle = {
+      version: 2,
+      generatedAt: new Date().toISOString(),
+      source: 'debug',
+      debugMode,
+      sessionId: sessionId ?? null,
+
+      // Existing fields from FightRecorder (compatible with E2E format)
+      config: fightLog
+        ? {
+            p1FighterId: fightLog.fighterId,
+            p2FighterId: fightLog.opponentId,
+            stageId: fightLog.stageId,
+            seed: fightLog.config?.seed ?? null,
+            speed: fightLog.config?.speed ?? 1,
+            aiDifficulty: fightLog.config?.aiDifficulty ?? null,
+          }
+        : null,
+
+      confirmedInputs: fightLog?.confirmedInputs ?? [],
+
+      p1: fightLog
+        ? {
+            playerSlot: fightLog.playerSlot,
+            inputs: fightLog.inputs,
+            checksums: fightLog.checksums,
+            roundEvents: fightLog.roundEvents,
+            networkEvents: fightLog.networkEvents,
+            finalState: fightLog.finalState,
+            finalStateHash: fightLog.finalStateHash,
+            totalFrames: fightLog.totalFrames,
+            rollbackCount: fightLog.rollbackCount,
+            maxRollbackFrames: fightLog.maxRollbackFrames,
+            desyncCount: fightLog.desyncCount,
+          }
+        : null,
+
+      p2: null, // Single-peer debug bundles only have local data
+
+      // NEW: diagnostic data
+      diagnostics: {
+        telemetry: telemetry?.toJSON() ?? null,
+        logBuffer: Logger.getBuffer(),
+        matchState: {
+          transitions: matchState?.getTransitionHistory() ?? [],
+          finalState: matchState?.state ?? null,
+        },
+        environment: DebugBundleExporter._collectEnvironment(),
+      },
+    };
+
+    return bundle;
+  }
+
+  /**
+   * Collect debug bundles from both peers and the server.
+   * @param {object} options
+   * @param {Function} options.generateLocalBundle - returns local bundle
+   * @param {import('./net/NetworkFacade.js').NetworkFacade} options.networkManager
+   * @param {number} [options.timeout=3000] - timeout for remote peer response
+   * @returns {Promise<object>} Combined bundle
+   */
+  static async collectAll({ generateLocalBundle, networkManager, timeout = 3000 }) {
+    const localBundle = generateLocalBundle();
+    const nm = networkManager;
+
+    const combined = {
+      version: 2,
+      source: 'debug-combined',
+      collectedBy: nm.playerSlot === 0 ? 'p1' : 'p2',
+      collectedAt: new Date().toISOString(),
+      local: localBundle,
+      remote: null,
+      remoteError: null,
+      server: null,
+      serverError: null,
+    };
+
+    // Collect remote peer data and server diagnostics in parallel
+    const [remoteResult, serverResult] = await Promise.allSettled([
+      DebugBundleExporter._requestRemoteBundle(nm, timeout),
+      DebugBundleExporter._fetchServerDiagnostics(nm),
+    ]);
+
+    if (remoteResult.status === 'fulfilled') {
+      combined.remote = remoteResult.value;
+    } else {
+      combined.remoteError = remoteResult.reason?.message ?? 'timeout';
+    }
+
+    if (serverResult.status === 'fulfilled') {
+      combined.server = serverResult.value;
+    } else {
+      combined.serverError = serverResult.reason?.message ?? 'fetch_failed';
+    }
+
+    return combined;
+  }
+
+  /**
+   * Copy bundle to clipboard as JSON.
+   * @param {object} bundle
+   * @returns {Promise<boolean>} true if copied successfully
+   */
+  static async copyToClipboard(bundle) {
+    const json = JSON.stringify(bundle);
+    try {
+      await navigator.clipboard.writeText(json);
+      log.info('Bundle copied to clipboard', { size: json.length });
+      return true;
+    } catch (err) {
+      log.warn('Clipboard copy failed, falling back to download', { err: err.message });
+      DebugBundleExporter.downloadBundle(bundle);
+      return false;
+    }
+  }
+
+  /**
+   * Download bundle as JSON file.
+   * @param {object} bundle
+   */
+  static downloadBundle(bundle) {
+    const json = JSON.stringify(bundle, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const roomId = bundle.config?.stageId || bundle.local?.config?.stageId || 'debug';
+    a.href = url;
+    a.download = `debug-${roomId}-${Date.now()}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    log.info('Bundle downloaded', { size: json.length });
+  }
+
+  // --- Internal ---
+
+  static _collectEnvironment() {
+    const env = {
+      userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+      platform: typeof navigator !== 'undefined' ? navigator.platform : null,
+      connection: null,
+    };
+
+    if (typeof navigator !== 'undefined' && navigator.connection) {
+      const conn = navigator.connection;
+      env.connection = {
+        type: conn.effectiveType ?? conn.type ?? null,
+        downlink: conn.downlink ?? null,
+        rtt: conn.rtt ?? null,
+      };
+    }
+
+    return env;
+  }
+
+  static _requestRemoteBundle(nm, timeout) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        nm.signaling.off('debug_response');
+        reject(new Error('timeout'));
+      }, timeout);
+
+      nm.signaling.on('debug_response', (msg) => {
+        clearTimeout(timer);
+        nm.signaling.off('debug_response');
+        resolve(msg.bundle);
+      });
+
+      nm.signaling.send({ type: 'debug_request' });
+    });
+  }
+
+  static async _fetchServerDiagnostics(nm) {
+    try {
+      const host = nm._host;
+      const isLocal = host.includes('localhost') || host.includes('127.0.0.1');
+      const protocol = isLocal ? 'http' : 'https';
+      const url = `${protocol}://${host}/parties/main/${nm.roomId}/diagnostics`;
+
+      const response = await fetch(url, { signal: AbortSignal.timeout(3000) });
+      if (!response.ok) {
+        throw new Error(`fetch_failed: ${response.status}`);
+      }
+      return await response.json();
+    } catch (err) {
+      throw new Error('fetch_failed');
+    }
+  }
+}

--- a/src/systems/DebugOverlay.js
+++ b/src/systems/DebugOverlay.js
@@ -1,0 +1,143 @@
+import Phaser from 'phaser';
+import { GAME_HEIGHT, GAME_WIDTH } from '../config.js';
+
+/**
+ * Debug overlay HUD showing network health stats.
+ * Bottom-left, collapsed by default. Tap to expand.
+ * Only visible when game.debugMode is true.
+ */
+export class DebugOverlay {
+  /**
+   * @param {Phaser.Scene} scene
+   * @param {object} options
+   * @param {Function} options.getTelemetry - returns MatchTelemetry instance
+   * @param {Function} options.getConnectionMonitor - returns ConnectionMonitor
+   * @param {Function} options.getTransportManager - returns TransportManager
+   * @param {Function} options.getInputSync - returns InputSync
+   * @param {Function} options.getMatchState - returns MatchStateMachine
+   * @param {Function} [options.onExportDebug] - called when "Exportar Debug" is tapped
+   * @param {Function} [options.onExportAll] - called when "Exportar Todo" is tapped
+   */
+  constructor(scene, options) {
+    this.scene = scene;
+    this.options = options;
+    this.expanded = false;
+
+    const style = {
+      fontFamily: 'monospace',
+      fontSize: '8px',
+      color: '#00ff00',
+      backgroundColor: '#000000aa',
+      padding: { x: 4, y: 2 },
+    };
+
+    this.text = scene.add.text(2, GAME_HEIGHT - 14, '', style);
+    this.text.setDepth(200);
+    this.text.setScrollFactor(0);
+    this.text.setInteractive();
+    this.text.on('pointerdown', () => {
+      this.expanded = !this.expanded;
+      this._update();
+    });
+
+    // Export buttons (only visible when expanded)
+    this.exportBtn = scene.add.text(2, GAME_HEIGHT - 26, '[Exportar Debug]', {
+      ...style,
+      fontSize: '7px',
+    });
+    this.exportBtn.setDepth(200);
+    this.exportBtn.setScrollFactor(0);
+    this.exportBtn.setVisible(false);
+    this.exportBtn.setInteractive();
+    this.exportBtn.on('pointerdown', () => {
+      if (options.onExportDebug) options.onExportDebug();
+    });
+
+    this.exportAllBtn = scene.add.text(82, GAME_HEIGHT - 26, '[Todo]', {
+      ...style,
+      fontSize: '7px',
+    });
+    this.exportAllBtn.setDepth(200);
+    this.exportAllBtn.setScrollFactor(0);
+    this.exportAllBtn.setVisible(false);
+    this.exportAllBtn.setInteractive();
+    this.exportAllBtn.on('pointerdown', () => {
+      if (options.onExportAll) options.onExportAll();
+    });
+
+    // Update once per second
+    this._timer = scene.time.addEvent({
+      delay: 1000,
+      loop: true,
+      callback: () => this._update(),
+    });
+
+    this._update();
+  }
+
+  _update() {
+    const telemetry = this.options.getTelemetry?.();
+    const monitor = this.options.getConnectionMonitor?.();
+    const transport = this.options.getTransportManager?.();
+    const inputSync = this.options.getInputSync?.();
+    const matchState = this.options.getMatchState?.();
+
+    const rtt = monitor?.rtt ?? 0;
+    const mode = transport?._transportMode === 'webrtc' ? 'P2P' : 'WS';
+
+    if (!this.expanded) {
+      this.text.setText(`RTT: ${rtt}ms  ${mode}`);
+      this.text.setY(GAME_HEIGHT - 14);
+      this.exportBtn.setVisible(false);
+      this.exportAllBtn.setVisible(false);
+      return;
+    }
+
+    const rollbacks = telemetry?.rollbackCount ?? 0;
+    const maxDepth = telemetry?.maxRollbackDepth ?? 0;
+    const desyncs = telemetry?.desyncCount ?? 0;
+    const bufDepth = inputSync ? Object.keys(inputSync.remoteInputBuffer).length : 0;
+    const state = matchState?.state ?? '?';
+
+    const lines = [
+      `RTT: ${rtt}ms    ${mode}`,
+      `Rollbacks: ${rollbacks}  Max: ${maxDepth}`,
+      `Desyncs: ${desyncs}   Buf: ${bufDepth}`,
+      `Estado: ${state}`,
+    ];
+    this.text.setText(lines.join('\n'));
+    this.text.setY(GAME_HEIGHT - 42);
+    this.exportBtn.setVisible(true);
+    this.exportAllBtn.setVisible(true);
+  }
+
+  showToast(msg) {
+    const toast = this.scene.add.text(GAME_WIDTH / 2, GAME_HEIGHT - 50, msg, {
+      fontFamily: 'monospace',
+      fontSize: '9px',
+      color: '#ffffff',
+      backgroundColor: '#333333cc',
+      padding: { x: 6, y: 3 },
+    });
+    toast.setOrigin(0.5);
+    toast.setDepth(201);
+    toast.setScrollFactor(0);
+    this.scene.tweens.add({
+      targets: toast,
+      alpha: 0,
+      delay: 1500,
+      duration: 500,
+      onComplete: () => toast.destroy(),
+    });
+  }
+
+  destroy() {
+    if (this._timer) {
+      this._timer.destroy();
+      this._timer = null;
+    }
+    this.text?.destroy();
+    this.exportBtn?.destroy();
+    this.exportAllBtn?.destroy();
+  }
+}

--- a/src/systems/Logger.js
+++ b/src/systems/Logger.js
@@ -1,0 +1,106 @@
+/**
+ * Structured, leveled, per-module logger with ring buffer storage.
+ * Static singleton — modules get lightweight wrappers via Logger.create('ModuleName').
+ *
+ * When global level is OFF (default), _log() returns after a single integer
+ * comparison. No string formatting, no object allocation.
+ */
+
+export const LogLevel = {
+  OFF: 0,
+  ERROR: 1,
+  WARN: 2,
+  INFO: 3,
+  DEBUG: 4,
+  TRACE: 5,
+};
+
+const LEVEL_NAMES = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'];
+
+export class Logger {
+  static _globalLevel = LogLevel.OFF;
+  static _moduleOverrides = new Map();
+  static _ringBuffer = [];
+  static _ringBufferMax = 256;
+
+  /**
+   * Create a per-module logger instance.
+   * @param {string} module - Module name (e.g. 'TransportManager')
+   * @returns {{ error, warn, info, debug, trace }} Logger wrapper
+   */
+  static create(module) {
+    return {
+      error: (msg, data) => Logger._log(module, LogLevel.ERROR, msg, data),
+      warn: (msg, data) => Logger._log(module, LogLevel.WARN, msg, data),
+      info: (msg, data) => Logger._log(module, LogLevel.INFO, msg, data),
+      debug: (msg, data) => Logger._log(module, LogLevel.DEBUG, msg, data),
+      trace: (msg, data) => Logger._log(module, LogLevel.TRACE, msg, data),
+    };
+  }
+
+  static setGlobalLevel(level) {
+    Logger._globalLevel = level;
+  }
+
+  static getGlobalLevel() {
+    return Logger._globalLevel;
+  }
+
+  static setModuleLevel(module, level) {
+    Logger._moduleOverrides.set(module, level);
+  }
+
+  static clearModuleLevel(module) {
+    Logger._moduleOverrides.delete(module);
+  }
+
+  /**
+   * Get a copy of the ring buffer contents.
+   * @returns {Array<{ts: number, module: string, level: number, levelName: string, msg: string, data: any}>}
+   */
+  static getBuffer() {
+    return Logger._ringBuffer.slice();
+  }
+
+  /**
+   * Clear ring buffer. Useful for tests.
+   */
+  static clearBuffer() {
+    Logger._ringBuffer.length = 0;
+  }
+
+  /**
+   * Reset all state (global level, overrides, buffer). For tests.
+   */
+  static reset() {
+    Logger._globalLevel = LogLevel.OFF;
+    Logger._moduleOverrides.clear();
+    Logger._ringBuffer.length = 0;
+  }
+
+  static _log(module, level, msg, data) {
+    const threshold = Logger._moduleOverrides.get(module) ?? Logger._globalLevel;
+    if (level > threshold) return;
+
+    const entry = {
+      ts: Date.now(),
+      module,
+      level,
+      levelName: LEVEL_NAMES[level],
+      msg,
+      data,
+    };
+
+    Logger._ringBuffer.push(entry);
+    if (Logger._ringBuffer.length > Logger._ringBufferMax) {
+      Logger._ringBuffer.shift();
+    }
+
+    const prefix = `[${module}]`;
+    if (level <= LogLevel.WARN) {
+      console.warn(prefix, msg, data ?? '');
+    } else {
+      console.log(prefix, msg, data ?? '');
+    }
+  }
+}

--- a/src/systems/MatchStateMachine.js
+++ b/src/systems/MatchStateMachine.js
@@ -144,6 +144,9 @@ export class MatchStateMachine {
   constructor(initialState = MatchState.MAIN_MENU) {
     this._state = initialState;
     this._listeners = [];
+    /** @type {Array<{ts: number, from: string, to: string, event: string}>} */
+    this._transitionHistory = [];
+    this._maxHistorySize = 100;
   }
 
   get state() {
@@ -173,6 +176,12 @@ export class MatchStateMachine {
     const prevState = this._state;
     this._state = nextState;
 
+    // Record transition history
+    this._transitionHistory.push({ ts: Date.now(), from: prevState, to: nextState, event });
+    if (this._transitionHistory.length > this._maxHistorySize) {
+      this._transitionHistory.shift();
+    }
+
     for (const cb of this._listeners) {
       cb(prevState, nextState, event);
     }
@@ -201,6 +210,14 @@ export class MatchStateMachine {
       const idx = this._listeners.indexOf(callback);
       if (idx >= 0) this._listeners.splice(idx, 1);
     };
+  }
+
+  /**
+   * Get a copy of the transition history.
+   * @returns {Array<{ts: number, from: string, to: string, event: string}>}
+   */
+  getTransitionHistory() {
+    return this._transitionHistory.slice();
   }
 
   /**

--- a/src/systems/MatchTelemetry.js
+++ b/src/systems/MatchTelemetry.js
@@ -1,0 +1,123 @@
+/**
+ * Always-on lightweight match telemetry counters.
+ * Updated via callbacks from RollbackManager and ConnectionMonitor.
+ * Zero allocation — just integer increments and array pushes.
+ *
+ * Total memory: under 200 bytes (excluding rttSamples which caps at ~480 bytes).
+ */
+
+const MAX_RTT_SAMPLES = 60;
+const RTT_SAMPLE_INTERVAL_MS = 3000;
+
+export class MatchTelemetry {
+  /**
+   * @param {string} matchId - Room ID or 'local'
+   */
+  constructor(matchId) {
+    this.matchId = matchId;
+    this.startedAt = Date.now();
+    this.transportMode = 'websocket';
+    this.transportChanges = 0;
+    this.rollbackCount = 0;
+    this.maxRollbackDepth = 0;
+    this.desyncCount = 0;
+    this.resyncCount = 0;
+    this.rttSamples = [];
+    this.rttMin = Infinity;
+    this.rttMax = 0;
+    this.rttSum = 0;
+    this.disconnectionCount = 0;
+    this.reconnectionCount = 0;
+
+    this._rttSampleTimer = null;
+    this._connectionMonitor = null;
+  }
+
+  /**
+   * Wire to a ConnectionMonitor for periodic RTT sampling.
+   * @param {import('./net/ConnectionMonitor.js').ConnectionMonitor} monitor
+   */
+  wireConnectionMonitor(monitor) {
+    this._connectionMonitor = monitor;
+    this._rttSampleTimer = setInterval(() => {
+      this._sampleRTT();
+    }, RTT_SAMPLE_INTERVAL_MS);
+  }
+
+  recordRollback(frame, depth) {
+    this.rollbackCount++;
+    if (depth > this.maxRollbackDepth) {
+      this.maxRollbackDepth = depth;
+    }
+  }
+
+  recordDesync() {
+    this.desyncCount++;
+  }
+
+  recordResync() {
+    this.resyncCount++;
+  }
+
+  recordTransportChange(mode) {
+    if (mode !== this.transportMode) {
+      this.transportMode = mode;
+      this.transportChanges++;
+    }
+  }
+
+  recordDisconnection() {
+    this.disconnectionCount++;
+  }
+
+  recordReconnection() {
+    this.reconnectionCount++;
+  }
+
+  _sampleRTT() {
+    if (!this._connectionMonitor) return;
+    const rtt = this._connectionMonitor.rtt;
+    if (rtt <= 0) return;
+
+    if (this.rttSamples.length >= MAX_RTT_SAMPLES) {
+      this.rttSamples.shift();
+    }
+    this.rttSamples.push(rtt);
+
+    if (rtt < this.rttMin) this.rttMin = rtt;
+    if (rtt > this.rttMax) this.rttMax = rtt;
+    this.rttSum += rtt;
+  }
+
+  /**
+   * Get a snapshot of telemetry data for inclusion in debug bundles.
+   */
+  toJSON() {
+    const count = this.rttSamples.length;
+    return {
+      matchId: this.matchId,
+      startedAt: this.startedAt,
+      matchDurationMs: Date.now() - this.startedAt,
+      transportMode: this.transportMode,
+      transportChanges: this.transportChanges,
+      rollbackCount: this.rollbackCount,
+      maxRollbackDepth: this.maxRollbackDepth,
+      desyncCount: this.desyncCount,
+      resyncCount: this.resyncCount,
+      rttSamples: this.rttSamples.slice(),
+      rttMin: this.rttMin === Infinity ? 0 : this.rttMin,
+      rttMax: this.rttMax,
+      rttAvg: count > 0 ? Math.round(this.rttSum / count) : 0,
+      disconnectionCount: this.disconnectionCount,
+      reconnectionCount: this.reconnectionCount,
+    };
+  }
+
+  destroy() {
+    if (this._rttSampleTimer) {
+      clearInterval(this._rttSampleTimer);
+      this._rttSampleTimer = null;
+    }
+    this._connectionMonitor = null;
+  }
+}

--- a/src/systems/net/ConnectionMonitor.js
+++ b/src/systems/net/ConnectionMonitor.js
@@ -1,3 +1,7 @@
+import { Logger } from '../Logger.js';
+
+const log = Logger.create('ConnectionMonitor');
+
 const PONG_TIMEOUT_MS = 6000;
 const PING_INTERVAL_MS = 3000;
 
@@ -40,6 +44,10 @@ export class ConnectionMonitor {
         Date.now() - this._lastPongTime > PONG_TIMEOUT_MS
       ) {
         this._pongTimeoutFired = true;
+        log.warn('Pong timeout', {
+          lastPongTime: this._lastPongTime,
+          elapsed: Date.now() - this._lastPongTime,
+        });
         this.stop();
         if (this._onTimeout) this._onTimeout();
         return;
@@ -85,6 +93,7 @@ export class ConnectionMonitor {
     if (msg.t) {
       this.latency = Date.now() - msg.t;
       this.rtt = this.latency;
+      log.debug('Pong received', { rtt: this.rtt });
     }
   }
 }

--- a/src/systems/net/InputSync.js
+++ b/src/systems/net/InputSync.js
@@ -1,4 +1,7 @@
 import { decodeInput } from '../InputBuffer.js';
+import { Logger } from '../Logger.js';
+
+const log = Logger.create('InputSync');
 
 const ATTACK_FLAGS = ['lp', 'hp', 'lk', 'hk', 'sp'];
 
@@ -79,7 +82,13 @@ export class InputSync {
       msg.history = history;
     }
 
-    if (this.transport?.isWebRTCReady()) {
+    const p2p = this.transport?.isWebRTCReady();
+    log.trace('Input send', {
+      frame,
+      transport: p2p ? 'p2p' : 'ws',
+      historyLen: history?.length ?? 0,
+    });
+    if (p2p) {
       // P2P: fast path for opponent
       this.transport.sendP2P(msg);
       // Server: spectator relay only
@@ -260,12 +269,19 @@ export class InputSync {
     } else {
       this.remoteInputBuffer[msg.frame] = msg.state;
       this.lastRemoteInput = msg.state;
+      const bufferDepth = Object.keys(this.remoteInputBuffer).length;
+      log.debug('Input arrival', { frame: msg.frame, bufferDepth });
       // Process redundant input history — fill gaps without overwriting confirmed data
       if (msg.history) {
+        let gapCount = 0;
         for (const [hFrame, encodedInput] of msg.history) {
           if (!(hFrame in this.remoteInputBuffer)) {
             this.remoteInputBuffer[hFrame] = decodeInput(encodedInput);
+            gapCount++;
           }
+        }
+        if (gapCount > 0) {
+          log.debug('Redundant history applied', { frame: msg.frame, gapCount });
         }
       }
     }

--- a/src/systems/net/NetworkFacade.js
+++ b/src/systems/net/NetworkFacade.js
@@ -1,8 +1,11 @@
+import { Logger } from '../Logger.js';
 import { ConnectionMonitor } from './ConnectionMonitor.js';
 import { InputSync } from './InputSync.js';
 import { SignalingClient } from './SignalingClient.js';
 import { SpectatorRelay } from './SpectatorRelay.js';
 import { TransportManager } from './TransportManager.js';
+
+const log = Logger.create('NetworkFacade');
 
 /**
  * Composes all networking modules and exposes the same public API
@@ -50,6 +53,7 @@ export class NetworkFacade {
 
     // Wire opponent_joined → fetch TURN credentials, then init WebRTC
     this.signaling.on('opponent_joined', (msg) => {
+      log.debug('Opponent joined', { slot: this.signaling.playerSlot });
       if (!this.signaling.isSpectator) {
         this._fetchTurnThenInitWebRTC();
       }
@@ -58,6 +62,7 @@ export class NetworkFacade {
 
     // Wire opponent_reconnected → re-init WebRTC (credentials already cached)
     this.signaling.on('opponent_reconnected', (msg) => {
+      log.debug('Opponent reconnected', { slot: this.signaling.playerSlot });
       if (!this.signaling.isSpectator) {
         this.transport.initWebRTC(this.signaling.playerSlot);
       }
@@ -133,6 +138,9 @@ export class NetworkFacade {
 
   // --- Proxy properties ---
 
+  get sessionId() {
+    return this.signaling.sessionId;
+  }
   get playerSlot() {
     return this.signaling.playerSlot;
   }
@@ -266,6 +274,12 @@ export class NetworkFacade {
   onTransportRestored(cb) {
     this.transport.onTransportRestored(cb);
   }
+  onDebugRequest(cb) {
+    this.signaling.on('debug_request', cb);
+  }
+  onDebugResponse(cb) {
+    this.signaling.on('debug_response', cb);
+  }
 
   // --- Public API: send messages ---
 
@@ -304,6 +318,12 @@ export class NetworkFacade {
   }
   sendPotion(target, potionType) {
     this.spectator.sendPotion(target, potionType);
+  }
+  sendDebugRequest() {
+    this.signaling.send({ type: 'debug_request' });
+  }
+  sendDebugResponse(bundle) {
+    this.signaling.send({ type: 'debug_response', bundle });
   }
   sendRejoin(slot, reset = false) {
     const msg = { type: 'rejoin', slot };
@@ -378,9 +398,14 @@ export class NetworkFacade {
   async _fetchTurnThenInitWebRTC() {
     try {
       await this.transport.fetchTurnCredentials(this._host, this.roomId);
+      log.info('TURN fetch complete', { iceServers: this.transport._iceServers?.length ?? 0 });
     } catch (_) {
-      // Non-fatal: proceed with STUN-only
+      log.warn('TURN fetch failed, proceeding with STUN-only');
     }
+    log.debug('WebRTC init trigger', {
+      slot: this.signaling.playerSlot,
+      offerer: this.signaling.playerSlot === 0,
+    });
     this.transport.initWebRTC(this.signaling.playerSlot);
   }
 

--- a/src/systems/net/SignalingClient.js
+++ b/src/systems/net/SignalingClient.js
@@ -1,4 +1,7 @@
 import PartySocket from 'partysocket';
+import { Logger } from '../Logger.js';
+
+const log = Logger.create('SignalingClient');
 
 /** Message types that support callback buffering (B5) — handler may not be registered yet when message arrives */
 const BUFFERABLE_TYPES = new Set(['sync', 'round_event', 'start', 'frame_sync']);
@@ -22,6 +25,12 @@ export class SignalingClient {
     this.playerSlot = -1;
     this.connected = false;
     this.isSpectator = false;
+
+    /** Session ID for client-server log correlation */
+    this.sessionId =
+      typeof crypto !== 'undefined' && crypto.randomUUID
+        ? crypto.randomUUID().slice(0, 8)
+        : Math.random().toString(36).slice(2, 10);
 
     /** @type {Map<string, Function>} message type → handler */
     this._handlers = new Map();
@@ -52,8 +61,9 @@ export class SignalingClient {
       startClosed: false,
     };
 
+    socketOptions.query = { sessionId: this.sessionId };
     if (spectator) {
-      socketOptions.query = { spectate: '1' };
+      socketOptions.query.spectate = '1';
     }
 
     this.socket = new PartySocket(socketOptions);
@@ -63,15 +73,18 @@ export class SignalingClient {
       try {
         this._handleMessage(JSON.parse(event.data));
       } catch (_e) {
-        // Silently ignore malformed messages
+        log.warn('JSON parse error on message');
       }
     };
 
     this._boundOnOpen = () => {
       this.connected = true;
+      log.info('Socket open', { roomId, sessionId: this.sessionId });
       // B4: Flush pending messages on reconnect
       if (this._pendingMessages.length > 0) {
+        const count = this._pendingMessages.length;
         const pending = this._pendingMessages.splice(0);
+        log.debug('Pending queue flush (B4)', { count });
         for (const msg of pending) {
           this.send(msg);
         }
@@ -81,10 +94,12 @@ export class SignalingClient {
 
     this._boundOnClose = () => {
       this.connected = false;
+      log.info('Socket close', { roomId, sessionId: this.sessionId });
       if (this._onSocketClose) this._onSocketClose();
     };
 
     this._boundOnError = () => {
+      log.warn('Socket error', { roomId });
       if (this._onSocketError) this._onSocketError();
     };
 
@@ -103,11 +118,13 @@ export class SignalingClient {
    */
   on(type, cb) {
     this._handlers.set(type, cb);
+    log.debug('Handler registered', { type });
 
     // B5: Flush any buffered messages for this type
     const pending = this._pendingCallbackMessages.get(type);
     if (cb && pending && pending.length > 0) {
       const messages = pending.splice(0);
+      log.debug('Callback buffer flush (B5)', { type, count: messages.length });
       for (const msg of messages) {
         cb(msg);
       }
@@ -199,9 +216,11 @@ export class SignalingClient {
 
     const handler = this._handlers.get(msg.type);
     if (handler) {
+      log.trace('Message dispatch', { type: msg.type, hasHandler: true });
       handler(msg);
       return;
     }
+    log.trace('Message dispatch', { type: msg.type, hasHandler: false });
 
     // B5: Buffer messages for types that support it when no handler registered
     if (BUFFERABLE_TYPES.has(msg.type)) {

--- a/src/systems/net/SpectatorRelay.js
+++ b/src/systems/net/SpectatorRelay.js
@@ -1,3 +1,7 @@
+import { Logger } from '../Logger.js';
+
+const log = Logger.create('SpectatorRelay');
+
 /** Message types that SpectatorRelay buffers (B5 — handler may not be registered yet) */
 const BUFFERABLE_TYPES = new Set(['sync', 'round_event']);
 
@@ -140,6 +144,7 @@ export class SpectatorRelay {
     const pending = this._pendingMessages.get(type);
     if (pending && pending.length > 0) {
       const messages = pending.splice(0);
+      log.debug('Callback buffer flush (B5)', { type, count: messages.length });
       for (const msg of messages) {
         cb(msg);
       }

--- a/src/systems/net/TransportManager.js
+++ b/src/systems/net/TransportManager.js
@@ -1,4 +1,7 @@
+import { Logger } from '../Logger.js';
 import { WebRTCTransport } from '../WebRTCTransport.js';
+
+const log = Logger.create('TransportManager');
 
 const DEFAULT_ICE_SERVERS = [
   { urls: 'stun:stun.l.google.com:19302' },
@@ -51,14 +54,18 @@ export class TransportManager {
    */
   initWebRTC(playerSlot) {
     if (typeof RTCPeerConnection === 'undefined') {
-      console.log('[TM] WebRTC unavailable (no RTCPeerConnection)');
+      log.warn('WebRTC unavailable (no RTCPeerConnection)');
       return;
     }
 
     this.destroyWebRTC();
 
     const isOfferer = playerSlot === 0;
-    console.log(`[TM] initWebRTC slot=${playerSlot} offerer=${isOfferer}`);
+    log.info('WebRTC init', {
+      slot: playerSlot,
+      offerer: isOfferer,
+      iceServers: (this._iceServers || DEFAULT_ICE_SERVERS).length,
+    });
 
     const iceServers = this._iceServers || DEFAULT_ICE_SERVERS;
 
@@ -77,8 +84,10 @@ export class TransportManager {
       onOpen: () => {
         this._transportMode = 'webrtc';
         this._webrtcReady = true;
+        log.debug('DataChannel open');
         if (this._transportDegraded) {
           this._transportDegraded = false;
+          log.debug('Transport restored', { from: 'websocket', to: 'webrtc' });
           if (this._onTransportRestored) this._onTransportRestored();
         }
       },
@@ -86,8 +95,10 @@ export class TransportManager {
         const wasOpen = this._webrtcReady;
         this._transportMode = 'websocket';
         this._webrtcReady = false;
+        log.debug('DataChannel closed', { wasOpen });
         if (wasOpen) {
           this._transportDegraded = true;
+          log.debug('Transport degraded', { from: 'webrtc', to: 'websocket' });
           if (this._onTransportDegraded) this._onTransportDegraded();
         }
       },
@@ -130,17 +141,17 @@ export class TransportManager {
 
       const response = await fetch(url, { signal: AbortSignal.timeout(3000) });
       if (!response.ok) {
-        console.log(`[TM] TURN credential fetch failed: ${response.status}`);
+        log.warn('TURN credential fetch failed', { status: response.status });
         return;
       }
 
       const data = await response.json();
       if (data.iceServers) {
         this._iceServers = data.iceServers;
-        console.log(`[TM] TURN credentials fetched (${data.iceServers.length} servers)`);
+        log.info('TURN credentials fetched', { count: data.iceServers.length });
       }
     } catch (err) {
-      console.log('[TM] TURN credential fetch error:', err.message);
+      log.warn('TURN credential fetch error', { err: err.message });
       // Non-fatal: fall back to STUN-only
     }
   }

--- a/tests/systems/logger.test.js
+++ b/tests/systems/logger.test.js
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Logger, LogLevel } from '../../src/systems/Logger.js';
+
+describe('Logger', () => {
+  beforeEach(() => {
+    Logger.reset();
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty buffer when level is OFF', () => {
+    const log = Logger.create('Test');
+    log.debug('should not appear');
+    expect(Logger.getBuffer()).toHaveLength(0);
+  });
+
+  it('logs when global level is sufficient', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    Logger.setGlobalLevel(LogLevel.DEBUG);
+    const log = Logger.create('Test');
+    log.debug('hello', { key: 'value' });
+
+    const buf = Logger.getBuffer();
+    expect(buf).toHaveLength(1);
+    expect(buf[0].module).toBe('Test');
+    expect(buf[0].level).toBe(LogLevel.DEBUG);
+    expect(buf[0].msg).toBe('hello');
+    expect(buf[0].data).toEqual({ key: 'value' });
+    expect(buf[0].levelName).toBe('DEBUG');
+    expect(buf[0].ts).toBeGreaterThan(0);
+  });
+
+  it('filters by level threshold', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    Logger.setGlobalLevel(LogLevel.WARN);
+    const log = Logger.create('Test');
+
+    log.trace('no');
+    log.debug('no');
+    log.info('no');
+    log.warn('yes');
+    log.error('yes');
+
+    expect(Logger.getBuffer()).toHaveLength(2);
+    expect(Logger.getBuffer()[0].levelName).toBe('WARN');
+    expect(Logger.getBuffer()[1].levelName).toBe('ERROR');
+  });
+
+  it('supports per-module level overrides', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    Logger.setGlobalLevel(LogLevel.OFF);
+    Logger.setModuleLevel('Verbose', LogLevel.TRACE);
+
+    const verbose = Logger.create('Verbose');
+    const quiet = Logger.create('Quiet');
+
+    verbose.trace('should appear');
+    quiet.trace('should not');
+
+    expect(Logger.getBuffer()).toHaveLength(1);
+    expect(Logger.getBuffer()[0].module).toBe('Verbose');
+  });
+
+  it('caps ring buffer at max size', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    Logger.setGlobalLevel(LogLevel.DEBUG);
+    const log = Logger.create('Test');
+
+    for (let i = 0; i < 300; i++) {
+      log.debug(`msg-${i}`);
+    }
+
+    const buf = Logger.getBuffer();
+    expect(buf).toHaveLength(256);
+    expect(buf[0].msg).toBe('msg-44'); // first 44 were evicted
+    expect(buf[255].msg).toBe('msg-299');
+  });
+
+  it('routes WARN/ERROR to console.warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    Logger.setGlobalLevel(LogLevel.DEBUG);
+    const log = Logger.create('Test');
+
+    log.warn('warning');
+    log.error('error');
+    log.debug('debug');
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearModuleLevel removes override', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    Logger.setModuleLevel('Mod', LogLevel.DEBUG);
+    Logger.clearModuleLevel('Mod');
+
+    const log = Logger.create('Mod');
+    log.debug('should not appear');
+    expect(Logger.getBuffer()).toHaveLength(0);
+  });
+
+  it('clearBuffer empties the ring buffer', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    Logger.setGlobalLevel(LogLevel.DEBUG);
+    Logger.create('Test').debug('msg');
+    expect(Logger.getBuffer()).toHaveLength(1);
+
+    Logger.clearBuffer();
+    expect(Logger.getBuffer()).toHaveLength(0);
+  });
+});

--- a/tests/systems/match-telemetry.test.js
+++ b/tests/systems/match-telemetry.test.js
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MatchTelemetry } from '../../src/systems/MatchTelemetry.js';
+
+describe('MatchTelemetry', () => {
+  let telemetry;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    telemetry = new MatchTelemetry('test-room');
+  });
+
+  afterEach(() => {
+    telemetry.destroy();
+    vi.useRealTimers();
+  });
+
+  it('initializes with default values', () => {
+    const data = telemetry.toJSON();
+    expect(data.matchId).toBe('test-room');
+    expect(data.rollbackCount).toBe(0);
+    expect(data.maxRollbackDepth).toBe(0);
+    expect(data.desyncCount).toBe(0);
+    expect(data.transportMode).toBe('websocket');
+  });
+
+  it('tracks rollbacks', () => {
+    telemetry.recordRollback(100, 3);
+    telemetry.recordRollback(105, 5);
+    telemetry.recordRollback(110, 2);
+
+    const data = telemetry.toJSON();
+    expect(data.rollbackCount).toBe(3);
+    expect(data.maxRollbackDepth).toBe(5);
+  });
+
+  it('tracks desyncs and resyncs', () => {
+    telemetry.recordDesync();
+    telemetry.recordDesync();
+    telemetry.recordResync();
+
+    const data = telemetry.toJSON();
+    expect(data.desyncCount).toBe(2);
+    expect(data.resyncCount).toBe(1);
+  });
+
+  it('tracks transport changes', () => {
+    telemetry.recordTransportChange('webrtc');
+    telemetry.recordTransportChange('webrtc'); // duplicate, no change
+    telemetry.recordTransportChange('websocket');
+
+    const data = telemetry.toJSON();
+    expect(data.transportMode).toBe('websocket');
+    expect(data.transportChanges).toBe(2);
+  });
+
+  it('samples RTT from connection monitor', () => {
+    const mockMonitor = { rtt: 50 };
+    telemetry.wireConnectionMonitor(mockMonitor);
+
+    vi.advanceTimersByTime(3000);
+    expect(telemetry.rttSamples).toHaveLength(1);
+    expect(telemetry.rttSamples[0]).toBe(50);
+
+    mockMonitor.rtt = 100;
+    vi.advanceTimersByTime(3000);
+
+    const data = telemetry.toJSON();
+    expect(data.rttSamples).toHaveLength(2);
+    expect(data.rttMin).toBe(50);
+    expect(data.rttMax).toBe(100);
+    expect(data.rttAvg).toBe(75);
+  });
+
+  it('caps RTT samples at 60', () => {
+    const mockMonitor = { rtt: 42 };
+    telemetry.wireConnectionMonitor(mockMonitor);
+
+    for (let i = 0; i < 65; i++) {
+      vi.advanceTimersByTime(3000);
+    }
+
+    expect(telemetry.rttSamples).toHaveLength(60);
+  });
+
+  it('skips RTT sample when rtt is 0', () => {
+    const mockMonitor = { rtt: 0 };
+    telemetry.wireConnectionMonitor(mockMonitor);
+
+    vi.advanceTimersByTime(3000);
+    expect(telemetry.rttSamples).toHaveLength(0);
+  });
+
+  it('tracks disconnections and reconnections', () => {
+    telemetry.recordDisconnection();
+    telemetry.recordReconnection();
+    telemetry.recordDisconnection();
+
+    const data = telemetry.toJSON();
+    expect(data.disconnectionCount).toBe(2);
+    expect(data.reconnectionCount).toBe(1);
+  });
+
+  it('computes matchDurationMs', () => {
+    vi.advanceTimersByTime(5000);
+    const data = telemetry.toJSON();
+    expect(data.matchDurationMs).toBeGreaterThanOrEqual(5000);
+  });
+
+  it('returns 0 for rttMin when no samples', () => {
+    const data = telemetry.toJSON();
+    expect(data.rttMin).toBe(0);
+    expect(data.rttAvg).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- **Phase 1**: `Logger` (leveled, per-module, ring buffer, zero overhead when OFF) + `MatchTelemetry` (always-on counters) + instrument all 6 net modules with structured logging + session ID for client-server correlation
- **Phase 2**: `?debug=1` URL param + triple-tap gesture activates debug mode mid-match, decouples `FightRecorder` from autoplay, adds `DebugOverlay` HUD (RTT, transport, rollbacks, match state)
- **Phase 3**: `DebugBundleExporter` generates v2 bundles (FightRecorder + Logger buffer + telemetry + environment + state transitions), 1-click collection from both peers + server via `debug_request`/`debug_response` relay
- **Phase 4**: Structured JSON logging in PartyKit server (`_log()` + ring buffer), `GET /diagnostics` endpoint (token-protected), session ID extraction from connection query params
- **Auth integration**: Rebased onto main (post PR #54 merge), renamed RFC to 0005, instrumented all auth files (`supabase.js`, `api.js`, `LoginScene.js`, `TitleScene.js`, `VictoryScene.js`, `main.js`) with Logger — zero `console.log/warn/error` remaining

## New files
- `src/systems/Logger.js` — Static singleton logger
- `src/systems/MatchTelemetry.js` — Always-on match counters
- `src/systems/DebugOverlay.js` — Debug HUD overlay
- `src/systems/DebugBundleExporter.js` — Bundle generation + export
- `tests/systems/logger.test.js` — 8 tests
- `tests/systems/match-telemetry.test.js` — 10 tests

## Test plan
- [x] All 722 tests pass (includes 13 new auth tests from PR #54)
- [x] New Logger tests (level filtering, ring buffer cap, module overrides)
- [x] New MatchTelemetry tests (rollback tracking, RTT sampling, transport changes)
- [x] All 76 server tests pass with new logging infrastructure
- [x] Zero `console.log/warn/error` in `src/services/`, `src/scenes/LoginScene.js`, `src/main.js`
- [ ] Manual: verify `?debug=1` activates overlay in online match
- [ ] Manual: verify triple-tap activates debug mode mid-match
- [ ] Manual: verify "Exportar Debug" copies bundle to clipboard
- [ ] Manual: verify "Exportar Todo" collects both peers + server diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)