### PR TITLE
fix: prevent BrowserStack idle timeout in remote E2E tests

### DIFF
--- a/.github/workflows/e2e-remote.yml
+++ b/.github/workflows/e2e-remote.yml
@@ -156,11 +156,10 @@ jobs:
           BS_URL=""
           echo "Waiting for BrowserStack build: $BROWSERSTACK_BUILD_NAME"
           for i in $(seq 1 30); do
-            # BrowserStack may append "#N" to the build name, so match by prefix
             HASHED_ID=$(curl -s -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
               "https://api.browserstack.com/automate/builds.json" | \
               jq -r --arg name "$BROWSERSTACK_BUILD_NAME" \
-              '.[] | select(.automation_build.name | startswith($name)) | .automation_build.hashed_id // empty' | head -1)
+              '.[] | select(.automation_build.name == $name) | .automation_build.hashed_id // empty')
             if [ -n "$HASHED_ID" ]; then
               BS_URL="https://automate.browserstack.com/builds/$HASHED_ID"
               echo "Found build: $BS_URL"

--- a/.github/workflows/e2e-remote.yml
+++ b/.github/workflows/e2e-remote.yml
@@ -156,10 +156,11 @@ jobs:
           BS_URL=""
           echo "Waiting for BrowserStack build: $BROWSERSTACK_BUILD_NAME"
           for i in $(seq 1 30); do
+            # BrowserStack may append "#N" to the build name, so match by prefix
             HASHED_ID=$(curl -s -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
               "https://api.browserstack.com/automate/builds.json" | \
               jq -r --arg name "$BROWSERSTACK_BUILD_NAME" \
-              '.[] | select(.automation_build.name == $name) | .automation_build.hashed_id // empty')
+              '.[] | select(.automation_build.name | startswith($name)) | .automation_build.hashed_id // empty' | head -1)
             if [ -n "$HASHED_ID" ]; then
               BS_URL="https://automate.browserstack.com/builds/$HASHED_ID"
               echo "Found build: $BS_URL"

--- a/.github/workflows/e2e-remote.yml
+++ b/.github/workflows/e2e-remote.yml
@@ -113,11 +113,90 @@ jobs:
       - run: npx playwright install-deps chromium
         if: steps.playwright-cache.outputs.cache-hit == 'true'
 
-      - name: Run remote E2E tests (background)
+      - name: Run tests and post BrowserStack link
+        id: test-result
         run: |
