### PR TITLE
feat: auto-upload debug bundles with admin panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - `docs/rfcs/0007-fix-desync-detection.md` — Fix desync detection between peers with different RTT
 - `docs/rfcs/0009-e2e-remote-browser-testing.md` — Remote browser E2E testing via BrowserStack
 - `docs/rfcs/0011-auto-upload-debug-bundles.md` — Auto-upload debug bundles to object storage
+- `docs/rfcs/0012-e2e-bot-user.md` — E2E bot user for debug bundle uploads (proposed)
 
 ## Online Multiplayer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ Decoupled architecture: Supabase for Auth (JWT) + Vercel Functions for data pers
 - **Database Schema**: 
     - Managed via `dbmate` (pure Postgres).
     - Migrations in `db/migrations/`.
-    - `profiles` table (id, nickname, wins, losses).
+    - `profiles` table (id, nickname, wins, losses, is_admin).
+    - `fights` table (id, room_id, players, fighters, stage, result, debug bundle status/TTL).
 - **Graceful Degradation**: If `VITE_SUPABASE_URL` or `VITE_SUPABASE_ANON_KEY` are missing, the game bypasses `LoginScene` and operates in "Guest Mode" automatically.
 
 ## Build & Run
@@ -169,6 +170,7 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - `docs/rfcs/0006-fix-p1-no-rollback.md` — Fix P1 never rolls back
 - `docs/rfcs/0007-fix-desync-detection.md` — Fix desync detection between peers with different RTT
 - `docs/rfcs/0009-e2e-remote-browser-testing.md` — Remote browser E2E testing via BrowserStack
+- `docs/rfcs/0011-auto-upload-debug-bundles.md` — Auto-upload debug bundles to object storage
 
 ## Online Multiplayer
 
@@ -202,6 +204,16 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - **Session ID**: Generated in SignalingClient, passed as PartySocket query param, included in all server logs and debug bundles for client-server correlation.
 - **Server logging**: `party/server.js` uses structured JSON logging (`_log()` method) with ring buffer. State transitions, connect/disconnect, rejoin, rate limits all logged.
 - **Server diagnostics**: `GET /parties/main/{roomId}/diagnostics` returns room state, players, event log. Token-protected via `DIAG_TOKEN` env var.
+
+## Debug Bundle Auto-Upload (RFC 0011)
+
+- **Fight ID**: UUID generated in PartyKit server when both players ready, included in `start` message, stored in `FightRecorder.log.fightId`.
+- **Auto-upload**: In debug mode, both peers independently upload debug bundles per-round and at match end via `POST /api/debug-bundles`.
+- **Storage interface** (`api/_lib/storage.js`): Pluggable backend — `STORAGE_BACKEND=local` (filesystem, dev) or `STORAGE_BACKEND=supabase` (Supabase Storage, prod). Path: `{fightId}/p{slot}_round{round}.json`.
+- **Fights table**: `db/migrations/20260401000000_create_fights.sql` — tracks all online fights with player IDs, fighters, stage, result, debug bundle status/TTL.
+- **Admin panel**: Preact SPA at `/admin/` (CDN imports, no build step). Protected by `is_admin` column on profiles table. `withAdmin()` middleware in `api/_lib/handler.js`.
+- **Admin API**: `GET /api/admin/fights` (paginated, filterable), `GET /api/admin/debug-bundle` (download).
+- **TTL cleanup**: Vercel Cron daily at 3 AM UTC (`api/cron/cleanup-bundles.js`), deletes bundles older than 7 days.
 
 ## CRITICAL: Keep this file updated
 

--- a/api/_lib/handler.js
+++ b/api/_lib/handler.js
@@ -100,3 +100,17 @@ export function withAuth(handler) {
     }
   };
 }
+
+/**
+ * Higher-order function for admin-only handlers.
+ * Wraps withAuth and additionally checks is_admin on the profiles table.
+ */
+export function withAdmin(handler) {
+  return withAuth(async (req, res, { userId, db }) => {
+    const result = await db.query('SELECT is_admin FROM profiles WHERE id = $1', [userId]);
+    if (result.rows.length === 0 || !result.rows[0].is_admin) {
+      return res.status(403).json({ error: 'Forbidden: Admin access required' });
+    }
+    return handler(req, res, { userId, db });
+  });
+}

