### PR TITLE
feat: add remote browser E2E testing via BrowserStack (RFC 0008)

### DIFF
--- a/.github/workflows/e2e-remote.yml
+++ b/.github/workflows/e2e-remote.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       preset: ${{ steps.parse.outputs.preset }}
+      party_host: ${{ steps.parse.outputs.party_host }}
       pr_number: ${{ github.event.issue.number }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
     steps:
@@ -33,6 +34,12 @@ jobs:
           PRESET=$(echo "$COMMENT" | grep -oP '(?<=--preset\s)\S+' || echo "default")
           echo "preset=$PRESET" >> "$GITHUB_OUTPUT"
           echo "Parsed preset: $PRESET"
+          # Extract --party-host value (optional)
+          PARTY_HOST=$(echo "$COMMENT" | grep -oP '(?<=--party-host\s)\S+' || echo "")
+          echo "party_host=$PARTY_HOST" >> "$GITHUB_OUTPUT"
+          if [ -n "$PARTY_HOST" ]; then
+            echo "Parsed party host: $PARTY_HOST"
+          fi
 
       - name: Get PR head SHA
         id: pr
@@ -87,6 +94,7 @@ jobs:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           REMOTE_E2E_PRESET: ${{ needs.parse-command.outputs.preset }}
+          REMOTE_E2E_PARTY_HOST: ${{ needs.parse-command.outputs.party_host }}
           DIAG_TOKEN: ${{ secrets.DIAG_TOKEN }}
 
       - name: Print test results
@@ -120,6 +128,7 @@ jobs:
             const fs = require('fs');
             const marker = '<!-- remote-e2e-results -->';
             const preset = '${{ needs.parse-command.outputs.preset }}';
+            const partyHost = '${{ needs.parse-command.outputs.party_host }}';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const success = '${{ job.status }}' === 'success';
             const icon = success ? ':white_check_mark:' : ':x:';
@@ -131,11 +140,13 @@ jobs:
               reportContent = '_No report generated — test may have failed before match completion._';
             }
 
+            const partyInfo = partyHost ? ` --party-host ${partyHost}` : '';
             const body = [
               marker,
               `## ${icon} Remote E2E Results (\`${preset}\`)`,
               '',
-              `Triggered by @${context.actor} via \`/e2e remote --preset ${preset}\``,
+              `Triggered by @${context.actor} via \`/e2e remote --preset ${preset}${partyInfo}\``,
+              partyHost ? `**Party server:** \`${partyHost}\`` : '',
               '',
               '<details>',
               '<summary>Match Report</summary>',

--- a/.github/workflows/e2e-remote.yml
+++ b/.github/workflows/e2e-remote.yml
@@ -1,22 +1,35 @@
 name: Remote E2E Tests (BrowserStack)
 
-# Trigger via PR comment: /e2e remote [--preset <name>]
-# Examples:
-#   /e2e remote
-#   /e2e remote --preset chrome-chrome
-#   /e2e remote --preset webkit-webkit
+# Two trigger modes:
+# 1. PR comment:  /e2e remote [--preset <name>] [--party-host <host>]
+# 2. Manual:      Actions tab → "Run workflow" → fill inputs
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      preset:
+        description: 'Browser preset'
+        type: choice
+        options:
+          - default
+          - chrome-chrome
+          - webkit-webkit
+        default: 'default'
+      party_host:
+        description: 'PartyKit host (optional, e.g. pr-80.a-los-traques.simon0191.partykit.dev)'
+        type: string
+        default: ''
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  # --- Job 1: Parse /e2e remote comment (only runs for issue_comment trigger) ---
   parse-command:
-    # Only run on PR comments (not issue comments) that start with /e2e remote
     if: >
+      github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/e2e remote')
     runs-on: ubuntu-latest
@@ -58,14 +71,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # --- Job 2: Run remote E2E tests (runs for both triggers) ---
   remote-e2e:
     needs: parse-command
+    # Run if: parse-command succeeded (issue_comment) OR was skipped (workflow_dispatch)
+    if: always() && (needs.parse-command.result == 'success' || needs.parse-command.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    # Resolve inputs from whichever trigger fired
+    env:
+      RESOLVED_PRESET: ${{ inputs.preset || needs.parse-command.outputs.preset || 'default' }}
+      RESOLVED_PARTY_HOST: ${{ inputs.party_host || needs.parse-command.outputs.party_host || '' }}
+      RESOLVED_SHA: ${{ needs.parse-command.outputs.head_sha || github.sha }}
+      RESOLVED_PR: ${{ needs.parse-command.outputs.pr_number || '' }}
+
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.parse-command.outputs.head_sha }}
+          ref: ${{ env.RESOLVED_SHA }}
 
       - uses: oven-sh/setup-bun@v2
 
@@ -93,8 +117,8 @@ jobs:
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-          REMOTE_E2E_PRESET: ${{ needs.parse-command.outputs.preset }}
-          REMOTE_E2E_PARTY_HOST: ${{ needs.parse-command.outputs.party_host }}
+          REMOTE_E2E_PRESET: ${{ env.RESOLVED_PRESET }}
+          REMOTE_E2E_PARTY_HOST: ${{ env.RESOLVED_PARTY_HOST }}
           DIAG_TOKEN: ${{ secrets.DIAG_TOKEN }}
 
       - name: Print test results
@@ -120,15 +144,16 @@ jobs:
           path: test-results/remote/
           retention-days: 14
 
+      # --- PR comment reporting (only when triggered from a PR) ---
       - name: Comment results on PR
-        if: always()
+        if: always() && env.RESOLVED_PR != ''
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const marker = '<!-- remote-e2e-results -->';
-            const preset = '${{ needs.parse-command.outputs.preset }}';
-            const partyHost = '${{ needs.parse-command.outputs.party_host }}';
+            const preset = process.env.RESOLVED_PRESET;
+            const partyHost = process.env.RESOLVED_PARTY_HOST;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const success = '${{ job.status }}' === 'success';
             const icon = success ? ':white_check_mark:' : ':x:';
@@ -158,10 +183,11 @@ jobs:
               `[Download debug bundles & logs](${runUrl}#artifacts)`,
             ].join('\n');
 
+            const prNumber = parseInt(process.env.RESOLVED_PR, 10);
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ needs.parse-command.outputs.pr_number }},
+              issue_number: prNumber,
             });
             const existing = comments.find(c => c.body.includes(marker));
             if (existing) {
@@ -175,13 +201,13 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: ${{ needs.parse-command.outputs.pr_number }},
+                issue_number: prNumber,
                 body,
               });
             }
 
       - name: React with result emoji
-        if: always()
+        if: always() && github.event_name == 'issue_comment'
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             REACTION="rocket"