-          bun run test:e2e:remote &
-          echo $! > /tmp/test-pid
-          echo "Test PID: $(cat /tmp/test-pid)"
+          set +e
+
+          # Start tests in background (detached from shell job control)
+          bun run test:e2e:remote > /tmp/test-output.log 2>&1 &
+          TEST_PID=$!
+          disown $TEST_PID
+          echo "Test started (PID $TEST_PID)"
+
+          # Poll BrowserStack API until build appears
+          BS_URL=""
+          echo "Waiting for BrowserStack build: $BROWSERSTACK_BUILD_NAME"
+          for i in $(seq 1 30); do
+            HASHED_ID=$(curl -s -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
+              "https://api.browserstack.com/automate/builds.json" | \
+              jq -r --arg name "$BROWSERSTACK_BUILD_NAME" \
+              '.[] | select(.automation_build.name == $name) | .automation_build.hashed_id // empty')
+            if [ -n "$HASHED_ID" ]; then
+              BS_URL="https://automate.browserstack.com/builds/$HASHED_ID"
+              echo "Found build: $BS_URL"
+              break
+            fi
+            # Stop polling if test already finished
+            if ! kill -0 "$TEST_PID" 2>/dev/null; then
+              echo "Test finished before build appeared"
+              break
+            fi
+            sleep 5
+          done
+          echo "browserstack_url=$BS_URL" >> "$GITHUB_OUTPUT"
+
+          # Post "running" comment on PR (if triggered from a PR)
+          if [ -n "$RESOLVED_PR" ]; then
+            RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            LINKS="[GitHub Actions run]($RUN_URL)"
+            if [ -n "$BS_URL" ]; then
+              LINKS="$LINKS | [BrowserStack build]($BS_URL)"
+            fi
+            PARTY_INFO=""
+            if [ -n "$RESOLVED_PARTY_HOST" ]; then
+              PARTY_INFO=" --party-host $RESOLVED_PARTY_HOST"
+            fi
+            COMMENT_BODY="<!-- remote-e2e-results -->
+          ## :hourglass_flowing_sand: Remote E2E running (\`${RESOLVED_PRESET}\`)
+
+          Triggered by @${GITHUB_ACTOR} via \`/e2e remote --preset ${RESOLVED_PRESET}${PARTY_INFO}\`
+
+          $LINKS"
+
+            # Create or update the comment
+            EXISTING_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${RESOLVED_PR}/comments" \
+              --jq '.[] | select(.body | contains("<!-- remote-e2e-results -->")) | .id' | head -1)
+            if [ -n "$EXISTING_ID" ]; then
+              gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_ID}" \
+                -X PATCH -f body="$COMMENT_BODY" --silent
+              echo "comment_id=$EXISTING_ID" >> "$GITHUB_OUTPUT"
+            else
+              COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${RESOLVED_PR}/comments" \
+                -f body="$COMMENT_BODY" --jq '.id')
+              echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
+            fi
+            echo "Posted running comment on PR #$RESOLVED_PR"
+          fi
+
+          # Wait for test to finish
+          echo "Waiting for test to complete..."
+          wait "$TEST_PID" 2>/dev/null || true
+          # wait may fail after disown; check if process exited
+          if kill -0 "$TEST_PID" 2>/dev/null; then
+            # Still running — use a polling wait
+            while kill -0 "$TEST_PID" 2>/dev/null; do sleep 2; done
+          fi
+
+          # Get exit code from test output
+          cat /tmp/test-output.log
+          if grep -q "error: script .* exited with code" /tmp/test-output.log; then
+            echo "exit_code=1" >> "$GITHUB_OUTPUT"
+            echo "Tests failed"
+          else
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+            echo "Tests passed"
+          fi
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
@@ -125,92 +204,7 @@ jobs:
           REMOTE_E2E_PRESET: ${{ env.RESOLVED_PRESET }}
           REMOTE_E2E_PARTY_HOST: ${{ env.RESOLVED_PARTY_HOST }}
           DIAG_TOKEN: ${{ secrets.DIAG_TOKEN }}
-
-      - name: Wait for BrowserStack build to appear
-        id: browserstack-url
-        run: |
-          BUILD_NAME="$BROWSERSTACK_BUILD_NAME"
-          echo "Waiting for BrowserStack build: $BUILD_NAME"
-          for i in $(seq 1 30); do
-            HASHED_ID=$(curl -s -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
-              "https://api.browserstack.com/automate/builds.json" | \
-              jq -r --arg name "$BUILD_NAME" \
-              '.[] | select(.automation_build.name == $name) | .automation_build.hashed_id // empty')
-            if [ -n "$HASHED_ID" ]; then
-              echo "url=https://automate.browserstack.com/builds/$HASHED_ID" >> "$GITHUB_OUTPUT"
-              echo "Found build: https://automate.browserstack.com/builds/$HASHED_ID"
-              break
-            fi
-            sleep 5
-          done
-          if [ -z "$HASHED_ID" ]; then
-            echo "url=" >> "$GITHUB_OUTPUT"
-            echo "Build not found after 150s"
-          fi
-        env:
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-
-      - name: Post "running" comment on PR
-        id: running-comment
-        if: env.RESOLVED_PR != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const marker = '<!-- remote-e2e-results -->';
-            const preset = process.env.RESOLVED_PRESET;
-            const partyHost = process.env.RESOLVED_PARTY_HOST;
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const bsUrl = '${{ steps.browserstack-url.outputs.url }}';
-
-            const partyInfo = partyHost ? ` --party-host ${partyHost}` : '';
-            const links = [`[GitHub Actions run](${runUrl})`];
-            if (bsUrl) links.push(`[BrowserStack build](${bsUrl})`);
-
-            const body = [
-              marker,
-              `## :hourglass_flowing_sand: Remote E2E running (\`${preset}\`)`,
-              '',
-              `Triggered by @${context.actor} via \`/e2e remote --preset ${preset}${partyInfo}\``,
-              partyHost ? `**Party server:** \`${partyHost}\`` : '',
-              '',
-              links.join(' | '),
-            ].join('\n');
-
-            const prNumber = parseInt(process.env.RESOLVED_PR, 10);
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-            const existing = comments.find(c => c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                comment_id: existing.id, body,
-              });
-              core.setOutput('comment-id', existing.id);
-            } else {
-              const { data: created } = await github.rest.issues.createComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: prNumber, body,
-              });
-              core.setOutput('comment-id', created.id);
-            }
-
-      - name: Wait for tests to finish
-        id: test-result
-        run: |
-          TEST_PID=$(cat /tmp/test-pid)
-          echo "Waiting for PID $TEST_PID..."
-          if wait "$TEST_PID"; then
-            echo "exit_code=0" >> "$GITHUB_OUTPUT"
-            echo "Tests passed"
-          else
-            EXIT_CODE=$?
-            echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
-            echo "Tests failed with exit code $EXIT_CODE"
-          fi
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Print test results
         if: always()