--- a/api/_lib/storage.js
+++ b/api/_lib/storage.js
@@ -21,8 +21,7 @@ function buildKey(fightId, slot, round) {
   const safeFightId = validatePathComponent(fightId, 'fightId');
   const safeSlot = validatePathComponent(slot, 'slot');
   const safeRound = validatePathComponent(round, 'round');
-  const playerNum = Number(safeSlot) + 1;
-  return `${safeFightId}/p${playerNum}_round${safeRound}.json`;
+  return `${safeFightId}/p${safeSlot}_round${safeRound}.json`;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,7 +69,7 @@ const localBackend = {
           const match = f.match(/^p(\d+)_round(\d+)\.json$/);
           if (!match) return null;
           return {
-            slot: Number.parseInt(match[1], 10) - 1,
+            slot: Number.parseInt(match[1], 10),
             round: Number.parseInt(match[2], 10),
             key: `${safeFightId}/${f}`,
           };
@@ -148,7 +147,7 @@ const supabaseBackend = {
         const match = f.name.match(/^p(\d+)_round(\d+)\.json$/);
         if (!match) return null;
         return {
-          slot: Number.parseInt(match[1], 10) - 1,
+          slot: Number.parseInt(match[1], 10),
           round: Number.parseInt(match[2], 10),
           key: `${safeFightId}/${f.name}`,
         };

--- a/api/_lib/storage.js
+++ b/api/_lib/storage.js
@@ -21,7 +21,8 @@ function buildKey(fightId, slot, round) {
   const safeFightId = validatePathComponent(fightId, 'fightId');
   const safeSlot = validatePathComponent(slot, 'slot');
   const safeRound = validatePathComponent(round, 'round');
-  return `${safeFightId}/p${safeSlot}_round${safeRound}.json`;
+  const playerNum = Number(safeSlot) + 1;
+  return `${safeFightId}/p${playerNum}_round${safeRound}.json`;
 }
 
 // ---------------------------------------------------------------------------
@@ -69,7 +70,7 @@ const localBackend = {
           const match = f.match(/^p(\d+)_round(\d+)\.json$/);
           if (!match) return null;
           return {
-            slot: Number.parseInt(match[1], 10),
+            slot: Number.parseInt(match[1], 10) - 1,
             round: Number.parseInt(match[2], 10),
             key: `${safeFightId}/${f}`,
           };
@@ -147,7 +148,7 @@ const supabaseBackend = {
         const match = f.name.match(/^p(\d+)_round(\d+)\.json$/);
         if (!match) return null;
         return {
-          slot: Number.parseInt(match[1], 10),
+          slot: Number.parseInt(match[1], 10) - 1,
           round: Number.parseInt(match[2], 10),
           key: `${safeFightId}/${f.name}`,
         };

--- a/api/_lib/storage.js
+++ b/api/_lib/storage.js
@@ -1,0 +1,176 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const BUNDLE_TTL_DAYS = 7;
+
+/**
+ * Validate storage path components to prevent path traversal.
+ */
+function validatePathComponent(value, name) {
+  const str = String(value);
+  if (str.includes('..') || str.includes('/') || str.includes('\\')) {
+    throw new Error(`Invalid ${name}: ${str}`);
+  }
+  return str;
+}
+
+/**
+ * Build storage key for a debug bundle.
+ */
+function buildKey(fightId, slot, round) {
+  const safeFightId = validatePathComponent(fightId, 'fightId');
+  const safeSlot = validatePathComponent(slot, 'slot');
+  const safeRound = validatePathComponent(round, 'round');
+  return `${safeFightId}/p${safeSlot}_round${safeRound}.json`;
+}
+
+// ---------------------------------------------------------------------------
+// Local filesystem backend
+// ---------------------------------------------------------------------------
+
+const LOCAL_BASE = path.join(process.cwd(), 'tmp', 'debug-bundles');
+
+const localBackend = {
+  async uploadBundle(fightId, slot, round, jsonString) {
+    const key = buildKey(fightId, slot, round);
+    const filePath = path.join(LOCAL_BASE, key);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, jsonString, 'utf-8');
+  },
+
+  async downloadBundle(fightId, slot, round) {
+    const key = buildKey(fightId, slot, round);
+    const filePath = path.join(LOCAL_BASE, key);
+    try {
+      return fs.readFileSync(filePath, 'utf-8');
+    } catch {
+      return null;
+    }
+  },
+
+  async deleteBundles(fightId) {
+    const safeFightId = validatePathComponent(fightId, 'fightId');
+    const dirPath = path.join(LOCAL_BASE, safeFightId);
+    try {
+      fs.rmSync(dirPath, { recursive: true, force: true });
+    } catch {
+      // Directory may not exist
+    }
+  },
+
+  async listBundles(fightId) {
+    const safeFightId = validatePathComponent(fightId, 'fightId');
+    const dirPath = path.join(LOCAL_BASE, safeFightId);
+    try {
+      const files = fs.readdirSync(dirPath);
+      return files
+        .filter((f) => f.endsWith('.json'))
+        .map((f) => {
+          const match = f.match(/^p(\d+)_round(\d+)\.json$/);
+          if (!match) return null;
+          return {
+            slot: Number.parseInt(match[1], 10),
+            round: Number.parseInt(match[2], 10),
+            key: `${safeFightId}/${f}`,
+          };
+        })
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Supabase Storage backend
+// ---------------------------------------------------------------------------
+
+let supabaseClient;
+
+function getSupabaseClient() {
+  if (supabaseClient) return supabaseClient;
+
+  const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required for supabase storage');
+  }
+
+  // Dynamic import would be cleaner but we need sync access
+  // eslint-disable-next-line
+  const { createClient } = require('@supabase/supabase-js');
+  supabaseClient = createClient(url, serviceKey);
+  return supabaseClient;
+}
+
+const BUCKET = 'debug-bundles';
+
+const supabaseBackend = {
+  async uploadBundle(fightId, slot, round, jsonString) {
+    const key = buildKey(fightId, slot, round);
+    const client = getSupabaseClient();
+    const { error } = await client.storage
+      .from(BUCKET)
+      .upload(key, jsonString, {
+        contentType: 'application/json',
+        upsert: true,
+      });
+    if (error) throw new Error(`Supabase upload failed: ${error.message}`);
+  },
+
+  async downloadBundle(fightId, slot, round) {
+    const key = buildKey(fightId, slot, round);
+    const client = getSupabaseClient();
+    const { data, error } = await client.storage.from(BUCKET).download(key);
+    if (error) return null;
+    return await data.text();
+  },
+
+  async deleteBundles(fightId) {
+    const safeFightId = validatePathComponent(fightId, 'fightId');
+    const client = getSupabaseClient();
+    const { data: files } = await client.storage.from(BUCKET).list(safeFightId);
+    if (files && files.length > 0) {
+      const paths = files.map((f) => `${safeFightId}/${f.name}`);
+      await client.storage.from(BUCKET).remove(paths);
+    }
+  },
+
+  async listBundles(fightId) {
+    const safeFightId = validatePathComponent(fightId, 'fightId');
+    const client = getSupabaseClient();
+    const { data: files } = await client.storage.from(BUCKET).list(safeFightId);
+    if (!files) return [];
+    return files
+      .filter((f) => f.name.endsWith('.json'))
+      .map((f) => {
+        const match = f.name.match(/^p(\d+)_round(\d+)\.json$/);
+        if (!match) return null;
+        return {
+          slot: Number.parseInt(match[1], 10),
+          round: Number.parseInt(match[2], 10),
+          key: `${safeFightId}/${f.name}`,
+        };
+      })
+      .filter(Boolean);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export the active backend
+// ---------------------------------------------------------------------------
+
+function getBackend() {
+  const backend = process.env.STORAGE_BACKEND || 'local';
+  if (backend === 'supabase') return supabaseBackend;
+  return localBackend;
+}
+
+export const storage = {
+  uploadBundle: (...args) => getBackend().uploadBundle(...args),
+  downloadBundle: (...args) => getBackend().downloadBundle(...args),
+  deleteBundles: (...args) => getBackend().deleteBundles(...args),
+  listBundles: (...args) => getBackend().listBundles(...args),
+};
+
+export { BUNDLE_TTL_DAYS, validatePathComponent };

--- a/api/admin/debug-bundle.js
+++ b/api/admin/debug-bundle.js
@@ -1,0 +1,23 @@
+import { withAdmin } from '../_lib/handler.js';
+import { storage } from '../_lib/storage.js';
+
+export default withAdmin(async (req, res, { userId, db }) => {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { fightId, slot, round } = req.query || {};
+
+  if (!fightId || slot === undefined || round === undefined) {
+    return res.status(400).json({ error: 'Missing required query params: fightId, slot, round' });
+  }
+
+  const content = await storage.downloadBundle(fightId, slot, round);
+  if (!content) {
+    return res.status(404).json({ error: 'Bundle not found' });
+  }
+
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Content-Disposition', `attachment; filename="debug-${fightId}-p${slot}-r${round}.json"`);
+  return res.status(200).send(content);
+});

--- a/api/admin/fights.js
+++ b/api/admin/fights.js
@@ -1,0 +1,70 @@
+import { withAdmin } from '../_lib/handler.js';
+import { storage } from '../_lib/storage.js';
+
+export default withAdmin(async (req, res, { userId, db }) => {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const page = Math.max(1, parseInt(req.query?.page, 10) || 1);
+  const limit = Math.min(100, Math.max(1, parseInt(req.query?.limit, 10) || 20));
+  const offset = (page - 1) * limit;
+  const hasDebug = req.query?.hasDebug === 'true';
+
+  const whereClause = hasDebug ? 'WHERE f.has_debug_bundle = TRUE' : '';
+
+  // Get total count
+  const countResult = await db.query(
+    `SELECT COUNT(*) FROM fights f ${whereClause}`,
+  );
+  const total = parseInt(countResult.rows[0].count, 10);
+
+  // Get paginated fights with player nicknames
+  const result = await db.query(
+    `SELECT
+      f.id,
+      f.room_id,
+      f.p1_user_id,
+      f.p2_user_id,
+      f.p1_fighter,
+      f.p2_fighter,
+      f.stage_id,
+      f.started_at,
+      f.ended_at,
+      f.winner_slot,
+      f.rounds_p1,
+      f.rounds_p2,
+      f.has_debug_bundle,
+      f.debug_bundle_expires_at,
+      p1.nickname AS p1_nickname,
+      p2.nickname AS p2_nickname
+    FROM fights f
+    LEFT JOIN profiles p1 ON f.p1_user_id = p1.id
+    LEFT JOIN profiles p2 ON f.p2_user_id = p2.id
+    ${whereClause}
+    ORDER BY f.started_at DESC
+    LIMIT $1 OFFSET $2`,
+    [limit, offset],
+  );
+
+  // For fights with debug bundles, list available bundle files
+  const fights = await Promise.all(
+    result.rows.map(async (fight) => {
+      let bundles = [];
+      if (fight.has_debug_bundle) {
+        bundles = await storage.listBundles(fight.id);
+      }
+      return {
+        ...fight,
+        bundles,
+      };
+    }),
+  );
+
+  return res.status(200).json({
+    fights,
+    total,
+    page,
+    limit,
+  });
+});

--- a/api/cron/cleanup-bundles.js
+++ b/api/cron/cleanup-bundles.js
@@ -1,0 +1,73 @@
+import pg from 'pg';
+import { storage } from '../_lib/storage.js';
+
+const { Pool } = pg;
+
+let pool;
+function getPool() {
+  if (!pool) {
+    pool = new Pool({
+      connectionString: process.env.DATABASE_URL,
+      ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: true } : false,
+    });
+  }
+  return pool;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  // Verify Vercel Cron secret
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const auth = req.headers.authorization;
+    if (auth !== `Bearer ${cronSecret}`) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+  }
+
+  const dbPool = getPool();
+  let client;
+  try {
+    client = await dbPool.connect();
+  } catch (err) {
+    console.error('Database connection failed:', err.message);
+    return res.status(500).json({ error: 'Database connection failed' });
+  }
+
+  try {
+    // Find expired fights with debug bundles
+    const result = await client.query(
+      `SELECT id FROM fights
+       WHERE has_debug_bundle = TRUE
+         AND debug_bundle_expires_at < NOW()`,
+    );
+
+    const expiredIds = result.rows.map((r) => r.id);
+
+    if (expiredIds.length === 0) {
+      return res.status(200).json({ deleted: 0 });
+    }
+
+    // Delete storage objects and update DB
+    let deleted = 0;
+    for (const fightId of expiredIds) {
+      try {
+        await storage.deleteBundles(fightId);
+        await client.query(
+          'UPDATE fights SET has_debug_bundle = FALSE WHERE id = $1',
+          [fightId],
+        );
+        deleted++;
+      } catch (err) {
+        console.error(`Failed to cleanup fight ${fightId}:`, err.message);
+      }
+    }
+
+    return res.status(200).json({ deleted, total: expiredIds.length });
+  } finally {
+    if (client) client.release();
+  }
+}

--- a/api/debug-bundles.js
+++ b/api/debug-bundles.js
@@ -1,0 +1,37 @@
+import { withAuth } from './_lib/handler.js';
+import { BUNDLE_TTL_DAYS, storage } from './_lib/storage.js';
+
+export default withAuth(async (req, res, { userId, db }) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { fightId, slot, round, bundle } = req.body;
+
+  if (!fightId || slot === undefined || round === undefined || !bundle) {
+    return res.status(400).json({
+      error: 'Missing required fields: fightId, slot, round, bundle',
+    });
+  }
+
+  // Validate fightId exists
+  const fightResult = await db.query('SELECT id FROM fights WHERE id = $1', [fightId]);
+  if (fightResult.rows.length === 0) {
+    return res.status(404).json({ error: 'Fight not found' });
+  }
+
+  // Upload bundle to storage
+  const jsonString = typeof bundle === 'string' ? bundle : JSON.stringify(bundle);
+  await storage.uploadBundle(fightId, slot, round, jsonString);
+
+  // Update fight record
+  await db.query(
+    `UPDATE fights
+     SET has_debug_bundle = TRUE,
+         debug_bundle_expires_at = COALESCE(debug_bundle_expires_at, NOW() + INTERVAL '${BUNDLE_TTL_DAYS} days')
+     WHERE id = $1`,
+    [fightId],
+  );
+
+  return res.status(201).json({ ok: true });
+});

--- a/api/fights.js
+++ b/api/fights.js
@@ -24,7 +24,7 @@ export default withAuth(async (req, res, { userId, db }) => {
   }
 
   if (req.method === 'PATCH') {
-    const { fightId, p2UserId, winnerSlot, roundsP1, roundsP2 } = req.body;
+    const { fightId, registerP2, winnerSlot, roundsP1, roundsP2 } = req.body;
 
     if (!fightId) {
       return res.status(400).json({ error: 'Missing required field: fightId' });
@@ -35,9 +35,9 @@ export default withAuth(async (req, res, { userId, db }) => {
     const values = [];
     let paramIndex = 1;
 
-    if (p2UserId !== undefined) {
+    if (registerP2) {
       sets.push(`p2_user_id = $${paramIndex++}`);
-      values.push(p2UserId);
+      values.push(userId);
     }
     if (winnerSlot !== undefined) {
       sets.push(`winner_slot = $${paramIndex++}`);

--- a/api/fights.js
+++ b/api/fights.js
@@ -1,0 +1,74 @@
+import { withAuth } from './_lib/handler.js';
+
+export default withAuth(async (req, res, { userId, db }) => {
+  if (req.method === 'POST') {
+    const { fightId, roomId, p1Fighter, p2Fighter, stageId } = req.body;
+
+    if (!fightId || !roomId || !p1Fighter || !p2Fighter || !stageId) {
+      return res.status(400).json({ error: 'Missing required fields: fightId, roomId, p1Fighter, p2Fighter, stageId' });
+    }
+
+    try {
+      await db.query(
+        `INSERT INTO fights (id, room_id, p1_user_id, p1_fighter, p2_fighter, stage_id)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [fightId, roomId, userId, p1Fighter, p2Fighter, stageId],
+      );
+      return res.status(201).json({ id: fightId });
+    } catch (err) {
+      if (err.code === '23505') {
+        return res.status(409).json({ error: 'Fight already exists' });
+      }
+      throw err;
+    }
+  }
+
+  if (req.method === 'PATCH') {
+    const { fightId, p2UserId, winnerSlot, roundsP1, roundsP2 } = req.body;
+
+    if (!fightId) {
+      return res.status(400).json({ error: 'Missing required field: fightId' });
+    }
+
+    // Build dynamic SET clause
+    const sets = [];
+    const values = [];
+    let paramIndex = 1;
+
+    if (p2UserId !== undefined) {
+      sets.push(`p2_user_id = $${paramIndex++}`);
+      values.push(p2UserId);
+    }
+    if (winnerSlot !== undefined) {
+      sets.push(`winner_slot = $${paramIndex++}`);
+      values.push(winnerSlot);
+      sets.push(`ended_at = NOW()`);
+    }
+    if (roundsP1 !== undefined) {
+      sets.push(`rounds_p1 = $${paramIndex++}`);
+      values.push(roundsP1);
+    }
+    if (roundsP2 !== undefined) {
+      sets.push(`rounds_p2 = $${paramIndex++}`);
+      values.push(roundsP2);
+    }
+
+    if (sets.length === 0) {
+      return res.status(400).json({ error: 'No fields to update' });
+    }
+
+    values.push(fightId);
+    const result = await db.query(
+      `UPDATE fights SET ${sets.join(', ')} WHERE id = $${paramIndex} RETURNING id`,
+      values,
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Fight not found' });
+    }
+
+    return res.status(200).json({ id: fightId });
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' });
+});

--- a/db/migrations/20260401000000_create_fights.sql
+++ b/db/migrations/20260401000000_create_fights.sql
@@ -1,0 +1,23 @@
+-- migrate:up
+CREATE TABLE fights (
+    id UUID PRIMARY KEY,
+    room_id TEXT NOT NULL,
+    p1_user_id UUID REFERENCES profiles(id),
+    p2_user_id UUID REFERENCES profiles(id),
+    p1_fighter TEXT NOT NULL,
+    p2_fighter TEXT NOT NULL,
+    stage_id TEXT NOT NULL,
+    started_at TIMESTAMPTZ DEFAULT NOW(),
+    ended_at TIMESTAMPTZ,
+    winner_slot SMALLINT,
+    rounds_p1 SMALLINT DEFAULT 0,
+    rounds_p2 SMALLINT DEFAULT 0,
+    has_debug_bundle BOOLEAN DEFAULT FALSE,
+    debug_bundle_expires_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_fights_started_at ON fights (started_at DESC);
+CREATE INDEX idx_fights_debug ON fights (has_debug_bundle) WHERE has_debug_bundle = TRUE;
+
+-- migrate:down
+DROP TABLE IF EXISTS fights;

--- a/db/migrations/20260401000001_add_is_admin_to_profiles.sql
+++ b/db/migrations/20260401000001_add_is_admin_to_profiles.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+ALTER TABLE profiles ADD COLUMN is_admin BOOLEAN DEFAULT FALSE;
+
+-- migrate:down
+ALTER TABLE profiles DROP COLUMN IF EXISTS is_admin;

--- a/docs/rfcs/0011-auto-upload-debug-bundles.md
+++ b/docs/rfcs/0011-auto-upload-debug-bundles.md
@@ -1,0 +1,200 @@
+# RFC 0011: Auto-Upload Debug Bundles
+
+**Status:** Proposed
+**Date:** 2026-04-01
+**Author:** Architecture Team
+**Predecessor:** [RFC 0005: Multiplayer Debuggability](0005-multiplayer-debuggability.md)
+
+---
+
+## Summary
+
+When debugging multiplayer issues, the current workflow (RFC 0005) requires manual export: tap the overlay, copy to clipboard or download, paste to Slack. This is fragile — if the game crashes mid-match, all debug data is lost. Players must also remember to export before leaving.
+
+This RFC adds automatic, persistent debug bundle uploads. Every online fight gets a unique ID. When debug mode is active, both peers independently upload their debug bundles after each round and at match end to an object storage backend. An admin panel at `/admin/fights` lets authorized users browse fights and download bundles. Bundles expire after 7 days to control costs.
+
+---
+
+## Goals and Non-Goals
+
+### Goals
+- Every online fight gets a unique UUID, generated server-side
+- Authorized users can enable debug mode (`?debug=1`) and bundles upload automatically
+- Per-round uploads so partial data survives crashes
+- Both peers upload independently for resilience
+- Pluggable storage backend: local filesystem (dev) vs Supabase Storage (prod)
+- Admin panel with paginated fight list, debug bundle filter, download links
+- 7-day TTL on debug bundles with automated cleanup
+
+### Non-Goals
+- Uploading bundles for local/AI matches (online only)
+- Real-time streaming of debug data during a match
+- Replay viewer in the admin panel (bundles are downloaded as JSON)
+- Automatic debug mode activation (still requires `?debug=1` or triple-tap)
+
+---
+
+## Architecture
+
+### Fight ID Generation
+
+```mermaid
+sequenceDiagram
+    participant P1 as P1 (Client)
+    participant S as PartyKit Server
+    participant P2 as P2 (Client)
+
+    P1->>S: ready (fighterId)
+    P2->>S: ready (fighterId)
+    Note over S: Both ready → generate fightId (UUID)
+    S->>P1: start { fightId, p1Id, p2Id, stageId }
+    S->>P2: start { fightId, p1Id, p2Id, stageId }
+```
+
+The PartyKit server generates a `crypto.randomUUID()` in `_handleReady()` when `both_ready` fires. Both peers receive the same `fightId` in the `start` message — single source of truth, zero coordination needed.
+
+### Upload Flow
+
+```mermaid
+sequenceDiagram
+    participant P1 as P1 (Client)
+    participant P2 as P2 (Client)
+    participant API as Vercel API
+    participant S as Object Storage
+
+    Note over P1,P2: Round 1 ends (round_ko / round_timeup)
+    P1->>API: POST /api/debug-bundles { fightId, slot:0, round:1, bundle }
+    P2->>API: POST /api/debug-bundles { fightId, slot:1, round:1, bundle }
+    API->>S: Upload p0_round1.json
+    API->>S: Upload p1_round1.json
+
+    Note over P1,P2: Match ends
+    P1->>API: POST /api/debug-bundles { fightId, slot:0, round:0, bundle }
+    P2->>API: POST /api/debug-bundles { fightId, slot:1, round:0, bundle }
+    API->>S: Upload p0_round0.json (full bundle)
+    API->>S: Upload p1_round0.json (full bundle)
+```
+
+Both peers upload independently. If one crashes mid-match, the other's per-round snapshots are still available. `round: 0` is the convention for the final full bundle at match end.
+
+### Storage Interface
+
+```
+api/_lib/storage.js
+├── uploadBundle(fightId, slot, round, jsonString)
+├── downloadBundle(fightId, slot, round) → string | null
+├── deleteBundles(fightId)
+└── listBundles(fightId) → [{slot, round, key}]
+```
+
+Two backends selected by `STORAGE_BACKEND` env var:
+- **`local`**: Writes to `/tmp/debug-bundles/{fightId}/p{slot}_round{round}.json`. For development.
+- **`supabase`**: Uses `@supabase/supabase-js` with `SUPABASE_SERVICE_ROLE_KEY` to upload to a `debug-bundles` bucket.
+
+### Database Schema
+
+**New `fights` table:**
+
+```sql
+CREATE TABLE fights (
+    id UUID PRIMARY KEY,                        -- fightId from PartyKit
+    room_id TEXT NOT NULL,
+    p1_user_id UUID REFERENCES profiles(id),
+    p2_user_id UUID REFERENCES profiles(id),
+    p1_fighter TEXT NOT NULL,
+    p2_fighter TEXT NOT NULL,
+    stage_id TEXT NOT NULL,
+    started_at TIMESTAMPTZ DEFAULT NOW(),
+    ended_at TIMESTAMPTZ,
+    winner_slot SMALLINT,                       -- 0 or 1, NULL if incomplete
+    rounds_p1 SMALLINT DEFAULT 0,
+    rounds_p2 SMALLINT DEFAULT 0,
+    has_debug_bundle BOOLEAN DEFAULT FALSE,
+    debug_bundle_expires_at TIMESTAMPTZ
+);
+```
+
+**New `is_admin` column on `profiles`:**
+
+```sql
+ALTER TABLE profiles ADD COLUMN is_admin BOOLEAN DEFAULT FALSE;
+```
+
+### Admin Panel
+
+Preact + HTM SPA at `/admin/`, loaded from CDN (no build step). Auth via existing Supabase JS client.
+
+**`/admin/fights`** page:
+- Table: Date, P1, P2, Stage, Winner, Rounds, Debug Bundle links
+- Filter: "Solo con debug bundle" checkbox
+- Pagination: prev/next, sorted by `started_at DESC`
+- Download links per peer per round
+
+### API Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/fights` | User | Create fight record (P1 at match start) |
+| PATCH | `/api/fights` | User | Update fight (P2 registers, match result) |
+| POST | `/api/debug-bundles` | User | Upload a debug bundle |
+| GET | `/api/admin/fights` | Admin | Paginated fight list |
+| GET | `/api/admin/debug-bundle` | Admin | Download a bundle |
+| GET | `/api/cron/cleanup-bundles` | Cron | Delete expired bundles |
+
+### TTL Cleanup
+
+Vercel Cron runs daily at 3 AM UTC. Queries for fights where `has_debug_bundle = TRUE AND debug_bundle_expires_at < NOW()`, deletes storage objects, clears the flag.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Fight ID + Database Schema
+- Database migrations (`fights` table, `is_admin` column)
+- fightId generation in `party/server.js` `_handleReady()`
+- Client-side propagation through scene chain to `FightRecorder`
+
+### Phase 2: Storage Interface + Upload API
+- Storage interface with local/supabase backends (`api/_lib/storage.js`)
+- Upload endpoint (`api/debug-bundles.js`)
+- Fight CRUD endpoint (`api/fights.js`)
+- `withAdmin()` middleware (`api/_lib/handler.js`)
+
+### Phase 3: Client-Side Auto-Upload
+- Per-round upload in `FightScene.js` on `roundEvent`
+- `DebugBundleExporter.uploadBundle()` helper
+- Fight record creation at match start
+
+### Phase 4: Admin Panel
+- Admin API endpoints (`api/admin/fights.js`, `api/admin/debug-bundle.js`)
+- Preact SPA (`public/admin/`)
+
+### Phase 5: TTL Cleanup
+- Cron endpoint (`api/cron/cleanup-bundles.js`)
+- `vercel.json` cron configuration
+
+---
+
+## Test Plan
+
+Every new module gets its own test file following existing Vitest patterns.
+
+### Phase 1
+- **`tests/party/server-fight-id.test.js`**: fightId generated on both_ready, included in start message, cleared on leave/disconnect, valid UUID format
+- **`tests/systems/fight-recorder-fight-id.test.js`**: fightId stored in log, backward-compatible when omitted
+
+### Phase 2
+- **`tests/api/storage.test.js`**: upload/download/delete/list operations, path traversal prevention
+- **`tests/api/debug-bundles.test.js`**: POST validation, storage calls, has_debug_bundle flag update, auth checks
+- **`tests/api/fights.test.js`**: POST creates record, PATCH updates fields, duplicate/missing fightId handling, auth
+- **`tests/api/handler-admin.test.js`**: is_admin check, 403 on non-admin, JWT verification inherited
+
+### Phase 3
+- **`tests/systems/debug-bundle-upload.test.js`**: correct API call, fire-and-forget on failure, no upload in guest mode
+
+### Phase 4
+- **`tests/api/admin/fights.test.js`**: pagination, hasDebug filter, nickname JOIN, total count, admin-only
+- **`tests/api/admin/debug-bundle.test.js`**: bundle download, 404/403/400 cases
+
+### Phase 5
+- **`tests/api/cron/cleanup-bundles.test.js`**: deletes expired, skips non-expired, handles empty set, CRON_SECRET auth

--- a/docs/rfcs/0012-e2e-bot-user.md
+++ b/docs/rfcs/0012-e2e-bot-user.md
@@ -1,0 +1,171 @@
+# RFC 0012: E2E Bot User for Debug Bundle Uploads
+
+**Status:** Proposed
+**Date:** 2026-04-02
+**Author:** Architecture Team
+**Predecessor:** [RFC 0011: Auto-Upload Debug Bundles](0011-auto-upload-debug-bundles.md)
+
+---
+
+## Summary
+
+RFC 0011 added automatic debug bundle uploads gated by `withAuth()` (Supabase JWT). Remote E2E tests run on BrowserStack against deployed staging with `?autoplay=1&debug=1` but have no logged-in user — API calls for debug data persistence will 401.
+
+This RFC introduces a **Supabase bot user** as a first-class citizen in the auth system. The E2E test harness signs in as the bot to get a real Supabase-issued JWT, then passes it to the remote browser. The backend requires zero changes — `withAuth()` verifies it like any other JWT.
+
+For real users, debug UI (`?debug=1`) always works. Uploads only happen when the user is logged in normally.
+
+---
+
+## Goals and Non-Goals
+
+### Goals
+- E2E tests can upload debug bundles to deployed staging
+- Bot user is a real Supabase Auth user with a profile row
+- Supabase remains the sole JWT issuer — we never sign our own tokens
+- Zero backend changes — existing `withAuth()` handles it
+
+### Non-Goals
+- Custom token signing or service account mechanisms
+- Gating `?debug=1` UI activation (overlay/logger are harmless)
+- Cleaning up the legacy HS256 path (separate concern)
+
+---
+
+## Architecture
+
+### Auth Flow for E2E Tests
+
+```mermaid
+sequenceDiagram
+    participant TH as Test Harness (Node.js)
+    participant SB as Supabase Auth
+    participant BS as BrowserStack Browser
+    participant API as Vercel API
+
+    TH->>SB: signInWithPassword(bot email, bot password)
+    SB-->>TH: { access_token (JWT, 1h expiry) }
+    TH->>BS: Navigate to game URL with ?authToken=<jwt>
+    Note over BS: BootScene reads ?authToken, stores on game object
+    BS->>API: POST /api/debug-bundles { Authorization: Bearer <jwt> }
+    Note over API: withAuth() verifies JWT via JWKS (asymmetric)
+    API-->>BS: 201 OK
+```
+
+### Auth Fallback Chain in `apiFetch()`
+
+```
+1. Supabase session JWT (normal logged-in user)
+2. Injected authToken from URL param (E2E bot)
+3. X-Dev-User-Id header (local dev bypass, non-production only)
+```
+
+---
+
+## Bot User Setup (One-Time, Manual)
+
+1. Create user in Supabase dashboard: `e2e-bot@a-los-traques.com`
+2. Note the user's UUID
+3. Create a profile row:
+   ```sql
+   INSERT INTO profiles (id, nickname) VALUES ('<bot-uuid>', 'E2E Bot');
+   ```
+4. Add env vars to CI/CD and BrowserStack:
+   - `E2E_BOT_EMAIL` — `e2e-bot@a-los-traques.com`
+   - `E2E_BOT_PASSWORD` — secure password
+
+---
+
+## Implementation
+
+### `tests/e2e/remote/remote-helpers.js` — Bot auth helper
+
+```js
+import { createClient } from '@supabase/supabase-js';
+
+export async function getE2EBotToken() {
+  const email = process.env.E2E_BOT_EMAIL;
+  const password = process.env.E2E_BOT_PASSWORD;
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+
+  if (!email || !password || !supabaseUrl || !supabaseKey) return null;
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) throw new Error(`E2E bot login failed: ${error.message}`);
+  return data.session.access_token;
+}
+```
+
+URL builders get an `authToken` option:
+```js
+if (opts.authToken) params.set('authToken', opts.authToken);
+```
+
+### `src/scenes/BootScene.js` — Read `?authToken` from URL
+
+```js
+const authToken = params.get('authToken');
+if (authToken) {
+  this.game.authToken = authToken;
+}
+```
+
+### `src/services/api.js` — Use injected authToken as fallback
+
+```js
+if (token) {
+  headers.Authorization = `Bearer ${token}`;
+}
+// Injected auth token (E2E bot or external auth)
+else if (window.game?.authToken) {
+  headers.Authorization = `Bearer ${window.game.authToken}`;
+}
+// Local development bypass
+else if (import.meta.env.DEV && !token) {
+  headers['X-Dev-User-Id'] = '00000000-0000-0000-0000-000000000000';
+}
+```
+
+### Backend — No changes
+
+`withAuth()` already verifies Supabase JWTs via JWKS (asymmetric path). The bot's JWT is indistinguishable from any user's JWT.
+
+### `api/fights.js` — No changes
+
+Bot userId is a real UUID with a profile row. FK constraints satisfied.
+
+---
+
+## Security
+
+| Concern | Mitigation |
+|---------|------------|
+| Token in URL | Lives only in BrowserStack session logs (private). 1-hour expiry. |
+| Bot credentials | Stored as CI/CD secrets, never in code |
+| Bot permissions | Same as any user — can create fights and upload bundles. No admin access. |
+| Token reuse | Supabase JWT has 1-hour default expiry (configurable). E2E tests run in minutes. |
+
+---
+
+## Test Plan
+
+### `tests/e2e/remote/remote-helpers.test.js` (new)
+- `getE2EBotToken()` calls `signInWithPassword` with env var credentials
+- Returns `access_token` string on success
+- Returns `null` when env vars are missing
+- Throws on auth failure (wrong password, etc.)
+
+### Update: `tests/systems/debug-bundle-upload.test.js`
+- Verify upload works when `window.game.authToken` is set (no Supabase session)
+
+### Existing tests — No changes needed
+- `withAuth()` JWT verification already tested
+- Fight and debug-bundle endpoints accept any valid userId
+
+### Manual verification
+1. Create bot user in Supabase dashboard
+2. Run remote E2E: `bun run test:e2e:remote`
+3. Verify debug bundles appear in storage
+4. Verify fight records have bot's userId as `p1_user_id`

--- a/party/server.js
+++ b/party/server.js
@@ -11,6 +11,7 @@ const RoomState = {
   SELECTING: 'selecting',
   READY_CHECK: 'ready_check',
   STAGE_SELECT: 'stage_select',
+  CREATING_FIGHT: 'creating_fight',
   FIGHTING: 'fighting',
   RECONNECTING: 'reconnecting',
 };
@@ -38,7 +39,12 @@ const ROOM_TRANSITIONS = {
     ws_close: RoomState.RECONNECTING,
   },
   [RoomState.STAGE_SELECT]: {
-    stage_chosen: RoomState.FIGHTING,
+    stage_chosen: RoomState.CREATING_FIGHT,
+    ws_close: RoomState.RECONNECTING,
+    leave: RoomState.SELECTING,
+  },
+  [RoomState.CREATING_FIGHT]: {
+    fight_created: RoomState.FIGHTING,
     ws_close: RoomState.RECONNECTING,
     leave: RoomState.SELECTING,
   },
@@ -48,6 +54,7 @@ const ROOM_TRANSITIONS = {
   },
   [RoomState.RECONNECTING]: {
     rejoin_fighting: RoomState.FIGHTING,
+    rejoin_creating_fight: RoomState.CREATING_FIGHT,
     rejoin_selecting: RoomState.SELECTING,
     rejoin_ready_check: RoomState.READY_CHECK,
     rejoin_stage_select: RoomState.STAGE_SELECT,
@@ -323,6 +330,23 @@ export default class FightRoom {
       case 'select_stage':
         this._handleStageSelect(slot, data);
         break;
+      case 'fight_created':
+        // Only P1 (slot 0) can confirm fight creation
+        if (slot !== 0) break;
+        if (this._transition('fight_created')) {
+          this._broadcast({
+            type: 'start',
+            fightId: this.fightInfo.fightId,
+            p1Id: this.fightInfo.p1Id,
+            p2Id: this.fightInfo.p2Id,
+            stageId: this.fightInfo.stageId,
+            isRandomStage: this.fightInfo.isRandomStage,
+          });
+        }
+        break;
+      case 'fight_confirmed':
+        this._sendToOther(slot, data);
+        break;
       case 'debug_request':
       case 'debug_response':
         this._sendToOther(slot, data);
@@ -362,14 +386,18 @@ export default class FightRoom {
     if (slot !== 0) return; // Only Player 1 can select stage
 
     if (this._transition('stage_chosen')) {
+      const fightId = crypto.randomUUID();
       this.fightInfo = {
+        fightId,
         p1Id: this.players[0].fighterId,
         p2Id: this.players[1].fighterId,
         stageId: data.stageId,
         isRandomStage: data.isRandomStage || false,
       };
-      this._broadcast({
-        type: 'start',
+      // Send create_fight to P1 only — P1 creates the DB record, then sends fight_created
+      this._sendToHost({
+        type: 'create_fight',
+        fightId,
         p1Id: this.players[0].fighterId,
         p2Id: this.players[1].fighterId,
         stageId: data.stageId,
@@ -445,6 +473,10 @@ export default class FightRoom {
       this._stateBeforeGrace = null;
       if (prevState === RoomState.FIGHTING) {
         this._transition('rejoin_fighting');
+      } else if (prevState === RoomState.CREATING_FIGHT) {
+        this._transition('rejoin_creating_fight');
+      } else if (prevState === RoomState.STAGE_SELECT) {
+        this._transition('rejoin_stage_select');
       } else if (prevState === RoomState.READY_CHECK) {
         this._transition('rejoin_ready_check');
       } else {
@@ -525,7 +557,9 @@ export default class FightRoom {
 
   _finalizeDisconnect(slot) {
     this._log({ type: 'grace_expired', slot, stateBeforeGrace: this._stateBeforeGrace });
-    const wasFighting = this._stateBeforeGrace === RoomState.FIGHTING;
+    const wasFighting =
+      this._stateBeforeGrace === RoomState.FIGHTING ||
+      this._stateBeforeGrace === RoomState.CREATING_FIGHT;
     this.players[slot] = null;
 
     if (wasFighting) {

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -1,0 +1,159 @@
+import { h, render } from 'https://esm.sh/preact@10.25.4';
+import { useEffect, useState } from 'https://esm.sh/preact@10.25.4/hooks';
+import htm from 'https://esm.sh/htm@3.1.1';
+import { FightsPage } from './pages/fights.js';
+
+const html = htm.bind(h);
+
+// ---------------------------------------------------------------------------
+// Auth helpers
+// ---------------------------------------------------------------------------
+
+let supabaseClient = null;
+
+async function getSupabase() {
+  if (supabaseClient) return supabaseClient;
+  const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2.101.1');
+
+  // Read Supabase config from the main app's env (injected by Vite)
+  // In production, these are baked into the main bundle. For admin, we read from meta tag or fallback.
+  const url = document.querySelector('meta[name="supabase-url"]')?.content
+    || window.__SUPABASE_URL
+    || '';
+  const key = document.querySelector('meta[name="supabase-anon-key"]')?.content
+    || window.__SUPABASE_ANON_KEY
+    || '';
+
+  if (!url || !key) {
+    // Dev mode: no auth needed, use dev bypass
+    return null;
+  }
+
+  supabaseClient = createClient(url, key);
+  return supabaseClient;
+}
+
+async function getAuthHeaders() {
+  const sb = await getSupabase();
+  if (!sb) {
+    // Dev mode bypass
+    return { 'X-Dev-User-Id': '00000000-0000-0000-0000-000000000000' };
+  }
+  const { data: { session } } = await sb.auth.getSession();
+  if (!session) return null;
+  return { Authorization: `Bearer ${session.access_token}` };
+}
+
+async function apiFetch(endpoint, options = {}) {
+  const authHeaders = await getAuthHeaders();
+  if (!authHeaders) throw new Error('Not authenticated');
+
+  const response = await fetch(`/api${endpoint}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders,
+      ...(options.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || `Request failed: ${response.status}`);
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (contentType?.includes('application/json')) {
+    return response.json();
+  }
+  return response;
+}
+
+// ---------------------------------------------------------------------------
+// App Component
+// ---------------------------------------------------------------------------
+
+function App() {
+  const [authed, setAuthed] = useState(null); // null = loading, true/false
+  const [error, setError] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  useEffect(() => {
+    checkAuth();
+  }, []);
+
+  async function checkAuth() {
+    const sb = await getSupabase();
+    if (!sb) {
+      // Dev mode: skip auth
+      setAuthed(true);
+      return;
+    }
+    const { data: { session } } = await sb.auth.getSession();
+    if (session) {
+      // Verify admin access
+      try {
+        await apiFetch('/admin/fights?page=1&limit=1');
+        setAuthed(true);
+      } catch {
+        setError('No tienes acceso de administrador');
+        setAuthed(false);
+      }
+    } else {
+      setAuthed(false);
+    }
+  }
+
+  async function handleLogin(e) {
+    e.preventDefault();
+    setError('');
+    const sb = await getSupabase();
+    if (!sb) return;
+
+    const { error: authError } = await sb.auth.signInWithPassword({ email, password });
+    if (authError) {
+      setError(authError.message);
+      return;
+    }
+    await checkAuth();
+  }
+
+  if (authed === null) {
+    return html`<div class="loading">Cargando...</div>`;
+  }
+
+  if (!authed) {
+    return html`
+      <div class="login-form">
+        <h2>Admin - Iniciar Sesión</h2>
+        <form onSubmit=${handleLogin}>
+          <input
+            type="email"
+            placeholder="Email"
+            value=${email}
+            onInput=${(e) => setEmail(e.target.value)}
+          />
+          <input
+            type="password"
+            placeholder="Contraseña"
+            value=${password}
+            onInput=${(e) => setPassword(e.target.value)}
+          />
+          <button type="submit">Entrar</button>
+          ${error && html`<div class="error">${error}</div>`}
+        </form>
+      </div>
+    `;
+  }
+
+  return html`
+    <nav>
+      <h1>A Los Traques Admin</h1>
+      <a href="/admin/" class="active">Peleas</a>
+    </nav>
+    <${FightsPage} apiFetch=${apiFetch} />
+  `;
+}
+
+render(html`<${App} />`, document.getElementById('app'));

--- a/public/admin/components/pagination.js
+++ b/public/admin/components/pagination.js
@@ -1,0 +1,26 @@
+import { h } from 'https://esm.sh/preact@10.25.4';
+import htm from 'https://esm.sh/htm@3.1.1';
+
+const html = htm.bind(h);
+
+export function Pagination({ page, totalPages, onPageChange }) {
+  return html`
+    <div class="pagination">
+      <button
+        disabled=${page <= 1}
+        onClick=${() => onPageChange(page - 1)}
+      >
+        Anterior
+      </button>
+      <span style="font-size: 13px; color: #888">
+        Página ${page} de ${totalPages}
+      </span>
+      <button
+        disabled=${page >= totalPages}
+        onClick=${() => onPageChange(page + 1)}
+      >
+        Siguiente
+      </button>
+    </div>
+  `;
+}

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>A Los Traques - Admin</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      min-height: 100vh;
+    }
+    #app { max-width: 1200px; margin: 0 auto; padding: 20px; }
+    nav {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      padding: 16px 0;
+      border-bottom: 1px solid #333;
+      margin-bottom: 24px;
+    }
+    nav h1 { font-size: 18px; color: #ffd700; }
+    nav a { color: #aaa; text-decoration: none; font-size: 14px; }
+    nav a:hover, nav a.active { color: #fff; }
+    .login-form {
+      max-width: 400px;
+      margin: 100px auto;
+      padding: 32px;
+      background: #16213e;
+      border-radius: 8px;
+    }
+    .login-form h2 { margin-bottom: 16px; color: #ffd700; }
+    .login-form input {
+      width: 100%;
+      padding: 10px;
+      margin-bottom: 12px;
+      background: #1a1a2e;
+      border: 1px solid #333;
+      border-radius: 4px;
+      color: #fff;
+      font-size: 14px;
+    }
+    .login-form button, .btn {
+      padding: 10px 20px;
+      background: #ffd700;
+      color: #1a1a2e;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-weight: bold;
+      font-size: 14px;
+    }
+    .login-form button:hover, .btn:hover { background: #ffed4a; }
+    .error { color: #ff6b6b; font-size: 13px; margin-top: 8px; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    th, td {
+      padding: 10px 12px;
+      text-align: left;
+      border-bottom: 1px solid #2a2a3e;
+    }
+    th { color: #ffd700; font-size: 12px; text-transform: uppercase; }
+    tr:hover { background: #16213e; }
+    .pagination {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 16px;
+      margin-top: 20px;
+    }
+    .pagination button {
+      padding: 8px 16px;
+      background: #333;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .pagination button:disabled { opacity: 0.4; cursor: not-allowed; }
+    .filters {
+      display: flex;
+      gap: 16px;
+      align-items: center;
+      margin-bottom: 16px;
+    }
+    .filters label { font-size: 13px; cursor: pointer; }
+    .bundle-link {
+      color: #4ecdc4;
+      text-decoration: none;
+      font-size: 12px;
+    }
+    .bundle-link:hover { text-decoration: underline; }
+    .badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 10px;
+      font-size: 11px;
+      font-weight: bold;
+    }
+    .badge-debug { background: #4ecdc4; color: #1a1a2e; }
+    .badge-none { background: #444; color: #888; }
+    .loading { text-align: center; padding: 40px; color: #888; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/public/admin/pages/fights.js
+++ b/public/admin/pages/fights.js
@@ -1,0 +1,160 @@
+import { h } from 'https://esm.sh/preact@10.25.4';
+import { useEffect, useState } from 'https://esm.sh/preact@10.25.4/hooks';
+import htm from 'https://esm.sh/htm@3.1.1';
+import { Pagination } from '../components/pagination.js';
+
+const html = htm.bind(h);
+
+function formatDate(dateStr) {
+  if (!dateStr) return '-';
+  const d = new Date(dateStr);
+  return d.toLocaleDateString('es-CL', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function BundleLinks({ fight, apiFetch }) {
+  if (!fight.has_debug_bundle || !fight.bundles?.length) {
+    return html`<span class="badge badge-none">-</span>`;
+  }
+
+  return html`
+    <div>
+      ${fight.bundles.map(
+        (b) => html`
+          <a
+            class="bundle-link"
+            href="/api/admin/debug-bundle?fightId=${fight.id}&slot=${b.slot}&round=${b.round}"
+            target="_blank"
+            title="P${b.slot} R${b.round === 0 ? 'Final' : b.round}"
+          >
+            P${b.slot}${b.round === 0 ? ' Final' : ` R${b.round}`}
+          </a>${' '}
+        `,
+      )}
+    </div>
+  `;
+}
+
+export function FightsPage({ apiFetch }) {
+  const [fights, setFights] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [hasDebug, setHasDebug] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    loadFights();
+  }, [page, hasDebug]);
+
+  async function loadFights() {
+    setLoading(true);
+    setError('');
+    try {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        limit: limit.toString(),
+      });
+      if (hasDebug) params.set('hasDebug', 'true');
+
+      const data = await apiFetch(`/admin/fights?${params}`);
+      setFights(data.fights);
+      setTotal(data.total);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const totalPages = Math.ceil(total / limit);
+
+  if (loading && fights.length === 0) {
+    return html`<div class="loading">Cargando peleas...</div>`;
+  }
+
+  return html`
+    <div>
+      <div class="filters">
+        <label>
+          <input
+            type="checkbox"
+            checked=${hasDebug}
+            onChange=${(e) => {
+              setHasDebug(e.target.checked);
+              setPage(1);
+            }}
+          />
+          ${' '}Solo con debug bundle
+        </label>
+        <span style="color: #888; font-size: 12px">${total} peleas</span>
+      </div>
+
+      ${error && html`<div class="error">${error}</div>`}
+
+      <table>
+        <thead>
+          <tr>
+            <th>Fecha</th>
+            <th>P1</th>
+            <th>P2</th>
+            <th>Escenario</th>
+            <th>Ganador</th>
+            <th>Rounds</th>
+            <th>Debug</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${fights.map(
+            (fight) => html`
+              <tr>
+                <td>${formatDate(fight.started_at)}</td>
+                <td>
+                  ${fight.p1_nickname || 'Anónimo'}
+                  <span style="color: #888; font-size: 11px"> (${fight.p1_fighter})</span>
+                </td>
+                <td>
+                  ${fight.p2_nickname || 'Anónimo'}
+                  <span style="color: #888; font-size: 11px"> (${fight.p2_fighter})</span>
+                </td>
+                <td>${fight.stage_id}</td>
+                <td>
+                  ${fight.winner_slot != null
+                    ? fight.winner_slot === 0
+                      ? fight.p1_nickname || 'P1'
+                      : fight.p2_nickname || 'P2'
+                    : '-'}
+                </td>
+                <td>${fight.rounds_p1} - ${fight.rounds_p2}</td>
+                <td>
+                  <${BundleLinks} fight=${fight} apiFetch=${apiFetch} />
+                </td>
+              </tr>
+            `,
+          )}
+          ${fights.length === 0 &&
+          html`
+            <tr>
+              <td colspan="7" style="text-align: center; color: #888; padding: 40px">
+                No se encontraron peleas
+              </td>
+            </tr>
+          `}
+        </tbody>
+      </table>
+
+      ${totalPages > 1 &&
+      html`<${Pagination}
+        page=${page}
+        totalPages=${totalPages}
+        onPageChange=${setPage}
+      />`}
+    </div>
+  `;
+}

--- a/public/admin/pages/fights.js
+++ b/public/admin/pages/fights.js
@@ -30,9 +30,9 @@ function BundleLinks({ fight, apiFetch }) {
             class="bundle-link"
             href="/api/admin/debug-bundle?fightId=${fight.id}&slot=${b.slot}&round=${b.round}"
             target="_blank"
-            title="P${b.slot + 1} R${b.round === 0 ? 'Final' : b.round}"
+            title="P${b.slot} R${b.round === 0 ? 'Final' : b.round}"
           >
-            P${b.slot + 1}${b.round === 0 ? ' Final' : ` R${b.round}`}
+            P${b.slot}${b.round === 0 ? ' Final' : ` R${b.round}`}
           </a>${' '}
         `,
       )}

--- a/public/admin/pages/fights.js
+++ b/public/admin/pages/fights.js
@@ -30,9 +30,9 @@ function BundleLinks({ fight, apiFetch }) {
             class="bundle-link"
             href="/api/admin/debug-bundle?fightId=${fight.id}&slot=${b.slot}&round=${b.round}"
             target="_blank"
-            title="P${b.slot} R${b.round === 0 ? 'Final' : b.round}"
+            title="P${b.slot + 1} R${b.round === 0 ? 'Final' : b.round}"
           >
-            P${b.slot}${b.round === 0 ? ' Final' : ` R${b.round}`}
+            P${b.slot + 1}${b.round === 0 ? ' Final' : ` R${b.round}`}
           </a>${' '}
         `,
       )}

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -85,6 +85,7 @@ export class FightScene extends Phaser.Scene {
       this.p2Id = fightersData[data && data.p2 != null ? data.p2 : 1].id;
     }
     this.stageId = data && (data.stageId || data.stage) ? data.stageId || data.stage : null;
+    this.fightId = data?.fightId || null;
     this.aiDifficulty = data?.difficulty ? data.difficulty : 'medium';
     this.gameMode = data?.gameMode || 'local';
     this.networkManager = data?.networkManager || null;
@@ -268,6 +269,7 @@ export class FightScene extends Phaser.Scene {
       const nm = this.networkManager;
       const slot = nm.getPlayerSlot();
       this.recorder = new FightRecorder({
+        fightId: this.fightId,
         roomId: nm.roomId,
         playerSlot: slot,
         fighterId: slot === 0 ? this.p1Id : this.p2Id,
@@ -976,6 +978,7 @@ export class FightScene extends Phaser.Scene {
     // Fight recorder for E2E testing and debug mode
     if (this.game.autoplay?.enabled || this.game.debugMode) {
       this.recorder = new FightRecorder({
+        fightId: this.fightId,
         roomId: nm.roomId,
         playerSlot: slot,
         fighterId: slot === 0 ? this.p1Id : this.p2Id,
@@ -1013,6 +1016,26 @@ export class FightScene extends Phaser.Scene {
     // Wire transport changes to telemetry
     nm.onTransportDegraded(() => this.telemetry.recordTransportChange('websocket'));
     nm.onTransportRestored(() => this.telemetry.recordTransportChange('webrtc'));
+
+    // Create fight record in DB (fire-and-forget, debug mode only)
+    if (this.game.debugMode && this.fightId) {
+      import('../services/api.js').then(({ createFight, updateFight }) => {
+        if (this.isHost) {
+          createFight({
+            fightId: this.fightId,
+            roomId: nm.roomId,
+            p1Fighter: this.p1Id,
+            p2Fighter: this.p2Id,
+            stageId: this.stageId,
+          }).catch((err) => log.warn('Failed to create fight record', { err: err.message }));
+        } else {
+          // P2 registers their user ID
+          updateFight({ fightId: this.fightId, p2UserId: undefined }).catch((err) =>
+            log.warn('Failed to register P2', { err: err.message }),
+          );
+        }
+      });
+    }
 
     // Debug overlay (only in debug mode)
     if (this.game.debugMode) {
@@ -1547,15 +1570,41 @@ export class FightScene extends Phaser.Scene {
         // Expose v2 debug bundle on window for remote E2E extraction
         if (this.game.debugMode && this.recorder) {
           import('../systems/DebugBundleExporter.js').then(({ DebugBundleExporter }) => {
-            window.__DEBUG_BUNDLE = DebugBundleExporter.generateBundle({
+            const bundle = DebugBundleExporter.generateBundle({
               recorder: this.recorder,
               telemetry: this.telemetry,
               matchState: this.matchState,
               sessionId: this.networkManager?.sessionId,
               debugMode: true,
             });
+            window.__DEBUG_BUNDLE = bundle;
+
+            // Auto-upload final bundle (round 0 = match end)
+            DebugBundleExporter.uploadBundle({
+              fightId: this.fightId,
+              slot: this.networkManager?.getPlayerSlot(),
+              round: 0,
+              bundle,
+            });
           });
         }
+      } else if (this.game.debugMode && this.recorder) {
+        // Per-round upload: snapshot after each round
+        import('../systems/DebugBundleExporter.js').then(({ DebugBundleExporter }) => {
+          const bundle = DebugBundleExporter.generateBundle({
+            recorder: this.recorder,
+            telemetry: this.telemetry,
+            matchState: this.matchState,
+            sessionId: this.networkManager?.sessionId,
+            debugMode: true,
+          });
+          DebugBundleExporter.uploadBundle({
+            fightId: this.fightId,
+            slot: this.networkManager?.getPlayerSlot(),
+            round: this.combat.roundNumber - 1,
+            bundle,
+          });
+        });
       }
     }
 

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -1017,26 +1017,6 @@ export class FightScene extends Phaser.Scene {
     nm.onTransportDegraded(() => this.telemetry.recordTransportChange('websocket'));
     nm.onTransportRestored(() => this.telemetry.recordTransportChange('webrtc'));
 
-    // Create fight record in DB (fire-and-forget, debug mode only)
-    if (this.game.debugMode && this.fightId) {
-      import('../services/api.js').then(({ createFight, updateFight }) => {
-        if (this.isHost) {
-          createFight({
-            fightId: this.fightId,
-            roomId: nm.roomId,
-            p1Fighter: this.p1Id,
-            p2Fighter: this.p2Id,
-            stageId: this.stageId,
-          }).catch((err) => log.warn('Failed to create fight record', { err: err.message }));
-        } else {
-          // P2 registers their user ID
-          updateFight({ fightId: this.fightId, p2UserId: undefined }).catch((err) =>
-            log.warn('Failed to register P2', { err: err.message }),
-          );
-        }
-      });
-    }
-
     // Debug overlay (only in debug mode)
     if (this.game.debugMode) {
       import('../systems/DebugOverlay.js').then(({ DebugOverlay }) => {

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -1546,30 +1546,10 @@ export class FightScene extends Phaser.Scene {
           this.combat,
           this.rollbackManager.currentFrame,
         );
+      }
 
-        // Expose v2 debug bundle on window for remote E2E extraction
-        if (this.game.debugMode && this.recorder) {
-          import('../systems/DebugBundleExporter.js').then(({ DebugBundleExporter }) => {
-            const bundle = DebugBundleExporter.generateBundle({
-              recorder: this.recorder,
-              telemetry: this.telemetry,
-              matchState: this.matchState,
-              sessionId: this.networkManager?.sessionId,
-              debugMode: true,
-            });
-            window.__DEBUG_BUNDLE = bundle;
-
-            // Auto-upload final bundle (round 0 = match end)
-            DebugBundleExporter.uploadBundle({
-              fightId: this.fightId,
-              slot: this.networkManager?.getPlayerSlot(),
-              round: 0,
-              bundle,
-            });
-          });
-        }
-      } else if (this.game.debugMode && this.recorder) {
-        // Per-round upload: snapshot after each round
+      // Upload debug bundle after every round (including final)
+      if (this.game.debugMode && this.recorder) {
         import('../systems/DebugBundleExporter.js').then(({ DebugBundleExporter }) => {
           const bundle = DebugBundleExporter.generateBundle({
             recorder: this.recorder,
@@ -1578,6 +1558,11 @@ export class FightScene extends Phaser.Scene {
             sessionId: this.networkManager?.sessionId,
             debugMode: true,
           });
+
+          if (roundEvent.matchOver) {
+            window.__DEBUG_BUNDLE = bundle;
+          }
+
           DebugBundleExporter.uploadBundle({
             fightId: this.fightId,
             slot: this.networkManager?.getPlayerSlot(),

--- a/src/scenes/PreFightScene.js
+++ b/src/scenes/PreFightScene.js
@@ -12,6 +12,7 @@ export class PreFightScene extends Phaser.Scene {
     this.p1Id = data.p1Id;
     this.p2Id = data.p2Id;
     this.stageId = data.stageId;
+    this.fightId = data.fightId || null;
     this.isRandomStage = data.isRandomStage || false;
     this.gameMode = data.gameMode || 'local';
     this.networkManager = data.networkManager || null;
@@ -313,6 +314,7 @@ export class PreFightScene extends Phaser.Scene {
         p1Id: this.p1Id,
         p2Id: this.p2Id,
         stageId: this.stageId,
+        fightId: this.fightId,
         gameMode: this.gameMode,
         networkManager: this.networkManager,
         matchContext: this.matchContext,

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -758,8 +758,6 @@ export class SelectScene extends Phaser.Scene {
     if (this.gameMode === 'online' && this._startData) {
       p1Id = this._startData.p1Id;
       p2Id = this._startData.p2Id;
-      // If we already have a stageId (e.g. from server), we could skip to PreFight
-      // but let's follow the new flow.
     } else {
       p1Id = this.fighters[this.p1Index].id;
       p2Id = this.fighters[this.p2Index].id;

--- a/src/scenes/StageSelectScene.js
+++ b/src/scenes/StageSelectScene.js
@@ -181,7 +181,39 @@ export class StageSelectScene extends Phaser.Scene {
     }
 
     if (this.gameMode === 'online' && this.networkManager) {
+      // P1: Listen for create_fight signal — create fight record, then confirm
+      this.networkManager.signaling.on('create_fight', (data) => {
+        this.headerText?.setText('CREANDO PELEA...');
+        import('../services/api.js').then(({ createFight }) => {
+          createFight({
+            fightId: data.fightId,
+            roomId: this.networkManager.roomId,
+            p1Fighter: data.p1Id,
+            p2Fighter: data.p2Id,
+            stageId: data.stageId,
+          })
+            .then(() => {
+              this.networkManager.signaling.send({ type: 'fight_created' });
+            })
+            .catch((err) => {
+              // Still send fight_created to unblock the match even if DB fails
+              console.warn('Fight creation failed, continuing anyway:', err.message);
+              this.networkManager.signaling.send({ type: 'fight_created' });
+            });
+        });
+      });
+
+      // Listen for start signal (sent by server after fight_created)
       this.networkManager.onStart((data) => {
+        this._fightId = data.fightId;
+
+        // P2: register as second player in the fight record
+        if (!this.isP1) {
+          import('../services/api.js').then(({ updateFight }) => {
+            updateFight({ fightId: data.fightId, registerP2: true }).catch(() => {});
+          });
+        }
+
         this.goToPreFight(data.stageId, data.isRandomStage);
       });
 
@@ -273,6 +305,7 @@ export class StageSelectScene extends Phaser.Scene {
         p1Id: this.p1Id,
         p2Id: this.p2Id,
         stageId: stageId,
+        fightId: this._fightId || null,
         isRandomStage: isRandomStage,
         gameMode: this.gameMode,
         networkManager: this.networkManager,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -83,32 +83,44 @@ export async function updateStats(isWin = true) {
 }
 
 /**
+ * Retry a function with exponential backoff.
+ */
+async function withRetry(fn, { maxRetries = 3, label = 'request' } = {}) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt === maxRetries) throw err;
+      const delay = 1000 * 2 ** attempt;
+      log.warn(`${label} failed, retrying`, { attempt, delay, err: err.message });
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+}
+
+/**
  * Create a fight record (called by P1 at match start)
  */
 export async function createFight({ fightId, roomId, p1Fighter, p2Fighter, stageId }) {
-  return apiFetch('/fights', {
-    method: 'POST',
-    body: JSON.stringify({ fightId, roomId, p1Fighter, p2Fighter, stageId }),
-  });
+  const body = JSON.stringify({ fightId, roomId, p1Fighter, p2Fighter, stageId });
+  return withRetry(() => apiFetch('/fights', { method: 'POST', body }), { label: 'createFight' });
 }
 
 /**
  * Update a fight record (P2 registration or match result)
  */
 export async function updateFight(fields) {
-  return apiFetch('/fights', {
-    method: 'PATCH',
-    body: JSON.stringify(fields),
-  });
+  const body = JSON.stringify(fields);
+  return withRetry(() => apiFetch('/fights', { method: 'PATCH', body }), { label: 'updateFight' });
 }
 
 /**
  * Upload a debug bundle for a fight round.
- * Fire-and-forget — errors are logged but not thrown.
+ * Retries up to 3 times with exponential backoff on failure.
  */
 export async function uploadDebugBundle({ fightId, slot, round, bundle }) {
-  return apiFetch('/debug-bundles', {
-    method: 'POST',
-    body: JSON.stringify({ fightId, slot, round, bundle }),
+  const body = JSON.stringify({ fightId, slot, round, bundle });
+  return withRetry(() => apiFetch('/debug-bundles', { method: 'POST', body }), {
+    label: 'uploadBundle',
   });
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -81,3 +81,34 @@ export async function updateStats(isWin = true) {
     body: JSON.stringify({ isWin }),
   });
 }
+
+/**
+ * Create a fight record (called by P1 at match start)
+ */
+export async function createFight({ fightId, roomId, p1Fighter, p2Fighter, stageId }) {
+  return apiFetch('/fights', {
+    method: 'POST',
+    body: JSON.stringify({ fightId, roomId, p1Fighter, p2Fighter, stageId }),
+  });
+}
+
+/**
+ * Update a fight record (P2 registration or match result)
+ */
+export async function updateFight(fields) {
+  return apiFetch('/fights', {
+    method: 'PATCH',
+    body: JSON.stringify(fields),
+  });
+}
+
+/**
+ * Upload a debug bundle for a fight round.
+ * Fire-and-forget — errors are logged but not thrown.
+ */
+export async function uploadDebugBundle({ fightId, slot, round, bundle }) {
+  return apiFetch('/debug-bundles', {
+    method: 'POST',
+    body: JSON.stringify({ fightId, slot, round, bundle }),
+  });
+}

--- a/src/systems/DebugBundleExporter.js
+++ b/src/systems/DebugBundleExporter.js
@@ -158,6 +158,25 @@ export class DebugBundleExporter {
     log.info('Bundle downloaded', { size: json.length });
   }
 
+  /**
+   * Upload a debug bundle to the server. Fire-and-forget.
+   * @param {object} options
+   * @param {string} options.fightId
+   * @param {number} options.slot - Player slot (0 or 1)
+   * @param {number} options.round - Round number (0 = match end)
+   * @param {object} options.bundle - The debug bundle object
+   */
+  static uploadBundle({ fightId, slot, round, bundle }) {
+    if (!fightId) {
+      log.debug('uploadBundle skipped: no fightId');
+      return;
+    }
+    import('../services/api.js')
+      .then(({ uploadDebugBundle }) => uploadDebugBundle({ fightId, slot, round, bundle }))
+      .then(() => log.info('Bundle uploaded', { fightId, slot, round }))
+      .catch((err) => log.warn('Bundle upload failed', { fightId, slot, round, err: err.message }));
+  }
+
   // --- Internal ---
 
   static _collectEnvironment() {

--- a/src/systems/FightRecorder.js
+++ b/src/systems/FightRecorder.js
@@ -7,12 +7,13 @@ import { encodeInput } from './InputBuffer.js';
  * Exposes all data via window.__FIGHT_LOG.
  */
 export class FightRecorder {
-  constructor({ roomId, playerSlot, fighterId, opponentId, stageId, config }) {
+  constructor({ fightId, roomId, playerSlot, fighterId, opponentId, stageId, config }) {
     this._lastEncodedInput = -1;
     this._lastConfirmedP1 = -1;
     this._lastConfirmedP2 = -1;
 
     this.log = {
+      fightId,
       roomId,
       playerSlot,
       fighterId,

--- a/tests/api/admin/debug-bundle.test.js
+++ b/tests/api/admin/debug-bundle.test.js
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import adminDebugBundleHandler from '../../../api/admin/debug-bundle.js';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn(async () => ({
+  query: mockQuery,
+  release: vi.fn(),
+}));
+
+vi.mock('jose');
+vi.mock('pg', () => {
+  class Pool {
+    constructor() {
+      this.connect = mockConnect;
+    }
+  }
+  return {
+    default: { Pool },
+    Pool,
+  };
+});
+
+const mockDownload = vi.fn();
+vi.mock('../../../api/_lib/storage.js', () => ({
+  BUNDLE_TTL_DAYS: 7,
+  storage: {
+    downloadBundle: (...args) => mockDownload(...args),
+  },
+}));
+
+describe('Admin Debug Bundle API', () => {
+  let req, res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      method: 'GET',
+      headers: { 'x-dev-user-id': 'admin-user' },
+      query: {},
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+      setHeader: vi.fn(),
+    };
+    process.env.DATABASE_URL = 'postgres://localhost';
+    process.env.NODE_ENV = 'development';
+  });
+
+  function mockAdminCheck(isAdmin = true) {
+    mockQuery.mockResolvedValueOnce({
+      rows: isAdmin ? [{ is_admin: true }] : [],
+    });
+  }
+
+  it('returns bundle content for valid params', async () => {
+    mockAdminCheck();
+    req.query = { fightId: 'fight-uuid', slot: '0', round: '1' };
+    const bundleContent = JSON.stringify({ version: 2, source: 'debug' });
+    mockDownload.mockResolvedValueOnce(bundleContent);
+
+    await adminDebugBundleHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith(bundleContent);
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      expect.stringContaining('debug-fight-uuid'),
+    );
+  });
+
+  it('returns 404 for non-existent bundle', async () => {
+    mockAdminCheck();
+    req.query = { fightId: 'fight-uuid', slot: '0', round: '99' };
+    mockDownload.mockResolvedValueOnce(null);
+
+    await adminDebugBundleHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 400 when fightId is missing', async () => {
+    mockAdminCheck();
+    req.query = { slot: '0', round: '1' };
+
+    await adminDebugBundleHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when slot is missing', async () => {
+    mockAdminCheck();
+    req.query = { fightId: 'fight-uuid', round: '1' };
+
+    await adminDebugBundleHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when round is missing', async () => {
+    mockAdminCheck();
+    req.query = { fightId: 'fight-uuid', slot: '0' };
+
+    await adminDebugBundleHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 403 for non-admin users', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ is_admin: false }] });
+    req.query = { fightId: 'fight-uuid', slot: '0', round: '1' };
+
+    await adminDebugBundleHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns 405 for non-GET methods', async () => {
+    mockAdminCheck();
+    req.method = 'POST';
+
+    await adminDebugBundleHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+});

--- a/tests/api/admin/fights.test.js
+++ b/tests/api/admin/fights.test.js
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import adminFightsHandler from '../../../api/admin/fights.js';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn(async () => ({
+  query: mockQuery,
+  release: vi.fn(),
+}));
+
+vi.mock('jose');
+vi.mock('pg', () => {
+  class Pool {
+    constructor() {
+      this.connect = mockConnect;
+    }
+  }
+  return {
+    default: { Pool },
+    Pool,
+  };
+});
+
+const mockListBundles = vi.fn();
+vi.mock('../../../api/_lib/storage.js', () => ({
+  BUNDLE_TTL_DAYS: 7,
+  storage: {
+    listBundles: (...args) => mockListBundles(...args),
+  },
+}));
+
+describe('Admin Fights API', () => {
+  let req, res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      method: 'GET',
+      headers: { 'x-dev-user-id': 'admin-user' },
+      query: {},
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    process.env.DATABASE_URL = 'postgres://localhost';
+    process.env.NODE_ENV = 'development';
+  });
+
+  function mockAdminCheck(isAdmin = true) {
+    // First query: is_admin check from withAdmin
+    mockQuery.mockResolvedValueOnce({
+      rows: isAdmin ? [{ is_admin: true }] : [],
+    });
+  }
+
+  it('returns paginated fights sorted by started_at DESC', async () => {
+    mockAdminCheck();
+    // Count query
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: '2' }] });
+    // Fights query
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'f1',
+          room_id: 'ABCD',
+          p1_fighter: 'simon',
+          p2_fighter: 'paula',
+          stage_id: 'beach',
+          started_at: '2026-04-01T10:00:00Z',
+          has_debug_bundle: false,
+          p1_nickname: 'Simon',
+          p2_nickname: 'Paula',
+        },
+        {
+          id: 'f2',
+          room_id: 'EFGH',
+          p1_fighter: 'jeko',
+          p2_fighter: 'gus',
+          stage_id: 'metro',
+          started_at: '2026-04-01T09:00:00Z',
+          has_debug_bundle: true,
+          p1_nickname: 'Jeko',
+          p2_nickname: 'Gus',
+        },
+      ],
+    });
+    mockListBundles.mockResolvedValueOnce([{ slot: 0, round: 1, key: 'f2/p0_round1.json' }]);
+
+    await adminFightsHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const data = res.json.mock.calls[0][0];
+    expect(data.fights).toHaveLength(2);
+    expect(data.total).toBe(2);
+    expect(data.page).toBe(1);
+    expect(data.limit).toBe(20);
+    // Second fight has bundles
+    expect(data.fights[1].bundles).toHaveLength(1);
+  });
+
+  it('respects pagination params', async () => {
+    mockAdminCheck();
+    req.query = { page: '2', limit: '10' };
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: '25' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await adminFightsHandler(req, res);
+
+    // Check OFFSET in query
+    const selectCall = mockQuery.mock.calls[2]; // 0=admin check, 1=count, 2=select
+    expect(selectCall[1]).toEqual([10, 10]); // limit=10, offset=10
+    const data = res.json.mock.calls[0][0];
+    expect(data.page).toBe(2);
+    expect(data.total).toBe(25);
+  });
+
+  it('filters by hasDebug=true', async () => {
+    mockAdminCheck();
+    req.query = { hasDebug: 'true' };
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: '1' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await adminFightsHandler(req, res);
+
+    // Count query should include WHERE clause
+    const countCall = mockQuery.mock.calls[1];
+    expect(countCall[0]).toContain('has_debug_bundle = TRUE');
+    // Select query should include WHERE clause
+    const selectCall = mockQuery.mock.calls[2];
+    expect(selectCall[0]).toContain('has_debug_bundle = TRUE');
+  });
+
+  it('includes player nicknames from profiles JOIN', async () => {
+    mockAdminCheck();
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: '1' }] });
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'f1',
+          has_debug_bundle: false,
+          p1_nickname: 'Simon',
+          p2_nickname: 'Paula',
+        },
+      ],
+    });
+
+    await adminFightsHandler(req, res);
+
+    const data = res.json.mock.calls[0][0];
+    expect(data.fights[0].p1_nickname).toBe('Simon');
+    expect(data.fights[0].p2_nickname).toBe('Paula');
+  });
+
+  it('returns 403 for non-admin users', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ is_admin: false }] });
+
+    await adminFightsHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns 405 for non-GET methods', async () => {
+    mockAdminCheck();
+    req.method = 'POST';
+
+    await adminFightsHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+});

--- a/tests/api/cron/cleanup-bundles.test.js
+++ b/tests/api/cron/cleanup-bundles.test.js
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn(async () => ({
+  query: mockQuery,
+  release: vi.fn(),
+}));
+
+vi.mock('pg', () => {
+  class Pool {
+    constructor() {
+      this.connect = mockConnect;
+    }
+  }
+  return {
+    default: { Pool },
+    Pool,
+  };
+});
+
+const mockDeleteBundles = vi.fn();
+vi.mock('../../../api/_lib/storage.js', () => ({
+  BUNDLE_TTL_DAYS: 7,
+  storage: {
+    deleteBundles: (...args) => mockDeleteBundles(...args),
+  },
+}));
+
+import handler from '../../../api/cron/cleanup-bundles.js';
+
+describe('Cleanup Bundles Cron', () => {
+  let req, res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      method: 'GET',
+      headers: {},
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    process.env.DATABASE_URL = 'postgres://localhost';
+    process.env.NODE_ENV = 'development';
+    delete process.env.CRON_SECRET;
+  });
+
+  it('deletes expired bundles and clears has_debug_bundle', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'fight-1' }, { id: 'fight-2' }],
+    });
+    // Two update queries (one per fight)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockDeleteBundles.mockResolvedValue();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ deleted: 2, total: 2 });
+    expect(mockDeleteBundles).toHaveBeenCalledWith('fight-1');
+    expect(mockDeleteBundles).toHaveBeenCalledWith('fight-2');
+    // Verify UPDATE was called for each fight
+    expect(mockQuery).toHaveBeenCalledWith(
+      'UPDATE fights SET has_debug_bundle = FALSE WHERE id = $1',
+      ['fight-1'],
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      'UPDATE fights SET has_debug_bundle = FALSE WHERE id = $1',
+      ['fight-2'],
+    );
+  });
+
+  it('handles empty result set gracefully', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ deleted: 0 });
+    expect(mockDeleteBundles).not.toHaveBeenCalled();
+  });
+
+  it('does not touch non-expired fights', async () => {
+    // Only returns expired ones (the query handles this)
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'expired-1' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockDeleteBundles.mockResolvedValue();
+
+    await handler(req, res);
+
+    // Only one fight deleted
+    expect(mockDeleteBundles).toHaveBeenCalledTimes(1);
+    expect(mockDeleteBundles).toHaveBeenCalledWith('expired-1');
+  });
+
+  it('verifies CRON_SECRET when set', async () => {
+    process.env.CRON_SECRET = 'my-secret';
+    req.headers.authorization = 'Bearer wrong-secret';
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(mockDeleteBundles).not.toHaveBeenCalled();
+  });
+
+  it('allows request with correct CRON_SECRET', async () => {
+    process.env.CRON_SECRET = 'my-secret';
+    req.headers.authorization = 'Bearer my-secret';
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('skips CRON_SECRET check when not configured', async () => {
+    // CRON_SECRET is deleted in beforeEach
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('returns 405 for non-GET methods', async () => {
+    req.method = 'POST';
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it('continues on individual delete failure', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'fight-ok' }, { id: 'fight-fail' }],
+    });
+    mockDeleteBundles
+      .mockResolvedValueOnce() // fight-ok succeeds
+      .mockRejectedValueOnce(new Error('storage error')); // fight-fail fails
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // update for fight-ok
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    // Only 1 successfully deleted
+    expect(res.json).toHaveBeenCalledWith({ deleted: 1, total: 2 });
+  });
+});

--- a/tests/api/debug-bundles.test.js
+++ b/tests/api/debug-bundles.test.js
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import debugBundlesHandler from '../../api/debug-bundles.js';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn(async () => ({
+  query: mockQuery,
+  release: vi.fn(),
+}));
+
+vi.mock('jose');
+vi.mock('pg', () => {
+  class Pool {
+    constructor() {
+      this.connect = mockConnect;
+    }
+  }
+  return {
+    default: { Pool },
+    Pool,
+  };
+});
+
+const mockUpload = vi.fn();
+vi.mock('../../api/_lib/storage.js', () => ({
+  BUNDLE_TTL_DAYS: 7,
+  storage: {
+    uploadBundle: (...args) => mockUpload(...args),
+  },
+}));
+
+describe('Debug Bundles API', () => {
+  let req, res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      method: 'POST',
+      headers: { 'x-dev-user-id': 'user-1' },
+      body: {},
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    process.env.DATABASE_URL = 'postgres://localhost';
+    process.env.NODE_ENV = 'development';
+  });
+
+  it('uploads bundle and returns 201', async () => {
+    req.body = {
+      fightId: 'fight-uuid',
+      slot: 0,
+      round: 1,
+      bundle: { version: 2, source: 'debug' },
+    };
+    // Fight exists
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'fight-uuid' }] });
+    // Update has_debug_bundle
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockUpload.mockResolvedValueOnce();
+
+    await debugBundlesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(mockUpload).toHaveBeenCalledWith(
+      'fight-uuid',
+      0,
+      1,
+      JSON.stringify({ version: 2, source: 'debug' }),
+    );
+  });
+
+  it('sets has_debug_bundle and debug_bundle_expires_at on the fight', async () => {
+    req.body = {
+      fightId: 'fight-uuid',
+      slot: 0,
+      round: 1,
+      bundle: { version: 2 },
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'fight-uuid' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockUpload.mockResolvedValueOnce();
+
+    await debugBundlesHandler(req, res);
+
+    const updateCall = mockQuery.mock.calls[1];
+    expect(updateCall[0]).toContain('has_debug_bundle = TRUE');
+    expect(updateCall[0]).toContain('debug_bundle_expires_at');
+    expect(updateCall[1]).toEqual(['fight-uuid']);
+  });
+
+  it('returns 400 when fightId is missing', async () => {
+    req.body = { slot: 0, round: 1, bundle: {} };
+
+    await debugBundlesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when slot is missing', async () => {
+    req.body = { fightId: 'fight-uuid', round: 1, bundle: {} };
+
+    await debugBundlesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when round is missing', async () => {
+    req.body = { fightId: 'fight-uuid', slot: 0, bundle: {} };
+
+    await debugBundlesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when bundle is missing', async () => {
+    req.body = { fightId: 'fight-uuid', slot: 0, round: 1 };
+
+    await debugBundlesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 404 when fight does not exist', async () => {
+    req.body = {
+      fightId: 'nonexistent',
+      slot: 0,
+      round: 1,
+      bundle: { version: 2 },
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await debugBundlesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 without auth', async () => {
+    req.headers = {};
+    req.body = {
+      fightId: 'fight-uuid',
+      slot: 0,
+      round: 1,
+      bundle: { version: 2 },
+    };
+
+    await debugBundlesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('returns 405 for non-POST methods', async () => {
+    req.method = 'GET';
+
+    await debugBundlesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it('handles string bundle content', async () => {
+    const bundleStr = '{"version":2}';
+    req.body = {
+      fightId: 'fight-uuid',
+      slot: 0,
+      round: 1,
+      bundle: bundleStr,
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'fight-uuid' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockUpload.mockResolvedValueOnce();
+
+    await debugBundlesHandler(req, res);
+
+    expect(mockUpload).toHaveBeenCalledWith('fight-uuid', 0, 1, bundleStr);
+  });
+});

--- a/tests/api/fights.test.js
+++ b/tests/api/fights.test.js
@@ -107,8 +107,8 @@ describe('Fights API', () => {
       req.method = 'PATCH';
     });
 
-    it('updates p2_user_id', async () => {
-      req.body = { fightId: 'fight-uuid', p2UserId: 'user-2' };
+    it('registers P2 user from auth', async () => {
+      req.body = { fightId: 'fight-uuid', registerP2: true };
       mockQuery.mockResolvedValueOnce({ rows: [{ id: 'fight-uuid' }] });
 
       await fightsHandler(req, res);
@@ -116,7 +116,7 @@ describe('Fights API', () => {
       expect(res.status).toHaveBeenCalledWith(200);
       expect(mockQuery).toHaveBeenCalledWith(
         expect.stringContaining('p2_user_id'),
-        expect.arrayContaining(['user-2', 'fight-uuid']),
+        expect.arrayContaining(['user-1', 'fight-uuid']),
       );
     });
 

--- a/tests/api/fights.test.js
+++ b/tests/api/fights.test.js
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fightsHandler from '../../api/fights.js';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn(async () => ({
+  query: mockQuery,
+  release: vi.fn(),
+}));
+
+vi.mock('jose');
+vi.mock('pg', () => {
+  class Pool {
+    constructor() {
+      this.connect = mockConnect;
+    }
+  }
+  return {
+    default: { Pool },
+    Pool,
+  };
+});
+
+describe('Fights API', () => {
+  let req, res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      method: 'POST',
+      headers: { 'x-dev-user-id': 'user-1' },
+      body: {},
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    process.env.DATABASE_URL = 'postgres://localhost';
+    process.env.NODE_ENV = 'development';
+  });
+
+  describe('POST /api/fights', () => {
+    it('creates a fight record with correct fields', async () => {
+      req.body = {
+        fightId: 'fight-uuid',
+        roomId: 'ABCD',
+        p1Fighter: 'simon',
+        p2Fighter: 'paula',
+        stageId: 'beach',
+      };
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await fightsHandler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ id: 'fight-uuid' });
+      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO fights'), [
+        'fight-uuid',
+        'ABCD',
+        'user-1',
+        'simon',
+        'paula',
+        'beach',
+      ]);
+    });
+
+    it('returns 400 when required fields are missing', async () => {
+      req.body = { fightId: 'fight-uuid' };
+
+      await fightsHandler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 409 on duplicate fightId', async () => {
+      req.body = {
+        fightId: 'fight-uuid',
+        roomId: 'ABCD',
+        p1Fighter: 'simon',
+        p2Fighter: 'paula',
+        stageId: 'beach',
+      };
+      mockQuery.mockRejectedValueOnce({ code: '23505' });
+
+      await fightsHandler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(409);
+    });
+
+    it('returns 401 without auth', async () => {
+      req.headers = {};
+      req.body = {
+        fightId: 'fight-uuid',
+        roomId: 'ABCD',
+        p1Fighter: 'simon',
+        p2Fighter: 'paula',
+        stageId: 'beach',
+      };
+
+      await fightsHandler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+  });
+
+  describe('PATCH /api/fights', () => {
+    beforeEach(() => {
+      req.method = 'PATCH';
+    });
+
+    it('updates p2_user_id', async () => {
+      req.body = { fightId: 'fight-uuid', p2UserId: 'user-2' };
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 'fight-uuid' }] });
+
+      await fightsHandler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('p2_user_id'),
+        expect.arrayContaining(['user-2', 'fight-uuid']),
+      );
+    });
+
+    it('updates match result fields', async () => {
+      req.body = {
+        fightId: 'fight-uuid',
+        winnerSlot: 0,
+        roundsP1: 2,
+        roundsP2: 1,
+      };
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 'fight-uuid' }] });
+
+      await fightsHandler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const queryStr = mockQuery.mock.calls[0][0];
+      expect(queryStr).toContain('winner_slot');
+      expect(queryStr).toContain('ended_at');
+      expect(queryStr).toContain('rounds_p1');
+      expect(queryStr).toContain('rounds_p2');
+    });
+
+    it('returns 404 for non-existent fightId', async () => {
+      req.body = { fightId: 'nonexistent', winnerSlot: 0 };
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await fightsHandler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('returns 400 when fightId is missing', async () => {
+      req.body = { winnerSlot: 0 };
+
+      await fightsHandler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 400 when no fields to update', async () => {
+      req.body = { fightId: 'fight-uuid' };
+
+      await fightsHandler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  it('returns 405 for unsupported methods', async () => {
+    req.method = 'DELETE';
+
+    await fightsHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+});

--- a/tests/api/handler-admin.test.js
+++ b/tests/api/handler-admin.test.js
@@ -1,0 +1,123 @@
+import { decodeProtectedHeader, jwtVerify } from 'jose';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { withAdmin } from '../../api/_lib/handler.js';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn(async () => ({
+  query: mockQuery,
+  release: vi.fn(),
+}));
+
+vi.mock('jose');
+vi.mock('pg', () => {
+  class Pool {
+    constructor() {
+      this.connect = mockConnect;
+    }
+  }
+  return {
+    default: { Pool },
+    Pool,
+  };
+});
+
+function setupDevAuth(req) {
+  req.headers['x-dev-user-id'] = 'admin-user-id';
+  process.env.NODE_ENV = 'development';
+}
+
+describe('withAdmin middleware', () => {
+  let req, res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = { headers: {} };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    process.env.DATABASE_URL = 'postgres://localhost:5432/test';
+    process.env.NODE_ENV = 'development';
+    process.env.SUPABASE_JWT_SECRET = 'test-secret';
+    process.env.SUPABASE_PROJECT_ID = 'test-project';
+  });
+
+  it('allows request when user is admin', async () => {
+    setupDevAuth(req);
+    mockQuery.mockResolvedValueOnce({ rows: [{ is_admin: true }] });
+
+    const handler = vi.fn().mockResolvedValue({ success: true });
+    const wrapped = withAdmin(handler);
+    await wrapped(req, res);
+
+    expect(handler).toHaveBeenCalledWith(
+      req,
+      res,
+      expect.objectContaining({ userId: 'admin-user-id' }),
+    );
+  });
+
+  it('returns 403 when user is_admin is false', async () => {
+    setupDevAuth(req);
+    mockQuery.mockResolvedValueOnce({ rows: [{ is_admin: false }] });
+
+    const handler = vi.fn();
+    const wrapped = withAdmin(handler);
+    await wrapped(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining('Admin') }),
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when user has no profile row', async () => {
+    setupDevAuth(req);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const handler = vi.fn();
+    const wrapped = withAdmin(handler);
+    await wrapped(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('still performs JWT verification (inherits from withAuth)', async () => {
+    req.headers.authorization = 'Bearer valid-token';
+    decodeProtectedHeader.mockReturnValue({ alg: 'HS256' });
+    jwtVerify.mockResolvedValue({ payload: { sub: 'jwt-user' } });
+    mockQuery.mockResolvedValueOnce({ rows: [{ is_admin: true }] });
+
+    const handler = vi.fn().mockResolvedValue({ success: true });
+    const wrapped = withAdmin(handler);
+    await wrapped(req, res);
+
+    expect(jwtVerify).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledWith(req, res, expect.objectContaining({ userId: 'jwt-user' }));
+  });
+
+  it('returns 401 without auth credentials', async () => {
+    const handler = vi.fn();
+    const wrapped = withAdmin(handler);
+    await wrapped(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('dev bypass works but still checks is_admin', async () => {
+    setupDevAuth(req);
+    // First call returns admin check
+    mockQuery.mockResolvedValueOnce({ rows: [{ is_admin: false }] });
+
+    const handler = vi.fn();
+    const wrapped = withAdmin(handler);
+    await wrapped(req, res);
+
+    // Auth passed (dev bypass) but admin check failed
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api/storage.test.js
+++ b/tests/api/storage.test.js
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { storage, validatePathComponent } from '../../api/_lib/storage.js';
+
+const TEST_BASE = path.join(process.cwd(), 'tmp', 'debug-bundles');
+
+describe('storage (local backend)', () => {
+  const fightId = 'test-fight-id-1234';
+  const bundleContent = JSON.stringify({ version: 2, source: 'debug', data: 'test' });
+
+  beforeEach(() => {
+    process.env.STORAGE_BACKEND = 'local';
+    // Clean up test directory
+    const dir = path.join(TEST_BASE, fightId);
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  afterEach(() => {
+    const dir = path.join(TEST_BASE, fightId);
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('uploads a bundle to the correct path', async () => {
+    await storage.uploadBundle(fightId, 0, 1, bundleContent);
+    const filePath = path.join(TEST_BASE, fightId, 'p0_round1.json');
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(bundleContent);
+  });
+
+  it('downloads an uploaded bundle', async () => {
+    await storage.uploadBundle(fightId, 0, 1, bundleContent);
+    const result = await storage.downloadBundle(fightId, 0, 1);
+    expect(result).toBe(bundleContent);
+  });
+
+  it('returns null for non-existent bundle', async () => {
+    const result = await storage.downloadBundle(fightId, 0, 99);
+    expect(result).toBeNull();
+  });
+
+  it('deletes all bundles for a fightId', async () => {
+    await storage.uploadBundle(fightId, 0, 1, bundleContent);
+    await storage.uploadBundle(fightId, 1, 1, bundleContent);
+    await storage.uploadBundle(fightId, 0, 0, bundleContent);
+
+    await storage.deleteBundles(fightId);
+
+    const dir = path.join(TEST_BASE, fightId);
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  it('lists bundles for a fightId', async () => {
+    await storage.uploadBundle(fightId, 0, 1, bundleContent);
+    await storage.uploadBundle(fightId, 1, 1, bundleContent);
+    await storage.uploadBundle(fightId, 0, 0, bundleContent);
+
+    const bundles = await storage.listBundles(fightId);
+    expect(bundles).toHaveLength(3);
+    expect(bundles).toContainEqual({ slot: 0, round: 0, key: `${fightId}/p0_round0.json` });
+    expect(bundles).toContainEqual({ slot: 0, round: 1, key: `${fightId}/p0_round1.json` });
+    expect(bundles).toContainEqual({ slot: 1, round: 1, key: `${fightId}/p1_round1.json` });
+  });
+
+  it('returns empty list for non-existent fightId', async () => {
+    const bundles = await storage.listBundles('nonexistent');
+    expect(bundles).toEqual([]);
+  });
+
+  it('handles delete on non-existent directory', async () => {
+    // Should not throw
+    await storage.deleteBundles('nonexistent');
+  });
+
+  it('overwrites existing bundle on re-upload', async () => {
+    await storage.uploadBundle(fightId, 0, 1, bundleContent);
+    const newContent = JSON.stringify({ version: 2, updated: true });
+    await storage.uploadBundle(fightId, 0, 1, newContent);
+    const result = await storage.downloadBundle(fightId, 0, 1);
+    expect(result).toBe(newContent);
+  });
+});
+
+describe('validatePathComponent', () => {
+  it('accepts valid path components', () => {
+    expect(() => validatePathComponent('abc-123', 'test')).not.toThrow();
+    expect(() => validatePathComponent('0', 'test')).not.toThrow();
+    expect(() => validatePathComponent('fight-uuid-here', 'test')).not.toThrow();
+  });
+
+  it('rejects path traversal with ..', () => {
+    expect(() => validatePathComponent('..', 'test')).toThrow('Invalid test');
+    expect(() => validatePathComponent('../etc/passwd', 'test')).toThrow('Invalid test');
+  });
+
+  it('rejects forward slashes', () => {
+    expect(() => validatePathComponent('a/b', 'test')).toThrow('Invalid test');
+  });
+
+  it('rejects backslashes', () => {
+    expect(() => validatePathComponent('a\\b', 'test')).toThrow('Invalid test');
+  });
+});

--- a/tests/api/storage.test.js
+++ b/tests/api/storage.test.js
@@ -31,7 +31,7 @@ describe('storage (local backend)', () => {
 
   it('uploads a bundle to the correct path', async () => {
     await storage.uploadBundle(fightId, 0, 1, bundleContent);
-    const filePath = path.join(TEST_BASE, fightId, 'p1_round1.json');
+    const filePath = path.join(TEST_BASE, fightId, 'p0_round1.json');
     expect(fs.existsSync(filePath)).toBe(true);
     expect(fs.readFileSync(filePath, 'utf-8')).toBe(bundleContent);
   });
@@ -65,9 +65,9 @@ describe('storage (local backend)', () => {
 
     const bundles = await storage.listBundles(fightId);
     expect(bundles).toHaveLength(3);
-    expect(bundles).toContainEqual({ slot: 0, round: 0, key: `${fightId}/p1_round0.json` });
-    expect(bundles).toContainEqual({ slot: 0, round: 1, key: `${fightId}/p1_round1.json` });
-    expect(bundles).toContainEqual({ slot: 1, round: 1, key: `${fightId}/p2_round1.json` });
+    expect(bundles).toContainEqual({ slot: 0, round: 0, key: `${fightId}/p0_round0.json` });
+    expect(bundles).toContainEqual({ slot: 0, round: 1, key: `${fightId}/p0_round1.json` });
+    expect(bundles).toContainEqual({ slot: 1, round: 1, key: `${fightId}/p1_round1.json` });
   });
 
   it('returns empty list for non-existent fightId', async () => {

--- a/tests/api/storage.test.js
+++ b/tests/api/storage.test.js
@@ -31,7 +31,7 @@ describe('storage (local backend)', () => {
 
   it('uploads a bundle to the correct path', async () => {
     await storage.uploadBundle(fightId, 0, 1, bundleContent);
-    const filePath = path.join(TEST_BASE, fightId, 'p0_round1.json');
+    const filePath = path.join(TEST_BASE, fightId, 'p1_round1.json');
     expect(fs.existsSync(filePath)).toBe(true);
     expect(fs.readFileSync(filePath, 'utf-8')).toBe(bundleContent);
   });
@@ -65,9 +65,9 @@ describe('storage (local backend)', () => {
 
     const bundles = await storage.listBundles(fightId);
     expect(bundles).toHaveLength(3);
-    expect(bundles).toContainEqual({ slot: 0, round: 0, key: `${fightId}/p0_round0.json` });
-    expect(bundles).toContainEqual({ slot: 0, round: 1, key: `${fightId}/p0_round1.json` });
-    expect(bundles).toContainEqual({ slot: 1, round: 1, key: `${fightId}/p1_round1.json` });
+    expect(bundles).toContainEqual({ slot: 0, round: 0, key: `${fightId}/p1_round0.json` });
+    expect(bundles).toContainEqual({ slot: 0, round: 1, key: `${fightId}/p1_round1.json` });
+    expect(bundles).toContainEqual({ slot: 1, round: 1, key: `${fightId}/p2_round1.json` });
   });
 
   it('returns empty list for non-existent fightId', async () => {

--- a/tests/party/server-fight-id.test.js
+++ b/tests/party/server-fight-id.test.js
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import FightRoom from '../../party/server.js';
+
+// --- Helpers ---
+
+function makeParty(connections = []) {
+  return {
+    id: 'test-room',
+    getConnections() {
+      return connections;
+    },
+  };
+}
+
+function makeConnection(id) {
+  return { id, send: vi.fn(), close: vi.fn() };
+}
+
+function makeCtx(params = {}) {
+  const url = new URL('http://localhost/party/room');
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return { request: { url: url.toString() } };
+}
+
+function readyBothPlayers(room, conn1, conn2) {
+  room.onConnect(conn1, makeCtx());
+  room.onConnect(conn2, makeCtx());
+  room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
+  room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'paula' }), conn2);
+}
+
+// --- Tests ---
+
+describe('FightRoom - fightId generation', () => {
+  let room, conn1, conn2, party;
+
+  beforeEach(() => {
+    conn1 = makeConnection('c1');
+    conn2 = makeConnection('c2');
+    party = makeParty([conn1, conn2]);
+    room = new FightRoom(party);
+  });
+
+  it('generates a fightId when both players ready', () => {
+    readyBothPlayers(room, conn1, conn2);
+    expect(room.fightInfo).not.toBeNull();
+    expect(room.fightInfo.fightId).toBeDefined();
+    expect(typeof room.fightInfo.fightId).toBe('string');
+  });
+
+  it('generates a valid UUID format fightId', () => {
+    readyBothPlayers(room, conn1, conn2);
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    expect(room.fightInfo.fightId).toMatch(uuidRegex);
+  });
+
+  it('includes fightId in the start broadcast message to both peers', () => {
+    readyBothPlayers(room, conn1, conn2);
+
+    const c1Messages = conn1.send.mock.calls.map((c) => JSON.parse(c[0]));
+    const c2Messages = conn2.send.mock.calls.map((c) => JSON.parse(c[0]));
+
+    const c1Start = c1Messages.find((m) => m.type === 'start');
+    const c2Start = c2Messages.find((m) => m.type === 'start');
+
+    expect(c1Start).toBeDefined();
+    expect(c2Start).toBeDefined();
+    expect(c1Start.fightId).toBe(room.fightInfo.fightId);
+    expect(c2Start.fightId).toBe(room.fightInfo.fightId);
+  });
+
+  it('includes fighter IDs and stage in start message alongside fightId', () => {
+    readyBothPlayers(room, conn1, conn2);
+
+    const c1Messages = conn1.send.mock.calls.map((c) => JSON.parse(c[0]));
+    const startMsg = c1Messages.find((m) => m.type === 'start');
+
+    expect(startMsg.p1Id).toBe('simon');
+    expect(startMsg.p2Id).toBe('paula');
+    expect(startMsg.stageId).toBeDefined();
+    expect(startMsg.fightId).toBeDefined();
+  });
+
+  it('stores fightId in fightInfo', () => {
+    readyBothPlayers(room, conn1, conn2);
+    expect(room.fightInfo.fightId).toBeDefined();
+    expect(room.fightInfo.p1Id).toBe('simon');
+    expect(room.fightInfo.p2Id).toBe('paula');
+  });
+
+  it('clears fightId when a player leaves', () => {
+    readyBothPlayers(room, conn1, conn2);
+    expect(room.fightInfo).not.toBeNull();
+
+    room.onMessage(JSON.stringify({ type: 'leave' }), conn1);
+    expect(room.fightInfo).toBeNull();
+  });
+
+  it('generates a new fightId for each fight', () => {
+    readyBothPlayers(room, conn1, conn2);
+    const firstFightId = room.fightInfo.fightId;
+
+    // Leave and start a new fight
+    room.onMessage(JSON.stringify({ type: 'leave' }), conn1);
+    room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
+    room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'paula' }), conn2);
+    const secondFightId = room.fightInfo.fightId;
+
+    expect(secondFightId).not.toBe(firstFightId);
+  });
+});

--- a/tests/party/server-fight-id.test.js
+++ b/tests/party/server-fight-id.test.js
@@ -31,6 +31,12 @@ function readyBothPlayers(room, conn1, conn2) {
   room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'paula' }), conn2);
 }
 
+/** Ready both players and complete the fight creation handshake → fighting state. */
+function startFight(room, conn1, conn2) {
+  readyBothPlayers(room, conn1, conn2);
+  room.onMessage(JSON.stringify({ type: 'fight_created' }), conn1);
+}
+
 // --- Tests ---
 
 describe('FightRoom - fightId generation', () => {
@@ -57,7 +63,7 @@ describe('FightRoom - fightId generation', () => {
   });
 
   it('includes fightId in the start broadcast message to both peers', () => {
-    readyBothPlayers(room, conn1, conn2);
+    startFight(room, conn1, conn2);
 
     const c1Messages = conn1.send.mock.calls.map((c) => JSON.parse(c[0]));
     const c2Messages = conn2.send.mock.calls.map((c) => JSON.parse(c[0]));
@@ -72,7 +78,7 @@ describe('FightRoom - fightId generation', () => {
   });
 
   it('includes fighter IDs and stage in start message alongside fightId', () => {
-    readyBothPlayers(room, conn1, conn2);
+    startFight(room, conn1, conn2);
 
     const c1Messages = conn1.send.mock.calls.map((c) => JSON.parse(c[0]));
     const startMsg = c1Messages.find((m) => m.type === 'start');

--- a/tests/party/server-fight-id.test.js
+++ b/tests/party/server-fight-id.test.js
@@ -24,16 +24,21 @@ function makeCtx(params = {}) {
   return { request: { url: url.toString() } };
 }
 
-function readyBothPlayers(room, conn1, conn2) {
+/** Ready both players and select stage → creating_fight state (fightId generated). */
+function readyAndSelectStage(room, conn1, conn2) {
   room.onConnect(conn1, makeCtx());
   room.onConnect(conn2, makeCtx());
   room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
   room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'paula' }), conn2);
+  room.onMessage(
+    JSON.stringify({ type: 'select_stage', stageId: 'beach', isRandomStage: false }),
+    conn1,
+  );
 }
 
-/** Ready both players and complete the fight creation handshake → fighting state. */
+/** Full handshake → fighting state. */
 function startFight(room, conn1, conn2) {
-  readyBothPlayers(room, conn1, conn2);
+  readyAndSelectStage(room, conn1, conn2);
   room.onMessage(JSON.stringify({ type: 'fight_created' }), conn1);
 }
 
@@ -50,14 +55,14 @@ describe('FightRoom - fightId generation', () => {
   });
 
   it('generates a fightId when both players ready', () => {
-    readyBothPlayers(room, conn1, conn2);
+    readyAndSelectStage(room, conn1, conn2);
     expect(room.fightInfo).not.toBeNull();
     expect(room.fightInfo.fightId).toBeDefined();
     expect(typeof room.fightInfo.fightId).toBe('string');
   });
 
   it('generates a valid UUID format fightId', () => {
-    readyBothPlayers(room, conn1, conn2);
+    readyAndSelectStage(room, conn1, conn2);
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
     expect(room.fightInfo.fightId).toMatch(uuidRegex);
   });
@@ -90,14 +95,14 @@ describe('FightRoom - fightId generation', () => {
   });
 
   it('stores fightId in fightInfo', () => {
-    readyBothPlayers(room, conn1, conn2);
+    readyAndSelectStage(room, conn1, conn2);
     expect(room.fightInfo.fightId).toBeDefined();
     expect(room.fightInfo.p1Id).toBe('simon');
     expect(room.fightInfo.p2Id).toBe('paula');
   });
 
   it('clears fightId when a player leaves', () => {
-    readyBothPlayers(room, conn1, conn2);
+    readyAndSelectStage(room, conn1, conn2);
     expect(room.fightInfo).not.toBeNull();
 
     room.onMessage(JSON.stringify({ type: 'leave' }), conn1);
@@ -105,13 +110,17 @@ describe('FightRoom - fightId generation', () => {
   });
 
   it('generates a new fightId for each fight', () => {
-    readyBothPlayers(room, conn1, conn2);
+    readyAndSelectStage(room, conn1, conn2);
     const firstFightId = room.fightInfo.fightId;
 
     // Leave and start a new fight
     room.onMessage(JSON.stringify({ type: 'leave' }), conn1);
     room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
     room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'paula' }), conn2);
+    room.onMessage(
+      JSON.stringify({ type: 'select_stage', stageId: 'metro', isRandomStage: false }),
+      conn1,
+    );
     const secondFightId = room.fightInfo.fightId;
 
     expect(secondFightId).not.toBe(firstFightId);

--- a/tests/party/server.test.js
+++ b/tests/party/server.test.js
@@ -23,6 +23,20 @@ function makeCtx(params = {}) {
   return { request: { url: url.toString() } };
 }
 
+/**
+ * Helper: ready both players, select stage, and complete fight creation handshake.
+ * After this, room.roomState === 'fighting' and start has been broadcast.
+ */
+function startFight(room, c1, c2) {
+  room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), c1);
+  room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'jeka' }), c2);
+  room.onMessage(
+    JSON.stringify({ type: 'select_stage', stageId: 'beach', isRandomStage: false }),
+    c1,
+  );
+  room.onMessage(JSON.stringify({ type: 'fight_created' }), c1);
+}
+
 // --- Tests ---
 
 describe('FightRoom', () => {
@@ -96,7 +110,7 @@ describe('FightRoom', () => {
       expect(room.roomState).toBe('stage_select');
     });
 
-    it('transitions stage_select → fighting when host selects stage', () => {
+    it('transitions stage_select → creating_fight when host selects stage', () => {
       room.onConnect(conn1, makeCtx());
       room.onConnect(conn2, makeCtx());
       room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
@@ -107,6 +121,19 @@ describe('FightRoom', () => {
         JSON.stringify({ type: 'select_stage', stageId: 'metro', isRandomStage: false }),
         conn1,
       );
+      expect(room.roomState).toBe('creating_fight');
+    });
+
+    it('transitions creating_fight → fighting when P1 sends fight_created', () => {
+      room.onConnect(conn1, makeCtx());
+      room.onConnect(conn2, makeCtx());
+      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
+      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'paula' }), conn2);
+      room.onMessage(
+        JSON.stringify({ type: 'select_stage', stageId: 'metro', isRandomStage: false }),
+        conn1,
+      );
+      room.onMessage(JSON.stringify({ type: 'fight_created' }), conn1);
       expect(room.roomState).toBe('fighting');
     });
 
@@ -217,11 +244,18 @@ describe('FightRoom', () => {
       conn1.send.mockClear();
       conn2.send.mockClear();
 
-      // Host selects stage
+      // Host selects stage → creating_fight
       room.onMessage(
         JSON.stringify({ type: 'select_stage', stageId: 'metro', isRandomStage: false }),
         conn1,
       );
+      expect(room.roomState).toBe('creating_fight');
+
+      conn1.send.mockClear();
+      conn2.send.mockClear();
+
+      // P1 confirms fight creation → fighting + start broadcast
+      room.onMessage(JSON.stringify({ type: 'fight_created' }), conn1);
       expect(room.roomState).toBe('fighting');
 
       // Both players should get start message
@@ -366,12 +400,7 @@ describe('FightRoom', () => {
     it('sends return_to_select (not disconnect) when grace expires during fight', () => {
       room.onConnect(conn1, makeCtx());
       room.onConnect(conn2, makeCtx());
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'jeka' }), conn2);
-      room.onMessage(
-        JSON.stringify({ type: 'select_stage', stageId: 'metro', isRandomStage: false }),
-        conn1,
-      );
+      startFight(room, conn1, conn2);
       expect(room.roomState).toBe('fighting');
 
       conn2.send.mockClear();
@@ -394,12 +423,7 @@ describe('FightRoom', () => {
     it('resets started and fightInfo when both players grace periods expire', () => {
       room.onConnect(conn1, makeCtx());
       room.onConnect(conn2, makeCtx());
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'jeka' }), conn2);
-      room.onMessage(
-        JSON.stringify({ type: 'select_stage', stageId: 'metro', isRandomStage: false }),
-        conn1,
-      );
+      startFight(room, conn1, conn2);
       expect(room.roomState).toBe('fighting');
 
       room.onClose(conn1);
@@ -595,12 +619,7 @@ describe('FightRoom', () => {
 
     it('reconnecting player during grace period can rejoin', () => {
       // Start a fight
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'jeka' }), conn2);
-      room.onMessage(
-        JSON.stringify({ type: 'select_stage', stageId: 'metro', isRandomStage: false }),
-        conn1,
-      );
+      startFight(room, conn1, conn2);
       expect(room.roomState).toBe('fighting');
 
       // P2 disconnects — grace timer starts
@@ -761,12 +780,7 @@ describe('FightRoom', () => {
     });
 
     it('broadcasts return_to_select to spectators when grace expires during fight', () => {
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'jeka' }), conn2);
-      room.onMessage(
-        JSON.stringify({ type: 'select_stage', stageId: 'metro', isRandomStage: false }),
-        conn1,
-      );
+      startFight(room, conn1, conn2);
       expect(room.roomState).toBe('fighting');
 
       room.onConnect(conn3, makeCtx({ spectate: '1' }));
@@ -782,12 +796,7 @@ describe('FightRoom', () => {
 
     it('rejoin with reset resets room to selecting and notifies opponent', () => {
       // Start a fight
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'jeka' }), conn2);
-      room.onMessage(
-        JSON.stringify({ type: 'select_stage', stageId: 'metro', isRandomStage: false }),
-        conn1,
-      );
+      startFight(room, conn1, conn2);
       expect(room.roomState).toBe('fighting');
 
       // P2 disconnects (page refresh scenario)
@@ -836,12 +845,7 @@ describe('FightRoom', () => {
       expect(room.roomState).toBe('selecting');
 
       // Both ready → fighting
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'jeka' }), conn2);
-      room.onMessage(
-        JSON.stringify({ type: 'select_stage', stageId: 'metro', isRandomStage: false }),
-        conn1,
-      );
+      startFight(room, conn1, conn2);
       expect(room.roomState).toBe('fighting');
 
       // Disconnect → reconnecting
@@ -898,12 +902,7 @@ describe('FightRoom', () => {
     });
 
     it('ignores ready after game has started', () => {
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'simon' }), conn1);
-      room.onMessage(JSON.stringify({ type: 'ready', fighterId: 'jeka' }), conn2);
-      room.onMessage(
-        JSON.stringify({ type: 'select_stage', stageId: 'metro', isRandomStage: false }),
-        conn1,
-      );
+      startFight(room, conn1, conn2);
       expect(room.roomState).toBe('fighting');
 
       // Reset ready flags but keep roomState as 'fighting' via direct manipulation

--- a/tests/systems/debug-bundle-upload.test.js
+++ b/tests/systems/debug-bundle-upload.test.js
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUploadDebugBundle = vi.fn();
+
+vi.mock('../../src/services/api.js', () => ({
+  uploadDebugBundle: (...args) => mockUploadDebugBundle(...args),
+}));
+
+// Mock Logger to avoid side effects
+vi.mock('../../src/systems/Logger.js', () => ({
+  Logger: {
+    create: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    }),
+    getBuffer: () => [],
+  },
+}));
+
+import { DebugBundleExporter } from '../../src/systems/DebugBundleExporter.js';
+
+describe('DebugBundleExporter.uploadBundle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls uploadDebugBundle with correct params', async () => {
+    mockUploadDebugBundle.mockResolvedValueOnce({ ok: true });
+
+    DebugBundleExporter.uploadBundle({
+      fightId: 'fight-uuid',
+      slot: 0,
+      round: 1,
+      bundle: { version: 2, source: 'debug' },
+    });
+
+    // Wait for the async import chain to resolve
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockUploadDebugBundle).toHaveBeenCalledWith({
+      fightId: 'fight-uuid',
+      slot: 0,
+      round: 1,
+      bundle: { version: 2, source: 'debug' },
+    });
+  });
+
+  it('does not call upload when fightId is missing', async () => {
+    DebugBundleExporter.uploadBundle({
+      fightId: null,
+      slot: 0,
+      round: 1,
+      bundle: { version: 2 },
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockUploadDebugBundle).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when upload fails', async () => {
+    mockUploadDebugBundle.mockRejectedValueOnce(new Error('Network error'));
+
+    DebugBundleExporter.uploadBundle({
+      fightId: 'fight-uuid',
+      slot: 0,
+      round: 1,
+      bundle: { version: 2 },
+    });
+
+    // Should not throw — fire-and-forget
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockUploadDebugBundle).toHaveBeenCalled();
+  });
+
+  it('does not call upload when fightId is undefined', async () => {
+    DebugBundleExporter.uploadBundle({
+      fightId: undefined,
+      slot: 0,
+      round: 1,
+      bundle: { version: 2 },
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockUploadDebugBundle).not.toHaveBeenCalled();
+  });
+});

--- a/tests/systems/fight-recorder-fight-id.test.js
+++ b/tests/systems/fight-recorder-fight-id.test.js
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { FightRecorder } from '../../src/systems/FightRecorder.js';
+
+describe('FightRecorder - fightId', () => {
+  let originalFightLog;
+
+  beforeEach(() => {
+    originalFightLog = globalThis.window?.__FIGHT_LOG;
+    globalThis.window = globalThis.window || {};
+  });
+
+  afterEach(() => {
+    if (originalFightLog !== undefined) {
+      globalThis.window.__FIGHT_LOG = originalFightLog;
+    } else {
+      delete globalThis.window?.__FIGHT_LOG;
+    }
+  });
+
+  it('stores fightId in the log', () => {
+    const recorder = new FightRecorder({
+      fightId: 'test-fight-uuid',
+      roomId: 'ABCD',
+      playerSlot: 0,
+      fighterId: 'simon',
+      opponentId: 'paula',
+      stageId: 'beach',
+    });
+    expect(recorder.log.fightId).toBe('test-fight-uuid');
+  });
+
+  it('exposes fightId via window.__FIGHT_LOG', () => {
+    new FightRecorder({
+      fightId: 'test-fight-uuid',
+      roomId: 'ABCD',
+      playerSlot: 0,
+      fighterId: 'simon',
+      opponentId: 'paula',
+      stageId: 'beach',
+    });
+    expect(window.__FIGHT_LOG.fightId).toBe('test-fight-uuid');
+  });
+
+  it('is backward-compatible when fightId is not provided', () => {
+    const recorder = new FightRecorder({
+      roomId: 'ABCD',
+      playerSlot: 0,
+      fighterId: 'simon',
+      opponentId: 'paula',
+      stageId: 'beach',
+    });
+    expect(recorder.log.fightId).toBeUndefined();
+    // Other fields still work
+    expect(recorder.log.roomId).toBe('ABCD');
+    expect(recorder.log.playerSlot).toBe(0);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/cleanup-bundles",
+      "schedule": "0 3 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Every online fight gets a unique UUID, generated server-side in PartyKit
- In debug mode (`?debug=1`), both peers independently upload debug bundles after each round and at match end to object storage
- Pluggable storage backend: local filesystem (dev) vs Supabase Storage (prod)
- Admin panel at `/admin/` (Preact SPA) with paginated, filterable fights list and bundle download links
- 7-day TTL on debug bundles with automated Vercel Cron cleanup
- `is_admin` column on profiles table for admin access control

See [RFC 0011](docs/rfcs/0011-auto-upload-debug-bundles.md) for full architecture details.

## New files

| Area | Files |
|------|-------|
| DB migrations | `db/migrations/20260401000000_create_fights.sql`, `20260401000001_add_is_admin_to_profiles.sql` |
| Storage | `api/_lib/storage.js` |
| API endpoints | `api/fights.js`, `api/debug-bundles.js`, `api/admin/fights.js`, `api/admin/debug-bundle.js`, `api/cron/cleanup-bundles.js` |
| Admin UI | `public/admin/index.html`, `public/admin/app.js`, `public/admin/pages/fights.js`, `public/admin/components/pagination.js` |
| Config | `vercel.json` (cron) |

## Test plan

- [x] 822 tests pass (55 files), including 73 new tests across 10 new test files
- [ ] Manual: run `bun run dev:all`, play a fight with `?debug=1`, verify bundles in `/tmp/debug-bundles/`
- [ ] Manual: visit `/admin/`, verify fights list with download links
- [ ] Manual: verify pagination and "solo con debug bundle" filter


🤖 Generated with [Claude Code](https://claude.com/claude-code)