--- a/.github/workflows/e2e-remote.yml
+++ b/.github/workflows/e2e-remote.yml
@@ -1,0 +1,183 @@
+name: Remote E2E Tests (BrowserStack)
+
+# Trigger via PR comment: /e2e remote [--preset <name>]
+# Examples:
+#   /e2e remote
+#   /e2e remote --preset chrome-chrome
+#   /e2e remote --preset webkit-webkit
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  parse-command:
+    # Only run on PR comments (not issue comments) that start with /e2e remote
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/e2e remote')
+    runs-on: ubuntu-latest
+    outputs:
+      preset: ${{ steps.parse.outputs.preset }}
+      pr_number: ${{ github.event.issue.number }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+    steps:
+      - name: Parse command arguments
+        id: parse
+        run: |
+          COMMENT="${{ github.event.comment.body }}"
+          # Extract --preset value (default: "default")
+          PRESET=$(echo "$COMMENT" | grep -oP '(?<=--preset\s)\S+' || echo "default")
+          echo "preset=$PRESET" >> "$GITHUB_OUTPUT"
+          echo "Parsed preset: $PRESET"
+
+      - name: Get PR head SHA
+        id: pr
+        run: |
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "PR head SHA: $HEAD_SHA"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: React to comment with eyes emoji
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=eyes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  remote-e2e:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse-command.outputs.head_sha }}
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - run: bun install
+
+      # Playwright is needed for chromium.connect() to BrowserStack CDP
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+      - run: npx playwright install chromium --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - run: npx playwright install-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+
+      - name: Run remote E2E tests
+        run: bun run test:e2e:remote
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          REMOTE_E2E_PRESET: ${{ needs.parse-command.outputs.preset }}
+          DIAG_TOKEN: ${{ secrets.DIAG_TOKEN }}
+
+      - name: Print test results
+        if: always()
+        run: |
+          if [ -d test-results/remote ]; then
+            echo "=== Remote E2E Test Results ==="
+            for f in test-results/remote/*.md test-results/remote/*.log test-results/remote/*.json; do
+              [ -f "$f" ] || continue
+              echo ""
+              echo "--- $f ---"
+              cat "$f"
+              echo ""
+            done
+          else
+            echo "No remote test results found"
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: remote-e2e-results
+          path: test-results/remote/
+          retention-days: 14
+
+      - name: Comment results on PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- remote-e2e-results -->';
+            const preset = '${{ needs.parse-command.outputs.preset }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const success = '${{ job.status }}' === 'success';
+            const icon = success ? ':white_check_mark:' : ':x:';
+
+            let reportContent = '';
+            try {
+              reportContent = fs.readFileSync(`test-results/remote/remote-${preset}-report.md`, 'utf8');
+            } catch {
+              reportContent = '_No report generated — test may have failed before match completion._';
+            }
+
+            const body = [
+              marker,
+              `## ${icon} Remote E2E Results (\`${preset}\`)`,
+              '',
+              `Triggered by @${context.actor} via \`/e2e remote --preset ${preset}\``,
+              '',
+              '<details>',
+              '<summary>Match Report</summary>',
+              '',
+              reportContent,
+              '',
+              '</details>',
+              '',
+              `[Download debug bundles & logs](${runUrl}#artifacts)`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.pr_number }},
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ needs.parse-command.outputs.pr_number }},
+                body,
+              });
+            }
+
+      - name: React with result emoji
+        if: always()
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            REACTION="rocket"
+          else
+            REACTION="-1"
+          fi
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content="$REACTION"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ Playwright-based framework that spawns two browser instances in autoplay mode, r
 ```bash
 bun run test:e2e          # Run E2E tests headless
 bun run test:e2e:headed   # Watch both browsers fight
+bun run test:e2e:remote   # Remote browsers via BrowserStack (requires BROWSERSTACK_USERNAME + BROWSERSTACK_ACCESS_KEY)
 ```
 
 **Autoplay URL params**: `?autoplay=1&createRoom=1&fighter=simon&seed=42&speed=2`
@@ -165,6 +166,9 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - `docs/rfcs/0002-multiplayer-redesign.md` — Multiplayer architecture redesign (Phases 1, 2A, 2B, 3 complete, Phase 4 next)
 - `docs/rfcs/0004-authentication-redesign-vercel.md` — Authentication & persistence (Supabase + Vercel)
 - `docs/rfcs/0005-multiplayer-debuggability.md` — Multiplayer debuggability (Phases 1-4 complete)
+- `docs/rfcs/0006-fix-p1-no-rollback.md` — Fix P1 never rolls back
+- `docs/rfcs/0007-fix-desync-detection.md` — Fix desync detection between peers with different RTT
+- `docs/rfcs/0008-e2e-remote-browser-testing.md` — Remote browser E2E testing via BrowserStack
 
 ## Online Multiplayer
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -236,15 +236,36 @@ const result = replayFromBundle(bundle);
 
 A Vitest test (`tests/systems/replay.test.js`) validates the replay engine against a known-good fixture.
 
+## Remote Browser Testing (BrowserStack)
+
+Run P1 and P2 on separate BrowserStack remote browsers for realistic cross-browser, cross-network testing. See [RFC 0008](rfcs/0008-e2e-remote-browser-testing.md) for full design.
+
+```bash
+# Requires BrowserStack credentials
+BROWSERSTACK_USERNAME=xxx BROWSERSTACK_ACCESS_KEY=yyy bun run test:e2e:remote
+
+# Specific browser preset (default, chrome-chrome, webkit-webkit)
+REMOTE_E2E_PRESET=chrome-chrome bun run test:e2e:remote
+```
+
+Key differences from local E2E:
+- Two independent BrowserStack sessions (separate machines) connected via Playwright CDP
+- Uses deployed staging infrastructure (Vercel + PartyKit cloud) — real network paths
+- `speed=1` (no overclock) to exercise real latency and transport behavior
+- `debug=1` always on — captures v2 debug bundles with telemetry and logger data
+- Results in `test-results/remote/` including report, combined bundle, and console logs
+
+### Architecture
+
+```
+tests/e2e/remote/
+  remote-multiplayer.spec.js       # Test spec — orchestrates two remote browsers
+  remote-config.js                 # Browser presets (Chrome/Win + WebKit/Mac, etc.)
+  remote-helpers.js                # BrowserStack connection + data extraction helpers
+  remote-playwright.config.js      # Playwright config (no webServer, longer timeouts)
+```
+
 ## Future Enhancements
-
-### BrowserStack Integration
-
-The framework is BrowserStack-compatible by design (URL-driven, `page.evaluate()` extraction). To run on real devices:
-
-1. Add `browserstack.yml` with credentials and device matrix (iPhone 15 Safari, Android Chrome)
-2. Deploy to staging or use BrowserStack Local tunnel
-3. Run: `npx browserstack-node-sdk playwright test --config tests/e2e/playwright.config.js`
 
 ### Network Condition Simulation
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -248,6 +248,14 @@ BROWSERSTACK_USERNAME=xxx BROWSERSTACK_ACCESS_KEY=yyy bun run test:e2e:remote
 REMOTE_E2E_PRESET=chrome-chrome bun run test:e2e:remote
 ```
 
+**Trigger from CI** — post a PR comment:
+```
+/e2e remote
+/e2e remote --preset chrome-chrome
+```
+
+Results are posted back as a PR comment with debug bundles as downloadable artifacts.
+
 Key differences from local E2E:
 - Two independent BrowserStack sessions (separate machines) connected via Playwright CDP
 - Uses deployed staging infrastructure (Vercel + PartyKit cloud) — real network paths

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -248,13 +248,12 @@ BROWSERSTACK_USERNAME=xxx BROWSERSTACK_ACCESS_KEY=yyy bun run test:e2e:remote
 REMOTE_E2E_PRESET=chrome-chrome bun run test:e2e:remote
 ```
 
-**Trigger from CI** — post a PR comment:
-```
-/e2e remote
-/e2e remote --preset chrome-chrome
-```
+**Trigger from CI** — two options:
 
-Results are posted back as a PR comment with debug bundles as downloadable artifacts.
+1. **PR comment**: post `/e2e remote` or `/e2e remote --preset chrome-chrome --party-host myhost.partykit.dev`
+2. **Manual**: Actions tab → "Remote E2E Tests (BrowserStack)" → "Run workflow" (works from any branch)
+
+Results are posted back as a PR comment (if triggered from PR) with debug bundles as downloadable artifacts.
 
 Key differences from local E2E:
 - Two independent BrowserStack sessions (separate machines) connected via Playwright CDP

--- a/docs/rfcs/0008-e2e-remote-browser-testing.md
+++ b/docs/rfcs/0008-e2e-remote-browser-testing.md
@@ -271,7 +271,22 @@ Trigger a remote E2E run from any PR by posting a comment:
 /e2e remote --preset chrome-chrome --party-host pr-80.a-los-traques.simon0191.partykit.dev
 ```
 
-The workflow (`.github/workflows/e2e-remote.yml`) is triggered by `issue_comment` events:
+> **Note:** The `issue_comment` trigger requires the workflow file to exist on the default branch (`main`). Until merged, use the manual trigger instead.
+
+### CI (manual trigger via Actions tab)
+
+After the workflow is on `main`, go to **Actions → "Remote E2E Tests (BrowserStack)" → "Run workflow"** and fill in the inputs:
+
+- **Branch**: any branch (uses that branch's code)
+- **Browser preset**: dropdown — `default`, `chrome-chrome`, `webkit-webkit`
+- **PartyKit host**: optional text field
+
+This is useful for:
+- Testing before the `issue_comment` trigger is available (first merge)
+- Running against `main` directly without a PR
+- Quick ad-hoc testing from any branch
+
+The workflow (`.github/workflows/e2e-remote.yml`) supports both `issue_comment` and `workflow_dispatch` triggers:
 
 ```mermaid
 sequenceDiagram

--- a/docs/rfcs/0008-e2e-remote-browser-testing.md
+++ b/docs/rfcs/0008-e2e-remote-browser-testing.md
@@ -1,0 +1,289 @@
+# RFC 0008: E2E Remote Browser Testing
+
+**Status:** Proposed
+**Date:** 2026-04-01
+**Author:** Architecture Team
+**Predecessor:** [E2E Testing Framework](../e2e-testing.md), [RFC 0005: Multiplayer Debuggability](0005-multiplayer-debuggability.md)
+
+---
+
+## Summary
+
+Extend the E2E multiplayer testing framework to run P1 and P2 on **separate BrowserStack remote browsers**, connected through deployed PartyKit cloud infrastructure over real network paths. After match completion, full v2 debug bundles are extracted from both peers and saved locally for analysis.
+
+## Motivation
+
+The existing local E2E tests run both players on the same machine with sub-1ms RTT. This catches simulation determinism bugs but misses an entire class of issues that only manifest under real network conditions:
+
+- **RTT asymmetry** — RFC 0007 documented a desync that only appeared with 80ms+ asymmetric RTT producing different `maxRollbackFrames` values between peers
+- **WebRTC/TURN path** — local tests skip TURN entirely (direct localhost). Remote browsers exercise Cloudflare TURN credential flow and real ICE negotiation
+- **Cross-browser divergence** — the game targets iPhone 15 Safari but tests only run on Chromium. Different JS engines, floating-point implementations, and timer behaviors can cause subtle determinism breaks
+- **Geographic latency** — jitter, packet reordering, and transport fallback timing are invisible on localhost
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph Local["Local Machine (Orchestrator)"]
+        Script["tests/e2e/remote/run-remote-e2e.js"]
+        Report["Report + Bundle Generator"]
+    end
+
+    subgraph BS["BrowserStack Cloud"]
+        subgraph Worker1["Worker 1 (e.g. Chrome/Windows)"]
+            P1["P1 Browser<br/>autoplay=1 & createRoom=1<br/>& debug=1 & fighter=simon"]
+            P1Log["window.__FIGHT_LOG<br/>window.__DEBUG_BUNDLE"]
+        end
+        subgraph Worker2["Worker 2 (e.g. WebKit/macOS)"]
+            P2["P2 Browser<br/>autoplay=1 & room=XXXX<br/>& debug=1 & fighter=jeka"]
+            P2Log["window.__FIGHT_LOG<br/>window.__DEBUG_BUNDLE"]
+        end
+    end
+
+    subgraph Deployed["Deployed Infrastructure"]
+        Vercel["Vercel Staging<br/>(game client)"]
+        Party["PartyKit Cloud<br/>(signaling + relay)"]
+        TURN["Cloudflare TURN<br/>(NAT traversal)"]
+    end
+
+    Script -- "1. Connect P1 via CDP" --> Worker1
+    Script -- "3. Connect P2 via CDP<br/>(with room ID)" --> Worker2
+    Script -- "2. Poll roomId" --> P1Log
+    Script -- "4. Poll matchComplete" --> P1Log
+    Script -- "4. Poll matchComplete" --> P2Log
+    Script -- "5. Extract fight logs<br/>+ debug bundles" --> P1Log
+    Script -- "5. Extract fight logs<br/>+ debug bundles" --> P2Log
+    Report -- "6. Generate artifacts" --> Local
+
+    P1 -- "loads game" --> Vercel
+    P2 -- "loads game" --> Vercel
+    P1 <-- "WebSocket + WebRTC" --> Party
+    P2 <-- "WebSocket + WebRTC" --> Party
+    P1 <-. "P2P DataChannel<br/>(via TURN)" .-> P2
+```
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant O as Orchestrator<br/>(local machine)
+    participant BS as BrowserStack<br/>CDP endpoint
+    participant P1 as P1 Browser<br/>(Chrome/Windows)
+    participant P2 as P2 Browser<br/>(WebKit/macOS)
+    participant PK as PartyKit Cloud
+
+    Note over O: bun run test:e2e:remote
+
+    O->>BS: chromium.connect(wss://cdp.browserstack.com/playwright?caps=P1)
+    BS-->>O: P1 browser session
+
+    O->>P1: page.goto(staging/?autoplay=1&createRoom=1&debug=1&fighter=simon&seed=42)
+    P1->>PK: WebSocket connect, create room
+
+    loop Poll every 2s (max 60s)
+        O->>P1: page.evaluate(() => window.__AUTOPLAY_ROOM_ID)
+        P1-->>O: null → ... → "ABCD"
+    end
+
+    O->>BS: chromium.connect(wss://cdp.browserstack.com/playwright?caps=P2)
+    BS-->>O: P2 browser session
+
+    O->>P2: page.goto(staging/?autoplay=1&room=ABCD&debug=1&fighter=jeka&seed=42)
+    P2->>PK: WebSocket connect, join room ABCD
+
+    Note over P1,P2: WebRTC P2P negotiation via PartyKit signaling<br/>TURN via Cloudflare if needed
+
+    par Match in progress
+        P1->>P1: AutoplayController drives AI inputs
+        P2->>P2: AutoplayController drives AI inputs
+        P1<-->P2: Input exchange (DataChannel or WS fallback)
+    end
+
+    par Wait for both (max 180s)
+        O->>P1: page.waitForFunction(__FIGHT_LOG?.matchComplete)
+        O->>P2: page.waitForFunction(__FIGHT_LOG?.matchComplete)
+    end
+
+    par Extract data
+        O->>P1: page.evaluate(() => window.__FIGHT_LOG)
+        P1-->>O: fightLogP1
+        O->>P1: page.evaluate(() => window.__DEBUG_BUNDLE)
+        P1-->>O: v2 debug bundle P1
+        O->>P2: page.evaluate(() => window.__FIGHT_LOG)
+        P2-->>O: fightLogP2
+        O->>P2: page.evaluate(() => window.__DEBUG_BUNDLE)
+        P2-->>O: v2 debug bundle P2
+    end
+
+    O->>PK: GET /parties/main/ABCD/diagnostics
+    PK-->>O: server diagnostics
+
+    Note over O: Generate report + combined bundle<br/>→ test-results/remote/
+
+    O->>P1: browser.close()
+    O->>P2: browser.close()
+```
+
+## Design Decisions
+
+### Why Playwright CDP Connect (not browserstack-node-sdk)
+
+BrowserStack's `browserstack-node-sdk` wraps the entire Playwright test runner and launches both contexts on the **same remote machine** — defeating our goal of geographic separation. Instead, we use Playwright's `chromium.connect()` to BrowserStack's CDP WebSocket endpoint directly, creating two **independent sessions** on different machines. This gives us:
+
+- Independent control over each browser (different OS/browser for P1 vs P2)
+- Full `page.evaluate()`, `page.waitForFunction()`, `page.on('console')` — identical APIs to local tests
+- Zero changes to existing Playwright helpers
+
+### Why deployed infrastructure (not BrowserStack Local tunnel)
+
+- **Realism**: Remote browsers hit deployed servers over real internet = true production conditions
+- **WebRTC**: TURN/STUN works naturally over public internet; tunnels can interfere with ICE
+- **Simplicity**: No tunnel binary, no port forwarding
+- We already deploy to Vercel (frontend) and PartyKit cloud (multiplayer)
+
+The `REMOTE_E2E_BASE_URL` env var overrides the staging URL for custom deployments.
+
+### Why speed=1 (no overclock)
+
+Local E2E uses `speed=2` for faster CI. Remote tests use `speed=1` because we want to exercise real network timing — latency, jitter, transport fallback decisions. Overclocking hides timing-sensitive bugs like the ones identified in RFC 0006 and 0007.
+
+### Room ID coordination — no changes needed
+
+Identical pattern to local E2E: poll `window.__AUTOPLAY_ROOM_ID` on P1 via `page.evaluate()`, pass to P2's URL. Playwright's CDP protocol supports `waitForFunction` over the WebSocket tunnel to BrowserStack.
+
+## File Structure
+
+### New Files
+
+```
+tests/e2e/remote/
+  remote-multiplayer.spec.js       # Test spec — connects two remote browsers, runs match
+  remote-config.js                 # Browser capability presets + defaults
+  remote-helpers.js                # connectRemoteBrowser(), extractDebugBundle(), etc.
+  remote-playwright.config.js      # Playwright config (no webServer, longer timeouts)
+docs/rfcs/0008-e2e-remote-browser-testing.md   # This RFC
+```
+
+### Modified Files
+
+```
+package.json                       # Add test:e2e:remote script
+src/scenes/FightScene.js           # Expose window.__DEBUG_BUNDLE on match end (debug mode)
+docs/e2e-testing.md                # Add "Remote Browser Testing" section
+CLAUDE.md                          # Add remote E2E commands
+```
+
+## Browser Presets
+
+| Preset | P1 | P2 | Purpose |
+|--------|----|----|---------|
+| `default` | Chrome / Windows 11 | WebKit / macOS Sonoma | Cross-browser, cross-OS |
+| `chrome-chrome` | Chrome / Windows 11 | Chrome / macOS Sonoma | Isolate network effects |
+| `webkit-webkit` | WebKit / macOS Sonoma | WebKit / macOS Ventura | Safari-like both sides |
+
+Select via `REMOTE_E2E_PRESET` env var:
+```bash
+REMOTE_E2E_PRESET=chrome-chrome bun run test:e2e:remote
+```
+
+## Debug Bundle Capture
+
+Two tiers of data extraction, both via `page.evaluate()` after match completion:
+
+**Tier 1 (always):** `window.__FIGHT_LOG` — inputs, checksums, round events, network events, final state. Identical to local E2E. Fed through existing `generateBundle()` and `generateReport()` helpers.
+
+**Tier 2 (with `debug=1`):** `window.__DEBUG_BUNDLE` — v2 format including Logger ring buffer, MatchTelemetry RTT samples, MatchStateMachine transition history, and environment info. Exposed by a small addition to FightScene.js on match completion.
+
+**Tier 3 (with `DIAG_TOKEN`):** Server diagnostics fetched directly from `GET /parties/main/{roomId}/diagnostics`. Combined with client bundles into a single artifact.
+
+### Output Structure
+
+```
+test-results/remote/
+  remote-default-report.md          # Markdown report (same format as local E2E)
+  remote-default-bundle.json        # Combined bundle with:
+                                    #   - v1 fight logs (both peers)
+                                    #   - v2 debug bundles (both peers)
+                                    #   - server diagnostics
+                                    #   - BrowserStack metadata
+  remote-default-console.log        # Console output from both browsers
+```
+
+## Timeouts
+
+| Operation | Local | Remote | Rationale |
+|-----------|-------|--------|-----------|
+| Room creation | 30s | 60s | Network roundtrip to PartyKit cloud |
+| Match completion | 110s | 180s | speed=1 + real latency |
+| Page load | default | 30s | Remote browser fetches from CDN |
+| Total test | 300s | 300s | Same overall budget |
+
+## Error Handling
+
+| Failure | Behavior |
+|---------|----------|
+| Missing `BROWSERSTACK_*` env vars | Clear error with setup instructions |
+| P1 session creation fails | Exit with BrowserStack error |
+| Room ID timeout (60s) | Capture P1 console, save partial data, exit 1 |
+| P2 session creation fails | Clean up P1 session, exit 1 |
+| Match timeout (180s) | Extract partial fight logs, generate partial report, exit 1 |
+| Game crash | Console logs captured in finally block |
+
+The `finally` block always attempts to: extract partial fight logs, save console output, mark BrowserStack sessions, clean up both sessions.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `BROWSERSTACK_USERNAME` | Yes | BrowserStack account username |
+| `BROWSERSTACK_ACCESS_KEY` | Yes | BrowserStack access key |
+| `REMOTE_E2E_BASE_URL` | No | Override staging URL |
+| `REMOTE_E2E_PRESET` | No | Browser preset (default: `default`) |
+| `DIAG_TOKEN` | No | PartyKit diagnostics token |
+
+## Commands
+
+```bash
+# Default: Chrome/Windows vs WebKit/macOS against deployed staging
+BROWSERSTACK_USERNAME=xxx BROWSERSTACK_ACCESS_KEY=yyy bun run test:e2e:remote
+
+# Specific preset
+REMOTE_E2E_PRESET=chrome-chrome BROWSERSTACK_USERNAME=xxx BROWSERSTACK_ACCESS_KEY=yyy bun run test:e2e:remote
+
+# With server diagnostics
+DIAG_TOKEN=zzz BROWSERSTACK_USERNAME=xxx BROWSERSTACK_ACCESS_KEY=yyy bun run test:e2e:remote
+```
+
+## What Is Reused vs What Is New
+
+### Reused without modification
+- `AutoplayController` — reads URL params identically on remote browsers
+- `FightRecorder` → `window.__FIGHT_LOG` — populated identically
+- `waitForRoomId()` / `waitForMatchComplete()` — `page.waitForFunction` works over CDP to BrowserStack
+- `extractFightLog()` — `page.evaluate` works over CDP
+- `generateReport()` / `generateBundle()` — process fight logs identically
+- `?partyHost=` URL param for targeting deployed PartyKit
+- `?debug=1` for enabling FightRecorder + debug infrastructure
+- Server `/diagnostics` endpoint
+
+### Reused with parameter override
+- `waitForRoomId(page, 60_000)` — existing timeout param
+- `waitForMatchComplete(page, 180_000)` — existing timeout param
+
+### New
+- Remote Playwright config (no `webServer`, longer timeout)
+- `connectRemoteBrowser()` — `chromium.connect(wss://cdp.browserstack.com/...)`
+- Remote URL builders (always `speed=1`, `debug=1`, `partyHost=...`)
+- `extractDebugBundle()` — tries `__DEBUG_BUNDLE` then `__FIGHT_LOG`
+- `fetchServerDiagnostics()` — direct HTTP from orchestrator
+- Combined remote bundle format
+
+### Small modification to existing code
+- `FightScene.js` — expose `window.__DEBUG_BUNDLE` when debug mode active (8 lines, guarded by `this.game.debugMode`)
+
+## Future Enhancements
+
+- **CI integration**: Run remote E2E on a schedule (nightly) against staging
+- **Mobile presets**: iPhone 15 Safari + Android Chrome (requires BrowserStack App Automate for real devices)
+- **Network condition presets**: Combine with Toxiproxy for simulated 3G/4G latency
+- **Multi-preset matrix**: Run all presets in parallel, aggregate results

--- a/docs/rfcs/0008-e2e-remote-browser-testing.md
+++ b/docs/rfcs/0008-e2e-remote-browser-testing.md
@@ -182,9 +182,10 @@ CLAUDE.md                          # Add remote E2E commands
 | `chrome-chrome` | Chrome / Windows 11 | Chrome / macOS Sonoma | Isolate network effects |
 | `webkit-webkit` | WebKit / macOS Sonoma | WebKit / macOS Ventura | Safari-like both sides |
 
-Select via `REMOTE_E2E_PRESET` env var:
+Select via env vars:
 ```bash
 REMOTE_E2E_PRESET=chrome-chrome bun run test:e2e:remote
+REMOTE_E2E_PARTY_HOST=pr-80.a-los-traques.simon0191.partykit.dev bun run test:e2e:remote
 ```
 
 ## Debug Bundle Capture
@@ -240,6 +241,7 @@ The `finally` block always attempts to: extract partial fight logs, save console
 | `BROWSERSTACK_ACCESS_KEY` | Yes | BrowserStack access key |
 | `REMOTE_E2E_BASE_URL` | No | Override staging URL |
 | `REMOTE_E2E_PRESET` | No | Browser preset (default: `default`) |
+| `REMOTE_E2E_PARTY_HOST` | No | Override PartyKit host (e.g. `pr-80.a-los-traques.simon0191.partykit.dev`) |
 | `DIAG_TOKEN` | No | PartyKit diagnostics token |
 
 ## Commands
@@ -265,6 +267,8 @@ Trigger a remote E2E run from any PR by posting a comment:
 /e2e remote
 /e2e remote --preset chrome-chrome
 /e2e remote --preset webkit-webkit
+/e2e remote --party-host pr-80.a-los-traques.simon0191.partykit.dev
+/e2e remote --preset chrome-chrome --party-host pr-80.a-los-traques.simon0191.partykit.dev
 ```
 
 The workflow (`.github/workflows/e2e-remote.yml`) is triggered by `issue_comment` events:
@@ -297,8 +301,8 @@ sequenceDiagram
 
 **How it works:**
 
-1. Developer posts `/e2e remote` (with optional `--preset`) as a PR comment
-2. `parse-command` job validates it's a PR comment starting with `/e2e remote`, extracts preset, reacts with :eyes:
+1. Developer posts `/e2e remote` (with optional `--preset`, `--party-host`) as a PR comment
+2. `parse-command` job validates it's a PR comment starting with `/e2e remote`, extracts args, reacts with :eyes:
 3. `remote-e2e` job checks out the PR's head commit, installs deps, runs `bun run test:e2e:remote`
 4. Results are posted back as a PR comment (idempotent — updates existing comment on re-run)
 5. Debug bundles + logs uploaded as artifacts (14-day retention)

--- a/docs/rfcs/0008-e2e-remote-browser-testing.md
+++ b/docs/rfcs/0008-e2e-remote-browser-testing.md
@@ -161,6 +161,7 @@ tests/e2e/remote/
   remote-config.js                 # Browser capability presets + defaults
   remote-helpers.js                # connectRemoteBrowser(), extractDebugBundle(), etc.
   remote-playwright.config.js      # Playwright config (no webServer, longer timeouts)
+.github/workflows/e2e-remote.yml  # CI workflow — triggered by /e2e remote PR comment
 docs/rfcs/0008-e2e-remote-browser-testing.md   # This RFC
 ```
 
@@ -243,6 +244,8 @@ The `finally` block always attempts to: extract partial fight logs, save console
 
 ## Commands
 
+### Local
+
 ```bash
 # Default: Chrome/Windows vs WebKit/macOS against deployed staging
 BROWSERSTACK_USERNAME=xxx BROWSERSTACK_ACCESS_KEY=yyy bun run test:e2e:remote
@@ -253,6 +256,61 @@ REMOTE_E2E_PRESET=chrome-chrome BROWSERSTACK_USERNAME=xxx BROWSERSTACK_ACCESS_KE
 # With server diagnostics
 DIAG_TOKEN=zzz BROWSERSTACK_USERNAME=xxx BROWSERSTACK_ACCESS_KEY=yyy bun run test:e2e:remote
 ```
+
+### CI (PR comment trigger)
+
+Trigger a remote E2E run from any PR by posting a comment:
+
+```
+/e2e remote
+/e2e remote --preset chrome-chrome
+/e2e remote --preset webkit-webkit
+```
+
+The workflow (`.github/workflows/e2e-remote.yml`) is triggered by `issue_comment` events:
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant GH as GitHub
+    participant CI as GitHub Actions
+    participant BS as BrowserStack
+
+    Dev->>GH: Comment "/e2e remote --preset chrome-chrome"
+    GH->>CI: issue_comment event
+    CI->>GH: React with :eyes: emoji
+    CI->>CI: Parse --preset from comment body
+    CI->>CI: Checkout PR head SHA
+    CI->>BS: Run remote E2E test
+    BS-->>CI: Test results + debug bundles
+
+    alt Test passed
+        CI->>GH: React with :rocket: emoji
+        CI->>GH: Post/update PR comment with report
+    else Test failed
+        CI->>GH: React with :-1: emoji
+        CI->>GH: Post/update PR comment with report
+    end
+
+    CI->>GH: Upload artifacts (bundles, logs, report)
+```
+
+**How it works:**
+
+1. Developer posts `/e2e remote` (with optional `--preset`) as a PR comment
+2. `parse-command` job validates it's a PR comment starting with `/e2e remote`, extracts preset, reacts with :eyes:
+3. `remote-e2e` job checks out the PR's head commit, installs deps, runs `bun run test:e2e:remote`
+4. Results are posted back as a PR comment (idempotent — updates existing comment on re-run)
+5. Debug bundles + logs uploaded as artifacts (14-day retention)
+6. Final reaction emoji indicates pass (:rocket:) or fail (:-1:)
+
+**Required secrets:**
+
+| Secret | Description |
+|--------|-------------|
+| `BROWSERSTACK_USERNAME` | BrowserStack account username |
+| `BROWSERSTACK_ACCESS_KEY` | BrowserStack access key |
+| `DIAG_TOKEN` | PartyKit diagnostics token (optional) |
 
 ## What Is Reused vs What Is New
 
@@ -283,7 +341,7 @@ DIAG_TOKEN=zzz BROWSERSTACK_USERNAME=xxx BROWSERSTACK_ACCESS_KEY=yyy bun run tes
 
 ## Future Enhancements
 
-- **CI integration**: Run remote E2E on a schedule (nightly) against staging
+- **Scheduled nightly runs**: Add `schedule` trigger to `e2e-remote.yml` for continuous monitoring
 - **Mobile presets**: iPhone 15 Safari + Android Chrome (requires BrowserStack App Automate for real devices)
 - **Network condition presets**: Combine with Toxiproxy for simulated 3G/4G latency
 - **Multi-preset matrix**: Run all presets in parallel, aggregate results

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:run": "vitest run",
     "test:e2e": "npx playwright test --config tests/e2e/playwright.config.js",
     "test:e2e:headed": "npx playwright test --config tests/e2e/playwright.config.js --headed",
+    "test:e2e:remote": "npx playwright test --config tests/e2e/remote/remote-playwright.config.js",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write ."

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -1458,6 +1458,19 @@ export class FightScene extends Phaser.Scene {
           this.combat,
           this.rollbackManager.currentFrame,
         );
+
+        // Expose v2 debug bundle on window for remote E2E extraction
+        if (this.game.debugMode && this.recorder) {
+          import('../systems/DebugBundleExporter.js').then(({ DebugBundleExporter }) => {
+            window.__DEBUG_BUNDLE = DebugBundleExporter.generateBundle({
+              recorder: this.recorder,
+              telemetry: this.telemetry,
+              matchState: this.matchState,
+              sessionId: this.networkManager?.sessionId,
+              debugMode: true,
+            });
+          });
+        }
       }
     }
 

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: '.',
   testMatch: '**/*.spec.js',