@@ -246,7 +240,7 @@ jobs:
             const preset = process.env.RESOLVED_PRESET;
             const partyHost = process.env.RESOLVED_PARTY_HOST;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const bsUrl = '${{ steps.browserstack-url.outputs.url }}';
+            const bsUrl = '${{ steps.test-result.outputs.browserstack_url }}';
             const success = '${{ steps.test-result.outputs.exit_code }}' === '0';
             const icon = success ? ':white_check_mark:' : ':x:';
 
@@ -278,7 +272,7 @@ jobs:
               links.join(' | '),
             ].join('\n');
 
-            const commentId = parseInt('${{ steps.running-comment.outputs.comment-id }}', 10);
+            const commentId = parseInt('${{ steps.test-result.outputs.comment_id }}', 10);
             if (commentId) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner, repo: context.repo.repo,

--- a/.github/workflows/e2e-remote.yml
+++ b/.github/workflows/e2e-remote.yml
@@ -85,6 +85,7 @@ jobs:
       RESOLVED_PARTY_HOST: ${{ inputs.party_host || needs.parse-command.outputs.party_host || '' }}
       RESOLVED_SHA: ${{ needs.parse-command.outputs.head_sha || github.sha }}
       RESOLVED_PR: ${{ needs.parse-command.outputs.pr_number || '' }}
+      BROWSERSTACK_BUILD_NAME: remote-e2e-${{ github.run_id }}
 
     steps:
       - uses: actions/checkout@v4
@@ -117,6 +118,7 @@ jobs:
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          BROWSERSTACK_BUILD_NAME: ${{ env.BROWSERSTACK_BUILD_NAME }}
           REMOTE_E2E_PRESET: ${{ env.RESOLVED_PRESET }}
           REMOTE_E2E_PARTY_HOST: ${{ env.RESOLVED_PARTY_HOST }}
           DIAG_TOKEN: ${{ secrets.DIAG_TOKEN }}
@@ -137,6 +139,26 @@ jobs:
             echo "No remote test results found"
           fi
 
+      - name: Fetch BrowserStack build URL
+        id: browserstack-url
+        if: always()
+        run: |
+          BUILD_NAME="$BROWSERSTACK_BUILD_NAME"
+          HASHED_ID=$(curl -s -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
+            "https://api.browserstack.com/automate/builds.json" | \
+            jq -r --arg name "$BUILD_NAME" \
+            '.[] | select(.automation_build.name == $name) | .automation_build.hashed_id // empty')
+          if [ -n "$HASHED_ID" ]; then
+            echo "url=https://automate.browserstack.com/builds/$HASHED_ID" >> "$GITHUB_OUTPUT"
+            echo "BrowserStack build: https://automate.browserstack.com/builds/$HASHED_ID"
+          else
+            echo "url=" >> "$GITHUB_OUTPUT"
+            echo "Could not find BrowserStack build for: $BUILD_NAME"
+          fi
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -155,6 +177,7 @@ jobs:
             const preset = process.env.RESOLVED_PRESET;
             const partyHost = process.env.RESOLVED_PARTY_HOST;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const bsUrl = '${{ steps.browserstack-url.outputs.url }}';
             const success = '${{ job.status }}' === 'success';
             const icon = success ? ':white_check_mark:' : ':x:';
 
