### PR TITLE
fix(hud): resolve Player 2 ESP bar visibility and charging direction issues

### DIFF
--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -510,9 +510,10 @@ export class FightScene extends Phaser.Scene {
       .setOrigin(0, 0)
       .setDepth(depth);
     this.spBarP1 = this.add
-      .rectangle(SPECIAL_P1_X, SPECIAL_BAR_Y, 0, SPECIAL_BAR_H, 0xffcc00)
+      .rectangle(SPECIAL_P1_X, SPECIAL_BAR_Y, SPECIAL_BAR_W, SPECIAL_BAR_H, 0xffcc00)
       .setOrigin(0, 0)
-      .setDepth(depth + 1);
+      .setDepth(depth + 1)
+      .setScale(0, 1);
     this.add
       .rectangle(
         SPECIAL_P1_X + SPECIAL_BAR_W / 2,
@@ -541,9 +542,16 @@ export class FightScene extends Phaser.Scene {
       .setOrigin(0, 0)
       .setDepth(depth);
     this.spBarP2 = this.add
-      .rectangle(SPECIAL_P2_X + SPECIAL_BAR_W, SPECIAL_BAR_Y, 0, SPECIAL_BAR_H, 0xffcc00)
+      .rectangle(
+        SPECIAL_P2_X + SPECIAL_BAR_W,
+        SPECIAL_BAR_Y,
+        SPECIAL_BAR_W,
+        SPECIAL_BAR_H,
+        0xffcc00,
+      )
       .setOrigin(1, 0)
-      .setDepth(depth + 1);
+      .setDepth(depth + 1)
+      .setScale(0, 1);
     this.add
       .rectangle(
         SPECIAL_P2_X + SPECIAL_BAR_W / 2,
@@ -832,8 +840,8 @@ export class FightScene extends Phaser.Scene {
     // Special bars
     const spRatioP1 = Phaser.Math.Clamp(this.p1Fighter.special / MAX_SPECIAL_FP, 0, 1);
     const spRatioP2 = Phaser.Math.Clamp(this.p2Fighter.special / MAX_SPECIAL_FP, 0, 1);
-    this.spBarP1.width = SPECIAL_BAR_W * spRatioP1;
-    this.spBarP2.width = SPECIAL_BAR_W * spRatioP2;
+    this.spBarP1.scaleX = spRatioP1;
+    this.spBarP2.scaleX = spRatioP2;
 
     // Flash special bar when it's at least 50% (enough for a special)
     const flashTimer = Math.floor(Date.now() / 150) % 2 === 0;
@@ -850,7 +858,7 @@ export class FightScene extends Phaser.Scene {
       // HUD effects
       this.spParticlesP1.emitting = true;
       this.spParticlesP1.setPosition(
-        SPECIAL_P1_X + (SPECIAL_BAR_W * spRatioP1) / 2,
+        SPECIAL_P1_X + SPECIAL_BAR_W * spRatioP1,
         SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
       );
     } else {
@@ -870,7 +878,7 @@ export class FightScene extends Phaser.Scene {
       // HUD effects
       this.spParticlesP2.emitting = true;
       this.spParticlesP2.setPosition(
-        SPECIAL_P2_X + SPECIAL_BAR_W - (SPECIAL_BAR_W * spRatioP2) / 2,
+        SPECIAL_P2_X + SPECIAL_BAR_W - SPECIAL_BAR_W * spRatioP2,
         SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
       );
     } else {
@@ -881,8 +889,8 @@ export class FightScene extends Phaser.Scene {
     // Stamina bars
     const staRatioP1 = Phaser.Math.Clamp(this.p1Fighter.stamina / MAX_STAMINA_FP, 0, 1);
     const staRatioP2 = Phaser.Math.Clamp(this.p2Fighter.stamina / MAX_STAMINA_FP, 0, 1);
-    this.staBarP1.width = STAMINA_BAR_W * staRatioP1;
-    this.staBarP2.width = STAMINA_BAR_W * staRatioP2;
+    this.staBarP1.scaleX = staRatioP1;
+    this.staBarP2.scaleX = staRatioP2;
 
     // Flash red when depleted
     this.staBarP1.setFillStyle(staRatioP1 < 0.15 ? 0xff4444 : 0x00cccc);

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -240,7 +240,10 @@ export class SelectScene extends Phaser.Scene {
         color: '#888899',
       });
       const barBg = this.add.rectangle(panelX + 30, sy + 4, 60, 6, 0x222233).setOrigin(0, 0.5);
-      const bar = this.add.rectangle(panelX + 30, sy + 4, 0, 6, 0x44cc88).setOrigin(0, 0.5);
+      const bar = this.add
+        .rectangle(panelX + 30, sy + 4, 60, 6, 0x44cc88)
+        .setOrigin(0, 0.5)
+        .setScale(0, 1);
 
       this.p1StatLabels.push(label);
       this.p1StatBarBgs.push(barBg);
@@ -248,22 +251,22 @@ export class SelectScene extends Phaser.Scene {
     });
 
     // Divider
-    this.add.rectangle(panelX + 75, 170, 150, 1, 0x333355);
+    this.add.rectangle(panelX + 75, 150, 150, 1, 0x333355);
 
     // P2 info
-    this.add.text(panelX, 178, 'JUGADOR 2', {
+    this.add.text(panelX, 158, 'JUGADOR 2', {
       fontFamily: 'Arial Black, Arial',
       fontSize: '10px',
       color: '#ff3333',
     });
 
-    this.p2NameText = this.add.text(panelX, 193, 'Aleatorio', {
-      fontFamily: 'Arial',
+    this.p2NameText = this.add.text(panelX, 173, 'Aleatorio', {
+      fontFamily: 'Arial Black, Arial',
       fontSize: '14px',
       color: '#888888',
     });
 
-    this.p2SubtitleText = this.add.text(panelX, 210, '', {
+    this.p2SubtitleText = this.add.text(panelX, 190, '', {
       fontFamily: 'Arial',
       fontSize: '9px',
       color: '#aaaacc',
@@ -272,12 +275,12 @@ export class SelectScene extends Phaser.Scene {
 
     // P2 Portrait (image or rectangle placeholder)
     this.p2PortraitImg = this.add
-      .image(panelX + 130, 198, '__DEFAULT')
+      .image(panelX + 130, 178, '__DEFAULT')
       .setDisplaySize(45, 45)
       .setVisible(false);
-    this.p2Portrait = this.add.rectangle(panelX + 130, 198, 45, 45, 0x333333);
+    this.p2Portrait = this.add.rectangle(panelX + 130, 178, 45, 45, 0x333333);
     this.p2RandomText = this.add
-      .text(panelX + 130, 198, '?', {
+      .text(panelX + 130, 178, '?', {
         fontFamily: 'Arial Black',
         fontSize: '24px',
         color: '#ffffff',
@@ -289,14 +292,18 @@ export class SelectScene extends Phaser.Scene {
     this.p2StatBars = [];
     this.p2StatBarBgs = [];
     statNames.forEach((_stat, i) => {
-      const sy = 228 + i * 14;
+      const sy = 208 + i * 14;
       this.add.text(panelX, sy, statLabels[i], {
         fontFamily: 'Arial',
         fontSize: '8px',
         color: '#888899',
       });
+      // P2 bars charge Right-to-Left (Edge to Center)
       const barBg = this.add.rectangle(panelX + 30, sy + 4, 60, 6, 0x222233).setOrigin(0, 0.5);
-      const bar = this.add.rectangle(panelX + 30, sy + 4, 0, 6, 0xcc4444).setOrigin(0, 0.5);
+      const bar = this.add
+        .rectangle(panelX + 90, sy + 4, 60, 6, 0xcc4444)
+        .setOrigin(1, 0.5)
+        .setScale(0, 1);
 
       this.p2StatBarBgs.push(barBg);
       this.p2StatBars.push(bar);
@@ -518,7 +525,7 @@ export class SelectScene extends Phaser.Scene {
 
     statNames.forEach((stat, i) => {
       const val = isRandom ? 0 : fighter.stats[stat];
-      this.p1StatBars[i].width = (val / 5) * 60;
+      this.p1StatBars[i].scaleX = val / 5;
 
       // Add or update stat value text if it doesn't exist
       if (!this.p1StatValues) this.p1StatValues = [];
@@ -724,12 +731,12 @@ export class SelectScene extends Phaser.Scene {
 
     statNames.forEach((stat, i) => {
       const val = isRandom ? 0 : p2Fighter.stats[stat];
-      this.p2StatBars[i].width = (val / 5) * 60;
+      this.p2StatBars[i].scaleX = val / 5;
 
       // Add or update stat value text if it doesn't exist
       if (!this.p2StatValues) this.p2StatValues = [];
       if (!this.p2StatValues[i]) {
-        const sy = 228 + i * 14;
+        const sy = 208 + i * 14;
         this.p2StatValues[i] = this.add
           .text(panelX + 95, sy, '', {
             fontFamily: 'Arial',

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -298,11 +298,11 @@ export class SelectScene extends Phaser.Scene {
         fontSize: '8px',
         color: '#888899',
       });
-      // P2 bars charge Right-to-Left (Edge to Center)
+      // P2 bars charge Left-to-Right (Normal)
       const barBg = this.add.rectangle(panelX + 30, sy + 4, 60, 6, 0x222233).setOrigin(0, 0.5);
       const bar = this.add
-        .rectangle(panelX + 90, sy + 4, 60, 6, 0xcc4444)
-        .setOrigin(1, 0.5)
+        .rectangle(panelX + 30, sy + 4, 60, 6, 0xcc4444)
+        .setOrigin(0, 0.5)
         .setScale(0, 1);
 
       this.p2StatBarBgs.push(barBg);


### PR DESCRIPTION
## Description
This pull request addresses several visual issues related to the Player 2 (P2) HUD elements in both the selection and battle scenes.

### Changes:
- **SelectScene.js**:
  - Shifted the Player 2 information panel and stat bars up by 20 pixels to ensure the "ESP" bar is fully visible within the 270p resolution.
  - Reverted P2 statistics bars to grow from **Left-to-Right** (Normal), ensuring consistency with Player 1's display in the selection scene.
  - Both P1 and P2 now grow "normally" towards the right.
- **FightScene.js**:
  - Corrected the Player 2 yellow special (ESP) bar charging direction for battle. It now grows from **Right-to-Left** (towards the center) using `scaleX` and a right-anchored origin, as is standard for mirrored HUDs.
  - Aligned special bar particle emitters to the "leading edge" (the growing tip) for both players, providing better visual feedback as the bars charge.
- **Code Quality**:
  - Applied project-wide linting and formatting fixes via `biome`.
  - Verified that all 752 existing unit tests pass.

## Motivation
Previously, the Player 2 "ESP" bar in the selection scene was cut off, and the battle HUD's special bar was charging in an inconsistent direction. These changes provide a polished, symmetrical experience in battle while maintaining standard growth directions in the menu.

## Testing

- [ ] Verified visibility and charging direction in both `SelectScene` and `FightScene`.

- Ran `npm run test:run` (All 752 tests passed).
- Ran `npm run lint` (All checks passed).

<img width="1900" height="229" alt="Captura de pantalla 2026-04-02 141025" src="https://github.com/user-attachments/assets/14aaccb7-a907-46af-9660-6546e6379e97" />
<img width="727" height="1053" alt="Captura de pantalla 2026-04-02 145347" src="https://github.com/user-attachments/assets/9b8ef828-3ee4-4663-846e-491135fe575a" />