+  testIgnore: '**/remote/**', // remote tests have their own config
   timeout: 300_000,
   retries: 1, // retry once — latent desync bug causes occasional flaky failures
   workers: 1, // tests share servers, run sequentially

--- a/tests/e2e/remote/remote-config.js
+++ b/tests/e2e/remote/remote-config.js
@@ -11,84 +11,84 @@
 const buildName = `remote-e2e-${new Date().toISOString().slice(0, 19).replace(/:/g, '')}`;
 
 export const PRESETS = {
-	// Default: Chrome on Windows (P1) + Safari on macOS (P2)
-	default: {
-		p1: {
-			browser: 'chrome',
-			browser_version: 'latest',
-			os: 'Windows',
-			os_version: '11',
-			name: 'E2E-P1-Chrome-Win',
-			build: buildName,
-			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
-			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
-		},
-		p2: {
-			browser: 'playwright-webkit',
-			browser_version: 'latest',
-			os: 'OS X',
-			os_version: 'Sonoma',
-			name: 'E2E-P2-WebKit-Mac',
-			build: buildName,
-			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
-			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
-		},
-	},
+  // Default: Chrome on Windows (P1) + Safari on macOS (P2)
+  default: {
+    p1: {
+      browser: 'chrome',
+      browser_version: 'latest',
+      os: 'Windows',
+      os_version: '11',
+      name: 'E2E-P1-Chrome-Win',
+      build: buildName,
+      'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+      'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+    },
+    p2: {
+      browser: 'playwright-webkit',
+      browser_version: 'latest',
+      os: 'OS X',
+      os_version: 'Sonoma',
+      name: 'E2E-P2-WebKit-Mac',
+      build: buildName,
+      'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+      'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+    },
+  },
 
-	// Same browser: isolate network effects from browser differences
-	'chrome-chrome': {
-		p1: {
-			browser: 'chrome',
-			browser_version: 'latest',
-			os: 'Windows',
-			os_version: '11',
-			name: 'E2E-P1-Chrome-Win',
-			build: buildName,
-			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
-			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
-		},
-		p2: {
-			browser: 'chrome',
-			browser_version: 'latest',
-			os: 'OS X',
-			os_version: 'Sonoma',
-			name: 'E2E-P2-Chrome-Mac',
-			build: buildName,
-			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
-			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
-		},
-	},
+  // Same browser: isolate network effects from browser differences
+  'chrome-chrome': {
+    p1: {
+      browser: 'chrome',
+      browser_version: 'latest',
+      os: 'Windows',
+      os_version: '11',
+      name: 'E2E-P1-Chrome-Win',
+      build: buildName,
+      'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+      'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+    },
+    p2: {
+      browser: 'chrome',
+      browser_version: 'latest',
+      os: 'OS X',
+      os_version: 'Sonoma',
+      name: 'E2E-P2-Chrome-Mac',
+      build: buildName,
+      'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+      'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+    },
+  },
 
-	// WebKit on both: test Safari-like behavior on both sides
-	'webkit-webkit': {
-		p1: {
-			browser: 'playwright-webkit',
-			browser_version: 'latest',
-			os: 'OS X',
-			os_version: 'Sonoma',
-			name: 'E2E-P1-WebKit-Mac',
-			build: buildName,
-			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
-			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
-		},
-		p2: {
-			browser: 'playwright-webkit',
-			browser_version: 'latest',
-			os: 'OS X',
-			os_version: 'Ventura',
-			name: 'E2E-P2-WebKit-Mac',
-			build: buildName,
-			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
-			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
-		},
-	},
+  // WebKit on both: test Safari-like behavior on both sides
+  'webkit-webkit': {
+    p1: {
+      browser: 'playwright-webkit',
+      browser_version: 'latest',
+      os: 'OS X',
+      os_version: 'Sonoma',
+      name: 'E2E-P1-WebKit-Mac',
+      build: buildName,
+      'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+      'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+    },
+    p2: {
+      browser: 'playwright-webkit',
+      browser_version: 'latest',
+      os: 'OS X',
+      os_version: 'Ventura',
+      name: 'E2E-P2-WebKit-Mac',
+      build: buildName,
+      'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+      'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+    },
+  },
 };
 
 // Server URLs
 export const STAGING_BASE_URL =