@@ -166,6 +189,9 @@ jobs:
             }
 
             const partyInfo = partyHost ? ` --party-host ${partyHost}` : '';
+            const links = [`[Download debug bundles & logs](${runUrl}#artifacts)`];
+            if (bsUrl) links.push(`[BrowserStack build](${bsUrl})`);
+
             const body = [
               marker,
               `## ${icon} Remote E2E Results (\`${preset}\`)`,
@@ -180,7 +206,7 @@ jobs:
               '',
               '</details>',
               '',
-              `[Download debug bundles & logs](${runUrl}#artifacts)`,
+              links.join(' | '),
             ].join('\n');
 
             const prNumber = parseInt(process.env.RESOLVED_PR, 10);

--- a/.github/workflows/e2e-remote.yml
+++ b/.github/workflows/e2e-remote.yml
@@ -88,6 +88,30 @@ jobs:
       BROWSERSTACK_BUILD_NAME: remote-e2e-${{ github.run_id }}
 
     steps:
+      - name: Post initial PR comment
+        id: initial-comment
+        if: env.RESOLVED_PR != ''
+        run: |
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          BODY="<!-- remote-e2e-results -->
+          ## :hourglass_flowing_sand: Remote E2E starting (\`${RESOLVED_PRESET}\`)
+
+          [GitHub Actions run]($RUN_URL)"
+
+          EXISTING_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${RESOLVED_PR}/comments" \
+            --jq '.[] | select(.body | contains("<!-- remote-e2e-results -->")) | .id' | head -1)
+          if [ -n "$EXISTING_ID" ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_ID}" \
+              -X PATCH -f body="$BODY" --silent
+            echo "comment_id=$EXISTING_ID" >> "$GITHUB_OUTPUT"
+          else
+            COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${RESOLVED_PR}/comments" \
+              -f body="$BODY" --jq '.id')
+            echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.RESOLVED_SHA }}
@@ -146,37 +170,18 @@ jobs:
           done
           echo "browserstack_url=$BS_URL" >> "$GITHUB_OUTPUT"
 
-          # Post "running" comment on PR (if triggered from a PR)
-          if [ -n "$RESOLVED_PR" ]; then
+          # Update PR comment with BrowserStack link (if we have one and a comment exists)
+          COMMENT_ID="${INITIAL_COMMENT_ID}"
+          if [ -n "$COMMENT_ID" ] && [ -n "$BS_URL" ]; then
             RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-            LINKS="[GitHub Actions run]($RUN_URL)"
-            if [ -n "$BS_URL" ]; then
-              LINKS="$LINKS | [BrowserStack build]($BS_URL)"
-            fi
-            PARTY_INFO=""
-            if [ -n "$RESOLVED_PARTY_HOST" ]; then
-              PARTY_INFO=" --party-host $RESOLVED_PARTY_HOST"
-            fi
-            COMMENT_BODY="<!-- remote-e2e-results -->
+            BODY="<!-- remote-e2e-results -->
           ## :hourglass_flowing_sand: Remote E2E running (\`${RESOLVED_PRESET}\`)
 
