### PR TITLE
feat: Mobile UI Ergonomics & Special Gauge Visual Enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.45.0",
-    "@supabase/supabase-js": "^2.100.0",
+    "@supabase/supabase-js": "^2.101.1",
     "jose": "^6.2.2",
     "partykit": "^0.0.115",
     "partysocket": "^1.1.16",

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -143,6 +143,7 @@ export class BootScene extends Phaser.Scene {
     this.generateRect('hp_bar_fill_p2', 150, 12, 0x00cc44);
     this.generateRect('special_bar_bg', 100, 8, 0x333333);
     this.generateRect('special_bar_fill', 100, 8, 0xffcc00);
+    this.generateRect('white_pixel', 2, 2, 0xffffff);
 
     // Parse debug mode URL param
     const params = new URLSearchParams(window.location.search);

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -551,6 +551,30 @@ export class FightScene extends Phaser.Scene {
       .rectangle(SPECIAL_P2_X + SPECIAL_BAR_W / 2, SPECIAL_BAR_Y + SPECIAL_BAR_H / 2, 1, SPECIAL_BAR_H, 0xffffff, 0.3)
       .setDepth(depth + 2);
 
+    // --- Special effects for HUD bars ---
+    // HUD Particle emitters
+    this.spParticlesP1 = this.add.particles(0, 0, 'white_pixel', {
+      speed: { min: 10, max: 20 },
+      angle: { min: 260, max: 280 },
+      scale: { start: 1, end: 0 },
+      alpha: { start: 0.6, end: 0 },
+      lifespan: 400,
+      frequency: 100,
+      tint: 0xffcc00,
+      emitting: false
+    }).setDepth(depth - 1);
+
+    this.spParticlesP2 = this.add.particles(0, 0, 'white_pixel', {
+      speed: { min: 10, max: 20 },
+      angle: { min: 260, max: 280 },
+      scale: { start: 1, end: 0 },
+      alpha: { start: 0.6, end: 0 },
+      lifespan: 400,
+      frequency: 100,
+      tint: 0xffcc00,
+      emitting: false
+    }).setDepth(depth - 1);
+
     // --- Player name labels ---
     const p1Color = this.p1Data.color.replace('0x', '#');
     const p2Color = this.p2Data.color.replace('0x', '#');
@@ -795,6 +819,7 @@ export class FightScene extends Phaser.Scene {
     // Flash special bar when it's at least 50% (enough for a special)
     const flashTimer = Math.floor(Date.now() / 150) % 2 === 0;
     
+    // Effects for P1
     if (spRatioP1 >= 0.5) {
       if (spRatioP1 >= 1.0) {
         this.spBarP1.setFillStyle(flashTimer ? 0xffff00 : 0xffcc00);
@@ -802,10 +827,16 @@ export class FightScene extends Phaser.Scene {
         // Subtle pulse for 50%
         this.spBarP1.setFillStyle(flashTimer ? 0xffdd00 : 0xffaa00);
       }
+      
+      // HUD effects
+      this.spParticlesP1.emitting = true;
+      this.spParticlesP1.setPosition(SPECIAL_P1_X + (SPECIAL_BAR_W * spRatioP1) / 2, SPECIAL_BAR_Y + SPECIAL_BAR_H / 2);
     } else {
       this.spBarP1.setFillStyle(0xffcc00);
+      this.spParticlesP1.emitting = false;
     }
 
+    // Effects for P2
     if (spRatioP2 >= 0.5) {
       if (spRatioP2 >= 1.0) {
         this.spBarP2.setFillStyle(flashTimer ? 0xffff00 : 0xffcc00);
@@ -813,8 +844,13 @@ export class FightScene extends Phaser.Scene {
         // Subtle pulse for 50%
         this.spBarP2.setFillStyle(flashTimer ? 0xffdd00 : 0xffaa00);
       }
+
+      // HUD effects
+      this.spParticlesP2.emitting = true;
+      this.spParticlesP2.setPosition(SPECIAL_P2_X + SPECIAL_BAR_W - (SPECIAL_BAR_W * spRatioP2) / 2, SPECIAL_BAR_Y + SPECIAL_BAR_H / 2);
     } else {
       this.spBarP2.setFillStyle(0xffcc00);
+      this.spParticlesP2.emitting = false;
     }
 
     // Stamina bars

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -142,8 +142,9 @@ export class FightScene extends Phaser.Scene {
       this.frameCounter = 0;
       this._setupSpectatorMode();
     } else {
+      const slot = this.gameMode === 'online' && this.networkManager ? this.networkManager.getPlayerSlot() : 0;
       this.inputManager = new InputManager(this);
-      this.touchControls = new TouchControls(this, this.inputManager);
+      this.touchControls = new TouchControls(this, this.inputManager, slot);
 
       // -- AI controller (local mode only) --
       if (this.gameMode !== 'online') {
@@ -521,6 +522,10 @@ export class FightScene extends Phaser.Scene {
       .setStrokeStyle(1, 0x666666)
       .setFillStyle()
       .setDepth(depth + 2);
+    // 50% marker P1
+    this.add
+      .rectangle(SPECIAL_P1_X + SPECIAL_BAR_W / 2, SPECIAL_BAR_Y + SPECIAL_BAR_H / 2, 1, SPECIAL_BAR_H, 0xffffff, 0.3)
+      .setDepth(depth + 2);
 
     // P2 special
     this.spBgP2 = this.add
@@ -540,6 +545,10 @@ export class FightScene extends Phaser.Scene {
       )
       .setStrokeStyle(1, 0x666666)
       .setFillStyle()
+      .setDepth(depth + 2);
+    // 50% marker P2
+    this.add
+      .rectangle(SPECIAL_P2_X + SPECIAL_BAR_W / 2, SPECIAL_BAR_Y + SPECIAL_BAR_H / 2, 1, SPECIAL_BAR_H, 0xffffff, 0.3)
       .setDepth(depth + 2);
 
     // --- Player name labels ---
@@ -783,11 +792,30 @@ export class FightScene extends Phaser.Scene {
     this.spBarP1.width = SPECIAL_BAR_W * spRatioP1;
     this.spBarP2.width = SPECIAL_BAR_W * spRatioP2;
 
-    // Flash special bar when full
-    if (spRatioP1 >= 1) this.spBarP1.setFillStyle(0xffff00);
-    else this.spBarP1.setFillStyle(0xffcc00);
-    if (spRatioP2 >= 1) this.spBarP2.setFillStyle(0xffff00);
-    else this.spBarP2.setFillStyle(0xffcc00);
+    // Flash special bar when it's at least 50% (enough for a special)
+    const flashTimer = Math.floor(Date.now() / 150) % 2 === 0;
+    
+    if (spRatioP1 >= 0.5) {
+      if (spRatioP1 >= 1.0) {
+        this.spBarP1.setFillStyle(flashTimer ? 0xffff00 : 0xffcc00);
+      } else {
+        // Subtle pulse for 50%
+        this.spBarP1.setFillStyle(flashTimer ? 0xffdd00 : 0xffaa00);
+      }
+    } else {
+      this.spBarP1.setFillStyle(0xffcc00);
+    }
+
+    if (spRatioP2 >= 0.5) {
+      if (spRatioP2 >= 1.0) {
+        this.spBarP2.setFillStyle(flashTimer ? 0xffff00 : 0xffcc00);
+      } else {
+        // Subtle pulse for 50%
+        this.spBarP2.setFillStyle(flashTimer ? 0xffdd00 : 0xffaa00);
+      }
+    } else {
+      this.spBarP2.setFillStyle(0xffcc00);
+    }
 
     // Stamina bars
     const staRatioP1 = Phaser.Math.Clamp(this.p1Fighter.stamina / MAX_STAMINA_FP, 0, 1);

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -142,7 +142,8 @@ export class FightScene extends Phaser.Scene {
       this.frameCounter = 0;
       this._setupSpectatorMode();
     } else {
-      const slot = this.gameMode === 'online' && this.networkManager ? this.networkManager.getPlayerSlot() : 0;
+      const slot =
+        this.gameMode === 'online' && this.networkManager ? this.networkManager.getPlayerSlot() : 0;
       this.inputManager = new InputManager(this);
       this.touchControls = new TouchControls(this, this.inputManager, slot);
 
@@ -524,7 +525,14 @@ export class FightScene extends Phaser.Scene {
       .setDepth(depth + 2);
     // 50% marker P1
     this.add
-      .rectangle(SPECIAL_P1_X + SPECIAL_BAR_W / 2, SPECIAL_BAR_Y + SPECIAL_BAR_H / 2, 1, SPECIAL_BAR_H, 0xffffff, 0.3)
+      .rectangle(
+        SPECIAL_P1_X + SPECIAL_BAR_W / 2,
+        SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
+        1,
+        SPECIAL_BAR_H,
+        0xffffff,
+        0.3,
+      )
       .setDepth(depth + 2);
 
     // P2 special
@@ -548,32 +556,43 @@ export class FightScene extends Phaser.Scene {
       .setDepth(depth + 2);
     // 50% marker P2
     this.add
-      .rectangle(SPECIAL_P2_X + SPECIAL_BAR_W / 2, SPECIAL_BAR_Y + SPECIAL_BAR_H / 2, 1, SPECIAL_BAR_H, 0xffffff, 0.3)
+      .rectangle(
+        SPECIAL_P2_X + SPECIAL_BAR_W / 2,
+        SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
+        1,
+        SPECIAL_BAR_H,
+        0xffffff,
+        0.3,
+      )
       .setDepth(depth + 2);
 
     // --- Special effects for HUD bars ---
     // HUD Particle emitters
-    this.spParticlesP1 = this.add.particles(0, 0, 'white_pixel', {
-      speed: { min: 10, max: 20 },
-      angle: { min: 260, max: 280 },
-      scale: { start: 1, end: 0 },
-      alpha: { start: 0.6, end: 0 },
-      lifespan: 400,
-      frequency: 100,
-      tint: 0xffcc00,
-      emitting: false
-    }).setDepth(depth - 1);
+    this.spParticlesP1 = this.add
+      .particles(0, 0, 'white_pixel', {
+        speed: { min: 10, max: 20 },
+        angle: { min: 260, max: 280 },
+        scale: { start: 1, end: 0 },
+        alpha: { start: 0.6, end: 0 },
+        lifespan: 400,
+        frequency: 100,
+        tint: 0xffcc00,
+        emitting: false,
+      })
+      .setDepth(depth - 1);
 
-    this.spParticlesP2 = this.add.particles(0, 0, 'white_pixel', {
-      speed: { min: 10, max: 20 },
-      angle: { min: 260, max: 280 },
-      scale: { start: 1, end: 0 },
-      alpha: { start: 0.6, end: 0 },
-      lifespan: 400,
-      frequency: 100,
-      tint: 0xffcc00,
-      emitting: false
-    }).setDepth(depth - 1);
+    this.spParticlesP2 = this.add
+      .particles(0, 0, 'white_pixel', {
+        speed: { min: 10, max: 20 },
+        angle: { min: 260, max: 280 },
+        scale: { start: 1, end: 0 },
+        alpha: { start: 0.6, end: 0 },
+        lifespan: 400,
+        frequency: 100,
+        tint: 0xffcc00,
+        emitting: false,
+      })
+      .setDepth(depth - 1);
 
     // --- Player name labels ---
     const p1Color = this.p1Data.color.replace('0x', '#');
@@ -818,7 +837,7 @@ export class FightScene extends Phaser.Scene {
 
     // Flash special bar when it's at least 50% (enough for a special)
     const flashTimer = Math.floor(Date.now() / 150) % 2 === 0;
-    
+
     // Effects for P1
     if (spRatioP1 >= 0.5) {
       if (spRatioP1 >= 1.0) {
@@ -827,10 +846,13 @@ export class FightScene extends Phaser.Scene {
         // Subtle pulse for 50%
         this.spBarP1.setFillStyle(flashTimer ? 0xffdd00 : 0xffaa00);
       }
-      
+
       // HUD effects
       this.spParticlesP1.emitting = true;
-      this.spParticlesP1.setPosition(SPECIAL_P1_X + (SPECIAL_BAR_W * spRatioP1) / 2, SPECIAL_BAR_Y + SPECIAL_BAR_H / 2);
+      this.spParticlesP1.setPosition(
+        SPECIAL_P1_X + (SPECIAL_BAR_W * spRatioP1) / 2,
+        SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
+      );
     } else {
       this.spBarP1.setFillStyle(0xffcc00);
       this.spParticlesP1.emitting = false;
@@ -847,7 +869,10 @@ export class FightScene extends Phaser.Scene {
 
       // HUD effects
       this.spParticlesP2.emitting = true;
-      this.spParticlesP2.setPosition(SPECIAL_P2_X + SPECIAL_BAR_W - (SPECIAL_BAR_W * spRatioP2) / 2, SPECIAL_BAR_Y + SPECIAL_BAR_H / 2);
+      this.spParticlesP2.setPosition(
+        SPECIAL_P2_X + SPECIAL_BAR_W - (SPECIAL_BAR_W * spRatioP2) / 2,
+        SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
+      );
     } else {
       this.spBarP2.setFillStyle(0xffcc00);
       this.spParticlesP2.emitting = false;

--- a/src/systems/DebugBundleExporter.js
+++ b/src/systems/DebugBundleExporter.js
@@ -208,7 +208,7 @@ export class DebugBundleExporter {
         throw new Error(`fetch_failed: ${response.status}`);
       }
       return await response.json();
-    } catch (err) {
+    } catch (_err) {
       throw new Error('fetch_failed');
     }
   }

--- a/src/systems/MatchTelemetry.js
+++ b/src/systems/MatchTelemetry.js
@@ -44,7 +44,7 @@ export class MatchTelemetry {
     }, RTT_SAMPLE_INTERVAL_MS);
   }
 
-  recordRollback(frame, depth) {
+  recordRollback(_frame, depth) {
     this.rollbackCount++;
     if (depth > this.maxRollbackDepth) {
       this.maxRollbackDepth = depth;

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -113,18 +113,20 @@ export class TouchControls {
           .setDepth(100)
           .setVisible(false);
         this.specialGlow = glow;
-        
+
         // Particles for ES button
-        this.specialParticles = scene.add.particles(cx, cy, 'white_pixel', {
-          speed: { min: 10, max: 25 },
-          angle: { min: 0, max: 360 },
-          scale: { start: 1.2, end: 0 },
-          alpha: { start: 0.6, end: 0 },
-          lifespan: 500,
-          frequency: 80,
-          tint: 0xffcc00,
-          emitting: false
-        }).setDepth(100);
+        this.specialParticles = scene.add
+          .particles(cx, cy, 'white_pixel', {
+            speed: { min: 10, max: 25 },
+            angle: { min: 0, max: 360 },
+            scale: { start: 1.2, end: 0 },
+            alpha: { start: 0.6, end: 0 },
+            lifespan: 500,
+            frequency: 80,
+            tint: 0xffcc00,
+            emitting: false,
+          })
+          .setDepth(100);
 
         // Add a pulsing tween for the glow
         scene.tweens.add({
@@ -133,7 +135,7 @@ export class TouchControls {
           scale: 1.1,
           duration: 600,
           yoyo: true,
-          loop: -1
+          loop: -1,
         });
       }
 
@@ -366,16 +368,16 @@ export class TouchControls {
     if (fighter && this.specialGlow) {
       const isAvailable = fighter.special >= SPECIAL_COST_FP;
       this.specialGlow.setVisible(isAvailable);
-      
+
       // Update ES button effects
       if (isAvailable) {
         this.specialParticles.emitting = true;
       } else {
         this.specialParticles.emitting = false;
       }
-      
+
       // Also update the special button's text/border color when available
-      const spBtn = this.buttons.find(b => b.key === 'special');
+      const spBtn = this.buttons.find((b) => b.key === 'special');
       if (spBtn) {
         if (isAvailable) {
           spBtn.graphic.setStrokeStyle(2, 0xffcc00, 0.8);
@@ -387,15 +389,11 @@ export class TouchControls {
       }
     }
 
-    // 2. The joystick is driven entirely by pointer events, so nothing extra needed
-    // here. But we re-check the active joystick pointer in case the event was
-    // missed (e.g. pointer moved outside canvas and came back).
+    // 2. Monitor joystick pointer life
     if (this.joystickActive) {
       const pointer = this.getPointerById(this.joystickPointerId);
-      if (pointer?.isDown) {
-        this.updateJoystickFromPointer(pointer);
-      } else {
-        // Lost the pointer
+      if (!pointer || !pointer.isDown) {
+        // Lost the pointer or it was released without trigger
         this.handlePointerUp({ id: this.joystickPointerId });
       }
     }
@@ -408,11 +406,6 @@ export class TouchControls {
     const mgr = this.scene.input.manager;
     for (let i = 1; i <= mgr.pointersTotal; i++) {
       const p = this.scene.input[`pointer${i}`] || mgr.pointers[i];
-      if (p && p.id === id) return p;
-    }
-    // Also check pointer1..pointer5 on the input plugin
-    for (let i = 1; i <= 5; i++) {
-      const p = this.scene.input[`pointer${i}`];
       if (p && p.id === id) return p;
     }
     return null;

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -1,5 +1,6 @@
 import Phaser from 'phaser';
 import { GAME_HEIGHT, GAME_WIDTH } from '../config.js';
+import { SPECIAL_COST_FP } from './FixedPoint.js';
 
 /**
  * Virtual gamepad overlay for touch devices.
@@ -9,9 +10,10 @@ import { GAME_HEIGHT, GAME_WIDTH } from '../config.js';
  * Supports multi-touch so the player can move and attack simultaneously.
  */
 export class TouchControls {
-  constructor(scene, inputManager) {
+  constructor(scene, inputManager, playerIndex = 0) {
     this.scene = scene;
     this.input = inputManager;
+    this.playerIndex = playerIndex;
     this.enabled = false;
 
     // Only enable on touch devices
@@ -32,6 +34,7 @@ export class TouchControls {
     this.joystickThumb = null;
     this.buttons = []; // { graphic, hitArea, label, key }[]
     this.activeButtonPointers = {}; // pointerId -> button key
+    this.specialGlow = null;
 
     this.createJoystick();
     this.createButtons();
@@ -75,21 +78,21 @@ export class TouchControls {
     const gap = 6;
 
     // Anchor point for button cluster: bottom-right area
-    // We position relative to GAME_WIDTH / GAME_HEIGHT so it scales with the canvas
-    const baseX = GAME_WIDTH - 70;
+    // Moved further toward the right edge (from 70 to 45)
+    const baseX = GAME_WIDTH - 45;
     const baseY = GAME_HEIGHT - 60;
 
     // Button definitions with positions relative to baseX/baseY
-    //   Top row:     [SP]
-    //   Middle row:  [LP] [LK]
-    //   Bottom row:  [HP] [HK]
+    //   Top row:           [ES]
+    //   Middle row:  [LP]  [LK]
+    //   Bottom row:  [HP]  [HK]
     const defs = [
       // key in touchState, label, dx, dy
       {
         key: 'special',
         label: 'ES',
-        dx: -(btnRadius + gap / 2),
-        dy: -(btnRadius * 2 + gap) * 1.15,
+        dx: 0, // Aligned with the right column
+        dy: -(btnRadius * 2 + gap) * 1.4, // Higher up
       },
       { key: 'lightPunch', label: 'PL', dx: -(btnRadius * 2 + gap), dy: 0 },
       { key: 'lightKick', label: 'PaL', dx: 0, dy: 0 },
@@ -100,6 +103,26 @@ export class TouchControls {
     for (const def of defs) {
       const cx = baseX + def.dx;
       const cy = baseY + def.dy;
+
+      // Special button glow (behind the button)
+      let glow = null;
+      if (def.key === 'special') {
+        glow = scene.add
+          .circle(cx, cy, btnRadius + 4, 0xffcc00, 0.4)
+          .setDepth(100)
+          .setVisible(false);
+        this.specialGlow = glow;
+        
+        // Add a pulsing tween for the glow
+        scene.tweens.add({
+          targets: glow,
+          alpha: 0.1,
+          scale: 1.1,
+          duration: 600,
+          yoyo: true,
+          loop: -1
+        });
+      }
 
       // Button background circle
       const bg = scene.add
@@ -122,6 +145,7 @@ export class TouchControls {
       this.buttons.push({
         graphic: bg,
         text: txt,
+        glow: glow,
         key: def.key,
         cx,
         cy,
@@ -324,7 +348,26 @@ export class TouchControls {
   update() {
     if (!this.enabled) return;
 
-    // The joystick is driven entirely by pointer events, so nothing extra needed
+    // 1. Monitor special meter for glow effect
+    const fighter = this.playerIndex === 0 ? this.scene.p1Fighter : this.scene.p2Fighter;
+    if (fighter && this.specialGlow) {
+      const isAvailable = fighter.special >= SPECIAL_COST_FP;
+      this.specialGlow.setVisible(isAvailable);
+      
+      // Also update the special button's text/border color when available
+      const spBtn = this.buttons.find(b => b.key === 'special');
+      if (spBtn) {
+        if (isAvailable) {
+          spBtn.graphic.setStrokeStyle(2, 0xffcc00, 0.8);
+          spBtn.text.setColor('#ffcc00').setAlpha(1);
+        } else {
+          spBtn.graphic.setStrokeStyle(1.5, 0xffffff, 0.35);
+          spBtn.text.setColor('#ffffff').setAlpha(0.5);
+        }
+      }
+    }
+
+    // 2. The joystick is driven entirely by pointer events, so nothing extra needed
     // here. But we re-check the active joystick pointer in case the event was
     // missed (e.g. pointer moved outside canvas and came back).
     if (this.joystickActive) {
@@ -376,6 +419,7 @@ export class TouchControls {
     for (const btn of this.buttons) {
       btn.graphic.destroy();
       btn.text.destroy();
+      if (btn.glow) btn.glow.destroy();
     }
     this.buttons = [];
     this.activeButtonPointers = {};

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -35,6 +35,7 @@ export class TouchControls {
     this.buttons = []; // { graphic, hitArea, label, key }[]
     this.activeButtonPointers = {}; // pointerId -> button key
     this.specialGlow = null;
+    this.specialParticles = null;
 
     this.createJoystick();
     this.createButtons();
@@ -113,6 +114,18 @@ export class TouchControls {
           .setVisible(false);
         this.specialGlow = glow;
         
+        // Particles for ES button
+        this.specialParticles = scene.add.particles(cx, cy, 'white_pixel', {
+          speed: { min: 10, max: 25 },
+          angle: { min: 0, max: 360 },
+          scale: { start: 1.2, end: 0 },
+          alpha: { start: 0.6, end: 0 },
+          lifespan: 500,
+          frequency: 80,
+          tint: 0xffcc00,
+          emitting: false
+        }).setDepth(100);
+
         // Add a pulsing tween for the glow
         scene.tweens.add({
           targets: glow,
@@ -354,6 +367,13 @@ export class TouchControls {
       const isAvailable = fighter.special >= SPECIAL_COST_FP;
       this.specialGlow.setVisible(isAvailable);
       
+      // Update ES button effects
+      if (isAvailable) {
+        this.specialParticles.emitting = true;
+      } else {
+        this.specialParticles.emitting = false;
+      }
+      
       // Also update the special button's text/border color when available
       const spBtn = this.buttons.find(b => b.key === 'special');
       if (spBtn) {
@@ -415,6 +435,7 @@ export class TouchControls {
     if (this.joystickBase) this.joystickBase.destroy();
     if (this.joystickBaseRing) this.joystickBaseRing.destroy();
     if (this.joystickThumb) this.joystickThumb.destroy();
+    if (this.specialParticles) this.specialParticles.destroy();
 
     for (const btn of this.buttons) {
       btn.graphic.destroy();

--- a/tests/systems/desync-detection.test.js
+++ b/tests/systems/desync-detection.test.js
@@ -253,7 +253,7 @@ describe('RollbackManager checksum exchange', () => {
     const rm1 = new RollbackManager(nm1, 0, { inputDelay: 2, maxRollbackFrames: 7 });
     const rm2 = new RollbackManager(nm2, 1, { inputDelay: 2, maxRollbackFrames: 11 });
 
-    const s = mockScene();
+    const _s = mockScene();
     const p1a = mockFighter(144);
     const p2a = mockFighter(336);
     const ca = mockCombat();


### PR DESCRIPTION
﻿## Summary
This PR introduces ergonomic improvements to the mobile touch interface and enhances the visual feedback for the Special Attack system across all platforms. It also addresses critical bugs found during implementation.
Resolves #69 

## Changes

### 📱 Mobile UI & Ergonomics
- **Button Repositioning**: Shifted the right-hand action button cluster closer to the screen edge for better accessibility on modern mobile devices.
- **Special Button Isolation**: Separated the \"ES\" (Special) button from the primary attack cluster, moving it higher and aligning it with the right column to prevent accidental triggers.
- **Touch Stability**: Fixed a jitter issue in the virtual joystick by simplifying the update loop to rely exclusively on pointer events.

### ✨ Visual Feedback Enhancements
- **Special Gauge 50% Marker**: Added a white midpoint indicator line to the HUD special bars, clearly showing when a special move is available.
- **Dynamic Meter States**:
    - **$\ge$ 50%**: The bar now pulses yellow and emits floating \"energy\" particles.
    - **100%**: The bar flashes rapidly to signal a full charge.
- **Button Feedback**: The mobile \"ES\" button now glows yellow and displays a pulsing aura when the special move is ready ($\ge$ 50%).

### 🐛 Bug Fixes
- **White Screen Fix**: Resolved a TypeError in FightScene.js where the engine attempted to access properties of an undefined object (spShine).
- **Texture Initialization**: Added procedural generation for the white_pixel texture in BootScene to support new particle effects without adding external assets.

## Verification
- **Unit Tests**: All 732 tests passed successfully (
pm run test:run).
- **Manual Testing**: Verified button ergonomics and joystick responsiveness on mobile viewports.
- **Linting**: Ensured 100% compliance with project formatting standards.
![Screenshot_20260401-002656~2.jpg](https://github.com/user-attachments/assets/0fde4b87-96a6-4b2e-b3e5-032008def841)

![Screenshot_20260401-002656.jpg](https://github.com/user-attachments/assets/50e6dd0b-36a6-44c3-816e-3e58a200636f)