-	process.env.REMOTE_E2E_BASE_URL || 'https://a-los-traques.vercel.app';
+  process.env.REMOTE_E2E_BASE_URL || 'https://a-los-traques.vercel.app';
 export const STAGING_PARTY_HOST =
-	process.env.REMOTE_E2E_PARTY_HOST || 'a-los-traques.simon0191.partykit.dev';
+  process.env.REMOTE_E2E_PARTY_HOST || 'a-los-traques.simon0191.partykit.dev';
 
 // Timeouts — remote browsers are slower than local
 export const REMOTE_ROOM_TIMEOUT = 60_000; // 60s (vs 30s local)

--- a/tests/e2e/remote/remote-config.js
+++ b/tests/e2e/remote/remote-config.js
@@ -87,7 +87,8 @@ export const PRESETS = {
 // Server URLs
 export const STAGING_BASE_URL =
 	process.env.REMOTE_E2E_BASE_URL || 'https://a-los-traques.vercel.app';
-export const STAGING_PARTY_HOST = 'a-los-traques.simon0191.partykit.dev';
+export const STAGING_PARTY_HOST =
+	process.env.REMOTE_E2E_PARTY_HOST || 'a-los-traques.simon0191.partykit.dev';
 
 // Timeouts — remote browsers are slower than local
 export const REMOTE_ROOM_TIMEOUT = 60_000; // 60s (vs 30s local)

--- a/tests/e2e/remote/remote-config.js
+++ b/tests/e2e/remote/remote-config.js
@@ -1,0 +1,95 @@
+/**
+ * Browser capability presets and defaults for remote E2E testing via BrowserStack.
+ *
+ * Each preset defines P1 and P2 browser capabilities. The two sessions run on
+ * separate BrowserStack machines so they communicate over real network infrastructure.
+ *
+ * Uses Playwright CDP connection (not browserstack-node-sdk) so each browser
+ * is an independent session — enabling cross-browser, cross-OS testing.
+ */
+
+const buildName = `remote-e2e-${new Date().toISOString().slice(0, 19).replace(/:/g, '')}`;
+
+export const PRESETS = {
+	// Default: Chrome on Windows (P1) + Safari on macOS (P2)
+	default: {
+		p1: {
+			browser: 'chrome',
+			browser_version: 'latest',
+			os: 'Windows',
+			os_version: '11',
+			name: 'E2E-P1-Chrome-Win',
+			build: buildName,
+			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+		},
+		p2: {
+			browser: 'playwright-webkit',
+			browser_version: 'latest',
+			os: 'OS X',
+			os_version: 'Sonoma',
+			name: 'E2E-P2-WebKit-Mac',
+			build: buildName,
+			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+		},
+	},
+
+	// Same browser: isolate network effects from browser differences
+	'chrome-chrome': {
+		p1: {
+			browser: 'chrome',
+			browser_version: 'latest',
+			os: 'Windows',
+			os_version: '11',
+			name: 'E2E-P1-Chrome-Win',
+			build: buildName,
+			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+		},
+		p2: {
+			browser: 'chrome',
+			browser_version: 'latest',
+			os: 'OS X',
+			os_version: 'Sonoma',
+			name: 'E2E-P2-Chrome-Mac',
+			build: buildName,
+			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+		},
+	},
+
+	// WebKit on both: test Safari-like behavior on both sides
+	'webkit-webkit': {
+		p1: {
+			browser: 'playwright-webkit',
+			browser_version: 'latest',
+			os: 'OS X',
+			os_version: 'Sonoma',
+			name: 'E2E-P1-WebKit-Mac',
+			build: buildName,
+			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+		},
+		p2: {
+			browser: 'playwright-webkit',
+			browser_version: 'latest',
+			os: 'OS X',
+			os_version: 'Ventura',
+			name: 'E2E-P2-WebKit-Mac',
+			build: buildName,
+			'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+			'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+		},
+	},
+};
+
+// Server URLs
+export const STAGING_BASE_URL =
+	process.env.REMOTE_E2E_BASE_URL || 'https://a-los-traques.vercel.app';
+export const STAGING_PARTY_HOST = 'a-los-traques.simon0191.partykit.dev';
+
+// Timeouts — remote browsers are slower than local
+export const REMOTE_ROOM_TIMEOUT = 60_000; // 60s (vs 30s local)
+export const REMOTE_MATCH_TIMEOUT = 180_000; // 3min (speed=1, real latency)
+export const REMOTE_PAGE_LOAD_TIMEOUT = 30_000; // 30s initial page load

--- a/tests/e2e/remote/remote-helpers.js
+++ b/tests/e2e/remote/remote-helpers.js
@@ -12,10 +12,10 @@ import { chromium } from '@playwright/test';
  * @returns {Promise<import('@playwright/test').Browser>}
  */
 export async function connectRemoteBrowser(capabilities) {
-	const capsJson = JSON.stringify(capabilities);
-	const wsUrl = `wss://cdp.browserstack.com/playwright?caps=${encodeURIComponent(capsJson)}`;
-	const browser = await chromium.connect(wsUrl);
-	return browser;
+  const capsJson = JSON.stringify(capabilities);
+  const wsUrl = `wss://cdp.browserstack.com/playwright?caps=${encodeURIComponent(capsJson)}`;
+  const browser = await chromium.connect(wsUrl);
+  return browser;
 }
 
 /**
@@ -23,34 +23,34 @@ export async function connectRemoteBrowser(capabilities) {
  * Always uses speed=1 and debug=1 for realistic network testing.
  */
 export function remoteP1Url(baseUrl, partyHost, opts = {}) {
-	const params = new URLSearchParams({
-		autoplay: '1',
-		createRoom: '1',
-		speed: String(opts.speed ?? 1),
-		debug: '1',
-	});
-	if (partyHost) params.set('partyHost', partyHost);
-	if (opts.fighter) params.set('fighter', opts.fighter);
-	if (opts.seed != null) params.set('seed', String(opts.seed));
-	if (opts.aiDifficulty) params.set('aiDifficulty', opts.aiDifficulty);
-	return `${baseUrl}?${params}`;
+  const params = new URLSearchParams({
+    autoplay: '1',
+    createRoom: '1',
+    speed: String(opts.speed ?? 1),
+    debug: '1',
+  });
+  if (partyHost) params.set('partyHost', partyHost);
+  if (opts.fighter) params.set('fighter', opts.fighter);
+  if (opts.seed != null) params.set('seed', String(opts.seed));
+  if (opts.aiDifficulty) params.set('aiDifficulty', opts.aiDifficulty);
+  return `${baseUrl}?${params}`;
 }
 
 /**
  * Build autoplay URL for P2 (room joiner) on remote infrastructure.
  */
 export function remoteP2Url(baseUrl, roomId, partyHost, opts = {}) {
-	const params = new URLSearchParams({
-		autoplay: '1',
-		room: roomId,
-		speed: String(opts.speed ?? 1),
-		debug: '1',
-	});
-	if (partyHost) params.set('partyHost', partyHost);
-	if (opts.fighter) params.set('fighter', opts.fighter);
-	if (opts.seed != null) params.set('seed', String(opts.seed));
-	if (opts.aiDifficulty) params.set('aiDifficulty', opts.aiDifficulty);
-	return `${baseUrl}?${params}`;
+  const params = new URLSearchParams({
+    autoplay: '1',
+    room: roomId,
+    speed: String(opts.speed ?? 1),
+    debug: '1',
+  });
+  if (partyHost) params.set('partyHost', partyHost);
+  if (opts.fighter) params.set('fighter', opts.fighter);
+  if (opts.seed != null) params.set('seed', String(opts.seed));
+  if (opts.aiDifficulty) params.set('aiDifficulty', opts.aiDifficulty);
+  return `${baseUrl}?${params}`;
 }
 
 /**
@@ -58,34 +58,26 @@ export function remoteP2Url(baseUrl, roomId, partyHost, opts = {}) {
  * Tries window.__DEBUG_BUNDLE first (richer v2 data), falls back to __FIGHT_LOG.
  */
 export async function extractDebugBundle(page) {
-	return page.evaluate(() => {
-		if (window.__DEBUG_BUNDLE) return { version: 2, data: window.__DEBUG_BUNDLE };
-		if (window.__FIGHT_LOG) return { version: 1, data: window.__FIGHT_LOG };
-		return null;
-	});
+  return page.evaluate(() => {
+    if (window.__DEBUG_BUNDLE) return { version: 2, data: window.__DEBUG_BUNDLE };
+    if (window.__FIGHT_LOG) return { version: 1, data: window.__FIGHT_LOG };
+    return null;
+  });
 }
 
 /**
  * Mark a BrowserStack session as passed or failed via executor API.
  */
 export async function markSessionStatus(page, passed, reason) {
-	try {
-		await page.evaluate(
-			([status, msg]) => {
-				// biome-ignore lint/security/noGlobalEval: BrowserStack executor API requires this pattern
-				window.navigator.userAgent; // no-op to ensure page context
-				const script = `browserstack_executor: ${JSON.stringify({
-					action: 'setSessionStatus',
-					arguments: { status, reason: msg },
-				})}`;
-				// BrowserStack uses JavascriptExecutor pattern
-				return new Function(`return ${JSON.stringify(script)}`)();
-			},
-			[passed ? 'passed' : 'failed', reason || ''],
-		);
-	} catch {
-		// Non-fatal — BrowserStack status is best-effort
-	}
+  try {
+    const cmd = JSON.stringify({
+      action: 'setSessionStatus',
+      arguments: { status: passed ? 'passed' : 'failed', reason: reason || '' },
+    });
+    await page.evaluate((c) => `browserstack_executor: ${c}`, cmd);
+  } catch {
+    // Non-fatal — BrowserStack status is best-effort
+  }
 }
 
 /**
@@ -93,20 +85,17 @@ export async function markSessionStatus(page, passed, reason) {
  * Returns null if unavailable (missing token, server unreachable, etc.)
  */
 export async function fetchServerDiagnostics(partyHost, roomId) {
-	const token = process.env.DIAG_TOKEN;
-	if (!token) return null;
+  const token = process.env.DIAG_TOKEN;
+  if (!token) return null;
 
-	try {
-		const resp = await fetch(
-			`https://${partyHost}/parties/main/${roomId}/diagnostics`,
-			{
-				headers: { Authorization: `Bearer ${token}` },
-				signal: AbortSignal.timeout(5_000),
-			},
-		);
-		if (resp.ok) return resp.json();
-		return null;
-	} catch {
-		return null;
-	}
+  try {
+    const resp = await fetch(`https://${partyHost}/parties/main/${roomId}/diagnostics`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (resp.ok) return resp.json();
+    return null;
+  } catch {
+    return null;
+  }
 }

--- a/tests/e2e/remote/remote-helpers.js
+++ b/tests/e2e/remote/remote-helpers.js
@@ -1,0 +1,112 @@
+/**
+ * Helpers for connecting to BrowserStack remote browsers via Playwright CDP
+ * and extracting debug data from remote game instances.
+ */
+import { chromium } from '@playwright/test';
+
+/**
+ * Connect to a BrowserStack browser via Playwright CDP WebSocket.
+ * Returns a Playwright Browser object with full page.evaluate() support.
+ *
+ * @param {object} capabilities - BrowserStack capabilities (browser, os, etc.)
+ * @returns {Promise<import('@playwright/test').Browser>}
+ */
+export async function connectRemoteBrowser(capabilities) {
+	const capsJson = JSON.stringify(capabilities);
+	const wsUrl = `wss://cdp.browserstack.com/playwright?caps=${encodeURIComponent(capsJson)}`;
+	const browser = await chromium.connect(wsUrl);
+	return browser;
+}
+
+/**
+ * Build autoplay URL for P1 (room creator) on remote infrastructure.
+ * Always uses speed=1 and debug=1 for realistic network testing.
+ */
+export function remoteP1Url(baseUrl, partyHost, opts = {}) {
+	const params = new URLSearchParams({
+		autoplay: '1',
+		createRoom: '1',
+		speed: String(opts.speed ?? 1),
+		debug: '1',
+	});
+	if (partyHost) params.set('partyHost', partyHost);
+	if (opts.fighter) params.set('fighter', opts.fighter);
+	if (opts.seed != null) params.set('seed', String(opts.seed));
+	if (opts.aiDifficulty) params.set('aiDifficulty', opts.aiDifficulty);
+	return `${baseUrl}?${params}`;
+}
+
+/**
+ * Build autoplay URL for P2 (room joiner) on remote infrastructure.
+ */
+export function remoteP2Url(baseUrl, roomId, partyHost, opts = {}) {
+	const params = new URLSearchParams({
+		autoplay: '1',
+		room: roomId,
+		speed: String(opts.speed ?? 1),
+		debug: '1',
+	});
+	if (partyHost) params.set('partyHost', partyHost);
+	if (opts.fighter) params.set('fighter', opts.fighter);
+	if (opts.seed != null) params.set('seed', String(opts.seed));
+	if (opts.aiDifficulty) params.set('aiDifficulty', opts.aiDifficulty);
+	return `${baseUrl}?${params}`;
+}
+
+/**
+ * Extract v2 debug bundle from a remote browser page.
+ * Tries window.__DEBUG_BUNDLE first (richer v2 data), falls back to __FIGHT_LOG.
+ */
+export async function extractDebugBundle(page) {
+	return page.evaluate(() => {
+		if (window.__DEBUG_BUNDLE) return { version: 2, data: window.__DEBUG_BUNDLE };
+		if (window.__FIGHT_LOG) return { version: 1, data: window.__FIGHT_LOG };
+		return null;
+	});
+}
+
+/**
+ * Mark a BrowserStack session as passed or failed via executor API.
+ */
+export async function markSessionStatus(page, passed, reason) {
+	try {
+		await page.evaluate(
+			([status, msg]) => {
+				// biome-ignore lint/security/noGlobalEval: BrowserStack executor API requires this pattern
+				window.navigator.userAgent; // no-op to ensure page context
+				const script = `browserstack_executor: ${JSON.stringify({
+					action: 'setSessionStatus',
+					arguments: { status, reason: msg },
+				})}`;
+				// BrowserStack uses JavascriptExecutor pattern
+				return new Function(`return ${JSON.stringify(script)}`)();
+			},
+			[passed ? 'passed' : 'failed', reason || ''],
+		);
+	} catch {
+		// Non-fatal — BrowserStack status is best-effort
+	}
+}
+
+/**
+ * Fetch server diagnostics from the PartyKit cloud server.
+ * Returns null if unavailable (missing token, server unreachable, etc.)
+ */
+export async function fetchServerDiagnostics(partyHost, roomId) {
+	const token = process.env.DIAG_TOKEN;
+	if (!token) return null;
+
+	try {
+		const resp = await fetch(
+			`https://${partyHost}/parties/main/${roomId}/diagnostics`,
+			{
+				headers: { Authorization: `Bearer ${token}` },
+				signal: AbortSignal.timeout(5_000),
+			},
+		);
+		if (resp.ok) return resp.json();
+		return null;
+	} catch {
+		return null;
+	}
+}

--- a/tests/e2e/remote/remote-multiplayer.spec.js
+++ b/tests/e2e/remote/remote-multiplayer.spec.js
@@ -41,7 +41,8 @@ function validateEnv() {
 }
 
 test.describe('Remote multiplayer (BrowserStack)', () => {
-  test(`cross-browser match with debug bundles [${presetName}]`, async (_fixtures, testInfo) => {
+  // biome-ignore lint/correctness/noEmptyPattern: Playwright requires destructured first arg
+  test(`cross-browser match with debug bundles [${presetName}]`, async ({}, testInfo) => {
     validateEnv();
 
     const preset = PRESETS[presetName];

--- a/tests/e2e/remote/remote-multiplayer.spec.js
+++ b/tests/e2e/remote/remote-multiplayer.spec.js
@@ -1,0 +1,252 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from '@playwright/test';
+import { extractFightLog, waitForMatchComplete, waitForRoomId } from '../helpers/browser-helpers.js';
+import { generateBundle } from '../helpers/bundle-generator.js';
+import { generateReport } from '../helpers/report-generator.js';
+import {
+	PRESETS,
+	REMOTE_MATCH_TIMEOUT,
+	REMOTE_PAGE_LOAD_TIMEOUT,
+	REMOTE_ROOM_TIMEOUT,
+	STAGING_BASE_URL,
+	STAGING_PARTY_HOST,
+} from './remote-config.js';
+import {
+	connectRemoteBrowser,
+	extractDebugBundle,
+	fetchServerDiagnostics,
+	markSessionStatus,
+	remoteP1Url,
+	remoteP2Url,
+} from './remote-helpers.js';
+
+const RESULTS_DIR = 'test-results/remote';
+
+// Parse --preset from REMOTE_E2E_PRESET env var (default: 'default')
+const presetName = process.env.REMOTE_E2E_PRESET || 'default';
+
+function validateEnv() {
+	if (!process.env.BROWSERSTACK_USERNAME || !process.env.BROWSERSTACK_ACCESS_KEY) {
+		throw new Error(
+			'Missing BrowserStack credentials.\n' +
+				'Set BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY environment variables.\n' +
+				'Get them from: https://www.browserstack.com/accounts/settings',
+		);
+	}
+}
+
+test.describe('Remote multiplayer (BrowserStack)', () => {
+	test(`cross-browser match with debug bundles [${presetName}]`, async ({}, testInfo) => {
+		validateEnv();
+
+		const preset = PRESETS[presetName];
+		if (!preset) {
+			throw new Error(
+				`Unknown preset "${presetName}". Available: ${Object.keys(PRESETS).join(', ')}`,
+			);
+		}
+
+		const testName = `remote-${presetName}`;
+		const startedAt = new Date().toISOString();
+
+		console.log(`Connecting P1 (${preset.p1.browser} / ${preset.p1.os || 'default'})...`);
+		const browserP1 = await connectRemoteBrowser(preset.p1);
+		const ctxP1 = await browserP1.newContext({ viewport: { width: 960, height: 540 } });
+		const pageP1 = await ctxP1.newPage();
+
+		const p1Console = [];
+		const p2Console = [];
+		pageP1.on('console', (msg) => p1Console.push(`[${msg.type()}] ${msg.text()}`));
+
+		let browserP2 = null;
+		let pageP2 = null;
+		let logP1 = null;
+		let logP2 = null;
+		let usedP1Url = '';
+		let usedP2Url = '';
+		let roomId = '';
+
+		try {
+			// --- P1: create room ---
+			usedP1Url = remoteP1Url(STAGING_BASE_URL, STAGING_PARTY_HOST, {
+				fighter: 'simon',
+				seed: 42,
+			});
+			console.log(`P1 navigating to: ${usedP1Url}`);
+			await pageP1.goto(usedP1Url, { timeout: REMOTE_PAGE_LOAD_TIMEOUT });
+
+			roomId = await waitForRoomId(pageP1, REMOTE_ROOM_TIMEOUT);
+			console.log(`Room created: ${roomId}`);
+
+			// --- P2: join room ---
+			console.log(`Connecting P2 (${preset.p2.browser} / ${preset.p2.os || 'default'})...`);
+			browserP2 = await connectRemoteBrowser(preset.p2);
+			const ctxP2 = await browserP2.newContext({ viewport: { width: 960, height: 540 } });
+			pageP2 = await ctxP2.newPage();
+			pageP2.on('console', (msg) => p2Console.push(`[${msg.type()}] ${msg.text()}`));
+
+			usedP2Url = remoteP2Url(STAGING_BASE_URL, roomId, STAGING_PARTY_HOST, {
+				fighter: 'jeka',
+				seed: 42,
+			});
+			console.log(`P2 navigating to: ${usedP2Url}`);
+			await pageP2.goto(usedP2Url, { timeout: REMOTE_PAGE_LOAD_TIMEOUT });
+
+			// --- Wait for match completion ---
+			console.log('Waiting for match to complete (speed=1, real network)...');
+			await Promise.all([
+				waitForMatchComplete(pageP1, REMOTE_MATCH_TIMEOUT),
+				waitForMatchComplete(pageP2, REMOTE_MATCH_TIMEOUT),
+			]);
+			console.log('Match complete on both sides.');
+
+			// --- Extract fight logs ---
+			[logP1, logP2] = await Promise.all([
+				extractFightLog(pageP1),
+				extractFightLog(pageP2),
+			]);
+
+			// --- Extract v2 debug bundles (richer telemetry data) ---
+			const [debugP1, debugP2] = await Promise.all([
+				extractDebugBundle(pageP1),
+				extractDebugBundle(pageP2),
+			]);
+
+			// --- Fetch server diagnostics ---
+			const serverDiag = await fetchServerDiagnostics(STAGING_PARTY_HOST, roomId);
+
+			// --- Generate artifacts ---
+			fs.mkdirSync(RESULTS_DIR, { recursive: true });
+
+			const report = generateReport(logP1, logP2, testName);
+			const bundle = generateBundle(logP1, logP2, { p1: usedP1Url, p2: usedP2Url });
+
+			// Enhanced remote bundle with v2 debug data + server diagnostics + metadata
+			const completedAt = new Date().toISOString();
+			const remoteBundle = {
+				...bundle,
+				source: 'remote-e2e',
+				preset: presetName,
+				metadata: {
+					startedAt,
+					completedAt,
+					durationMs: new Date(completedAt) - new Date(startedAt),
+					roomId,
+					p1: {
+						browser: `${preset.p1.browser} / ${preset.p1.os || 'device'} ${preset.p1.os_version || ''}`.trim(),
+						fighter: 'simon',
+					},
+					p2: {
+						browser: `${preset.p2.browser} / ${preset.p2.os || 'device'} ${preset.p2.os_version || ''}`.trim(),
+						fighter: 'jeka',
+					},
+				},
+				debugBundles: {
+					p1: debugP1,
+					p2: debugP2,
+				},
+				serverDiagnostics: serverDiag,
+			};
+
+			fs.writeFileSync(path.join(RESULTS_DIR, `${testName}-report.md`), report);
+			fs.writeFileSync(
+				path.join(RESULTS_DIR, `${testName}-bundle.json`),
+				JSON.stringify(remoteBundle, null, 2),
+			);
+
+			// Attach to Playwright results
+			await testInfo.attach('report', {
+				path: path.join(RESULTS_DIR, `${testName}-report.md`),
+				contentType: 'text/markdown',
+			});
+			await testInfo.attach('bundle', {
+				path: path.join(RESULTS_DIR, `${testName}-bundle.json`),
+				contentType: 'application/json',
+			});
+
+			// --- Determinism analysis (informational, not hard failure) ---
+			const p1Checksums = new Map(logP1.checksums.map((c) => [c.frame, c.hash]));
+			const p2Checksums = new Map(logP2.checksums.map((c) => [c.frame, c.hash]));
+			const sharedFrames = [...p1Checksums.keys()].filter((f) => p2Checksums.has(f));
+			const mismatches = sharedFrames.filter(
+				(f) => p1Checksums.get(f) !== p2Checksums.get(f),
+			);
+
+			if (mismatches.length > 0) {
+				console.warn(
+					`Checksum mismatches: ${mismatches.length}/${sharedFrames.length} shared frames`,
+				);
+				console.warn(`First mismatch at frame ${mismatches[0]}`);
+			} else {
+				console.log(
+					`All ${sharedFrames.length} shared checksums match — deterministic!`,
+				);
+			}
+
+			console.log(
+				`Desyncs: P1=${logP1.desyncCount}, P2=${logP2.desyncCount}`,
+			);
+			console.log(
+				`Winner: ${logP1.result?.winnerId || logP2.result?.winnerId || 'unknown'}`,
+			);
+
+			// Mark BrowserStack sessions
+			const passed = logP1.matchComplete && logP2.matchComplete;
+			await markSessionStatus(pageP1, passed, 'Match completed');
+			if (pageP2) await markSessionStatus(pageP2, passed, 'Match completed');
+		} finally {
+			// Always capture console logs
+			if (p1Console.length || p2Console.length) {
+				fs.mkdirSync(RESULTS_DIR, { recursive: true });
+				const consolePath = path.join(RESULTS_DIR, `${testName}-console.log`);
+				fs.writeFileSync(
+					consolePath,
+					`=== P1 Console (${p1Console.length} messages) ===\n${p1Console.join('\n')}\n\n` +
+						`=== P2 Console (${p2Console.length} messages) ===\n${p2Console.join('\n')}\n`,
+				);
+				await testInfo.attach('console-logs', {
+					path: consolePath,
+					contentType: 'text/plain',
+				});
+			}
+
+			// Always try to extract partial data on failure
+			if (!logP1 || !logP2) {
+				try {
+					if (!logP1 && pageP1) logP1 = await extractFightLog(pageP1);
+					if (!logP2 && pageP2) logP2 = await extractFightLog(pageP2);
+					if (logP1 || logP2) {
+						fs.mkdirSync(RESULTS_DIR, { recursive: true });
+						if (logP1)
+							fs.writeFileSync(
+								path.join(RESULTS_DIR, `${testName}-partial-p1.json`),
+								JSON.stringify(logP1, null, 2),
+							);
+						if (logP2)
+							fs.writeFileSync(
+								path.join(RESULTS_DIR, `${testName}-partial-p2.json`),
+								JSON.stringify(logP2, null, 2),
+							);
+					}
+				} catch {
+					// Best-effort partial extraction
+				}
+			}
+
+			// Clean up sessions
+			try {
+				await browserP1.close();
+			} catch {
+				/* session may already be closed */
+			}
+			if (browserP2) {
+				try {
+					await browserP2.close();
+				} catch {
+					/* session may already be closed */
+				}
+			}
+		}
+	});
+});

--- a/tests/e2e/remote/remote-multiplayer.spec.js
+++ b/tests/e2e/remote/remote-multiplayer.spec.js
@@ -1,24 +1,28 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { test } from '@playwright/test';
-import { extractFightLog, waitForMatchComplete, waitForRoomId } from '../helpers/browser-helpers.js';
+import {
+  extractFightLog,
+  waitForMatchComplete,
+  waitForRoomId,
+} from '../helpers/browser-helpers.js';
 import { generateBundle } from '../helpers/bundle-generator.js';
 import { generateReport } from '../helpers/report-generator.js';
 import {
-	PRESETS,
-	REMOTE_MATCH_TIMEOUT,
-	REMOTE_PAGE_LOAD_TIMEOUT,
-	REMOTE_ROOM_TIMEOUT,
-	STAGING_BASE_URL,
-	STAGING_PARTY_HOST,
+  PRESETS,
+  REMOTE_MATCH_TIMEOUT,
+  REMOTE_PAGE_LOAD_TIMEOUT,
+  REMOTE_ROOM_TIMEOUT,
+  STAGING_BASE_URL,
+  STAGING_PARTY_HOST,
 } from './remote-config.js';
 import {
-	connectRemoteBrowser,
-	extractDebugBundle,
-	fetchServerDiagnostics,
-	markSessionStatus,
-	remoteP1Url,
-	remoteP2Url,
+  connectRemoteBrowser,
+  extractDebugBundle,
+  fetchServerDiagnostics,
+  markSessionStatus,
+  remoteP1Url,
+  remoteP2Url,
 } from './remote-helpers.js';
 
 const RESULTS_DIR = 'test-results/remote';
@@ -27,226 +31,217 @@ const RESULTS_DIR = 'test-results/remote';
 const presetName = process.env.REMOTE_E2E_PRESET || 'default';
 
 function validateEnv() {
-	if (!process.env.BROWSERSTACK_USERNAME || !process.env.BROWSERSTACK_ACCESS_KEY) {
-		throw new Error(
-			'Missing BrowserStack credentials.\n' +
-				'Set BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY environment variables.\n' +
-				'Get them from: https://www.browserstack.com/accounts/settings',
-		);
-	}
+  if (!process.env.BROWSERSTACK_USERNAME || !process.env.BROWSERSTACK_ACCESS_KEY) {
+    throw new Error(
+      'Missing BrowserStack credentials.\n' +
+        'Set BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY environment variables.\n' +
+        'Get them from: https://www.browserstack.com/accounts/settings',
+    );
+  }
 }
 
 test.describe('Remote multiplayer (BrowserStack)', () => {
-	test(`cross-browser match with debug bundles [${presetName}]`, async ({}, testInfo) => {
-		validateEnv();
+  test(`cross-browser match with debug bundles [${presetName}]`, async (_fixtures, testInfo) => {
+    validateEnv();
 
-		const preset = PRESETS[presetName];
-		if (!preset) {
-			throw new Error(
-				`Unknown preset "${presetName}". Available: ${Object.keys(PRESETS).join(', ')}`,
-			);
-		}
+    const preset = PRESETS[presetName];
+    if (!preset) {
+      throw new Error(
+        `Unknown preset "${presetName}". Available: ${Object.keys(PRESETS).join(', ')}`,
+      );
+    }
 
-		const testName = `remote-${presetName}`;
-		const startedAt = new Date().toISOString();
+    const testName = `remote-${presetName}`;
+    const startedAt = new Date().toISOString();
 
-		console.log(`Connecting P1 (${preset.p1.browser} / ${preset.p1.os || 'default'})...`);
-		const browserP1 = await connectRemoteBrowser(preset.p1);
-		const ctxP1 = await browserP1.newContext({ viewport: { width: 960, height: 540 } });
-		const pageP1 = await ctxP1.newPage();
+    console.log(`Connecting P1 (${preset.p1.browser} / ${preset.p1.os || 'default'})...`);
+    const browserP1 = await connectRemoteBrowser(preset.p1);
+    const ctxP1 = await browserP1.newContext({ viewport: { width: 960, height: 540 } });
+    const pageP1 = await ctxP1.newPage();
 
-		const p1Console = [];
-		const p2Console = [];
-		pageP1.on('console', (msg) => p1Console.push(`[${msg.type()}] ${msg.text()}`));
+    const p1Console = [];
+    const p2Console = [];
+    pageP1.on('console', (msg) => p1Console.push(`[${msg.type()}] ${msg.text()}`));
 
-		let browserP2 = null;
-		let pageP2 = null;
-		let logP1 = null;
-		let logP2 = null;
-		let usedP1Url = '';
-		let usedP2Url = '';
-		let roomId = '';
+    let browserP2 = null;
+    let pageP2 = null;
+    let logP1 = null;
+    let logP2 = null;
+    let usedP1Url = '';
+    let usedP2Url = '';
+    let roomId = '';
 
-		try {
-			// --- P1: create room ---
-			usedP1Url = remoteP1Url(STAGING_BASE_URL, STAGING_PARTY_HOST, {
-				fighter: 'simon',
-				seed: 42,
-			});
-			console.log(`P1 navigating to: ${usedP1Url}`);
-			await pageP1.goto(usedP1Url, { timeout: REMOTE_PAGE_LOAD_TIMEOUT });
+    try {
+      // --- P1: create room ---
+      usedP1Url = remoteP1Url(STAGING_BASE_URL, STAGING_PARTY_HOST, {
+        fighter: 'simon',
+        seed: 42,
+      });
+      console.log(`P1 navigating to: ${usedP1Url}`);
+      await pageP1.goto(usedP1Url, { timeout: REMOTE_PAGE_LOAD_TIMEOUT });
 
-			roomId = await waitForRoomId(pageP1, REMOTE_ROOM_TIMEOUT);
-			console.log(`Room created: ${roomId}`);
+      roomId = await waitForRoomId(pageP1, REMOTE_ROOM_TIMEOUT);
+      console.log(`Room created: ${roomId}`);
 
-			// --- P2: join room ---
-			console.log(`Connecting P2 (${preset.p2.browser} / ${preset.p2.os || 'default'})...`);
-			browserP2 = await connectRemoteBrowser(preset.p2);
-			const ctxP2 = await browserP2.newContext({ viewport: { width: 960, height: 540 } });
-			pageP2 = await ctxP2.newPage();
-			pageP2.on('console', (msg) => p2Console.push(`[${msg.type()}] ${msg.text()}`));
+      // --- P2: join room ---
+      console.log(`Connecting P2 (${preset.p2.browser} / ${preset.p2.os || 'default'})...`);
+      browserP2 = await connectRemoteBrowser(preset.p2);
+      const ctxP2 = await browserP2.newContext({ viewport: { width: 960, height: 540 } });
+      pageP2 = await ctxP2.newPage();
+      pageP2.on('console', (msg) => p2Console.push(`[${msg.type()}] ${msg.text()}`));
 
-			usedP2Url = remoteP2Url(STAGING_BASE_URL, roomId, STAGING_PARTY_HOST, {
-				fighter: 'jeka',
-				seed: 42,
-			});
-			console.log(`P2 navigating to: ${usedP2Url}`);
-			await pageP2.goto(usedP2Url, { timeout: REMOTE_PAGE_LOAD_TIMEOUT });
+      usedP2Url = remoteP2Url(STAGING_BASE_URL, roomId, STAGING_PARTY_HOST, {
+        fighter: 'jeka',
+        seed: 42,
+      });
+      console.log(`P2 navigating to: ${usedP2Url}`);
+      await pageP2.goto(usedP2Url, { timeout: REMOTE_PAGE_LOAD_TIMEOUT });
 
-			// --- Wait for match completion ---
-			console.log('Waiting for match to complete (speed=1, real network)...');
-			await Promise.all([
-				waitForMatchComplete(pageP1, REMOTE_MATCH_TIMEOUT),
-				waitForMatchComplete(pageP2, REMOTE_MATCH_TIMEOUT),
-			]);
-			console.log('Match complete on both sides.');
+      // --- Wait for match completion ---
+      console.log('Waiting for match to complete (speed=1, real network)...');
+      await Promise.all([
+        waitForMatchComplete(pageP1, REMOTE_MATCH_TIMEOUT),
+        waitForMatchComplete(pageP2, REMOTE_MATCH_TIMEOUT),
+      ]);
+      console.log('Match complete on both sides.');
 
-			// --- Extract fight logs ---
-			[logP1, logP2] = await Promise.all([
-				extractFightLog(pageP1),
-				extractFightLog(pageP2),
-			]);
+      // --- Extract fight logs ---
+      [logP1, logP2] = await Promise.all([extractFightLog(pageP1), extractFightLog(pageP2)]);
 
-			// --- Extract v2 debug bundles (richer telemetry data) ---
-			const [debugP1, debugP2] = await Promise.all([
-				extractDebugBundle(pageP1),
-				extractDebugBundle(pageP2),
-			]);
+      // --- Extract v2 debug bundles (richer telemetry data) ---
+      const [debugP1, debugP2] = await Promise.all([
+        extractDebugBundle(pageP1),
+        extractDebugBundle(pageP2),
+      ]);
 
-			// --- Fetch server diagnostics ---
-			const serverDiag = await fetchServerDiagnostics(STAGING_PARTY_HOST, roomId);
+      // --- Fetch server diagnostics ---
+      const serverDiag = await fetchServerDiagnostics(STAGING_PARTY_HOST, roomId);
 
-			// --- Generate artifacts ---
-			fs.mkdirSync(RESULTS_DIR, { recursive: true });
+      // --- Generate artifacts ---
+      fs.mkdirSync(RESULTS_DIR, { recursive: true });
 
-			const report = generateReport(logP1, logP2, testName);
-			const bundle = generateBundle(logP1, logP2, { p1: usedP1Url, p2: usedP2Url });
+      const report = generateReport(logP1, logP2, testName);
+      const bundle = generateBundle(logP1, logP2, { p1: usedP1Url, p2: usedP2Url });
 
-			// Enhanced remote bundle with v2 debug data + server diagnostics + metadata
-			const completedAt = new Date().toISOString();
-			const remoteBundle = {
-				...bundle,
-				source: 'remote-e2e',
-				preset: presetName,
-				metadata: {
-					startedAt,
-					completedAt,
-					durationMs: new Date(completedAt) - new Date(startedAt),
-					roomId,
-					p1: {
-						browser: `${preset.p1.browser} / ${preset.p1.os || 'device'} ${preset.p1.os_version || ''}`.trim(),
-						fighter: 'simon',
-					},
-					p2: {
-						browser: `${preset.p2.browser} / ${preset.p2.os || 'device'} ${preset.p2.os_version || ''}`.trim(),
-						fighter: 'jeka',
-					},
-				},
-				debugBundles: {
-					p1: debugP1,
-					p2: debugP2,
-				},
-				serverDiagnostics: serverDiag,
-			};
+      // Enhanced remote bundle with v2 debug data + server diagnostics + metadata
+      const completedAt = new Date().toISOString();
+      const remoteBundle = {
+        ...bundle,
+        source: 'remote-e2e',
+        preset: presetName,
+        metadata: {
+          startedAt,
+          completedAt,
+          durationMs: new Date(completedAt) - new Date(startedAt),
+          roomId,
+          p1: {
+            browser:
+              `${preset.p1.browser} / ${preset.p1.os || 'device'} ${preset.p1.os_version || ''}`.trim(),
+            fighter: 'simon',
+          },
+          p2: {
+            browser:
+              `${preset.p2.browser} / ${preset.p2.os || 'device'} ${preset.p2.os_version || ''}`.trim(),
+            fighter: 'jeka',
+          },
+        },
+        debugBundles: {
+          p1: debugP1,
+          p2: debugP2,
+        },
+        serverDiagnostics: serverDiag,
+      };
 
-			fs.writeFileSync(path.join(RESULTS_DIR, `${testName}-report.md`), report);
-			fs.writeFileSync(
-				path.join(RESULTS_DIR, `${testName}-bundle.json`),
-				JSON.stringify(remoteBundle, null, 2),
-			);
+      fs.writeFileSync(path.join(RESULTS_DIR, `${testName}-report.md`), report);
+      fs.writeFileSync(
+        path.join(RESULTS_DIR, `${testName}-bundle.json`),
+        JSON.stringify(remoteBundle, null, 2),
+      );
 
-			// Attach to Playwright results
-			await testInfo.attach('report', {
-				path: path.join(RESULTS_DIR, `${testName}-report.md`),
-				contentType: 'text/markdown',
-			});
-			await testInfo.attach('bundle', {
-				path: path.join(RESULTS_DIR, `${testName}-bundle.json`),
-				contentType: 'application/json',
-			});
+      // Attach to Playwright results
+      await testInfo.attach('report', {
+        path: path.join(RESULTS_DIR, `${testName}-report.md`),
+        contentType: 'text/markdown',
+      });
+      await testInfo.attach('bundle', {
+        path: path.join(RESULTS_DIR, `${testName}-bundle.json`),
+        contentType: 'application/json',
+      });
 
-			// --- Determinism analysis (informational, not hard failure) ---
-			const p1Checksums = new Map(logP1.checksums.map((c) => [c.frame, c.hash]));
-			const p2Checksums = new Map(logP2.checksums.map((c) => [c.frame, c.hash]));
-			const sharedFrames = [...p1Checksums.keys()].filter((f) => p2Checksums.has(f));
-			const mismatches = sharedFrames.filter(
-				(f) => p1Checksums.get(f) !== p2Checksums.get(f),
-			);
+      // --- Determinism analysis (informational, not hard failure) ---
+      const p1Checksums = new Map(logP1.checksums.map((c) => [c.frame, c.hash]));
+      const p2Checksums = new Map(logP2.checksums.map((c) => [c.frame, c.hash]));
+      const sharedFrames = [...p1Checksums.keys()].filter((f) => p2Checksums.has(f));
+      const mismatches = sharedFrames.filter((f) => p1Checksums.get(f) !== p2Checksums.get(f));
 
-			if (mismatches.length > 0) {
-				console.warn(
-					`Checksum mismatches: ${mismatches.length}/${sharedFrames.length} shared frames`,
-				);
-				console.warn(`First mismatch at frame ${mismatches[0]}`);
-			} else {
-				console.log(
-					`All ${sharedFrames.length} shared checksums match — deterministic!`,
-				);
-			}
+      if (mismatches.length > 0) {
+        console.warn(
+          `Checksum mismatches: ${mismatches.length}/${sharedFrames.length} shared frames`,
+        );
+        console.warn(`First mismatch at frame ${mismatches[0]}`);
+      } else {
+        console.log(`All ${sharedFrames.length} shared checksums match — deterministic!`);
+      }
 
-			console.log(
-				`Desyncs: P1=${logP1.desyncCount}, P2=${logP2.desyncCount}`,
-			);
-			console.log(
-				`Winner: ${logP1.result?.winnerId || logP2.result?.winnerId || 'unknown'}`,
-			);
+      console.log(`Desyncs: P1=${logP1.desyncCount}, P2=${logP2.desyncCount}`);
+      console.log(`Winner: ${logP1.result?.winnerId || logP2.result?.winnerId || 'unknown'}`);
 
-			// Mark BrowserStack sessions
-			const passed = logP1.matchComplete && logP2.matchComplete;
-			await markSessionStatus(pageP1, passed, 'Match completed');
-			if (pageP2) await markSessionStatus(pageP2, passed, 'Match completed');
-		} finally {
-			// Always capture console logs
-			if (p1Console.length || p2Console.length) {
-				fs.mkdirSync(RESULTS_DIR, { recursive: true });
-				const consolePath = path.join(RESULTS_DIR, `${testName}-console.log`);
-				fs.writeFileSync(
-					consolePath,
-					`=== P1 Console (${p1Console.length} messages) ===\n${p1Console.join('\n')}\n\n` +
-						`=== P2 Console (${p2Console.length} messages) ===\n${p2Console.join('\n')}\n`,
-				);
-				await testInfo.attach('console-logs', {
-					path: consolePath,
-					contentType: 'text/plain',
-				});
-			}
+      // Mark BrowserStack sessions
+      const passed = logP1.matchComplete && logP2.matchComplete;
+      await markSessionStatus(pageP1, passed, 'Match completed');
+      if (pageP2) await markSessionStatus(pageP2, passed, 'Match completed');
+    } finally {
+      // Always capture console logs
+      if (p1Console.length || p2Console.length) {
+        fs.mkdirSync(RESULTS_DIR, { recursive: true });
+        const consolePath = path.join(RESULTS_DIR, `${testName}-console.log`);
+        fs.writeFileSync(
+          consolePath,
+          `=== P1 Console (${p1Console.length} messages) ===\n${p1Console.join('\n')}\n\n` +
+            `=== P2 Console (${p2Console.length} messages) ===\n${p2Console.join('\n')}\n`,
+        );
+        await testInfo.attach('console-logs', {
+          path: consolePath,
+          contentType: 'text/plain',
+        });
+      }
 
-			// Always try to extract partial data on failure
-			if (!logP1 || !logP2) {
-				try {
-					if (!logP1 && pageP1) logP1 = await extractFightLog(pageP1);
-					if (!logP2 && pageP2) logP2 = await extractFightLog(pageP2);
-					if (logP1 || logP2) {
-						fs.mkdirSync(RESULTS_DIR, { recursive: true });
-						if (logP1)
-							fs.writeFileSync(
-								path.join(RESULTS_DIR, `${testName}-partial-p1.json`),
-								JSON.stringify(logP1, null, 2),
-							);
-						if (logP2)
-							fs.writeFileSync(
-								path.join(RESULTS_DIR, `${testName}-partial-p2.json`),
-								JSON.stringify(logP2, null, 2),
-							);
-					}
-				} catch {
-					// Best-effort partial extraction
-				}
-			}
+      // Always try to extract partial data on failure
+      if (!logP1 || !logP2) {
+        try {
+          if (!logP1 && pageP1) logP1 = await extractFightLog(pageP1);
+          if (!logP2 && pageP2) logP2 = await extractFightLog(pageP2);
+          if (logP1 || logP2) {
+            fs.mkdirSync(RESULTS_DIR, { recursive: true });
+            if (logP1)
+              fs.writeFileSync(
+                path.join(RESULTS_DIR, `${testName}-partial-p1.json`),
+                JSON.stringify(logP1, null, 2),
+              );
+            if (logP2)
+              fs.writeFileSync(
+                path.join(RESULTS_DIR, `${testName}-partial-p2.json`),
+                JSON.stringify(logP2, null, 2),
+              );
+          }
+        } catch {
+          // Best-effort partial extraction
+        }
+      }
 
-			// Clean up sessions
-			try {
-				await browserP1.close();
-			} catch {
-				/* session may already be closed */
-			}
-			if (browserP2) {
-				try {
-					await browserP2.close();
-				} catch {
-					/* session may already be closed */
-				}
-			}
-		}
-	});
+      // Clean up sessions
+      try {
+        await browserP1.close();
+      } catch {
+        /* session may already be closed */
+      }
+      if (browserP2) {
+        try {
+          await browserP2.close();
+        } catch {
+          /* session may already be closed */
+        }
+      }
+    }
+  });
 });

--- a/tests/e2e/remote/remote-playwright.config.js
+++ b/tests/e2e/remote/remote-playwright.config.js
@@ -9,16 +9,16 @@ import { defineConfig } from '@playwright/test';
  * - Longer timeout (speed=1 + real network latency)
  */
 export default defineConfig({
-	testDir: '.',
-	testMatch: '**/*.spec.js',
-	timeout: 300_000, // 5 minutes per test
-	retries: 0, // remote sessions cost $, don't retry
-	workers: 1,
+  testDir: '.',
+  testMatch: '**/*.spec.js',
+  timeout: 300_000, // 5 minutes per test
+  retries: 0, // remote sessions cost $, don't retry
+  workers: 1,
 
-	use: {
-		headless: true,
-		viewport: { width: 960, height: 540 },
-	},
+  use: {
+    headless: true,
+    viewport: { width: 960, height: 540 },
+  },
 
-	// No webServer — remote tests hit deployed staging
+  // No webServer — remote tests hit deployed staging
 });

--- a/tests/e2e/remote/remote-playwright.config.js
+++ b/tests/e2e/remote/remote-playwright.config.js
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Playwright config for remote BrowserStack E2E tests.
+ *
+ * Key differences from local config:
+ * - No webServer (uses deployed staging infrastructure)
+ * - No retries (remote sessions are expensive)
+ * - Longer timeout (speed=1 + real network latency)
+ */
+export default defineConfig({
+	testDir: '.',
+	testMatch: '**/*.spec.js',
+	timeout: 300_000, // 5 minutes per test
+	retries: 0, // remote sessions cost $, don't retry
+	workers: 1,
+
+	use: {
+		headless: true,
+		viewport: { width: 960, height: 540 },
+	},
+
+	// No webServer — remote tests hit deployed staging
+});


### PR DESCRIPTION
Extends the E2E multiplayer testing framework to run P1 and P2 on
separate BrowserStack remote browsers connected through deployed
infrastructure. This enables testing under real network conditions
(latency, TURN, cross-browser) that local tests cannot exercise.

New files:
- tests/e2e/remote/ — orchestrator spec, config, helpers, Playwright config
- docs/rfcs/0008-e2e-remote-browser-testing.md — full RFC

Changes:
- FightScene: expose window.__DEBUG_BUNDLE for remote extraction
- package.json: add test:e2e:remote script
- docs/e2e-testing.md: add remote testing section
- CLAUDE.md: add RFCs 0006-0008 and remote E2E command

https://claude.ai/code/session_01U5sBy9C3251RVEnbQu7B9X