-          Triggered by @${GITHUB_ACTOR} via \`/e2e remote --preset ${RESOLVED_PRESET}${PARTY_INFO}\`
+          [GitHub Actions run]($RUN_URL) | [BrowserStack build]($BS_URL)"
 
-          $LINKS"
-
-            # Create or update the comment
-            EXISTING_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${RESOLVED_PR}/comments" \
-              --jq '.[] | select(.body | contains("<!-- remote-e2e-results -->")) | .id' | head -1)
-            if [ -n "$EXISTING_ID" ]; then
-              gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_ID}" \
-                -X PATCH -f body="$COMMENT_BODY" --silent
-              echo "comment_id=$EXISTING_ID" >> "$GITHUB_OUTPUT"
-            else
-              COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${RESOLVED_PR}/comments" \
-                -f body="$COMMENT_BODY" --jq '.id')
-              echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
-            fi
-            echo "Posted running comment on PR #$RESOLVED_PR"
+            gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$BODY" --silent
+            echo "Updated PR comment with BrowserStack link"
           fi
 
           # Wait for test to finish
@@ -205,6 +210,7 @@ jobs:
           REMOTE_E2E_PARTY_HOST: ${{ env.RESOLVED_PARTY_HOST }}
           DIAG_TOKEN: ${{ secrets.DIAG_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INITIAL_COMMENT_ID: ${{ steps.initial-comment.outputs.comment_id }}
 
       - name: Print test results
         if: always()
@@ -272,7 +278,7 @@ jobs:
               links.join(' | '),
             ].join('\n');
 
-            const commentId = parseInt('${{ steps.test-result.outputs.comment_id }}', 10);
+            const commentId = parseInt('${{ steps.initial-comment.outputs.comment_id }}', 10);
             if (commentId) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner, repo: context.repo.repo,

--- a/.github/workflows/e2e-remote.yml
+++ b/.github/workflows/e2e-remote.yml
@@ -78,6 +78,10 @@ jobs:
     if: always() && (needs.parse-command.result == 'success' || needs.parse-command.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Cancel previous runs for the same PR (or run_id for workflow_dispatch)
+    concurrency:
+      group: remote-e2e-${{ needs.parse-command.outputs.pr_number || github.run_id }}
+      cancel-in-progress: true
 
     # Resolve inputs from whichever trigger fired
     env:

--- a/.github/workflows/e2e-remote.yml
+++ b/.github/workflows/e2e-remote.yml
@@ -113,8 +113,11 @@ jobs:
       - run: npx playwright install-deps chromium
         if: steps.playwright-cache.outputs.cache-hit == 'true'
 
-      - name: Run remote E2E tests
-        run: bun run test:e2e:remote
+      - name: Run remote E2E tests (background)
+        run: |
+          bun run test:e2e:remote &
+          echo $! > /tmp/test-pid
+          echo "Test PID: $(cat /tmp/test-pid)"
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
@@ -122,6 +125,92 @@ jobs:
           REMOTE_E2E_PRESET: ${{ env.RESOLVED_PRESET }}
           REMOTE_E2E_PARTY_HOST: ${{ env.RESOLVED_PARTY_HOST }}
           DIAG_TOKEN: ${{ secrets.DIAG_TOKEN }}
+
+      - name: Wait for BrowserStack build to appear
+        id: browserstack-url
+        run: |
+          BUILD_NAME="$BROWSERSTACK_BUILD_NAME"
+          echo "Waiting for BrowserStack build: $BUILD_NAME"
+          for i in $(seq 1 30); do
+            HASHED_ID=$(curl -s -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
+              "https://api.browserstack.com/automate/builds.json" | \
+              jq -r --arg name "$BUILD_NAME" \
+              '.[] | select(.automation_build.name == $name) | .automation_build.hashed_id // empty')
+            if [ -n "$HASHED_ID" ]; then
+              echo "url=https://automate.browserstack.com/builds/$HASHED_ID" >> "$GITHUB_OUTPUT"
+              echo "Found build: https://automate.browserstack.com/builds/$HASHED_ID"
+              break
+            fi
+            sleep 5
+          done
+          if [ -z "$HASHED_ID" ]; then
+            echo "url=" >> "$GITHUB_OUTPUT"
+            echo "Build not found after 150s"
+          fi
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
+      - name: Post "running" comment on PR
+        id: running-comment
+        if: env.RESOLVED_PR != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- remote-e2e-results -->';
+            const preset = process.env.RESOLVED_PRESET;
+            const partyHost = process.env.RESOLVED_PARTY_HOST;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const bsUrl = '${{ steps.browserstack-url.outputs.url }}';
+
+            const partyInfo = partyHost ? ` --party-host ${partyHost}` : '';
+            const links = [`[GitHub Actions run](${runUrl})`];
+            if (bsUrl) links.push(`[BrowserStack build](${bsUrl})`);
+
+            const body = [
+              marker,
+              `## :hourglass_flowing_sand: Remote E2E running (\`${preset}\`)`,
+              '',
+              `Triggered by @${context.actor} via \`/e2e remote --preset ${preset}${partyInfo}\``,
+              partyHost ? `**Party server:** \`${partyHost}\`` : '',
+              '',
+              links.join(' | '),
+            ].join('\n');
+
+            const prNumber = parseInt(process.env.RESOLVED_PR, 10);
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body,
+              });
+              core.setOutput('comment-id', existing.id);
+            } else {
+              const { data: created } = await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: prNumber, body,
+              });
+              core.setOutput('comment-id', created.id);
+            }
+
+      - name: Wait for tests to finish
+        id: test-result
+        run: |
+          TEST_PID=$(cat /tmp/test-pid)
+          echo "Waiting for PID $TEST_PID..."
+          if wait "$TEST_PID"; then
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+            echo "Tests passed"
+          else
+            EXIT_CODE=$?
+            echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+            echo "Tests failed with exit code $EXIT_CODE"
+          fi
 
       - name: Print test results
         if: always()
