### PR TITLE
Use PGLite for local dev database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@ VITE_SUPABASE_URL=https://your-project-id.supabase.co
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 
 # Backend Configuration (Vercel API)
-# Use your Supabase Postgres connection string
-DATABASE_URL=postgres://postgres:[YOUR-PASSWORD]@[YOUR-HOST]:5432/postgres
+# For local dev with PGLite (bun run dev:all starts it automatically):
+DATABASE_URL=postgres://localhost:5432/postgres
+# For production, use your Supabase Postgres connection string:
+# DATABASE_URL=postgres://postgres:[YOUR-PASSWORD]@[YOUR-HOST]:6543/postgres?pgbouncer=true
 # Your Supabase Project ID (the part between https:// and .supabase.co)
 SUPABASE_PROJECT_ID=your-project-id

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ test-results/
 .claude/worktrees
 .vercel
 
+# Local PGLite database
+.pglite/
+
 # Environment variables
 .env
 .env.local

--- a/api/_lib/handler.js
+++ b/api/_lib/handler.js
@@ -11,9 +11,7 @@ function getPool() {
   if (!pool) {
     pool = new Pool({
       connectionString: process.env.DATABASE_URL,
-      ssl: {
-        rejectUnauthorized: process.env.NODE_ENV === 'production',
-      },
+      ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: true } : false,
     });
   }
   return pool;
@@ -83,11 +81,6 @@ export function withAuth(handler) {
     }
 
     // 3. Database Access
-    if (!process.env.DATABASE_URL) {
-      console.error('DATABASE_URL is not configured');
-      return res.status(500).json({ error: 'Internal Server Error: Database configuration missing' });
-    }
-
     const dbPool = getPool();
     let client;
     try {

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
+        "@electric-sql/pglite": "^0.4.2",
+        "@electric-sql/pglite-socket": "^0.1.2",
         "@playwright/test": "^1.58.2",
         "concurrently": "^9.2.1",
         "vitest": "^4.1.0",
@@ -53,6 +55,10 @@
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20240718.0", "", {}, "sha512-7RqxXIM9HyhjfZ9ztXjITuc7mL0w4s+zXgypqKmMuvuObC3DgXutJ3bOYbQ+Ss5QbywrzWSNMlmGdL/ldg/yZg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.4.2", "", {}, "sha512-1GUUl/MZpy5QWgWisD3Epho3GkJrZ1MzVgQpo2pifQWUs96F9rXKZxeVLPhkwFYck34CH/kQ8lis6wX9ifn3kg=="],
+
+    "@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.1.2", "", { "peerDependencies": { "@electric-sql/pglite": "0.4.2" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-Hz+IIentlbz9Zpln7Ft0iTDtbLvIfmmwIIC0CCU6ViklsDzbOIZV9xqcbvME21O3pqjjDNhERc57ynRCdshkZA=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:all": "concurrently \"vite\" \"vercel dev --yes\"",
+    "dev:db": "node scripts/dev-db.js",
+    "dev:all": "concurrently \"node scripts/dev-db.js\" \"vite\" \"vercel dev --yes\"",
     "build": "vite build",
     "preview": "vite preview",
     "party:dev": "bunx partykit dev",
@@ -28,6 +29,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
+    "@electric-sql/pglite": "^0.4.2",
+    "@electric-sql/pglite-socket": "^0.1.2",
     "@playwright/test": "^1.58.2",
     "concurrently": "^9.2.1",
     "vitest": "^4.1.0"

--- a/scripts/dev-db.js
+++ b/scripts/dev-db.js
@@ -1,0 +1,13 @@
+import { PGlite } from '@electric-sql/pglite';
+import { PGLiteSocketServer } from '@electric-sql/pglite-socket';
+
+const db = await PGlite.create('.pglite');
+
+const server = new PGLiteSocketServer({
+  db,
+  port: 5432,
+  host: '127.0.0.1',
+});
+
+await server.start();
+console.log('PGLite dev database running on localhost:5432');

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -20,7 +20,7 @@ async function apiFetch(endpoint, options = {}) {
   }
   // Local development bypass (only if not in production and no token)
   else if (import.meta.env.DEV && !token) {
-    headers['X-Dev-User-Id'] = 'local-dev-user';
+    headers['X-Dev-User-Id'] = '00000000-0000-0000-0000-000000000000';
   }
 
   const response = await fetch(`${API_BASE}${endpoint}`, {

--- a/tests/api/handler.test.js
+++ b/tests/api/handler.test.js
@@ -102,8 +102,8 @@ describe('withAuth middleware', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
-  it('fails if DATABASE_URL is missing', async () => {
-    delete process.env.DATABASE_URL;
+  it('fails if database connection fails', async () => {
+    mockConnect.mockRejectedValueOnce(new Error('Connection refused'));
     req.headers['x-dev-user-id'] = 'dev-user';
     const handler = vi.fn();
     const wrapped = withAuth(handler);
@@ -111,7 +111,7 @@ describe('withAuth middleware', () => {
 
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ error: expect.stringContaining('Database configuration missing') }),
+      expect.objectContaining({ error: expect.stringContaining('Database connection failed') }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add PGLite + pglite-socket to run an embedded Postgres on `localhost:5432` during local dev, eliminating the need for a remote Supabase database connection
- dbmate, `pg`, and `psql` connect identically in both local and production environments
- Fix latent bug: dev user ID was `'local-dev-user'` but `profiles.id` is `UUID PRIMARY KEY`

## Changes
- `scripts/dev-db.js` — PGLite socket server (data persists in `.pglite/`)
- `package.json` — `dev:db` script, `dev:all` starts PGLite + Vite + Vercel dev
- `api/_lib/handler.js` — disable SSL in non-production (required for pglite-socket), remove `DATABASE_URL` missing guard
- `src/services/api.js` — fix dev user ID to valid UUID
- `.env.example` — default `DATABASE_URL` points to localhost

## Local dev workflow
```bash
# Set DATABASE_URL=postgres://localhost:5432/postgres in .env
bun run dev:all                     # Starts PGLite + Vite + Vercel dev
DATABASE_URL=postgres://localhost:5432/postgres dbmate up  # Run migrations (first time)
```

## Test plan
- [ ] `bun run dev:all` starts all three services
- [ ] `PGSSLMODE=disable psql -h localhost -p 5432 -d postgres` connects to PGLite
- [ ] `dbmate up` runs migrations against PGLite
- [ ] Profile and stats work in-game (guest + authenticated)
- [ ] Data persists across restarts (`.pglite/` directory)
- [ ] `bun test` passes (704 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)