### PR TITLE
feat: hybrid E2E test + fix debug bundle capture

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:e2e": "npx playwright test --config tests/e2e/playwright.config.js",
     "test:e2e:headed": "npx playwright test --config tests/e2e/playwright.config.js --headed",
     "test:e2e:remote": "npx playwright test --config tests/e2e/remote/remote-playwright.config.js",
+    "test:e2e:hybrid": "npx playwright test --config tests/e2e/remote/remote-playwright.config.js hybrid-multiplayer",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write ."

--- a/src/scenes/FightScene.js
+++ b/src/scenes/FightScene.js
@@ -15,6 +15,7 @@ import { tick } from '../simulation/SimulationEngine.js';
 import { AIController } from '../systems/AIController.js';
 import { AudioBridge } from '../systems/AudioBridge.js';
 import { CombatSystem } from '../systems/CombatSystem.js';
+import { DebugBundleExporter } from '../systems/DebugBundleExporter.js';
 import { DevConsole } from '../systems/DevConsole.js';
 import { FightRecorder } from '../systems/FightRecorder.js';
 import {
@@ -1553,36 +1554,21 @@ export class FightScene extends Phaser.Scene {
     // Record round events for BOTH peers at the exact simulation frame
     if (roundEvent) {
       this.recorder?.recordRoundEvent(this.rollbackManager.currentFrame, roundEvent);
-      if (roundEvent.matchOver) {
-        this.recorder?.captureEndState(
-          this.p1Fighter,
-          this.p2Fighter,
-          this.combat,
-          this.rollbackManager.currentFrame,
-        );
-      }
 
-      // Upload debug bundle after every round (including final)
-      if (this.game.debugMode && this.recorder) {
-        import('../systems/DebugBundleExporter.js').then(({ DebugBundleExporter }) => {
-          const bundle = DebugBundleExporter.generateBundle({
-            recorder: this.recorder,
-            telemetry: this.telemetry,
-            matchState: this.matchState,
-            sessionId: this.networkManager?.sessionId,
-            debugMode: true,
-          });
-
-          if (roundEvent.matchOver) {
-            window.__DEBUG_BUNDLE = bundle;
-          }
-
-          DebugBundleExporter.uploadBundle({
-            fightId: this.fightId,
-            slot: this.networkManager?.getPlayerSlot(),
-            round: this.combat.roundNumber - 1,
-            bundle,
-          });
+      // Upload per-round debug bundle (match-end bundle handled in onMatchOver)
+      if (!roundEvent.matchOver && this.game.debugMode && this.recorder) {
+        const bundle = DebugBundleExporter.generateBundle({
+          recorder: this.recorder,
+          telemetry: this.telemetry,
+          matchState: this.matchState,
+          sessionId: this.networkManager?.sessionId,
+          debugMode: true,
+        });
+        DebugBundleExporter.uploadBundle({
+          fightId: this.fightId,
+          slot: this.networkManager?.getPlayerSlot(),
+          round: this.combat.roundNumber - 1,
+          bundle,
         });
       }
     }
@@ -2364,6 +2350,28 @@ export class FightScene extends Phaser.Scene {
       this.matchState.transition(MatchEvent.ROUND_OVER);
     }
     this.matchState.transition(MatchEvent.MATCH_OVER);
+
+    // Capture end state + debug bundle for E2E testing (works for both P1 and P2)
+    if (this.recorder) {
+      const frame = this.rollbackManager?.currentFrame ?? this._localFrame;
+      this.recorder.captureEndState(this.p1Fighter, this.p2Fighter, this.combat, frame);
+    }
+    if (this.game.debugMode && this.recorder) {
+      const bundle = DebugBundleExporter.generateBundle({
+        recorder: this.recorder,
+        telemetry: this.telemetry,
+        matchState: this.matchState,
+        sessionId: this.networkManager?.sessionId,
+        debugMode: true,
+      });
+      window.__DEBUG_BUNDLE = bundle;
+      DebugBundleExporter.uploadBundle({
+        fightId: this.fightId,
+        slot: this.networkManager?.getPlayerSlot(),
+        round: 0,
+        bundle,
+      });
+    }
 
     // Host sends match-over event to guest
     this._sendRoundEvent('ko', winnerIndex);

--- a/src/scenes/VictoryScene.js
+++ b/src/scenes/VictoryScene.js
@@ -33,7 +33,7 @@ export class VictoryScene extends Phaser.Scene {
     }
 
     // Signal match completion for E2E test orchestration
-    if (this.game.autoplay?.enabled && window.__FIGHT_LOG) {
+    if ((this.game.autoplay?.enabled || this.game.debugMode) && window.__FIGHT_LOG) {
       window.__FIGHT_LOG.matchComplete = true;
       window.__FIGHT_LOG.completedAt = Date.now();
       window.__FIGHT_LOG.result = { winnerId: this.winnerId, loserId: this.loserId };

--- a/tests/e2e/remote/hybrid-config.js
+++ b/tests/e2e/remote/hybrid-config.js
@@ -1,0 +1,43 @@
+/**
+ * Browser capability presets for hybrid E2E testing: local Chromium (P1) + BrowserStack (P2).
+ *
+ * P1 is always the local Chromium launched by Playwright on the developer's machine.
+ * Only P2 needs BrowserStack capabilities — this halves BrowserStack session cost
+ * compared to the fully-remote test.
+ *
+ * Controlled via HYBRID_E2E_PRESET env var (default: 'default').
+ */
+
+const buildName =
+  process.env.BROWSERSTACK_BUILD_NAME ||
+  `hybrid-e2e-${new Date().toISOString().slice(0, 19).replace(/:/g, '')}`;
+
+export const HYBRID_PRESETS = {
+  // Default: local Chromium (P1) vs Chrome on Windows (P2)
+  default: {
+    p2: {
+      browser: 'chrome',
+      browser_version: 'latest',
+      os: 'Windows',
+      os_version: '11',
+      name: 'Hybrid-P2-Chrome-Win',
+      build: buildName,
+      'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+      'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+    },
+  },
+
+  // Local Chromium (P1) vs Safari/WebKit on macOS (P2)
+  'local-webkit': {
+    p2: {
+      browser: 'playwright-webkit',
+      browser_version: 'latest',
+      os: 'OS X',
+      os_version: 'Sonoma',
+      name: 'Hybrid-P2-WebKit-Mac',
+      build: buildName,
+      'browserstack.username': process.env.BROWSERSTACK_USERNAME,
+      'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
+    },
+  },
+};

--- a/tests/e2e/remote/hybrid-multiplayer.spec.js
+++ b/tests/e2e/remote/hybrid-multiplayer.spec.js
@@ -25,6 +25,7 @@ import {
   STAGING_PARTY_HOST,
 } from './remote-config.js';
 import {
+  applyVercelBypass,
   connectRemoteBrowser,
   extractDebugBundle,
   fetchServerDiagnostics,
@@ -67,6 +68,7 @@ test.describe('Hybrid multiplayer (local + BrowserStack)', () => {
     console.log(`Launching P1 locally (Chromium, ${headed ? 'headed' : 'headless'})...`);
     const browserP1 = await chromium.launch({ headless: !headed });
     const ctxP1 = await browserP1.newContext({ viewport: { width: 960, height: 540 } });
+    await applyVercelBypass(ctxP1);
     const pageP1 = await ctxP1.newPage();
 
     const p1Console = [];
@@ -99,6 +101,7 @@ test.describe('Hybrid multiplayer (local + BrowserStack)', () => {
       );
       browserP2 = await connectRemoteBrowser(preset.p2);
       const ctxP2 = await browserP2.newContext({ viewport: { width: 960, height: 540 } });
+      await applyVercelBypass(ctxP2);
       pageP2 = await ctxP2.newPage();
       pageP2.on('console', (msg) => p2Console.push(`[${msg.type()}] ${msg.text()}`));
 

--- a/tests/e2e/remote/hybrid-multiplayer.spec.js
+++ b/tests/e2e/remote/hybrid-multiplayer.spec.js
@@ -1,0 +1,262 @@
+/**
+ * Hybrid E2E test: local browser (P1) + BrowserStack browser (P2).
+ *
+ * Simulates a real-world match where two players are in different physical
+ * locations. P1 runs on the developer's laptop, P2 runs on BrowserStack.
+ * Both hit the deployed staging URL — the WebRTC P2P traffic traverses the
+ * real internet between the laptop and BrowserStack's data center.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { chromium, test } from '@playwright/test';
+import {
+  extractFightLog,
+  waitForMatchComplete,
+  waitForRoomId,
+} from '../helpers/browser-helpers.js';
+import { generateBundle } from '../helpers/bundle-generator.js';
+import { generateReport } from '../helpers/report-generator.js';
+import { HYBRID_PRESETS } from './hybrid-config.js';
+import {
+  REMOTE_MATCH_TIMEOUT,
+  REMOTE_PAGE_LOAD_TIMEOUT,
+  REMOTE_ROOM_TIMEOUT,
+  STAGING_BASE_URL,
+  STAGING_PARTY_HOST,
+} from './remote-config.js';
+import {
+  connectRemoteBrowser,
+  extractDebugBundle,
+  fetchServerDiagnostics,
+  markSessionStatus,
+  remoteP1Url,
+  remoteP2Url,
+} from './remote-helpers.js';
+
+const RESULTS_DIR = 'test-results/hybrid';
+
+const presetName = process.env.HYBRID_E2E_PRESET || 'default';
+
+function validateEnv() {
+  if (!process.env.BROWSERSTACK_USERNAME || !process.env.BROWSERSTACK_ACCESS_KEY) {
+    throw new Error(
+      'Missing BrowserStack credentials.\n' +
+        'Set BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY environment variables.\n' +
+        'Get them from: https://www.browserstack.com/accounts/settings',
+    );
+  }
+}
+
+test.describe('Hybrid multiplayer (local + BrowserStack)', () => {
+  // biome-ignore lint/correctness/noEmptyPattern: Playwright requires destructured first arg
+  test(`hybrid match with debug bundles [${presetName}]`, async ({}, testInfo) => {
+    validateEnv();
+
+    const preset = HYBRID_PRESETS[presetName];
+    if (!preset) {
+      throw new Error(
+        `Unknown preset "${presetName}". Available: ${Object.keys(HYBRID_PRESETS).join(', ')}`,
+      );
+    }
+
+    const testName = `hybrid-${presetName}`;
+    const startedAt = new Date().toISOString();
+
+    // --- P1: launch locally ---
+    const headed = process.env.HYBRID_HEADED === '1';
+    console.log(`Launching P1 locally (Chromium, ${headed ? 'headed' : 'headless'})...`);
+    const browserP1 = await chromium.launch({ headless: !headed });
+    const ctxP1 = await browserP1.newContext({ viewport: { width: 960, height: 540 } });
+    const pageP1 = await ctxP1.newPage();
+
+    const p1Console = [];
+    const p2Console = [];
+    pageP1.on('console', (msg) => p1Console.push(`[${msg.type()}] ${msg.text()}`));
+
+    let browserP2 = null;
+    let pageP2 = null;
+    let logP1 = null;
+    let logP2 = null;
+    let usedP1Url = '';
+    let usedP2Url = '';
+    let roomId = '';
+
+    try {
+      // --- P1: create room ---
+      usedP1Url = remoteP1Url(STAGING_BASE_URL, STAGING_PARTY_HOST, {
+        fighter: 'simon',
+        seed: 42,
+      });
+      console.log(`P1 (local) navigating to: ${usedP1Url}`);
+      await pageP1.goto(usedP1Url, { timeout: REMOTE_PAGE_LOAD_TIMEOUT });
+
+      roomId = await waitForRoomId(pageP1, REMOTE_ROOM_TIMEOUT);
+      console.log(`Room created: ${roomId}`);
+
+      // --- P2: join room on BrowserStack ---
+      console.log(
+        `Connecting P2 (${preset.p2.browser} / ${preset.p2.os || 'default'}) on BrowserStack...`,
+      );
+      browserP2 = await connectRemoteBrowser(preset.p2);
+      const ctxP2 = await browserP2.newContext({ viewport: { width: 960, height: 540 } });
+      pageP2 = await ctxP2.newPage();
+      pageP2.on('console', (msg) => p2Console.push(`[${msg.type()}] ${msg.text()}`));
+
+      usedP2Url = remoteP2Url(STAGING_BASE_URL, roomId, STAGING_PARTY_HOST, {
+        fighter: 'jeka',
+        seed: 42,
+      });
+      console.log(`P2 (BrowserStack) navigating to: ${usedP2Url}`);
+      await pageP2.goto(usedP2Url, { timeout: REMOTE_PAGE_LOAD_TIMEOUT });
+
+      // --- Wait for match completion ---
+      // Poll P2 every 10s to keep CDP WebSocket active (BrowserStack idle timeout).
+      // P1 is local so no keep-alive needed, but polling both is harmless.
+      console.log('Waiting for match to complete (speed=1, real network)...');
+      const pollOpts = { pollInterval: 10_000 };
+      await Promise.all([
+        waitForMatchComplete(pageP1, REMOTE_MATCH_TIMEOUT, pollOpts),
+        waitForMatchComplete(pageP2, REMOTE_MATCH_TIMEOUT, pollOpts),
+      ]);
+      console.log('Match complete on both sides.');
+
+      // --- Extract fight logs ---
+      [logP1, logP2] = await Promise.all([extractFightLog(pageP1), extractFightLog(pageP2)]);
+
+      // --- Extract v2 debug bundles ---
+      const [debugP1, debugP2] = await Promise.all([
+        extractDebugBundle(pageP1),
+        extractDebugBundle(pageP2),
+      ]);
+
+      // --- Fetch server diagnostics ---
+      const serverDiag = await fetchServerDiagnostics(STAGING_PARTY_HOST, roomId);
+
+      // --- Generate artifacts ---
+      fs.mkdirSync(RESULTS_DIR, { recursive: true });
+
+      const report = generateReport(logP1, logP2, testName);
+      const bundle = generateBundle(logP1, logP2, { p1: usedP1Url, p2: usedP2Url });
+
+      const completedAt = new Date().toISOString();
+      const hybridBundle = {
+        ...bundle,
+        source: 'hybrid-e2e',
+        preset: presetName,
+        metadata: {
+          startedAt,
+          completedAt,
+          durationMs: new Date(completedAt) - new Date(startedAt),
+          roomId,
+          topology: 'hybrid',
+          p1: {
+            location: 'local',
+            browser: 'Chromium (Playwright)',
+            fighter: 'simon',
+          },
+          p2: {
+            location: 'browserstack',
+            browser:
+              `${preset.p2.browser} / ${preset.p2.os || 'device'} ${preset.p2.os_version || ''}`.trim(),
+            fighter: 'jeka',
+          },
+        },
+        debugBundles: {
+          p1: debugP1,
+          p2: debugP2,
+        },
+        serverDiagnostics: serverDiag,
+      };
+
+      fs.writeFileSync(path.join(RESULTS_DIR, `${testName}-report.md`), report);
+      fs.writeFileSync(
+        path.join(RESULTS_DIR, `${testName}-bundle.json`),
+        JSON.stringify(hybridBundle, null, 2),
+      );
+
+      // Attach to Playwright results
+      await testInfo.attach('report', {
+        path: path.join(RESULTS_DIR, `${testName}-report.md`),
+        contentType: 'text/markdown',
+      });
+      await testInfo.attach('bundle', {
+        path: path.join(RESULTS_DIR, `${testName}-bundle.json`),
+        contentType: 'application/json',
+      });
+
+      // --- Determinism analysis (informational, not hard failure) ---
+      const p1Checksums = new Map(logP1.checksums.map((c) => [c.frame, c.hash]));
+      const p2Checksums = new Map(logP2.checksums.map((c) => [c.frame, c.hash]));
+      const sharedFrames = [...p1Checksums.keys()].filter((f) => p2Checksums.has(f));
+      const mismatches = sharedFrames.filter((f) => p1Checksums.get(f) !== p2Checksums.get(f));
+
+      if (mismatches.length > 0) {
+        console.warn(
+          `Checksum mismatches: ${mismatches.length}/${sharedFrames.length} shared frames`,
+        );
+        console.warn(`First mismatch at frame ${mismatches[0]}`);
+      } else {
+        console.log(`All ${sharedFrames.length} shared checksums match — deterministic!`);
+      }
+
+      console.log(`Desyncs: P1=${logP1.desyncCount}, P2=${logP2.desyncCount}`);
+      console.log(`Winner: ${logP1.result?.winnerId || logP2.result?.winnerId || 'unknown'}`);
+
+      // Mark BrowserStack session (P2 only — P1 is local)
+      const passed = logP1.matchComplete && logP2.matchComplete;
+      await markSessionStatus(pageP2, passed, 'Match completed');
+    } finally {
+      // Always capture console logs
+      if (p1Console.length || p2Console.length) {
+        fs.mkdirSync(RESULTS_DIR, { recursive: true });
+        const consolePath = path.join(RESULTS_DIR, `${testName}-console.log`);
+        fs.writeFileSync(
+          consolePath,
+          `=== P1 Console [local] (${p1Console.length} messages) ===\n${p1Console.join('\n')}\n\n` +
+            `=== P2 Console [BrowserStack] (${p2Console.length} messages) ===\n${p2Console.join('\n')}\n`,
+        );
+        await testInfo.attach('console-logs', {
+          path: consolePath,
+          contentType: 'text/plain',
+        });
+      }
+
+      // Always try to extract partial data on failure
+      if (!logP1 || !logP2) {
+        try {
+          if (!logP1 && pageP1) logP1 = await extractFightLog(pageP1);
+          if (!logP2 && pageP2) logP2 = await extractFightLog(pageP2);
+          if (logP1 || logP2) {
+            fs.mkdirSync(RESULTS_DIR, { recursive: true });
+            if (logP1)
+              fs.writeFileSync(
+                path.join(RESULTS_DIR, `${testName}-partial-p1.json`),
+                JSON.stringify(logP1, null, 2),
+              );
+            if (logP2)
+              fs.writeFileSync(
+                path.join(RESULTS_DIR, `${testName}-partial-p2.json`),
+                JSON.stringify(logP2, null, 2),
+              );
+          }
+        } catch {
+          // Best-effort partial extraction
+        }
+      }
+
+      // Clean up sessions
+      try {
+        await browserP1.close();
+      } catch {
+        /* browser may already be closed */
+      }
+      if (browserP2) {
+        try {
+          await browserP2.close();
+        } catch {
+          /* session may already be closed */
+        }
+      }
+    }
+  });
+});

--- a/tests/e2e/remote/remote-helpers.js
+++ b/tests/e2e/remote/remote-helpers.js
@@ -33,6 +33,8 @@ export function remoteP1Url(baseUrl, partyHost, opts = {}) {
   if (opts.fighter) params.set('fighter', opts.fighter);
   if (opts.seed != null) params.set('seed', String(opts.seed));
   if (opts.aiDifficulty) params.set('aiDifficulty', opts.aiDifficulty);
+  if (process.env.VERCEL_PROTECTION_BYPASS)
+    params.set('x-vercel-protection-bypass', process.env.VERCEL_PROTECTION_BYPASS);
   return `${baseUrl}?${params}`;
 }
 
@@ -50,6 +52,8 @@ export function remoteP2Url(baseUrl, roomId, partyHost, opts = {}) {
   if (opts.fighter) params.set('fighter', opts.fighter);
   if (opts.seed != null) params.set('seed', String(opts.seed));
   if (opts.aiDifficulty) params.set('aiDifficulty', opts.aiDifficulty);
+  if (process.env.VERCEL_PROTECTION_BYPASS)
+    params.set('x-vercel-protection-bypass', process.env.VERCEL_PROTECTION_BYPASS);
   return `${baseUrl}?${params}`;
 }
 

--- a/tests/e2e/remote/remote-helpers.js
+++ b/tests/e2e/remote/remote-helpers.js
@@ -33,8 +33,6 @@ export function remoteP1Url(baseUrl, partyHost, opts = {}) {
   if (opts.fighter) params.set('fighter', opts.fighter);
   if (opts.seed != null) params.set('seed', String(opts.seed));
   if (opts.aiDifficulty) params.set('aiDifficulty', opts.aiDifficulty);
-  if (process.env.VERCEL_PROTECTION_BYPASS)
-    params.set('x-vercel-protection-bypass', process.env.VERCEL_PROTECTION_BYPASS);
   return `${baseUrl}?${params}`;
 }
 
@@ -52,9 +50,18 @@ export function remoteP2Url(baseUrl, roomId, partyHost, opts = {}) {
   if (opts.fighter) params.set('fighter', opts.fighter);
   if (opts.seed != null) params.set('seed', String(opts.seed));
   if (opts.aiDifficulty) params.set('aiDifficulty', opts.aiDifficulty);
-  if (process.env.VERCEL_PROTECTION_BYPASS)
-    params.set('x-vercel-protection-bypass', process.env.VERCEL_PROTECTION_BYPASS);
   return `${baseUrl}?${params}`;
+}
+
+/**
+ * Apply Vercel deployment protection bypass headers to a browser context.
+ * Must be called before any page.goto() so all requests (HTML, JS, CSS) include the header.
+ */
+export async function applyVercelBypass(context) {
+  const secret = process.env.VERCEL_PROTECTION_BYPASS;
+  if (secret) {
+    await context.setExtraHTTPHeaders({ 'x-vercel-protection-bypass': secret });
+  }
 }
 
 /**

--- a/tests/e2e/remote/remote-helpers.js
+++ b/tests/e2e/remote/remote-helpers.js
@@ -59,9 +59,20 @@ export function remoteP2Url(baseUrl, roomId, partyHost, opts = {}) {
  */
 export async function applyVercelBypass(context) {
   const secret = process.env.VERCEL_PROTECTION_BYPASS;
-  if (secret) {
-    await context.setExtraHTTPHeaders({ 'x-vercel-protection-bypass': secret });
-  }
+  if (!secret) return;
+
+  const baseUrl = process.env.REMOTE_E2E_BASE_URL;
+  if (!baseUrl) return;
+
+  // Only add the bypass header to requests matching the Vercel deployment URL.
+  // Using context.route() instead of setExtraHTTPHeaders avoids sending the
+  // header to cross-origin servers (PartyKit, etc.) which reject it via CORS.
+  const vercelOrigin = new URL(baseUrl).origin;
+  await context.route(`${vercelOrigin}/**`, (route) => {
+    route.continue({
+      headers: { ...route.request().headers(), 'x-vercel-protection-bypass': secret },
+    });
+  });
 }
 
 /**

--- a/tests/e2e/remote/remote-multiplayer.spec.js
+++ b/tests/e2e/remote/remote-multiplayer.spec.js
@@ -17,6 +17,7 @@ import {
   STAGING_PARTY_HOST,
 } from './remote-config.js';
 import {
+  applyVercelBypass,
   connectRemoteBrowser,
   extractDebugBundle,
   fetchServerDiagnostics,
@@ -58,6 +59,7 @@ test.describe('Remote multiplayer (BrowserStack)', () => {
     console.log(`Connecting P1 (${preset.p1.browser} / ${preset.p1.os || 'default'})...`);
     const browserP1 = await connectRemoteBrowser(preset.p1);
     const ctxP1 = await browserP1.newContext({ viewport: { width: 960, height: 540 } });
+    await applyVercelBypass(ctxP1);
     const pageP1 = await ctxP1.newPage();
 
     const p1Console = [];
@@ -88,6 +90,7 @@ test.describe('Remote multiplayer (BrowserStack)', () => {
       console.log(`Connecting P2 (${preset.p2.browser} / ${preset.p2.os || 'default'})...`);
       browserP2 = await connectRemoteBrowser(preset.p2);
       const ctxP2 = await browserP2.newContext({ viewport: { width: 960, height: 540 } });
+      await applyVercelBypass(ctxP2);
       pageP2 = await ctxP2.newPage();
       pageP2.on('console', (msg) => p2Console.push(`[${msg.type()}] ${msg.text()}`));
 


### PR DESCRIPTION
## Summary
- **Hybrid E2E test**: New test mode where P1 runs locally and P2 runs on BrowserStack, simulating real network conditions between physically separated players. Both hit deployed staging — WebRTC P2P traffic traverses the real internet.
- **Fix debug bundle capture**: `window.__DEBUG_BUNDLE` was never available in E2E tests due to (1) async dynamic import race condition on P1 and (2) missing code path for P2. Moved `captureEndState` + bundle generation to `onMatchOver()` — the convergence point for both peers.
- **Fix VictoryScene**: `matchComplete` now also signals in debug mode, not just autoplay.
- **Vercel preview support**: `VERCEL_PROTECTION_BYPASS` env var adds bypass header scoped to the Vercel origin only (avoids CORS issues with PartyKit).

## Changes
- `tests/e2e/remote/hybrid-config.js` — BrowserStack presets for P2 (default: Chrome/Win, local-webkit: WebKit/macOS)
- `tests/e2e/remote/hybrid-multiplayer.spec.js` — Hybrid test: local `chromium.launch()` P1 + BrowserStack CDP P2
- `tests/e2e/remote/remote-helpers.js` — `applyVercelBypass()` via `context.route()` scoped to Vercel origin
- `tests/e2e/remote/remote-multiplayer.spec.js` — Also wired `applyVercelBypass` for the fully-remote test
- `src/scenes/FightScene.js` — Move `captureEndState` + debug bundle to `onMatchOver()`; static import for `DebugBundleExporter`
- `src/scenes/VictoryScene.js` — Extend `matchComplete` guard to include `debugMode`
- `package.json` — Add `test:e2e:hybrid` script

## Test results
Hybrid test passes (local Chromium + BrowserStack Chrome/Win11, `seed=42`, `speed=1`):
- Debug bundles: both v2 ✅ (was v1)
- `finalState`/`finalStateHash`: both populated ✅ (was null)
- KO frames: match perfectly ✅
- 4 desyncs on P2 under asymmetric rollback load — tracked in #93

## Test plan
- [x] `bun run test:run` — 826 unit tests pass
- [x] `bun run lint` — clean
- [x] Run hybrid E2E against Vercel preview with `VERCEL_PROTECTION_BYPASS`
- [x] Verify v2 debug bundles and non-null finalState in output
- [ ] Re-run after CORS fix deployed to confirm TURN credentials fetch succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)