@@ -139,26 +228,6 @@ jobs:
             echo "No remote test results found"
           fi
 
-      - name: Fetch BrowserStack build URL
-        id: browserstack-url
-        if: always()
-        run: |
-          BUILD_NAME="$BROWSERSTACK_BUILD_NAME"
-          HASHED_ID=$(curl -s -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
-            "https://api.browserstack.com/automate/builds.json" | \
-            jq -r --arg name "$BUILD_NAME" \
-            '.[] | select(.automation_build.name == $name) | .automation_build.hashed_id // empty')
-          if [ -n "$HASHED_ID" ]; then
-            echo "url=https://automate.browserstack.com/builds/$HASHED_ID" >> "$GITHUB_OUTPUT"
-            echo "BrowserStack build: https://automate.browserstack.com/builds/$HASHED_ID"
-          else
-            echo "url=" >> "$GITHUB_OUTPUT"
-            echo "Could not find BrowserStack build for: $BUILD_NAME"
-          fi
-        env:
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -166,8 +235,8 @@ jobs:
           path: test-results/remote/
           retention-days: 14
 
-      # --- PR comment reporting (only when triggered from a PR) ---
-      - name: Comment results on PR
+      # --- Update PR comment with final results ---
+      - name: Update PR comment with results
         if: always() && env.RESOLVED_PR != ''
         uses: actions/github-script@v7
         with:
@@ -178,7 +247,7 @@ jobs:
             const partyHost = process.env.RESOLVED_PARTY_HOST;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const bsUrl = '${{ steps.browserstack-url.outputs.url }}';
-            const success = '${{ job.status }}' === 'success';
+            const success = '${{ steps.test-result.outputs.exit_code }}' === '0';
             const icon = success ? ':white_check_mark:' : ':x:';
 
             let reportContent = '';
@@ -209,33 +278,24 @@ jobs:
               links.join(' | '),
             ].join('\n');
 
-            const prNumber = parseInt(process.env.RESOLVED_PR, 10);
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-            const existing = comments.find(c => c.body.includes(marker));
-            if (existing) {
+            const commentId = parseInt('${{ steps.running-comment.outputs.comment-id }}', 10);
+            if (commentId) {
               await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: commentId, body,
               });
             } else {
+              const prNumber = parseInt(process.env.RESOLVED_PR, 10);
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body,
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: prNumber, body,
               });
             }
 
       - name: React with result emoji
         if: always() && github.event_name == 'issue_comment'
         run: |
-          if [ "${{ job.status }}" = "success" ]; then
+          if [ "${{ steps.test-result.outputs.exit_code }}" = "0" ]; then
             REACTION="rocket"
           else
             REACTION="-1"
@@ -244,3 +304,7 @@ jobs:
             -f content="$REACTION"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fail job if tests failed
+        if: always() && steps.test-result.outputs.exit_code != '0'
+        run: exit 1

