### PR TITLE
feat: Radial Special Indicators & HUD Drain-to-Center Layout

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "A Los Traques",
+  "short_name": "Traques",
+  "description": "Juego de lucha minimalista",
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "landscape",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -83,6 +83,13 @@ export class BootScene extends Phaser.Scene {
     this.load.audio('ui_confirm', 'assets/audio/ui_confirm.mp3');
     this.load.audio('ui_cancel', 'assets/audio/ui_cancel.mp3');
 
+    // Button Icons
+    this.load.image('btn_lp', 'assets/ui/btn_lp.png');
+    this.load.image('btn_hp', 'assets/ui/btn_hp.png');
+    this.load.image('btn_lk', 'assets/ui/btn_lk.png');
+    this.load.image('btn_hk', 'assets/ui/btn_hk.png');
+    this.load.image('btn_special', 'assets/ui/btn_special.png');
+
     // Load stage background images (only for those that have actual image files)
     for (const stage of stages) {
       if (stage.texture?.startsWith('stages_')) {

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -40,23 +40,28 @@ import { VFXBridge } from '../systems/VFXBridge.js';
 // ---------------------------------------------------------------------------
 const log = Logger.create('FightScene');
 
-const BAR_W = 160;
+const BAR_W = 140;
 const BAR_H = 10;
 const BAR_Y = 12;
-const BAR_P1_X = 16;
-const BAR_P2_X = GAME_WIDTH - 16 - BAR_W;
-
-const SPECIAL_BAR_W = 100;
-const SPECIAL_BAR_H = 6;
-const SPECIAL_BAR_Y = BAR_Y + BAR_H + 4;
-const SPECIAL_P1_X = BAR_P1_X;
-const SPECIAL_P2_X = GAME_WIDTH - 16 - SPECIAL_BAR_W;
+const BAR_GAP = 54; // Gap for clock (was roughly 128)
+const BAR_P1_X = GAME_WIDTH / 2 - BAR_GAP / 2 - BAR_W;
+const BAR_P2_X = GAME_WIDTH / 2 + BAR_GAP / 2;
 
 const STAMINA_BAR_W = 100;
-const STAMINA_BAR_H = 5;
-const STAMINA_BAR_Y = SPECIAL_BAR_Y + SPECIAL_BAR_H + 3;
-const STAMINA_P1_X = BAR_P1_X;
-const STAMINA_P2_X = GAME_WIDTH - 16 - STAMINA_BAR_W;
+const STAMINA_BAR_H = 4;
+const STAMINA_BAR_Y = BAR_Y + BAR_H + 3;
+const STAMINA_P1_X = GAME_WIDTH / 2 - BAR_GAP / 2 - STAMINA_BAR_W;
+const STAMINA_P2_X = GAME_WIDTH / 2 + BAR_GAP / 2;
+
+// Radial Special Indicator constants
+const RADIAL_RADIUS = 12;
+const RADIAL_Y = BAR_Y + BAR_H / 2;
+const RADIAL_OFFSET_X = 22; // Distance from the outer edge of health bar
+const RADIAL_P1_X = BAR_P1_X - RADIAL_OFFSET_X;
+const RADIAL_P2_X = BAR_P2_X + BAR_W + RADIAL_OFFSET_X;
+
+// Special meter bar is being replaced by radial indicator, but we'll keep
+// some relative positions for other UI if needed.
 
 export class FightScene extends Phaser.Scene {
   constructor() {
@@ -473,14 +478,14 @@ export class FightScene extends Phaser.Scene {
     const depth = 20;
 
     // --- Health bars ---
-    // P1 health (fills from left to right)
+    // P1 health (anchored at right, drains towards center)
     this.hpBgP1 = this.add
       .rectangle(BAR_P1_X, BAR_Y, BAR_W, BAR_H, 0x333333)
       .setOrigin(0, 0)
       .setDepth(depth);
     this.hpBarP1 = this.add
-      .rectangle(BAR_P1_X, BAR_Y, BAR_W, BAR_H, 0x00cc44)
-      .setOrigin(0, 0)
+      .rectangle(BAR_P1_X + BAR_W, BAR_Y, BAR_W, BAR_H, 0x00cc44)
+      .setOrigin(1, 0)
       .setDepth(depth + 1);
     this.add
       .rectangle(BAR_P1_X + BAR_W / 2, BAR_Y + BAR_H / 2, BAR_W + 2, BAR_H + 2)
@@ -488,14 +493,14 @@ export class FightScene extends Phaser.Scene {
       .setFillStyle()
       .setDepth(depth + 2);
 
-    // P2 health (fills from right to left)
+    // P2 health (anchored at left, drains towards center)
     this.hpBgP2 = this.add
       .rectangle(BAR_P2_X, BAR_Y, BAR_W, BAR_H, 0x333333)
       .setOrigin(0, 0)
       .setDepth(depth);
     this.hpBarP2 = this.add
-      .rectangle(BAR_P2_X + BAR_W, BAR_Y, BAR_W, BAR_H, 0xcc2200)
-      .setOrigin(1, 0)
+      .rectangle(BAR_P2_X, BAR_Y, BAR_W, BAR_H, 0xcc2200)
+      .setOrigin(0, 0)
       .setDepth(depth + 1);
     this.add
       .rectangle(BAR_P2_X + BAR_W / 2, BAR_Y + BAR_H / 2, BAR_W + 2, BAR_H + 2)
@@ -503,103 +508,63 @@ export class FightScene extends Phaser.Scene {
       .setFillStyle()
       .setDepth(depth + 2);
 
-    // --- Special meter bars ---
-    // P1 special
-    this.spBgP1 = this.add
-      .rectangle(SPECIAL_P1_X, SPECIAL_BAR_Y, SPECIAL_BAR_W, SPECIAL_BAR_H, 0x222222)
-      .setOrigin(0, 0)
-      .setDepth(depth);
-    this.spBarP1 = this.add
-      .rectangle(SPECIAL_P1_X, SPECIAL_BAR_Y, SPECIAL_BAR_W, SPECIAL_BAR_H, 0xffcc00)
-      .setOrigin(0, 0)
-      .setDepth(depth + 1)
-      .setScale(0, 1);
+    // --- Special Indicators (Radial) ---
+    // P1 Special
+    this.spRadialP1 = this.add.graphics().setDepth(depth + 1);
+    this.add.circle(RADIAL_P1_X, RADIAL_Y, RADIAL_RADIUS, 0x222222).setDepth(depth);
     this.add
-      .rectangle(
-        SPECIAL_P1_X + SPECIAL_BAR_W / 2,
-        SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
-        SPECIAL_BAR_W + 2,
-        SPECIAL_BAR_H + 2,
-      )
+      .circle(RADIAL_P1_X, RADIAL_Y, RADIAL_RADIUS)
       .setStrokeStyle(1, 0x666666)
-      .setFillStyle()
       .setDepth(depth + 2);
-    // 50% marker P1
-    this.add
-      .rectangle(
-        SPECIAL_P1_X + SPECIAL_BAR_W / 2,
-        SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
-        1,
-        SPECIAL_BAR_H,
-        0xffffff,
-        0.3,
-      )
-      .setDepth(depth + 2);
+    this.spRadialTextP1 = this.add
+      .text(RADIAL_P1_X, RADIAL_Y, '⚡', {
+        fontSize: '10px',
+        fontFamily: 'monospace',
+        color: '#ffffff',
+      })
+      .setOrigin(0.5)
+      .setDepth(depth + 3);
 
-    // P2 special
-    this.spBgP2 = this.add
-      .rectangle(SPECIAL_P2_X, SPECIAL_BAR_Y, SPECIAL_BAR_W, SPECIAL_BAR_H, 0x222222)
-      .setOrigin(0, 0)
-      .setDepth(depth);
-    this.spBarP2 = this.add
-      .rectangle(
-        SPECIAL_P2_X + SPECIAL_BAR_W,
-        SPECIAL_BAR_Y,
-        SPECIAL_BAR_W,
-        SPECIAL_BAR_H,
-        0xffcc00,
-      )
-      .setOrigin(1, 0)
-      .setDepth(depth + 1)
-      .setScale(0, 1);
+    // P2 Special
+    this.spRadialP2 = this.add.graphics().setDepth(depth + 1);
+    this.add.circle(RADIAL_P2_X, RADIAL_Y, RADIAL_RADIUS, 0x222222).setDepth(depth);
     this.add
-      .rectangle(
-        SPECIAL_P2_X + SPECIAL_BAR_W / 2,
-        SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
-        SPECIAL_BAR_W + 2,
-        SPECIAL_BAR_H + 2,
-      )
+      .circle(RADIAL_P2_X, RADIAL_Y, RADIAL_RADIUS)
       .setStrokeStyle(1, 0x666666)
-      .setFillStyle()
       .setDepth(depth + 2);
-    // 50% marker P2
-    this.add
-      .rectangle(
-        SPECIAL_P2_X + SPECIAL_BAR_W / 2,
-        SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
-        1,
-        SPECIAL_BAR_H,
-        0xffffff,
-        0.3,
-      )
-      .setDepth(depth + 2);
+    this.spRadialTextP2 = this.add
+      .text(RADIAL_P2_X, RADIAL_Y, '⚡', {
+        // P2 is usually AI or remote, so generic icon
+        fontSize: '10px',
+        fontFamily: 'monospace',
+        color: '#ffffff',
+      })
+      .setOrigin(0.5)
+      .setDepth(depth + 3);
+
+    // Track previous special values for threshold effects
+    this.prevSpecialP1 = 0;
+    this.prevSpecialP2 = 0;
 
     // --- Special effects for HUD bars ---
     // HUD Particle emitters
+    const particleConfig = {
+      speed: { min: 10, max: 20 },
+      angle: { min: 0, max: 360 },
+      scale: { start: 1, end: 0 },
+      alpha: { start: 0.6, end: 0 },
+      lifespan: 400,
+      frequency: 100,
+      tint: 0xffcc00,
+      emitting: false,
+    };
+
     this.spParticlesP1 = this.add
-      .particles(0, 0, 'white_pixel', {
-        speed: { min: 10, max: 20 },
-        angle: { min: 260, max: 280 },
-        scale: { start: 1, end: 0 },
-        alpha: { start: 0.6, end: 0 },
-        lifespan: 400,
-        frequency: 100,
-        tint: 0xffcc00,
-        emitting: false,
-      })
+      .particles(0, 0, 'white_pixel', particleConfig)
       .setDepth(depth - 1);
 
     this.spParticlesP2 = this.add
-      .particles(0, 0, 'white_pixel', {
-        speed: { min: 10, max: 20 },
-        angle: { min: 260, max: 280 },
-        scale: { start: 1, end: 0 },
-        alpha: { start: 0.6, end: 0 },
-        lifespan: 400,
-        frequency: 100,
-        tint: 0xffcc00,
-        emitting: false,
-      })
+      .particles(0, 0, 'white_pixel', particleConfig)
       .setDepth(depth - 1);
 
     // --- Player name labels ---
@@ -607,24 +572,25 @@ export class FightScene extends Phaser.Scene {
     const p2Color = this.p2Data.color.replace('0x', '#');
 
     this.add
-      .text(BAR_P1_X, BAR_Y - 11, this.p1Data.name, {
+      .text(BAR_P1_X + BAR_W, BAR_Y - 11, this.p1Data.name, {
         fontSize: '9px',
         fontFamily: 'monospace',
         color: p1Color,
         stroke: '#000000',
         strokeThickness: 2,
       })
+      .setOrigin(1, 0)
       .setDepth(depth + 3);
 
     this.add
-      .text(BAR_P2_X + BAR_W, BAR_Y - 11, this.p2Data.name, {
+      .text(BAR_P2_X, BAR_Y - 11, this.p2Data.name, {
         fontSize: '9px',
         fontFamily: 'monospace',
         color: p2Color,
         stroke: '#000000',
         strokeThickness: 2,
       })
-      .setOrigin(1, 0)
+      .setOrigin(0, 0)
       .setDepth(depth + 3);
 
     // --- Timer display (center top) ---
@@ -659,14 +625,20 @@ export class FightScene extends Phaser.Scene {
     }
 
     // --- Stamina bars ---
-    // P1 stamina
+    // P1 stamina (anchored at right, drains towards center)
     this.staBgP1 = this.add
       .rectangle(STAMINA_P1_X, STAMINA_BAR_Y, STAMINA_BAR_W, STAMINA_BAR_H, 0x222222)
       .setOrigin(0, 0)
       .setDepth(depth);
     this.staBarP1 = this.add
-      .rectangle(STAMINA_P1_X, STAMINA_BAR_Y, STAMINA_BAR_W, STAMINA_BAR_H, 0x00cccc)
-      .setOrigin(0, 0)
+      .rectangle(
+        STAMINA_P1_X + STAMINA_BAR_W,
+        STAMINA_BAR_Y,
+        STAMINA_BAR_W,
+        STAMINA_BAR_H,
+        0x00cccc,
+      )
+      .setOrigin(1, 0)
       .setDepth(depth + 1);
     this.add
       .rectangle(
@@ -679,20 +651,14 @@ export class FightScene extends Phaser.Scene {
       .setFillStyle()
       .setDepth(depth + 2);
 
-    // P2 stamina
+    // P2 stamina (anchored at left, drains towards center)
     this.staBgP2 = this.add
       .rectangle(STAMINA_P2_X, STAMINA_BAR_Y, STAMINA_BAR_W, STAMINA_BAR_H, 0x222222)
       .setOrigin(0, 0)
       .setDepth(depth);
     this.staBarP2 = this.add
-      .rectangle(
-        STAMINA_P2_X + STAMINA_BAR_W,
-        STAMINA_BAR_Y,
-        STAMINA_BAR_W,
-        STAMINA_BAR_H,
-        0x00cccc,
-      )
-      .setOrigin(1, 0)
+      .rectangle(STAMINA_P2_X, STAMINA_BAR_Y, STAMINA_BAR_W, STAMINA_BAR_H, 0x00cccc)
+      .setOrigin(0, 0)
       .setDepth(depth + 1);
     this.add
       .rectangle(
@@ -704,40 +670,6 @@ export class FightScene extends Phaser.Scene {
       .setStrokeStyle(1, 0x444444)
       .setFillStyle()
       .setDepth(depth + 2);
-
-    // --- Bar labels ---
-    const labelStyle = {
-      fontSize: '5px',
-      fontFamily: 'monospace',
-      stroke: '#000000',
-      strokeThickness: 1,
-    };
-
-    // ESP labels (special)
-    this.add
-      .text(SPECIAL_P1_X + SPECIAL_BAR_W + 3, SPECIAL_BAR_Y, 'ESP', {
-        ...labelStyle,
-        color: '#ffcc00',
-      })
-      .setOrigin(0, 0)
-      .setDepth(depth + 3);
-    this.add
-      .text(SPECIAL_P2_X - 3, SPECIAL_BAR_Y, 'ESP', { ...labelStyle, color: '#ffcc00' })
-      .setOrigin(1, 0)
-      .setDepth(depth + 3);
-
-    // STA labels (stamina)
-    this.add
-      .text(STAMINA_P1_X + STAMINA_BAR_W + 3, STAMINA_BAR_Y, 'STA', {
-        ...labelStyle,
-        color: '#00cccc',
-      })
-      .setOrigin(0, 0)
-      .setDepth(depth + 3);
-    this.add
-      .text(STAMINA_P2_X - 3, STAMINA_BAR_Y, 'STA', { ...labelStyle, color: '#00cccc' })
-      .setOrigin(1, 0)
-      .setDepth(depth + 3);
 
     // --- Pause button (below timer, local mode only) ---
     if (this.gameMode !== 'online') {
@@ -825,8 +757,8 @@ export class FightScene extends Phaser.Scene {
     const ratioP1 = Phaser.Math.Clamp(this.p1Fighter.hp / MAX_HP, 0, 1);
     const ratioP2 = Phaser.Math.Clamp(this.p2Fighter.hp / MAX_HP, 0, 1);
 
-    this.hpBarP1.width = BAR_W * ratioP1;
-    this.hpBarP2.width = BAR_W * ratioP2;
+    this.hpBarP1.setScale(ratioP1, 1);
+    this.hpBarP2.setScale(ratioP2, 1);
 
     // Color shifts as HP drops
     if (ratioP1 < 0.3) this.hpBarP1.setFillStyle(0xff4444);
@@ -837,60 +769,15 @@ export class FightScene extends Phaser.Scene {
     else if (ratioP2 < 0.6) this.hpBarP2.setFillStyle(0xffaa00);
     else this.hpBarP2.setFillStyle(0xcc2200);
 
-    // Special bars
-    const spRatioP1 = Phaser.Math.Clamp(this.p1Fighter.special / MAX_SPECIAL_FP, 0, 1);
-    const spRatioP2 = Phaser.Math.Clamp(this.p2Fighter.special / MAX_SPECIAL_FP, 0, 1);
-    this.spBarP1.scaleX = spRatioP1;
-    this.spBarP2.scaleX = spRatioP2;
-
-    // Flash special bar when it's at least 50% (enough for a special)
-    const flashTimer = Math.floor(Date.now() / 150) % 2 === 0;
-
-    // Effects for P1
-    if (spRatioP1 >= 0.5) {
-      if (spRatioP1 >= 1.0) {
-        this.spBarP1.setFillStyle(flashTimer ? 0xffff00 : 0xffcc00);
-      } else {
-        // Subtle pulse for 50%
-        this.spBarP1.setFillStyle(flashTimer ? 0xffdd00 : 0xffaa00);
-      }
-
-      // HUD effects
-      this.spParticlesP1.emitting = true;
-      this.spParticlesP1.setPosition(
-        SPECIAL_P1_X + SPECIAL_BAR_W * spRatioP1,
-        SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
-      );
-    } else {
-      this.spBarP1.setFillStyle(0xffcc00);
-      this.spParticlesP1.emitting = false;
-    }
-
-    // Effects for P2
-    if (spRatioP2 >= 0.5) {
-      if (spRatioP2 >= 1.0) {
-        this.spBarP2.setFillStyle(flashTimer ? 0xffff00 : 0xffcc00);
-      } else {
-        // Subtle pulse for 50%
-        this.spBarP2.setFillStyle(flashTimer ? 0xffdd00 : 0xffaa00);
-      }
-
-      // HUD effects
-      this.spParticlesP2.emitting = true;
-      this.spParticlesP2.setPosition(
-        SPECIAL_P2_X + SPECIAL_BAR_W - SPECIAL_BAR_W * spRatioP2,
-        SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
-      );
-    } else {
-      this.spBarP2.setFillStyle(0xffcc00);
-      this.spParticlesP2.emitting = false;
-    }
+    // Special Indicators (Radial)
+    this._updateRadialIndicator(this.spRadialP1, this.spRadialTextP1, this.p1Fighter, 'P1');
+    this._updateRadialIndicator(this.spRadialP2, this.spRadialTextP2, this.p2Fighter, 'P2');
 
     // Stamina bars
     const staRatioP1 = Phaser.Math.Clamp(this.p1Fighter.stamina / MAX_STAMINA_FP, 0, 1);
     const staRatioP2 = Phaser.Math.Clamp(this.p2Fighter.stamina / MAX_STAMINA_FP, 0, 1);
-    this.staBarP1.scaleX = staRatioP1;
-    this.staBarP2.scaleX = staRatioP2;
+    this.staBarP1.setScale(staRatioP1, 1);
+    this.staBarP2.setScale(staRatioP2, 1);
 
     // Flash red when depleted
     this.staBarP1.setFillStyle(staRatioP1 < 0.15 ? 0xff4444 : 0x00cccc);
@@ -898,6 +785,107 @@ export class FightScene extends Phaser.Scene {
 
     // Timer
     this.timerText.setText(String(Math.max(0, this.combat.timer)));
+    this._updateHUD_Extra();
+  }
+
+  /**
+   * Updates a radial special indicator.
+   */
+  _updateRadialIndicator(graphics, text, fighter, playerKey) {
+    const spRatio = Phaser.Math.Clamp(fighter.special / MAX_SPECIAL_FP, 0, 1);
+    const prevSp = playerKey === 'P1' ? this.prevSpecialP1 : this.prevSpecialP2;
+    const prevSpRatio = Phaser.Math.Clamp(prevSp / MAX_SPECIAL_FP, 0, 1);
+
+    const centerX = playerKey === 'P1' ? RADIAL_P1_X : RADIAL_P2_X;
+    const centerY = RADIAL_Y;
+
+    // Threshold logic (50%)
+    if (spRatio >= 0.5 && prevSpRatio < 0.5) {
+      // Threshold reached!
+      this.tweens.add({
+        targets: [graphics, text],
+        scale: 1.4,
+        duration: 100,
+        yoyo: true,
+        ease: 'Quad.easeOut',
+      });
+
+      // Vibration (only for local P1 or if on mobile)
+      if (
+        playerKey === 'P1' &&
+        this.gameMode !== 'spectator' &&
+        typeof navigator !== 'undefined' &&
+        navigator.vibrate
+      ) {
+        navigator.vibrate(50);
+      }
+    }
+
+    // Update previous value
+    if (playerKey === 'P1') this.prevSpecialP1 = fighter.special;
+    else this.prevSpecialP2 = fighter.special;
+
+    graphics.clear();
+
+    const flashTimer = Math.floor(Date.now() / 150) % 2 === 0;
+    let color = 0xffcc00;
+
+    if (spRatio >= 1.0) {
+      color = flashTimer ? 0xffff00 : 0xffcc00;
+    } else if (spRatio >= 0.5) {
+      color = flashTimer ? 0xffdd00 : 0xffaa00;
+    }
+
+    // Draw arc
+    if (spRatio > 0) {
+      graphics.lineStyle(3, color, 1);
+      // arc(x, y, radius, startAngle, endAngle, anticlockwise)
+      // angles in radians. -Math.PI/2 is top.
+      graphics.beginPath();
+      graphics.arc(
+        centerX,
+        centerY,
+        RADIAL_RADIUS - 1.5,
+        -Math.PI / 2,
+        -Math.PI / 2 + Math.PI * 2 * spRatio,
+        false,
+      );
+      graphics.strokePath();
+    }
+
+    // Text color
+    if (spRatio >= 0.5) {
+      text.setColor('#ffcc00');
+    } else {
+      text.setColor('#ffffff');
+    }
+
+    // Particle effects
+    const particles = playerKey === 'P1' ? this.spParticlesP1 : this.spParticlesP2;
+    if (spRatio >= 0.5) {
+      if (typeof particles.start === 'function' && !particles.emitting) {
+        particles.start();
+      } else {
+        particles.emitting = true;
+      }
+      particles.setPosition(centerX, centerY);
+      // Phaser 3.60+ uses setParticleTint for emitters
+      if (typeof particles.setParticleTint === 'function') {
+        particles.setParticleTint(color);
+      } else if (typeof particles.setTint === 'function') {
+        particles.setTint(color);
+      }
+    } else {
+      if (typeof particles.stop === 'function') {
+        particles.stop();
+      } else {
+        particles.emitting = false;
+      }
+    }
+  }
+
+  _updateHUD_Extra() {
+    // This is a helper to finish updating the HUD
     if (this.combat.timer <= 10) {
       this.timerText.setColor('#ff4444');
     } else {

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -510,9 +510,10 @@ export class FightScene extends Phaser.Scene {
       .setOrigin(0, 0)
       .setDepth(depth);
     this.spBarP1 = this.add
-      .rectangle(SPECIAL_P1_X, SPECIAL_BAR_Y, 0, SPECIAL_BAR_H, 0xffcc00)
+      .rectangle(SPECIAL_P1_X, SPECIAL_BAR_Y, SPECIAL_BAR_W, SPECIAL_BAR_H, 0xffcc00)
       .setOrigin(0, 0)
-      .setDepth(depth + 1);
+      .setDepth(depth + 1)
+      .setScale(0, 1);
     this.add
       .rectangle(
         SPECIAL_P1_X + SPECIAL_BAR_W / 2,
@@ -541,9 +542,16 @@ export class FightScene extends Phaser.Scene {
       .setOrigin(0, 0)
       .setDepth(depth);
     this.spBarP2 = this.add
-      .rectangle(SPECIAL_P2_X + SPECIAL_BAR_W, SPECIAL_BAR_Y, 0, SPECIAL_BAR_H, 0xffcc00)
+      .rectangle(
+        SPECIAL_P2_X + SPECIAL_BAR_W,
+        SPECIAL_BAR_Y,
+        SPECIAL_BAR_W,
+        SPECIAL_BAR_H,
+        0xffcc00,
+      )
       .setOrigin(1, 0)
-      .setDepth(depth + 1);
+      .setDepth(depth + 1)
+      .setScale(0, 1);
     this.add
       .rectangle(
         SPECIAL_P2_X + SPECIAL_BAR_W / 2,
@@ -832,8 +840,8 @@ export class FightScene extends Phaser.Scene {
     // Special bars
     const spRatioP1 = Phaser.Math.Clamp(this.p1Fighter.special / MAX_SPECIAL_FP, 0, 1);
     const spRatioP2 = Phaser.Math.Clamp(this.p2Fighter.special / MAX_SPECIAL_FP, 0, 1);
-    this.spBarP1.width = SPECIAL_BAR_W * spRatioP1;
-    this.spBarP2.width = SPECIAL_BAR_W * spRatioP2;
+    this.spBarP1.scaleX = spRatioP1;
+    this.spBarP2.scaleX = spRatioP2;
 
     // Flash special bar when it's at least 50% (enough for a special)
     const flashTimer = Math.floor(Date.now() / 150) % 2 === 0;
@@ -850,7 +858,7 @@ export class FightScene extends Phaser.Scene {
       // HUD effects
       this.spParticlesP1.emitting = true;
       this.spParticlesP1.setPosition(
-        SPECIAL_P1_X + (SPECIAL_BAR_W * spRatioP1) / 2,
+        SPECIAL_P1_X + SPECIAL_BAR_W * spRatioP1,
         SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
       );
     } else {
@@ -870,7 +878,7 @@ export class FightScene extends Phaser.Scene {
       // HUD effects
       this.spParticlesP2.emitting = true;
       this.spParticlesP2.setPosition(
-        SPECIAL_P2_X + SPECIAL_BAR_W - (SPECIAL_BAR_W * spRatioP2) / 2,
+        SPECIAL_P2_X + SPECIAL_BAR_W - SPECIAL_BAR_W * spRatioP2,
         SPECIAL_BAR_Y + SPECIAL_BAR_H / 2,
       );
     } else {
@@ -881,8 +889,8 @@ export class FightScene extends Phaser.Scene {
     // Stamina bars
     const staRatioP1 = Phaser.Math.Clamp(this.p1Fighter.stamina / MAX_STAMINA_FP, 0, 1);
     const staRatioP2 = Phaser.Math.Clamp(this.p2Fighter.stamina / MAX_STAMINA_FP, 0, 1);
-    this.staBarP1.width = STAMINA_BAR_W * staRatioP1;
-    this.staBarP2.width = STAMINA_BAR_W * staRatioP2;
+    this.staBarP1.scaleX = staRatioP1;
+    this.staBarP2.scaleX = staRatioP2;
 
     // Flash red when depleted
     this.staBarP1.setFillStyle(staRatioP1 < 0.15 ? 0xff4444 : 0x00cccc);

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -240,7 +240,10 @@ export class SelectScene extends Phaser.Scene {
         color: '#888899',
       });
       const barBg = this.add.rectangle(panelX + 30, sy + 4, 60, 6, 0x222233).setOrigin(0, 0.5);
-      const bar = this.add.rectangle(panelX + 30, sy + 4, 0, 6, 0x44cc88).setOrigin(0, 0.5);
+      const bar = this.add
+        .rectangle(panelX + 30, sy + 4, 60, 6, 0x44cc88)
+        .setOrigin(0, 0.5)
+        .setScale(0, 1);
 
       this.p1StatLabels.push(label);
       this.p1StatBarBgs.push(barBg);
@@ -248,22 +251,22 @@ export class SelectScene extends Phaser.Scene {
     });
 
     // Divider
-    this.add.rectangle(panelX + 75, 170, 150, 1, 0x333355);
+    this.add.rectangle(panelX + 75, 150, 150, 1, 0x333355);
 
     // P2 info
-    this.add.text(panelX, 178, 'JUGADOR 2', {
+    this.add.text(panelX, 158, 'JUGADOR 2', {
       fontFamily: 'Arial Black, Arial',
       fontSize: '10px',
       color: '#ff3333',
     });
 
-    this.p2NameText = this.add.text(panelX, 193, 'Aleatorio', {
-      fontFamily: 'Arial',
+    this.p2NameText = this.add.text(panelX, 173, 'Aleatorio', {
+      fontFamily: 'Arial Black, Arial',
       fontSize: '14px',
       color: '#888888',
     });
 
-    this.p2SubtitleText = this.add.text(panelX, 210, '', {
+    this.p2SubtitleText = this.add.text(panelX, 190, '', {
       fontFamily: 'Arial',
       fontSize: '9px',
       color: '#aaaacc',
@@ -272,12 +275,12 @@ export class SelectScene extends Phaser.Scene {
 
     // P2 Portrait (image or rectangle placeholder)
     this.p2PortraitImg = this.add
-      .image(panelX + 130, 198, '__DEFAULT')
+      .image(panelX + 130, 178, '__DEFAULT')
       .setDisplaySize(45, 45)
       .setVisible(false);
-    this.p2Portrait = this.add.rectangle(panelX + 130, 198, 45, 45, 0x333333);
+    this.p2Portrait = this.add.rectangle(panelX + 130, 178, 45, 45, 0x333333);
     this.p2RandomText = this.add
-      .text(panelX + 130, 198, '?', {
+      .text(panelX + 130, 178, '?', {
         fontFamily: 'Arial Black',
         fontSize: '24px',
         color: '#ffffff',
@@ -289,14 +292,18 @@ export class SelectScene extends Phaser.Scene {
     this.p2StatBars = [];
     this.p2StatBarBgs = [];
     statNames.forEach((_stat, i) => {
-      const sy = 228 + i * 14;
+      const sy = 208 + i * 14;
       this.add.text(panelX, sy, statLabels[i], {
         fontFamily: 'Arial',
         fontSize: '8px',
         color: '#888899',
       });
+      // P2 bars charge Right-to-Left (Edge to Center)
       const barBg = this.add.rectangle(panelX + 30, sy + 4, 60, 6, 0x222233).setOrigin(0, 0.5);
-      const bar = this.add.rectangle(panelX + 30, sy + 4, 0, 6, 0xcc4444).setOrigin(0, 0.5);
+      const bar = this.add
+        .rectangle(panelX + 90, sy + 4, 60, 6, 0xcc4444)
+        .setOrigin(1, 0.5)
+        .setScale(0, 1);
 
       this.p2StatBarBgs.push(barBg);
       this.p2StatBars.push(bar);
@@ -518,7 +525,7 @@ export class SelectScene extends Phaser.Scene {
 
     statNames.forEach((stat, i) => {
       const val = isRandom ? 0 : fighter.stats[stat];
-      this.p1StatBars[i].width = (val / 5) * 60;
+      this.p1StatBars[i].scaleX = val / 5;
 
       // Add or update stat value text if it doesn't exist
       if (!this.p1StatValues) this.p1StatValues = [];
@@ -724,12 +731,12 @@ export class SelectScene extends Phaser.Scene {
 
     statNames.forEach((stat, i) => {
       const val = isRandom ? 0 : p2Fighter.stats[stat];
-      this.p2StatBars[i].width = (val / 5) * 60;
+      this.p2StatBars[i].scaleX = val / 5;
 
       // Add or update stat value text if it doesn't exist
       if (!this.p2StatValues) this.p2StatValues = [];
       if (!this.p2StatValues[i]) {
-        const sy = 228 + i * 14;
+        const sy = 208 + i * 14;
         this.p2StatValues[i] = this.add
           .text(panelX + 95, sy, '', {
             fontFamily: 'Arial',

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -298,11 +298,11 @@ export class SelectScene extends Phaser.Scene {
         fontSize: '8px',
         color: '#888899',
       });
-      // P2 bars charge Right-to-Left (Edge to Center)
+      // P2 bars charge Left-to-Right (Normal)
       const barBg = this.add.rectangle(panelX + 30, sy + 4, 60, 6, 0x222233).setOrigin(0, 0.5);
       const bar = this.add
-        .rectangle(panelX + 90, sy + 4, 60, 6, 0xcc4444)
-        .setOrigin(1, 0.5)
+        .rectangle(panelX + 30, sy + 4, 60, 6, 0xcc4444)
+        .setOrigin(0, 0.5)
         .setScale(0, 1);
 
       this.p2StatBarBgs.push(barBg);

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -1,6 +1,6 @@
 import Phaser from 'phaser';
 import { GAME_HEIGHT, GAME_WIDTH } from '../config.js';
-import { SPECIAL_COST_FP } from './FixedPoint.js';
+import { MAX_SPECIAL_FP, SPECIAL_COST_FP } from './FixedPoint.js';
 
 /**
  * Virtual gamepad overlay for touch devices.
@@ -36,6 +36,7 @@ export class TouchControls {
     this.activeButtonPointers = {}; // pointerId -> button key
     this.specialGlow = null;
     this.specialParticles = null;
+    this.specialRadial = null;
 
     this.createJoystick();
     this.createButtons();
@@ -88,17 +89,30 @@ export class TouchControls {
     //   Middle row:  [LP]  [LK]
     //   Bottom row:  [HP]  [HK]
     const defs = [
-      // key in touchState, label, dx, dy
+      // key in touchState, label, dx, dy, texture
       {
         key: 'special',
-        label: 'ES',
+        label: '⚡',
         dx: 0, // Aligned with the right column
         dy: -(btnRadius * 2 + gap) * 1.4, // Higher up
+        texture: 'btn_special',
       },
-      { key: 'lightPunch', label: 'PL', dx: -(btnRadius * 2 + gap), dy: 0 },
-      { key: 'lightKick', label: 'PaL', dx: 0, dy: 0 },
-      { key: 'heavyPunch', label: 'PP', dx: -(btnRadius * 2 + gap), dy: btnRadius * 2 + gap },
-      { key: 'heavyKick', label: 'PaP', dx: 0, dy: btnRadius * 2 + gap },
+      {
+        key: 'lightPunch',
+        label: 'PL',
+        dx: -(btnRadius * 2 + gap),
+        dy: 0,
+        texture: 'btn_lp',
+      },
+      { key: 'lightKick', label: 'PaL', dx: 0, dy: 0, texture: 'btn_lk' },
+      {
+        key: 'heavyPunch',
+        label: 'PP',
+        dx: -(btnRadius * 2 + gap),
+        dy: btnRadius * 2 + gap,
+        texture: 'btn_hp',
+      },
+      { key: 'heavyKick', label: 'PaP', dx: 0, dy: btnRadius * 2 + gap, texture: 'btn_hk' },
     ];
 
     for (const def of defs) {
@@ -128,6 +142,9 @@ export class TouchControls {
           })
           .setDepth(100);
 
+        // Radial progress arc for special button (Depth 105 to be on top of icon)
+        this.specialRadial = scene.add.graphics().setDepth(105);
+
         // Add a pulsing tween for the glow
         scene.tweens.add({
           targets: glow,
@@ -145,22 +162,27 @@ export class TouchControls {
         .setStrokeStyle(1.5, 0xffffff, 0.35)
         .setDepth(101);
 
-      // Label
-      const txt = scene.add
-        .text(cx, cy, def.label, {
-          fontFamily: 'monospace',
-          fontSize: '9px',
-          color: '#ffffff',
-          align: 'center',
-        })
-        .setOrigin(0.5)
-        .setAlpha(0.5)
-        .setDepth(102);
+      // Icon Image
+      let icon = null;
+      if (scene.textures.exists(def.texture)) {
+        icon = scene.add.image(cx, cy, def.texture).setDepth(102).setAlpha(0.6).setScale(0.8);
+      } else {
+        // Fallback to text if image is missing
+        icon = scene.add
+          .text(cx, cy, def.label, {
+            fontFamily: 'monospace',
+            fontSize: '9px',
+            color: '#ffffff',
+            align: 'center',
+          })
+          .setOrigin(0.5)
+          .setAlpha(0.5)
+          .setDepth(102);
+      }
 
       this.buttons.push({
         graphic: bg,
-        text: txt,
-        glow: glow,
+        icon: icon, // Renamed from text to icon
         key: def.key,
         cx,
         cy,
@@ -336,7 +358,7 @@ export class TouchControls {
     // Visual feedback
     btn.graphic.setAlpha(0.6);
     btn.graphic.setFillStyle(0xffffff, 0.45);
-    btn.text.setAlpha(0.9);
+    if (btn.icon) btn.icon.setAlpha(0.9);
     btn.pressed = true;
   }
 
@@ -351,7 +373,7 @@ export class TouchControls {
     if (!stillPressed) {
       btn.graphic.setAlpha(1);
       btn.graphic.setFillStyle(0xffffff, 0.2);
-      btn.text.setAlpha(0.5);
+      if (btn.icon) btn.icon.setAlpha(0.6);
       btn.pressed = false;
     }
   }
@@ -367,6 +389,8 @@ export class TouchControls {
     const fighter = this.playerIndex === 0 ? this.scene.p1Fighter : this.scene.p2Fighter;
     if (fighter && this.specialGlow) {
       const isAvailable = fighter.special >= SPECIAL_COST_FP;
+      const spRatio = Phaser.Math.Clamp(fighter.special / MAX_SPECIAL_FP, 0, 1);
+
       this.specialGlow.setVisible(isAvailable);
 
       // Update ES button effects
@@ -376,15 +400,54 @@ export class TouchControls {
         this.specialParticles.emitting = false;
       }
 
-      // Also update the special button's text/border color when available
+      // Update radial arc
       const spBtn = this.buttons.find((b) => b.key === 'special');
-      if (spBtn) {
+      if (spBtn && this.specialRadial) {
+        const graphics = this.specialRadial;
+        graphics.clear();
+
+        const flashTimer = Math.floor(Date.now() / 150) % 2 === 0;
+        let color = 0xffcc00; // Always yellow/gold
+        let alpha = 0.6;
+
+        if (spRatio >= 1.0) {
+          color = flashTimer ? 0xffff00 : 0xffcc00;
+          alpha = 0.9;
+        } else if (spRatio >= 0.5) {
+          // Keep base yellow but slightly higher alpha when ready
+          alpha = 0.8;
+        }
+
+        if (spRatio > 0) {
+          graphics.lineStyle(3, color, alpha);
+          graphics.beginPath();
+          // Arc around the special button - radius + 3 for clarity outside icon
+          graphics.arc(
+            spBtn.cx,
+            spBtn.cy,
+            spBtn.radius + 3,
+            -Math.PI / 2,
+            -Math.PI / 2 + Math.PI * 2 * spRatio,
+            false,
+          );
+          graphics.strokePath();
+        }
+
+        // Also update the special button's text/border color when available
         if (isAvailable) {
           spBtn.graphic.setStrokeStyle(2, 0xffcc00, 0.8);
-          spBtn.text.setColor('#ffcc00').setAlpha(1);
+          if (spBtn.icon) {
+            if (spBtn.icon.type === 'Text') spBtn.icon.setColor('#ffcc00');
+            else spBtn.icon.setTint(0xffcc00);
+            spBtn.icon.setAlpha(1);
+          }
         } else {
           spBtn.graphic.setStrokeStyle(1.5, 0xffffff, 0.35);
-          spBtn.text.setColor('#ffffff').setAlpha(0.5);
+          if (spBtn.icon) {
+            if (spBtn.icon.type === 'Text') spBtn.icon.setColor('#ffffff');
+            else spBtn.icon.clearTint();
+            spBtn.icon.setAlpha(0.6);
+          }
         }
       }
     }
@@ -429,10 +492,11 @@ export class TouchControls {
     if (this.joystickBaseRing) this.joystickBaseRing.destroy();
     if (this.joystickThumb) this.joystickThumb.destroy();
     if (this.specialParticles) this.specialParticles.destroy();
+    if (this.specialRadial) this.specialRadial.destroy();
 
     for (const btn of this.buttons) {
       btn.graphic.destroy();
-      btn.text.destroy();
+      if (btn.icon) btn.icon.destroy();
       if (btn.glow) btn.glow.destroy();
     }
     this.buttons = [];


### PR DESCRIPTION
# Description

This Pull Request implements a series of visual and functional enhancements to the battle HUD and mobile touch controls. The primary focus is on improving resource visibility and modernizing the interface using radial indicators and icon-based buttons.

## Key Changes

### 1. HUD Layout & Resource Draining
- **Repositioned HP and Stamina Bars:** Both Player 1 and Player 2 bars now anchor near the central clock (P1: originX = 1, P2: originX = 0).
- **Dynamic Resizing:** Bars now visually "drain into the clock" as HP or Stamina decreases, creating a more centered focus during combat.

### 2. Radial Special Attack Indicator
- **Unified Radial Progress:** Replaced linear special bars with circular "Special Attack Indicators."
- **PC Layout:** Added a fixed radial indicator near the top health bar featuring a ⚡ shortcut icon.
- **Mobile Integration:** Integrated a yellow radial progress ring directly onto the special attack button.
- **Visual Feedback:** 
    - Smooth 0-100% filling animation.
    - Threshold alerts (pulse/glow) when the meter reaches 50% (usable) and 100% (fully charged).
    - Haptic feedback (vibration) for local P1 when thresholds are met.

### 3. Mobile Touch Controls Enhancement
- **Icon-Based Buttons:** Updated `TouchControls` to support image textures (e.g., `btn_lp.png`, `btn_hp.png`).
- **Graceful Fallback:** Implemented logic to automatically revert to text labels if the specified icons are missing in `assets/ui/`.
- **Improved Z-Depth:** Radial progress arcs are rendered at a higher depth to ensure visibility over button icons.

### 4. Technical Fixes
- **Phaser Compatibility:** Refactored the particle system in `FightScene.js` to support modern Phaser 3.60+ API (e.g., `setParticleTint`, removing `createEmitter`).
- **Asset Integrity:** Added a `public/manifest.json` to resolve syntax errors during initial asset loading.

## Verification
- [x] Verified bar scaling directions on both sides.
- [x] Tested 50% threshold pulse and haptic triggers.
- [x] Confirmed particle tinting and emitting behavior on multiple frames.
- [x] Validated button fallback behavior by intentionally removing icons.
![Screenshot_20260402-193802.png](https://github.com/user-attachments/assets/c136c3e9-8889-40ba-98c1-c23d86ff3321)

