### PR TITLE
feat: Terraform infra for alostraques.com domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ test-results/
 .env
 .env.local
 .vs/
+
+# Terraform
+infra/.terraform/
+infra/*.tfvars

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,65 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.18.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:2FKT5YVLuHLmv7BnFxDC3UtipD3hSSrb0iJ9Ei2C/ks=",
+    "zh:47e7bdfd8eddd2685f383269c0b6936ef62edd6d8383c8d7757b0cce0a689737",
+    "zh:aa23eb6aa128667883cabc449ceca4072d0181f574cd727e08ebd6d69a4bfd48",
+    "zh:c3da673e05d3bd933c82e2b6ba0f85aa23c5e24fadd3932f7c066314feeb65a3",
+    "zh:c59f07c017fc78b79e80554a0737c9db2a2e681c3e46ff637942d28d1f1a3924",
+    "zh:d559074612835a37fa684d8d7d0cf68911487b71f4067acc59069cb00bb8baf0",
+    "zh:e12290a4eda757c183a4258230245dd170f0def389c37eb771db144ce3b382dd",
+    "zh:ed47e484432ba1bbbb4802061f395ebd253ae8e20be9b72552d3d830fd2ca268",
+    "zh:f35e08d468408697b3e7c4a7f548b874141ac8f8d395ab8edded322201cc7047",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.terraform.io/supabase/supabase" {
+  version     = "1.7.0"
+  constraints = "~> 1.0"
+  hashes = [
+    "h1:ql+5BwEjTh+tpQRYYqSh7E661Ht2yLPPkPxJ7NAuxzg=",
+    "zh:1ad20fff727b53bf72967511fc76909d2e73e1aa385808ec107de644ef23fb40",
+    "zh:330b5a55b65eae87f7de8ab9d02c70d58b4a317fda9ada9166d0d83191c16f31",
+    "zh:58644bb8b0bc23c6b65afc904c11c0c00ba3b209048dac666568ec01823a380b",
+    "zh:59e13950d8e6a8b3a68d28fb131f93c5d2c52601e14dae62303bf9514e2f8345",
+    "zh:6847fb09cb10bad889e59826a53a949830812d7908aeb07fe49b8c95acee5d42",
+    "zh:83aed2860f0ead9a90f0b4022fd3a3e9ca91ba2abe8f9e45d5d23a9f7b88f67c",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:89b7c8120f471cadd30b5df611717dd46d2227779bcce348b647c20ffb5017da",
+    "zh:a78a9218dde7bb58e62699d8facfefdb062a7d11e38d517ac2d1b9231cd360a7",
+    "zh:b84377dd541df61d2b6a4ca0aa813ff48996fbd14251be1309605d781e869d94",
+    "zh:c2fed594cc81d61a96193223ba488d3816ea65345b02b3dbd0d3a16d409c820e",
+    "zh:dedc02702b92798d2251b959574697eeb0bec7aaff13eefd355edd0d62fb0a37",
+    "zh:e16510d41c6d0e0abbc8391a16fa47f88753f3091eb201dc934e60e60e3555a9",
+    "zh:ee6fbbe127f5fbaa4db3dc80714cf1fca116813f09bc72cd5eac73d577dce1e1",
+    "zh:ef990054556afba5c709e3070add35a81ac7ddb7e961ea243d74d22f98e91ccb",
+  ]
+}
+
+provider "registry.terraform.io/vercel/vercel" {
+  version     = "4.6.1"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:Jcm+Xe+n3qETxZTJOLuVGJ61UzCAgndABrQopnzFVwI=",
+    "zh:240f12e66b5bfbc216b78b38761b4e62ebc5590fd8051d3f681ee2789c82437c",
+    "zh:34a6a8ecf0a389d9755ea3740fa48b4e12de57595209b26ac0a88aa65f0dd15b",
+    "zh:3feb6e58cebe1d441fd3caacfc8341e742905d22cceb7189fd0ea16cc8e66a66",
+    "zh:40826f814d6509a3e17f70425598214da3aead8ad8149821f4394b92fb8f1e83",
+    "zh:40ab52d0e84df0b98be68585e0be785de11c0e073264b3695eda314afdb62a66",
+    "zh:504f5e2d0d860ae9a8696a49a8855a3894badd928a5672521af09e13d0d68f10",
+    "zh:9317aafc789716433b4ad5b1f54ea807cba0faa7262752d298f24ee330503189",
+    "zh:9a4f4d4027182fea739a6d30e86c1f83f42f819e61344f9dbd84ade7d4fc3a27",
+    "zh:c2a196e526986546dee3825bb13c26aace145f0af26ac3ddbfe55499d1fd05c9",
+    "zh:cb69fc86f5ba56e5cd35b8044f56e26f8fe1e99e9c4571f368f834ca52a0c74f",
+    "zh:d2737c20efb5d5e08f153732a0dfe5685fb3989aa71db95805c921c0a3c77e55",
+    "zh:ee17a1817bc5220cb35f10feb737ec1bac6aedc31a7ba8c020965a1d1a610764",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+    "zh:f5798497eb2a7ec6015b5416987228019f9efe9ab05ca6332cf3f64f2cdef729",
+    "zh:fb984f9e18673acdd72ca4d29bf8bad34376bd9ff3252437e24c770862c85454",
+  ]
+}

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -1,0 +1,50 @@
+# Infrastructure (Terraform)
+
+Manages DNS, domain, and auth settings for `alostraques.com` via Terraform.
+
+## Resources
+
+| Provider | Resource | Purpose |
+|----------|----------|---------|
+| Cloudflare | `cloudflare_dns_record.apex` | CNAME `@` → `cname.vercel-dns.com` |
+| Cloudflare | `cloudflare_dns_record.www` | CNAME `www` → `cname.vercel-dns.com` |
+| Vercel | `vercel_project_domain.apex` | Binds `alostraques.com` to project |
+| Vercel | `vercel_project_domain.www` | Redirects `www` → apex (308) |
+| Supabase | `supabase_settings.auth` | Sets site_url + OAuth redirect allowlist |
+
+## State Backend
+
+State is stored in 1Password via [tfstateproxy](https://github.com/simon0191/tfstateproxy).
+Start the proxy before running any Terraform commands:
+
+```bash
+tfstateproxy serve --backend onepassword --op-vault <vault-name>
+```
+
+## Secrets
+
+All secrets come from 1Password. Run `./init-tfvars.sh` to generate `terraform.auto.tfvars` using the `op` CLI.
+
+The tfvars file is gitignored. Never commit it.
+
+## Commands
+
+```bash
+./init-tfvars.sh       # Generate terraform.auto.tfvars from 1Password
+terraform init         # Install providers (run once or after provider changes)
+terraform plan         # Preview changes
+terraform apply        # Apply changes
+```
+
+## DNS Setup
+
+Cloudflare is DNS-only (`proxied = false`). Vercel handles SSL via auto-provisioned Let's Encrypt certificates. No Cloudflare proxy/CDN in the path.
+
+## OAuth Redirect Allowlist
+
+Managed in `supabase.tf`. Current entries:
+- `https://alostraques.com/**` (production)
+- `https://www.alostraques.com/**` (www)
+- `https://a-los-traques.vercel.app/**` (Vercel default domain)
+- `https://a-los-traques-*.vercel.app/**` (Vercel preview deploys)
+- `http://localhost:5173/**` (local dev)

--- a/infra/dns.tf
+++ b/infra/dns.tf
@@ -1,0 +1,19 @@
+# Apex domain -> Vercel (DNS-only, Vercel handles SSL)
+resource "cloudflare_dns_record" "apex" {
+  zone_id = var.cloudflare_zone_id
+  name    = "@"
+  type    = "CNAME"
+  content = "cname.vercel-dns.com"
+  proxied = false
+  ttl     = 300
+}
+
+# www subdomain -> Vercel
+resource "cloudflare_dns_record" "www" {
+  zone_id = var.cloudflare_zone_id
+  name    = "www"
+  type    = "CNAME"
+  content = "cname.vercel-dns.com"
+  proxied = false
+  ttl     = 300
+}

--- a/infra/init-tfvars.sh
+++ b/infra/init-tfvars.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Generates terraform.auto.tfvars from 1Password secrets using the op CLI.
+# Usage: ./init-tfvars.sh
+set -euo pipefail
+
+TFVARS_FILE="$(dirname "$0")/terraform.auto.tfvars"
+
+cat > "$TFVARS_FILE" <<EOF
+cloudflare_api_token  = "$(op read "op://a-los-traques/k2v5rzytg527mgvkiegxzupmcq/credential")"
+cloudflare_zone_id    = "$(op read "op://a-los-traques/k2v5rzytg527mgvkiegxzupmcq/zone_id")"
+vercel_api_token      = "$(op read "op://a-los-traques/6wlocezvrxylct5jf3cewn2tea/credential")"
+vercel_project_id     = "$(op read "op://a-los-traques/6wlocezvrxylct5jf3cewn2tea/project_id")"
+supabase_access_token = "$(op read "op://a-los-traques/wj2elyoqu355i55oupxgmam3uy/credential")"
+supabase_project_ref  = "$(op read "op://a-los-traques/wj2elyoqu355i55oupxgmam3uy/project_id")"
+EOF
+
+echo "Wrote $TFVARS_FILE"

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,15 @@
+output "apex_domain" {
+  value = vercel_project_domain.apex.domain
+}
+
+output "www_domain" {
+  value = vercel_project_domain.www.domain
+}
+
+output "dns_apex_record_id" {
+  value = cloudflare_dns_record.apex.id
+}
+
+output "dns_www_record_id" {
+  value = cloudflare_dns_record.www.id
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_version = ">= 1.5"
+
+  backend "http" {
+    address        = "http://localhost:8080/state/a-los-traques"
+    lock_address   = "http://localhost:8080/state/a-los-traques"
+    unlock_address = "http://localhost:8080/state/a-los-traques"
+    lock_method    = "LOCK"
+    unlock_method  = "UNLOCK"
+  }
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 4.0"
+    }
+    supabase = {
+      source  = "supabase/supabase"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+provider "vercel" {
+  api_token = var.vercel_api_token
+}
+
+provider "supabase" {
+  access_token = var.supabase_access_token
+}

--- a/infra/supabase.tf
+++ b/infra/supabase.tf
@@ -1,0 +1,14 @@
+resource "supabase_settings" "auth" {
+  project_ref = var.supabase_project_ref
+
+  auth = jsonencode({
+    site_url             = "https://${var.domain}"
+    uri_allow_list       = join(",", [
+      "https://${var.domain}/**",
+      "https://www.${var.domain}/**",
+      "https://a-los-traques.vercel.app/**",
+      "https://a-los-traques-*.vercel.app/**",
+      "http://localhost:5173/**",
+    ])
+  })
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,46 @@
+# --- Cloudflare ---
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token with DNS edit permissions for the zone"
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare Zone ID for alostraques.com"
+  type        = string
+}
+
+# --- Vercel ---
+
+variable "vercel_api_token" {
+  description = "Vercel API token"
+  type        = string
+  sensitive   = true
+}
+
+variable "vercel_project_id" {
+  description = "Vercel project ID for a-los-traques"
+  type        = string
+}
+
+# --- Supabase ---
+
+variable "supabase_access_token" {
+  description = "Supabase access token (from supabase.com/dashboard/account/tokens)"
+  type        = string
+  sensitive   = true
+}
+
+variable "supabase_project_ref" {
+  description = "Supabase project ref (subdomain from your-project.supabase.co)"
+  type        = string
+}
+
+# --- Domain ---
+
+variable "domain" {
+  description = "The apex domain"
+  type        = string
+  default     = "alostraques.com"
+}

--- a/infra/vercel.tf
+++ b/infra/vercel.tf
@@ -1,0 +1,13 @@
+# Apex domain binding
+resource "vercel_project_domain" "apex" {
+  project_id = var.vercel_project_id
+  domain     = var.domain
+}
+
+# www -> apex redirect (308 permanent)
+resource "vercel_project_domain" "www" {
+  project_id           = var.vercel_project_id
+  domain               = "www.${var.domain}"
+  redirect             = vercel_project_domain.apex.domain
+  redirect_status_code = 308
+}

--- a/tests/e2e/remote/remote-config.js
+++ b/tests/e2e/remote/remote-config.js
@@ -87,8 +87,7 @@ export const PRESETS = {
 };
 
 // Server URLs
-export const STAGING_BASE_URL =
-  process.env.REMOTE_E2E_BASE_URL || 'https://a-los-traques.vercel.app';
+export const STAGING_BASE_URL = process.env.REMOTE_E2E_BASE_URL || 'https://alostraques.com';
 export const STAGING_PARTY_HOST =
   process.env.REMOTE_E2E_PARTY_HOST || 'a-los-traques.simon0191.partykit.dev';
 


### PR DESCRIPTION
## Summary
- Add `infra/` directory with Terraform configs for Cloudflare DNS, Vercel domain bindings, and Supabase OAuth redirect allowlist
- State stored in 1Password via tfstateproxy (HTTP backend)
- `init-tfvars.sh` script generates `terraform.auto.tfvars` from 1Password secrets using `op` CLI
- Update default E2E base URL to `https://alostraques.com`

## Test plan
- [x] `terraform init` succeeds
- [x] `terraform plan` shows 5 resources
- [x] `terraform apply` — 4/5 created, www domain needs re-apply after apex dependency fix
- [ ] Verify `https://alostraques.com` loads the game
- [ ] Verify `https://www.alostraques.com` redirects to apex
- [ ] Verify Google OAuth login works on new domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)