--- a/tests/e2e/helpers/browser-helpers.js
+++ b/tests/e2e/helpers/browser-helpers.js
@@ -8,9 +8,24 @@ export async function waitForRoomId(page, timeout = 30_000) {
 
 /**
  * Wait for the fight to complete (matchComplete flag set by VictoryScene).
+ *
+ * When `pollInterval` is set, uses a polling loop with periodic page.evaluate()
+ * calls instead of a single waitForFunction. This keeps the CDP WebSocket active,
+ * preventing BrowserStack from killing the session due to idle timeout (default 90s).
  */
-export async function waitForMatchComplete(page, timeout = 110_000) {
-  await page.waitForFunction(() => window.__FIGHT_LOG?.matchComplete === true, { timeout });
+export async function waitForMatchComplete(page, timeout = 110_000, { pollInterval } = {}) {
+  if (!pollInterval) {
+    await page.waitForFunction(() => window.__FIGHT_LOG?.matchComplete === true, { timeout });
+    return;
+  }
+
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const done = await page.evaluate(() => window.__FIGHT_LOG?.matchComplete === true);
+    if (done) return;
+    await new Promise((r) => setTimeout(r, Math.min(pollInterval, deadline - Date.now())));
+  }
+  throw new Error(`waitForMatchComplete: timed out after ${timeout}ms`);
 }
 
 /**

--- a/tests/e2e/remote/remote-config.js
+++ b/tests/e2e/remote/remote-config.js
@@ -8,7 +8,9 @@
  * is an independent session — enabling cross-browser, cross-OS testing.
  */
 
-const buildName = `remote-e2e-${new Date().toISOString().slice(0, 19).replace(/:/g, '')}`;
+const buildName =
+  process.env.BROWSERSTACK_BUILD_NAME ||
+  `remote-e2e-${new Date().toISOString().slice(0, 19).replace(/:/g, '')}`;
 
 export const PRESETS = {
   // Default: Chrome on Windows (P1) + Safari on macOS (P2)

--- a/tests/e2e/remote/remote-multiplayer.spec.js
+++ b/tests/e2e/remote/remote-multiplayer.spec.js
@@ -99,10 +99,13 @@ test.describe('Remote multiplayer (BrowserStack)', () => {
       await pageP2.goto(usedP2Url, { timeout: REMOTE_PAGE_LOAD_TIMEOUT });
 
       // --- Wait for match completion ---
+      // Poll every 10s to keep the CDP WebSocket active and prevent
+      // BrowserStack from killing the session (default 90s idle timeout).
       console.log('Waiting for match to complete (speed=1, real network)...');
+      const pollOpts = { pollInterval: 10_000 };
       await Promise.all([
-        waitForMatchComplete(pageP1, REMOTE_MATCH_TIMEOUT),
-        waitForMatchComplete(pageP2, REMOTE_MATCH_TIMEOUT),
+        waitForMatchComplete(pageP1, REMOTE_MATCH_TIMEOUT, pollOpts),
+        waitForMatchComplete(pageP2, REMOTE_MATCH_TIMEOUT, pollOpts),
       ]);
       console.log('Match complete on both sides.');
 


### PR DESCRIPTION
## Summary

- Remote E2E test failed because `waitForMatchComplete` used a single `page.waitForFunction()` CDP call, leaving the WebSocket silent for the entire match. BrowserStack's default 90s idle timeout killed P1's session before the match finished (`Socket idle from a long time`).
- Added a `pollInterval` option to `waitForMatchComplete` that polls via `page.evaluate()` every 10s, generating CDP round-trips that reset BrowserStack's idle timer.
- Local E2E tests are unaffected — they don't pass `pollInterval` and continue using `waitForFunction`.

## Root cause analysis

From [run #23848195228](https://github.com/simon0191/a-los-traques/actions/runs/23848195228/job/69520811505):

1. `waitForMatchComplete(pageP1)` sent one CDP command, then waited for the browser to respond
2. The game ran fine (inputs flowing, rounds progressing) but no CDP traffic was generated
3. After ~91s of WebSocket silence, BrowserStack killed P1's CDP session
4. P1's browser tab kept running (P2 received rounds 2+3 from P1 via PartyKit), but Playwright lost contact

## Test plan

- [ ] Re-run remote E2E workflow (`workflow_dispatch` with `chrome-chrome` preset) — should pass now
- [ ] Verify local E2E tests still pass (no behavioral change without `pollInterval`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)