### PR TITLE
feat: fighter balance simulation pipeline + data-driven rebalancing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,9 @@ bun run test:run     # Run tests once (CI)
 bun run lint         # Lint + format check (Biome)
 bun run lint:fix     # Auto-fix lint + format issues
 bun run format       # Format code only (Biome)
+bun run balance      # Run fighter balance simulation (full 16×16 matrix)
+bun run balance -- --fights=50           # Fewer fights per matchup (faster)
+bun run balance -- --p1=simon --p2=jeka  # Single matchup deep-dive
 ```
 
 ## Project Structure
@@ -59,12 +62,14 @@ public/
     audio/         # Music, SFX, announcer MP3s
 scripts/
   asset-pipeline/  # Gemini-based sprite generation pipeline
+  balance-sim/     # Headless AI-vs-AI balance simulation pipeline
 party/
   server.js        # PartyKit multiplayer server (+ TURN credential endpoint)
 tests/
   data/            # fighters.json data validation
   party/           # PartyKit server (slot assignment, rate limiting, routing)
   systems/         # combat-math, collision, AI difficulty
+  balance-sim/     # Balance simulation adapter + runner tests
 ```
 
 ## Conventions
@@ -180,6 +185,16 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - `docs/rfcs/0009-e2e-remote-browser-testing.md` — Remote browser E2E testing via BrowserStack
 - `docs/rfcs/0011-auto-upload-debug-bundles.md` — Auto-upload debug bundles to object storage
 - `docs/rfcs/0012-e2e-bot-user.md` — E2E bot user for debug bundle uploads (proposed)
+- `docs/rfcs/0013-fighter-balance-simulation.md` — Headless AI-vs-AI balance simulation pipeline
+
+## Balance Simulation
+
+Headless pipeline that runs AI-vs-AI fights to identify overpowered/underpowered fighters. Uses the pure simulation layer (no Phaser) with seeded AIController for deterministic, reproducible results.
+
+- **Scripts**: `scripts/balance-sim/` — adapter, match runner, report generator, CLI
+- **Key adapter**: `ai-input-adapter.js` reads `AIController.decision` and converts to encoded inputs for `tick()`
+- **Output**: `balance-report.json` (machine-readable) + `balance-report.md` (tier list, heatmap, outliers)
+- **Default**: 100 fights per matchup × 256 matchups = 25,600 fights, completes in ~20 seconds
 
 ## Online Multiplayer
 

--- a/docs/rfcs/0013-fighter-balance-simulation.md
+++ b/docs/rfcs/0013-fighter-balance-simulation.md
@@ -1,0 +1,148 @@
+# RFC 0013: Fighter Balance Simulation Pipeline
+
+**Status**: Proposed  
+**Date**: 2026-04-06
+
+## Problem
+
+Players report some fighters feel overpowered and others too weak. With 16 fighters, each having unique stats (speed, power, defense, special) and move frame data (startup, active, recovery, hitstun, blockstun, reach, damage × 5 moves), manual balancing is guesswork. We need empirical data.
+
+## Solution
+
+A CLI pipeline that runs thousands of deterministic AI-vs-AI headless fights, collects per-matchup statistics, and produces a balance report identifying tier placement and outlier matchups.
+
+### Why this is feasible now
+
+The simulation layer (`src/simulation/`) has **zero Phaser dependencies**:
+- `FighterSim` — pure state + logic
+- `CombatSim` — combat state machine
+- `SimulationEngine.tick()` — deterministic frame advance, returns `{ state, events, roundEvent }`
+- `AIController` — seeded PRNG (mulberry32), works with `FighterSim` directly
+
+Existing precedent: `tests/helpers/replay-engine.js` already runs complete headless fights.
+
+## Design
+
+### The AI-to-Input Adapter
+
+**Problem**: `AIController.applyDecisions()` mutates the fighter directly, but `tick()` expects encoded integer inputs and applies them via `applyInputToFighter()`. Using both would double-apply inputs.
+
+**Solution**: Read `AIController.decision` (set by `think()`) and convert to an encoded input integer without calling `applyDecisions()`:
+
+```js
+export function getEncodedInput(ai) {
+  ai.update(0, 0);  // ticks frame counter, fires think() on interval
+  
+  const d = ai.decision;
+  const encoded = encodeInput({
+    left: d.moveDir < 0, right: d.moveDir > 0,
+    up: d.jump, down: d.block,
+    lp: d.attack === 'lightPunch', hp: d.attack === 'heavyPunch',
+    lk: d.attack === 'lightKick',  hk: d.attack === 'heavyKick',
+    sp: d.attack === 'special',
+  });
+  
+  // Consume single-shot decisions (attacks fire once, movement persists)
+  if (d.jump) d.jump = false;
+  if (d.attack) d.attack = null;
+  
+  return encoded;
+}
+```
+
+### Match Runner
+
+```
+for each frame until matchOver or MAX_FRAMES:
+  1. Fast-forward round transitions (skip 300-frame cooldown)
+  2. Get encoded inputs from both AIs
+  3. tick(p1, p2, combat, p1Input, p2Input, frame)
+  4. Collect stats from events array (hits, blocks, KOs, damage)
+```
+
+- Both AIs use `hard` difficulty for fair comparison
+- Seed splitting: P1 gets `seed`, P2 gets `seed + 10000`
+- Fast-forward transitions: saves ~40% of total simulation frames
+
+### Matrix
+
+- 16 × 16 = 256 matchups (including mirrors for sanity checking)
+- Default 100 fights per matchup = 25,600 total fights
+- Deterministic seeds: `hash(p1Id + ':' + p2Id + ':' + fightIndex)`
+- Estimated runtime: 10-30 seconds (pure integer math, Bun)
+
+### Stats Collected
+
+From `tick()`'s events array per frame:
+- Hits landed, hits blocked, damage dealt/taken
+- Specials used, KO vs timeout ratio
+- Round-level HP remaining, fight duration
+
+### Report Output
+
+**`balance-report.json`** — machine-readable full results:
+```json
+{
+  "meta": { "timestamp", "fightsPerMatchup", "difficulty", "totalFights" },
+  "matrix": { "<p1Id>": { "<p2Id>": { "wins", "losses", "winRate", ... } } },
+  "fighters": { "<id>": { "overallWinRate", "avgDamagePerMatch", ... } },
+  "tierList": { "S": [...], "A": [...], "B": [...], "C": [...], "D": [...] }
+}
+```
+
+**`balance-report.md`** — human-readable summary:
+- 16×16 win rate heatmap table
+- Tier list (S: >57%, A: 53-57%, B: 47-53%, C: 43-47%, D: <43%)
+- Outlier matchups (>70% or <30% win rate)
+- Per-fighter breakdown
+
+### CLI
+
+```bash
+bun run balance                          # Full matrix, 100 fights/matchup
+bun run balance -- --fights=50           # Faster run
+bun run balance -- --difficulty=medium   # Different AI level
+bun run balance -- --p1=simon --p2=jeka  # Single matchup deep-dive
+```
+
+## File Plan
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `scripts/balance-sim/run.js` | CLI entry point |
+| `scripts/balance-sim/ai-input-adapter.js` | AI decision → encoded input |
+| `scripts/balance-sim/match-runner.js` | Single match + stat collection |
+| `scripts/balance-sim/report.js` | JSON + markdown generation |
+| `tests/balance-sim/ai-input-adapter.test.js` | Adapter tests |
+| `tests/balance-sim/match-runner.test.js` | Match runner tests |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `package.json` | Add `"balance"` script |
+| `CLAUDE.md` | Document the pipeline |
+
+## Reused Infrastructure
+
+- `SimulationEngine.tick()` — deterministic frame loop
+- `createFighterSim()` / `createCombatSim()` — headless sim objects
+- `AIController` — seeded AI with difficulty presets
+- `encodeInput()` / `decodeInput()` — input encoding
+- `fighters.json` — all 16 fighter definitions
+
+## Alternatives Considered
+
+1. **Modify AIController to produce encoded inputs directly**: Would pollute production code with balance-sim-only concerns. The adapter is cleaner.
+
+2. **Use `simulateFrame()` instead of `tick()`**: `simulateFrame()` doesn't return events, so we'd lose hit/block telemetry. `tick()` gives us everything.
+
+3. **Run in browser via autoplay mode**: Much slower (rendering overhead), harder to collect structured data, can't run 25K fights in reasonable time.
+
+## Risks
+
+- **AI behavior may not reflect human play**: AI-vs-AI reveals stat-driven imbalances but not exploits humans discover. This is a starting point, not the final word.
+- **Special stat (2-5) has no mechanical effect**: The `special` stat doesn't currently affect gameplay — it's essentially flavor. This will show up as a non-factor in the data, which is useful information.
+- **Same-difficulty AI eliminates skill asymmetry**: Both fighters use identical AI logic, so the results purely measure stat + frame data differences. This is the desired behavior for balance testing.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:e2e:hybrid": "npx playwright test --config tests/e2e/remote/remote-playwright.config.js hybrid-multiplayer",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "format": "biome format --write ."
+    "format": "biome format --write .",
+    "balance": "bun run scripts/balance-sim/run.js"
   },
   "dependencies": {
     "@google/genai": "^1.45.0",

--- a/scripts/balance-sim/ai-input-adapter.js
+++ b/scripts/balance-sim/ai-input-adapter.js
@@ -1,0 +1,59 @@
+/**
+ * Adapter that converts AIController decisions into encoded input integers
+ * compatible with SimulationEngine.tick().
+ *
+ * AIController.applyDecisions() mutates the fighter directly, but tick()
+ * expects encoded inputs. This adapter reads the decision object and
+ * produces the same encoded integer that applyInputToFighter() would consume.
+ */
+
+import { AIController } from '../../src/systems/AIController.js';
+import { encodeInput } from '../../src/systems/InputBuffer.js';
+
+/**
+ * Create a headless AI controller (no Phaser scene needed).
+ * @param {import('../../src/simulation/FighterSim.js').FighterSim} fighter
+ * @param {import('../../src/simulation/FighterSim.js').FighterSim} opponent
+ * @param {'easy'|'medium'|'hard'} difficulty
+ * @param {number} seed
+ * @returns {AIController}
+ */
+export function createHeadlessAI(fighter, opponent, difficulty, seed) {
+  const ai = new AIController(null, fighter, opponent, difficulty);
+  ai.setSeed(seed);
+  return ai;
+}
+
+/**
+ * Tick the AI and return an encoded input integer for this frame.
+ * Reads AIController.decision and converts to the format expected by tick().
+ * Consumes single-shot decisions (attack, jump) to prevent repeating.
+ *
+ * @param {AIController} ai
+ * @returns {number} Encoded input integer (9 bits)
+ */
+export function getEncodedInput(ai) {
+  // Tick the AI frame counter; fires think() when interval elapses
+  ai.update(0, 0);
+
+  const d = ai.decision;
+
+  const encoded = encodeInput({
+    left: d.moveDir < 0,
+    right: d.moveDir > 0,
+    up: d.jump,
+    down: d.block,
+    lp: d.attack === 'lightPunch',
+    hp: d.attack === 'heavyPunch',
+    lk: d.attack === 'lightKick',
+    hk: d.attack === 'heavyKick',
+    sp: d.attack === 'special',
+  });
+
+  // Consume single-shot decisions so they don't repeat every frame
+  // until the next think() cycle. Movement (moveDir) persists intentionally.
+  if (d.jump) d.jump = false;
+  if (d.attack) d.attack = null;
+
+  return encoded;
+}

--- a/scripts/balance-sim/match-runner.js
+++ b/scripts/balance-sim/match-runner.js
@@ -145,7 +145,32 @@ export function runMatchup(p1Id, p2Id, fightsPerMatchup, difficulty = 'hard') {
   for (let i = 0; i < fightsPerMatchup; i++) {
     // Deterministic seed per fight: hash of matchup + fight index
     const seed = simpleHash(`${p1Id}:${p2Id}:${i}`);
-    results.push(runMatch(p1Id, p2Id, seed, difficulty));
+
+    // Alternate sides to eliminate P1 positional advantage.
+    // Even fights: p1Id is P1. Odd fights: p2Id is P1 (result flipped).
+    if (i % 2 === 0) {
+      results.push(runMatch(p1Id, p2Id, seed, difficulty));
+    } else {
+      const flipped = runMatch(p2Id, p1Id, seed, difficulty);
+      // Flip perspective so p1Id is always "P1" in aggregation
+      results.push({
+        ...flipped,
+        p1Id,
+        p2Id,
+        winnerIndex: flipped.winnerIndex === 0 ? 1 : 0,
+        winnerId: flipped.winnerIndex === 0 ? p2Id : p1Id,
+        p1Stats: flipped.p2Stats,
+        p2Stats: flipped.p1Stats,
+        p1RoundsWon: flipped.p2RoundsWon,
+        p2RoundsWon: flipped.p1RoundsWon,
+        rounds: flipped.rounds.map((r) => ({
+          ...r,
+          winnerIndex: r.winnerIndex === 0 ? 1 : 0,
+          p1HpRemaining: r.p2HpRemaining,
+          p2HpRemaining: r.p1HpRemaining,
+        })),
+      });
+    }
   }
   return aggregateMatchup(p1Id, p2Id, results);
 }

--- a/scripts/balance-sim/match-runner.js
+++ b/scripts/balance-sim/match-runner.js
@@ -1,0 +1,268 @@
+/**
+ * Headless match runner — runs a single AI-vs-AI fight and collects stats.
+ * Uses SimulationEngine.tick() for deterministic frame advance with event telemetry.
+ */
+
+import { GAME_WIDTH, ROUND_TIME } from '../../src/config.js';
+import fightersData from '../../src/data/fighters.json' with { type: 'json' };
+import { createCombatSim } from '../../src/simulation/CombatSim.js';
+import { createFighterSim } from '../../src/simulation/FighterSim.js';
+import { tick } from '../../src/simulation/SimulationEngine.js';
+import { createHeadlessAI, getEncodedInput } from './ai-input-adapter.js';
+
+const P1_START_X = Math.trunc(GAME_WIDTH * 0.3);
+const P2_START_X = Math.trunc(GAME_WIDTH * 0.7);
+
+// Safety cap: 5 minutes at 60fps (should never be reached)
+const MAX_FRAMES = 60 * 60 * 5;
+
+function emptyPlayerStats() {
+  return {
+    damageDealt: 0,
+    damageBlocked: 0,
+    hitsLanded: 0,
+    hitsBlocked: 0,
+    specialsUsed: 0,
+    whiffs: 0,
+  };
+}
+
+/**
+ * Run a single headless match between two fighters.
+ *
+ * @param {string} p1Id - Fighter ID for player 1
+ * @param {string} p2Id - Fighter ID for player 2
+ * @param {number} seed - PRNG seed for deterministic AI
+ * @param {'easy'|'medium'|'hard'} [difficulty='hard']
+ * @returns {MatchResult}
+ */
+export function runMatch(p1Id, p2Id, seed, difficulty = 'hard') {
+  const p1Data = fightersData.find((f) => f.id === p1Id);
+  const p2Data = fightersData.find((f) => f.id === p2Id);
+  if (!p1Data) throw new Error(`Fighter not found: ${p1Id}`);
+  if (!p2Data) throw new Error(`Fighter not found: ${p2Id}`);
+
+  const p1 = createFighterSim(P1_START_X, 0, p1Data);
+  const p2 = createFighterSim(P2_START_X, 1, p2Data);
+  const combat = createCombatSim();
+
+  // Distinct PRNG streams for each AI
+  const ai1 = createHeadlessAI(p1, p2, difficulty, seed);
+  const ai2 = createHeadlessAI(p2, p1, difficulty, seed + 10000);
+
+  const p1Stats = emptyPlayerStats();
+  const p2Stats = emptyPlayerStats();
+  const rounds = [];
+
+  let roundStartFrame = 0;
+  let frame = 0;
+
+  for (; !combat.matchOver && frame < MAX_FRAMES; frame++) {
+    // Fast-forward round transitions (skip 300 dead frames between rounds)
+    if (!combat.roundActive && combat.transitionTimer > 0) {
+      combat.transitionTimer = 0;
+      p1.resetForRound(P1_START_X);
+      p2.resetForRound(P2_START_X);
+      combat.timer = ROUND_TIME;
+      combat._timerAccumulator = 0;
+      combat.roundActive = true;
+      roundStartFrame = frame;
+    }
+
+    const p1Input = getEncodedInput(ai1);
+    const p2Input = getEncodedInput(ai2);
+    const { events } = tick(p1, p2, combat, p1Input, p2Input, frame);
+
+    // Collect stats from events
+    for (const evt of events) {
+      switch (evt.type) {
+        case 'hit': {
+          const stats = evt.attackerIndex === 0 ? p1Stats : p2Stats;
+          stats.damageDealt += evt.damage;
+          stats.hitsLanded++;
+          break;
+        }
+        case 'hit_blocked': {
+          const stats = evt.attackerIndex === 0 ? p1Stats : p2Stats;
+          stats.damageBlocked += evt.damage;
+          stats.hitsBlocked++;
+          break;
+        }
+        case 'whiff': {
+          const stats = evt.playerIndex === 0 ? p1Stats : p2Stats;
+          stats.whiffs++;
+          break;
+        }
+        case 'special_charge': {
+          const stats = evt.playerIndex === 0 ? p1Stats : p2Stats;
+          stats.specialsUsed++;
+          break;
+        }
+        case 'round_ko':
+        case 'round_timeup': {
+          rounds.push({
+            winnerIndex: evt.winnerIndex,
+            type: evt.type === 'round_ko' ? 'ko' : 'timeup',
+            frames: frame - roundStartFrame,
+            p1HpRemaining: p1.hp,
+            p2HpRemaining: p2.hp,
+          });
+          roundStartFrame = frame;
+          break;
+        }
+      }
+    }
+  }
+
+  const winnerIndex = combat.p1RoundsWon > combat.p2RoundsWon ? 0 : 1;
+
+  return {
+    p1Id,
+    p2Id,
+    seed,
+    winnerIndex,
+    winnerId: winnerIndex === 0 ? p1Id : p2Id,
+    totalFrames: frame,
+    rounds,
+    p1Stats,
+    p2Stats,
+    p1RoundsWon: combat.p1RoundsWon,
+    p2RoundsWon: combat.p2RoundsWon,
+  };
+}
+
+/**
+ * Run a full matchup: N fights between two fighters with sequential seeds.
+ *
+ * @param {string} p1Id
+ * @param {string} p2Id
+ * @param {number} fightsPerMatchup
+ * @param {'easy'|'medium'|'hard'} difficulty
+ * @returns {MatchupResult}
+ */
+export function runMatchup(p1Id, p2Id, fightsPerMatchup, difficulty = 'hard') {
+  const results = [];
+  for (let i = 0; i < fightsPerMatchup; i++) {
+    // Deterministic seed per fight: hash of matchup + fight index
+    const seed = simpleHash(`${p1Id}:${p2Id}:${i}`);
+    results.push(runMatch(p1Id, p2Id, seed, difficulty));
+  }
+  return aggregateMatchup(p1Id, p2Id, results);
+}
+
+/**
+ * Run the full 16×16 matrix of all matchups.
+ *
+ * @param {object} options
+ * @param {number} [options.fightsPerMatchup=100]
+ * @param {'easy'|'medium'|'hard'} [options.difficulty='hard']
+ * @param {function} [options.onProgress] - Called after each matchup with (completed, total)
+ * @returns {{ matrix: Object, fighters: Object, meta: Object }}
+ */
+export function runFullMatrix({ fightsPerMatchup = 100, difficulty = 'hard', onProgress } = {}) {
+  const fighterIds = fightersData.map((f) => f.id);
+  const totalMatchups = fighterIds.length * fighterIds.length;
+  let completed = 0;
+
+  const matrix = {};
+  for (const p1Id of fighterIds) {
+    matrix[p1Id] = {};
+    for (const p2Id of fighterIds) {
+      matrix[p1Id][p2Id] = runMatchup(p1Id, p2Id, fightsPerMatchup, difficulty);
+      completed++;
+      if (onProgress) onProgress(completed, totalMatchups);
+    }
+  }
+
+  // Aggregate per-fighter stats across all matchups
+  const fighters = {};
+  for (const id of fighterIds) {
+    let totalWins = 0;
+    let totalMatches = 0;
+    let totalDamageDealt = 0;
+    let totalHitsLanded = 0;
+    let totalSpecials = 0;
+    let koWins = 0;
+    let timeupWins = 0;
+
+    for (const oppId of fighterIds) {
+      const m = matrix[id][oppId];
+      totalWins += m.p1Wins;
+      totalMatches += m.totalFights;
+      totalDamageDealt += m.avgP1DamageDealt * m.totalFights;
+      totalHitsLanded += m.avgP1HitsLanded * m.totalFights;
+      totalSpecials += m.avgP1SpecialsUsed * m.totalFights;
+      koWins += m.koWins;
+      timeupWins += m.timeupWins;
+    }
+
+    fighters[id] = {
+      name: fightersData.find((f) => f.id === id).name,
+      winRate: totalWins / totalMatches,
+      totalWins,
+      totalMatches,
+      avgDamagePerMatch: totalDamageDealt / totalMatches,
+      avgHitsPerMatch: totalHitsLanded / totalMatches,
+      avgSpecialsPerMatch: totalSpecials / totalMatches,
+      koWinRate: koWins / (koWins + timeupWins || 1),
+    };
+  }
+
+  return {
+    matrix,
+    fighters,
+    meta: {
+      timestamp: new Date().toISOString(),
+      fightsPerMatchup,
+      difficulty,
+      totalFights: totalMatchups * fightsPerMatchup,
+      totalMatchups,
+      fighterCount: fighterIds.length,
+    },
+  };
+}
+
+// -- Helpers --
+
+function aggregateMatchup(p1Id, p2Id, results) {
+  const totalFights = results.length;
+  const p1Wins = results.filter((r) => r.winnerIndex === 0).length;
+
+  let koWins = 0;
+  let timeupWins = 0;
+  for (const r of results) {
+    for (const round of r.rounds) {
+      if (round.winnerIndex === 0) {
+        if (round.type === 'ko') koWins++;
+        else timeupWins++;
+      }
+    }
+  }
+
+  const sum = (arr, fn) => arr.reduce((s, r) => s + fn(r), 0);
+
+  return {
+    p1Id,
+    p2Id,
+    totalFights,
+    p1Wins,
+    p2Wins: totalFights - p1Wins,
+    p1WinRate: p1Wins / totalFights,
+    koWins,
+    timeupWins,
+    avgP1DamageDealt: sum(results, (r) => r.p1Stats.damageDealt) / totalFights,
+    avgP2DamageDealt: sum(results, (r) => r.p2Stats.damageDealt) / totalFights,
+    avgP1HitsLanded: sum(results, (r) => r.p1Stats.hitsLanded) / totalFights,
+    avgP1SpecialsUsed: sum(results, (r) => r.p1Stats.specialsUsed) / totalFights,
+    avgTotalFrames: sum(results, (r) => r.totalFrames) / totalFights,
+  };
+}
+
+function simpleHash(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash + char) | 0;
+  }
+  return Math.abs(hash);
+}

--- a/scripts/balance-sim/report.js
+++ b/scripts/balance-sim/report.js
@@ -1,0 +1,153 @@
+/**
+ * Report generator — produces JSON and markdown balance reports
+ * from simulation matrix results.
+ */
+
+import fightersData from '../../src/data/fighters.json' with { type: 'json' };
+
+const TIER_THRESHOLDS = [
+  { tier: 'S', min: 0.57 },
+  { tier: 'A', min: 0.53 },
+  { tier: 'B', min: 0.47 },
+  { tier: 'C', min: 0.43 },
+  { tier: 'D', min: 0 },
+];
+
+/**
+ * Assign tier based on overall win rate.
+ */
+function getTier(winRate) {
+  for (const { tier, min } of TIER_THRESHOLDS) {
+    if (winRate >= min) return tier;
+  }
+  return 'D';
+}
+
+/**
+ * Build a tier list from fighter stats.
+ */
+function buildTierList(fighters) {
+  const tiers = { S: [], A: [], B: [], C: [], D: [] };
+  const sorted = Object.entries(fighters).sort((a, b) => b[1].winRate - a[1].winRate);
+  for (const [id, stats] of sorted) {
+    const tier = getTier(stats.winRate);
+    tiers[tier].push({ id, name: stats.name, winRate: stats.winRate });
+  }
+  return tiers;
+}
+
+/**
+ * Find matchups with extreme win rates.
+ */
+function findOutliers(matrix, threshold = 0.7) {
+  const outliers = [];
+  const fighterIds = Object.keys(matrix);
+  for (const p1Id of fighterIds) {
+    for (const p2Id of fighterIds) {
+      if (p1Id === p2Id) continue;
+      const m = matrix[p1Id][p2Id];
+      if (m.p1WinRate >= threshold) {
+        outliers.push({
+          p1Id,
+          p2Id,
+          p1Name: fightersData.find((f) => f.id === p1Id)?.name || p1Id,
+          p2Name: fightersData.find((f) => f.id === p2Id)?.name || p2Id,
+          winRate: m.p1WinRate,
+        });
+      }
+    }
+  }
+  return outliers.sort((a, b) => b.winRate - a.winRate);
+}
+
+/**
+ * Generate the full JSON report.
+ */
+export function generateJsonReport({ matrix, fighters, meta }) {
+  const tierList = buildTierList(fighters);
+  return { meta, matrix, fighters, tierList };
+}
+
+/**
+ * Generate a human-readable markdown report.
+ */
+export function generateMarkdownReport({ matrix, fighters, meta }) {
+  const tierList = buildTierList(fighters);
+  const outliers = findOutliers(matrix);
+  const fighterIds = Object.keys(matrix);
+  const lines = [];
+
+  lines.push('# Balance Report');
+  lines.push('');
+  lines.push(`- **Date**: ${meta.timestamp}`);
+  lines.push(`- **Fights per matchup**: ${meta.fightsPerMatchup}`);
+  lines.push(`- **AI difficulty**: ${meta.difficulty}`);
+  lines.push(`- **Total fights**: ${meta.totalFights.toLocaleString()}`);
+  lines.push('');
+
+  // Tier list
+  lines.push('## Tier List');
+  lines.push('');
+  const tierLabels = {
+    S: 'S (>57%)',
+    A: 'A (53-57%)',
+    B: 'B (47-53%)',
+    C: 'C (43-47%)',
+    D: 'D (<43%)',
+  };
+  for (const [tier, label] of Object.entries(tierLabels)) {
+    const members = tierList[tier];
+    if (members.length === 0) continue;
+    const names = members.map((m) => `${m.name} (${pct(m.winRate)})`).join(', ');
+    lines.push(`- **${label}**: ${names}`);
+  }
+  lines.push('');
+
+  // Per-fighter stats table
+  lines.push('## Fighter Stats');
+  lines.push('');
+  lines.push('| Fighter | Win Rate | Avg Dmg | Avg Hits | Avg Specials | KO Rate |');
+  lines.push('|---------|----------|---------|----------|--------------|---------|');
+  const sorted = Object.entries(fighters).sort((a, b) => b[1].winRate - a[1].winRate);
+  for (const [, stats] of sorted) {
+    lines.push(
+      `| ${stats.name} | ${pct(stats.winRate)} | ${stats.avgDamagePerMatch.toFixed(1)} | ${stats.avgHitsPerMatch.toFixed(1)} | ${stats.avgSpecialsPerMatch.toFixed(1)} | ${pct(stats.koWinRate)} |`,
+    );
+  }
+  lines.push('');
+
+  // Win rate heatmap
+  lines.push('## Matchup Matrix (P1 win rate)');
+  lines.push('');
+  const names = fighterIds.map((id) => fightersData.find((f) => f.id === id)?.name || id);
+  const shortNames = names.map((n) => n.slice(0, 4));
+  lines.push(`| | ${shortNames.join(' | ')} |`);
+  lines.push(`|---|${shortNames.map(() => '---').join('|')}|`);
+  for (let i = 0; i < fighterIds.length; i++) {
+    const cells = fighterIds.map((p2Id) => {
+      if (fighterIds[i] === p2Id) return ' -- ';
+      const wr = matrix[fighterIds[i]][p2Id].p1WinRate;
+      return pct(wr);
+    });
+    lines.push(`| ${shortNames[i]} | ${cells.join(' | ')} |`);
+  }
+  lines.push('');
+
+  // Outliers
+  if (outliers.length > 0) {
+    lines.push('## Outlier Matchups (>70% win rate)');
+    lines.push('');
+    lines.push('| Winner | Loser | Win Rate |');
+    lines.push('|--------|-------|----------|');
+    for (const o of outliers) {
+      lines.push(`| ${o.p1Name} | ${o.p2Name} | ${pct(o.winRate)} |`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function pct(n) {
+  return `${(n * 100).toFixed(1)}%`;
+}

--- a/scripts/balance-sim/run.js
+++ b/scripts/balance-sim/run.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env bun
+/**
+ * Fighter Balance Simulation CLI
+ *
+ * Usage:
+ *   bun run balance                            # Full matrix, 100 fights/matchup
+ *   bun run balance -- --fights=50             # Fewer fights (faster)
+ *   bun run balance -- --difficulty=medium      # Different AI level
+ *   bun run balance -- --p1=simon --p2=jeka    # Single matchup deep-dive
+ *   bun run balance -- --output=./my-report    # Custom output path
+ */
+
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { runFullMatrix, runMatchup } from './match-runner.js';
+import { generateJsonReport, generateMarkdownReport } from './report.js';
+
+function parseArgs(argv) {
+  const args = {
+    fights: 100,
+    difficulty: 'hard',
+    p1: null,
+    p2: null,
+    output: './balance-report',
+  };
+
+  for (const arg of argv.slice(2)) {
+    const [key, val] = arg.replace(/^--/, '').split('=');
+    switch (key) {
+      case 'fights':
+        args.fights = Number.parseInt(val, 10);
+        break;
+      case 'difficulty':
+        args.difficulty = val;
+        break;
+      case 'p1':
+        args.p1 = val;
+        break;
+      case 'p2':
+        args.p2 = val;
+        break;
+      case 'output':
+        args.output = val;
+        break;
+    }
+  }
+
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  // Single matchup mode
+  if (args.p1 && args.p2) {
+    console.log(`Running ${args.fights} fights: ${args.p1} vs ${args.p2} (${args.difficulty})`);
+    const start = performance.now();
+    const result = runMatchup(args.p1, args.p2, args.fights, args.difficulty);
+    const elapsed = ((performance.now() - start) / 1000).toFixed(2);
+
+    console.log(`\nResults (${elapsed}s):`);
+    console.log(
+      `  ${args.p1} wins: ${result.p1Wins}/${result.totalFights} (${(result.p1WinRate * 100).toFixed(1)}%)`,
+    );
+    console.log(
+      `  ${args.p2} wins: ${result.p2Wins}/${result.totalFights} (${((1 - result.p1WinRate) * 100).toFixed(1)}%)`,
+    );
+    console.log(
+      `  Avg damage: ${args.p1}=${result.avgP1DamageDealt.toFixed(1)}, ${args.p2}=${result.avgP2DamageDealt.toFixed(1)}`,
+    );
+    console.log(`  Avg fight duration: ${result.avgTotalFrames.toFixed(0)} frames`);
+    return;
+  }
+
+  // Full matrix mode
+  console.log(
+    `Running full balance simulation: ${args.fights} fights/matchup, ${args.difficulty} difficulty`,
+  );
+  console.log(`Total fights: ${(16 * 16 * args.fights).toLocaleString()}`);
+  console.log('');
+
+  const start = performance.now();
+  let lastPct = -1;
+
+  const data = runFullMatrix({
+    fightsPerMatchup: args.fights,
+    difficulty: args.difficulty,
+    onProgress: (completed, total) => {
+      const pct = Math.floor((completed / total) * 100);
+      if (pct > lastPct) {
+        lastPct = pct;
+        process.stderr.write(`\rProgress: ${pct}% (${completed}/${total} matchups)`);
+      }
+    },
+  });
+
+  const elapsed = ((performance.now() - start) / 1000).toFixed(2);
+  process.stderr.write(`\rProgress: 100% — done in ${elapsed}s\n`);
+
+  // Generate reports
+  const jsonReport = generateJsonReport(data);
+  const mdReport = generateMarkdownReport(data);
+
+  const jsonPath = resolve(`${args.output}.json`);
+  const mdPath = resolve(`${args.output}.md`);
+
+  writeFileSync(jsonPath, JSON.stringify(jsonReport, null, 2));
+  writeFileSync(mdPath, mdReport);
+
+  console.log(`\nReports written:`);
+  console.log(`  JSON: ${jsonPath}`);
+  console.log(`  Markdown: ${mdPath}`);
+
+  // Print summary
+  console.log(`\nTier List:`);
+  for (const [tier, members] of Object.entries(jsonReport.tierList)) {
+    if (members.length === 0) continue;
+    const names = members.map((m) => `${m.name} (${(m.winRate * 100).toFixed(1)}%)`).join(', ');
+    console.log(`  ${tier}: ${names}`);
+  }
+}
+
+main();

--- a/src/data/fighters.json
+++ b/src/data/fighters.json
@@ -64,7 +64,7 @@
     "stats": { "hp": 100, "speed": 5, "power": 2, "defense": 2, "special": 3 },
     "moves": {
       "lightPunch": {
-        "damage": 4,
+        "damage": 5,
         "startup": 1,
         "active": 2,
         "recovery": 2,
@@ -73,7 +73,7 @@
         "reach": 40
       },
       "heavyPunch": {
-        "damage": 9,
+        "damage": 11,
         "startup": 4,
         "active": 2,
         "recovery": 6,
@@ -82,7 +82,7 @@
         "reach": 40
       },
       "lightKick": {
-        "damage": 5,
+        "damage": 6,
         "startup": 2,
         "active": 2,
         "recovery": 3,
@@ -91,7 +91,7 @@
         "reach": 50
       },
       "heavyKick": {
-        "damage": 11,
+        "damage": 13,
         "startup": 5,
         "active": 2,
         "recovery": 7,
@@ -124,7 +124,7 @@
     "stats": { "hp": 100, "speed": 2, "power": 2, "defense": 3, "special": 5 },
     "moves": {
       "lightPunch": {
-        "damage": 4,
+        "damage": 6,
         "startup": 3,
         "active": 2,
         "recovery": 4,
@@ -132,7 +132,7 @@
         "blockstun": 9
       },
       "heavyPunch": {
-        "damage": 10,
+        "damage": 13,
         "startup": 6,
         "active": 3,
         "recovery": 8,
@@ -140,7 +140,7 @@
         "blockstun": 16
       },
       "lightKick": {
-        "damage": 5,
+        "damage": 7,
         "startup": 4,
         "active": 2,
         "recovery": 5,
@@ -148,7 +148,7 @@
         "blockstun": 10
       },
       "heavyKick": {
-        "damage": 11,
+        "damage": 14,
         "startup": 7,
         "active": 3,
         "recovery": 9,
@@ -236,7 +236,7 @@
     "stats": { "hp": 100, "speed": 3, "power": 2, "defense": 2, "special": 5 },
     "moves": {
       "lightPunch": {
-        "damage": 4,
+        "damage": 6,
         "startup": 3,
         "active": 2,
         "recovery": 4,
@@ -244,7 +244,7 @@
         "blockstun": 9
       },
       "heavyPunch": {
-        "damage": 10,
+        "damage": 13,
         "startup": 6,
         "active": 3,
         "recovery": 8,
@@ -252,7 +252,7 @@
         "blockstun": 14
       },
       "lightKick": {
-        "damage": 5,
+        "damage": 7,
         "startup": 4,
         "active": 2,
         "recovery": 5,
@@ -260,7 +260,7 @@
         "blockstun": 10
       },
       "heavyKick": {
-        "damage": 11,
+        "damage": 14,
         "startup": 7,
         "active": 3,
         "recovery": 9,
@@ -348,7 +348,7 @@
     "stats": { "hp": 100, "speed": 2, "power": 2, "defense": 3, "special": 5 },
     "moves": {
       "lightPunch": {
-        "damage": 4,
+        "damage": 6,
         "startup": 3,
         "active": 2,
         "recovery": 4,
@@ -356,7 +356,7 @@
         "blockstun": 9
       },
       "heavyPunch": {
-        "damage": 10,
+        "damage": 13,
         "startup": 6,
         "active": 3,
         "recovery": 8,
@@ -364,7 +364,7 @@
         "blockstun": 16
       },
       "lightKick": {
-        "damage": 5,
+        "damage": 7,
         "startup": 4,
         "active": 2,
         "recovery": 5,
@@ -372,7 +372,7 @@
         "blockstun": 10
       },
       "heavyKick": {
-        "damage": 11,
+        "damage": 14,
         "startup": 7,
         "active": 3,
         "recovery": 9,
@@ -404,7 +404,7 @@
     "stats": { "hp": 100, "speed": 4, "power": 2, "defense": 2, "special": 4 },
     "moves": {
       "lightPunch": {
-        "damage": 3,
+        "damage": 5,
         "startup": 1,
         "active": 2,
         "recovery": 2,
@@ -413,7 +413,7 @@
         "reach": 55
       },
       "heavyPunch": {
-        "damage": 8,
+        "damage": 11,
         "startup": 4,
         "active": 2,
         "recovery": 6,
@@ -422,7 +422,7 @@
         "reach": 55
       },
       "lightKick": {
-        "damage": 4,
+        "damage": 6,
         "startup": 2,
         "active": 2,
         "recovery": 3,
@@ -431,7 +431,7 @@
         "reach": 70
       },
       "heavyKick": {
-        "damage": 10,
+        "damage": 12,
         "startup": 5,
         "active": 2,
         "recovery": 7,
@@ -580,7 +580,7 @@
     "stats": { "hp": 100, "speed": 5, "power": 2, "defense": 1, "special": 4 },
     "moves": {
       "lightPunch": {
-        "damage": 4,
+        "damage": 5,
         "startup": 1,
         "active": 2,
         "recovery": 2,
@@ -589,7 +589,7 @@
         "reach": 40
       },
       "heavyPunch": {
-        "damage": 9,
+        "damage": 11,
         "startup": 4,
         "active": 2,
         "recovery": 6,
@@ -598,7 +598,7 @@
         "reach": 40
       },
       "lightKick": {
-        "damage": 5,
+        "damage": 6,
         "startup": 2,
         "active": 2,
         "recovery": 3,
@@ -607,7 +607,7 @@
         "reach": 50
       },
       "heavyKick": {
-        "damage": 10,
+        "damage": 12,
         "startup": 5,
         "active": 2,
         "recovery": 7,
@@ -641,47 +641,47 @@
     "moves": {
       "lightPunch": {
         "damage": 6,
-        "startup": 4,
+        "startup": 3,
         "active": 3,
         "recovery": 5,
         "hitstun": 14,
         "blockstun": 9,
-        "reach": 35,
+        "reach": 45,
         "height": 55
       },
       "heavyPunch": {
         "damage": 15,
-        "startup": 8,
+        "startup": 6,
         "active": 4,
         "recovery": 10,
         "hitstun": 22,
         "blockstun": 16,
-        "reach": 35,
+        "reach": 45,
         "height": 55
       },
       "lightKick": {
         "damage": 7,
-        "startup": 5,
+        "startup": 4,
         "active": 2,
         "recovery": 6,
         "hitstun": 16,
         "blockstun": 10,
-        "reach": 45,
+        "reach": 55,
         "height": 55
       },
       "heavyKick": {
         "damage": 16,
-        "startup": 9,
+        "startup": 7,
         "active": 3,
         "recovery": 11,
         "hitstun": 24,
         "blockstun": 17,
-        "reach": 45,
+        "reach": 55,
         "height": 55
       },
       "special": {
         "damage": 30,
-        "startup": 12,
+        "startup": 10,
         "active": 5,
         "recovery": 16,
         "hitstun": 32,
@@ -877,7 +877,7 @@
     "stats": { "hp": 100, "speed": 4, "power": 3, "defense": 2, "special": 4 },
     "moves": {
       "lightPunch": {
-        "damage": 4,
+        "damage": 5,
         "startup": 2,
         "active": 2,
         "recovery": 3,
@@ -885,7 +885,7 @@
         "blockstun": 8
       },
       "heavyPunch": {
-        "damage": 11,
+        "damage": 12,
         "startup": 5,
         "active": 3,
         "recovery": 7,
@@ -893,7 +893,7 @@
         "blockstun": 14
       },
       "lightKick": {
-        "damage": 5,
+        "damage": 6,
         "startup": 3,
         "active": 2,
         "recovery": 4,
@@ -901,7 +901,7 @@
         "blockstun": 9
       },
       "heavyKick": {
-        "damage": 13,
+        "damage": 14,
         "startup": 6,
         "active": 3,
         "recovery": 8,

--- a/src/data/fighters.json
+++ b/src/data/fighters.json
@@ -16,7 +16,7 @@
         "blockstun": 8
       },
       "heavyPunch": {
-        "damage": 13,
+        "damage": 12,
         "startup": 5,
         "active": 3,
         "recovery": 8,
@@ -32,7 +32,7 @@
         "blockstun": 9
       },
       "heavyKick": {
-        "damage": 15,
+        "damage": 14,
         "startup": 6,
         "active": 3,
         "recovery": 9,
@@ -40,7 +40,7 @@
         "blockstun": 15
       },
       "special": {
-        "damage": 28,
+        "damage": 26,
         "startup": 9,
         "active": 5,
         "recovery": 14,
@@ -64,7 +64,7 @@
     "stats": { "hp": 100, "speed": 5, "power": 2, "defense": 2, "special": 3 },
     "moves": {
       "lightPunch": {
-        "damage": 5,
+        "damage": 4,
         "startup": 1,
         "active": 2,
         "recovery": 2,
@@ -73,7 +73,7 @@
         "reach": 40
       },
       "heavyPunch": {
-        "damage": 11,
+        "damage": 10,
         "startup": 4,
         "active": 2,
         "recovery": 6,
@@ -91,7 +91,7 @@
         "reach": 50
       },
       "heavyKick": {
-        "damage": 13,
+        "damage": 12,
         "startup": 5,
         "active": 2,
         "recovery": 7,
@@ -236,7 +236,7 @@
     "stats": { "hp": 100, "speed": 3, "power": 2, "defense": 2, "special": 5 },
     "moves": {
       "lightPunch": {
-        "damage": 6,
+        "damage": 7,
         "startup": 3,
         "active": 2,
         "recovery": 4,
@@ -404,7 +404,7 @@
     "stats": { "hp": 100, "speed": 4, "power": 2, "defense": 2, "special": 4 },
     "moves": {
       "lightPunch": {
-        "damage": 5,
+        "damage": 4,
         "startup": 1,
         "active": 2,
         "recovery": 2,
@@ -580,7 +580,7 @@
     "stats": { "hp": 100, "speed": 5, "power": 2, "defense": 1, "special": 4 },
     "moves": {
       "lightPunch": {
-        "damage": 5,
+        "damage": 4,
         "startup": 1,
         "active": 2,
         "recovery": 2,
@@ -589,7 +589,7 @@
         "reach": 40
       },
       "heavyPunch": {
-        "damage": 11,
+        "damage": 12,
         "startup": 4,
         "active": 2,
         "recovery": 6,
@@ -607,7 +607,7 @@
         "reach": 50
       },
       "heavyKick": {
-        "damage": 12,
+        "damage": 14,
         "startup": 5,
         "active": 2,
         "recovery": 7,
@@ -651,7 +651,7 @@
       },
       "heavyPunch": {
         "damage": 15,
-        "startup": 6,
+        "startup": 7,
         "active": 4,
         "recovery": 10,
         "hitstun": 22,
@@ -671,7 +671,7 @@
       },
       "heavyKick": {
         "damage": 16,
-        "startup": 7,
+        "startup": 8,
         "active": 3,
         "recovery": 11,
         "hitstun": 24,
@@ -713,7 +713,7 @@
         "blockstun": 8
       },
       "heavyPunch": {
-        "damage": 14,
+        "damage": 13,
         "startup": 6,
         "active": 3,
         "recovery": 8,
@@ -729,7 +729,7 @@
         "blockstun": 9
       },
       "heavyKick": {
-        "damage": 15,
+        "damage": 14,
         "startup": 7,
         "active": 3,
         "recovery": 9,
@@ -785,16 +785,16 @@
         "blockstun": 10
       },
       "heavyKick": {
-        "damage": 14,
-        "startup": 8,
+        "damage": 15,
+        "startup": 7,
         "active": 3,
         "recovery": 10,
         "hitstun": 22,
         "blockstun": 15
       },
       "special": {
-        "damage": 26,
-        "startup": 10,
+        "damage": 28,
+        "startup": 9,
         "active": 5,
         "recovery": 15,
         "hitstun": 30,
@@ -885,7 +885,7 @@
         "blockstun": 8
       },
       "heavyPunch": {
-        "damage": 12,
+        "damage": 13,
         "startup": 5,
         "active": 3,
         "recovery": 7,

--- a/src/systems/combat-math.js
+++ b/src/systems/combat-math.js
@@ -7,10 +7,10 @@
  */
 export function calculateDamage(baseDamage, attackerPower, defenderDefense) {
   // Integer-scaled modifiers (1000x):
-  // powerMod: 700 + power*100 → range 800..1200 (was 0.8..1.2)
-  // defMod:  1100 - def*40   → range 900..1060 (was 0.90..1.06)
-  const powerMod = 700 + attackerPower * 100;
-  const defMod = 1100 - defenderDefense * 40;
+  // powerMod: 850 + power*50  → range 900..1100 (0.90..1.10)
+  // defMod:  1200 - def*60   → range 900..1140 (0.90..1.14)
+  const powerMod = 850 + attackerPower * 50;
+  const defMod = 1200 - defenderDefense * 60;
   return Math.round((baseDamage * powerMod * defMod) / 1_000_000);
 }
 

--- a/tests/balance-sim/ai-input-adapter.test.js
+++ b/tests/balance-sim/ai-input-adapter.test.js
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { createHeadlessAI, getEncodedInput } from '../../scripts/balance-sim/ai-input-adapter.js';
+import { GAME_WIDTH } from '../../src/config.js';
+import fightersData from '../../src/data/fighters.json' with { type: 'json' };
+import { createFighterSim } from '../../src/simulation/FighterSim.js';
+import { decodeInput } from '../../src/systems/InputBuffer.js';
+
+const P1_START_X = Math.trunc(GAME_WIDTH * 0.3);
+const P2_START_X = Math.trunc(GAME_WIDTH * 0.7);
+
+// Close enough for AI to consider attacking (within approachRange)
+const CLOSE_X1 = 200;
+const CLOSE_X2 = 250;
+
+function makeFighters(p1Id = 'simon', p2Id = 'jeka', { close = false } = {}) {
+  const p1Data = fightersData.find((f) => f.id === p1Id);
+  const p2Data = fightersData.find((f) => f.id === p2Id);
+  const x1 = close ? CLOSE_X1 : P1_START_X;
+  const x2 = close ? CLOSE_X2 : P2_START_X;
+  const p1 = createFighterSim(x1, 0, p1Data);
+  const p2 = createFighterSim(x2, 1, p2Data);
+  return { p1, p2 };
+}
+
+describe('createHeadlessAI', () => {
+  it('creates an AI controller without a Phaser scene', () => {
+    const { p1, p2 } = makeFighters();
+    const ai = createHeadlessAI(p1, p2, 'hard', 42);
+    expect(ai).toBeDefined();
+    expect(ai.fighter).toBe(p1);
+    expect(ai.opponent).toBe(p2);
+    expect(ai.difficulty).toBe('hard');
+  });
+});
+
+describe('getEncodedInput', () => {
+  it('returns a valid encoded input integer', () => {
+    const { p1, p2 } = makeFighters();
+    const ai = createHeadlessAI(p1, p2, 'hard', 42);
+    const input = getEncodedInput(ai);
+    expect(typeof input).toBe('number');
+    expect(input).toBeGreaterThanOrEqual(0);
+    expect(input).toBeLessThan(512); // 9 bits max
+  });
+
+  it('produces deterministic outputs with the same seed', () => {
+    const inputs1 = [];
+    const inputs2 = [];
+
+    for (let run = 0; run < 2; run++) {
+      const { p1, p2 } = makeFighters();
+      const ai = createHeadlessAI(p1, p2, 'hard', 42);
+      const target = run === 0 ? inputs1 : inputs2;
+      for (let i = 0; i < 100; i++) {
+        target.push(getEncodedInput(ai));
+      }
+    }
+
+    expect(inputs1).toEqual(inputs2);
+  });
+
+  it('produces different outputs with different seeds when in attack range', () => {
+    // Fighters must be close so the AI makes RNG-dependent decisions (attack/block)
+    const { p1: p1a, p2: p2a } = makeFighters('simon', 'jeka', { close: true });
+    const { p1: p1b, p2: p2b } = makeFighters('simon', 'jeka', { close: true });
+    const ai1 = createHeadlessAI(p1a, p2a, 'hard', 1);
+    const ai2 = createHeadlessAI(p1b, p2b, 'hard', 99999);
+
+    const inputs1 = [];
+    const inputs2 = [];
+    for (let i = 0; i < 100; i++) {
+      inputs1.push(getEncodedInput(ai1));
+      inputs2.push(getEncodedInput(ai2));
+    }
+
+    // With different seeds the sequences should diverge
+    expect(inputs1).not.toEqual(inputs2);
+  });
+
+  it('consumes attack decisions (fires only once)', () => {
+    // Position fighters close so AI will decide to attack
+    const { p1, p2 } = makeFighters('simon', 'jeka', { close: true });
+    const ai = createHeadlessAI(p1, p2, 'hard', 42);
+
+    // Run until the AI decides to attack
+    let attackFrame = -1;
+    for (let i = 0; i < 200; i++) {
+      const input = getEncodedInput(ai);
+      const decoded = decodeInput(input);
+      if (decoded.lp || decoded.hp || decoded.lk || decoded.hk || decoded.sp) {
+        attackFrame = i;
+        break;
+      }
+    }
+
+    // AI should eventually attack (hard difficulty, thinkInterval=5)
+    expect(attackFrame).toBeGreaterThanOrEqual(0);
+
+    // The frame immediately after should NOT repeat the same attack
+    // (it was consumed), unless think() fires again on this exact frame
+    const nextInput = getEncodedInput(ai);
+    const nextDecoded = decodeInput(nextInput);
+    const hasAttack =
+      nextDecoded.lp || nextDecoded.hp || nextDecoded.lk || nextDecoded.hk || nextDecoded.sp;
+    // Attack was consumed, so next frame should have no attack
+    // (unless think() coincidentally fires again — but even then, it resets first)
+    expect(hasAttack).toBe(false);
+  });
+
+  it('decodes to valid input fields', () => {
+    const { p1, p2 } = makeFighters();
+    const ai = createHeadlessAI(p1, p2, 'hard', 42);
+
+    for (let i = 0; i < 50; i++) {
+      const input = getEncodedInput(ai);
+      const decoded = decodeInput(input);
+      // All fields should be booleans
+      for (const key of ['left', 'right', 'up', 'down', 'lp', 'hp', 'lk', 'hk', 'sp']) {
+        expect(typeof decoded[key]).toBe('boolean');
+      }
+      // Can't press left and right simultaneously
+      expect(decoded.left && decoded.right).toBe(false);
+    }
+  });
+});

--- a/tests/balance-sim/match-runner.test.js
+++ b/tests/balance-sim/match-runner.test.js
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { runMatch, runMatchup } from '../../scripts/balance-sim/match-runner.js';
+
+describe('runMatch', () => {
+  it('runs a match to completion', () => {
+    const result = runMatch('simon', 'jeka', 42);
+    expect(result.p1Id).toBe('simon');
+    expect(result.p2Id).toBe('jeka');
+    expect(result.winnerIndex).toBeOneOf([0, 1]);
+    expect(result.winnerId).toBeOneOf(['simon', 'jeka']);
+    expect(result.totalFrames).toBeGreaterThan(0);
+    expect(result.rounds.length).toBeGreaterThanOrEqual(2); // best of 3
+    expect(result.p1RoundsWon + result.p2RoundsWon).toBeGreaterThanOrEqual(2);
+  });
+
+  it('produces deterministic results with the same seed', () => {
+    const r1 = runMatch('simon', 'jeka', 42);
+    const r2 = runMatch('simon', 'jeka', 42);
+    expect(r1.winnerIndex).toBe(r2.winnerIndex);
+    expect(r1.totalFrames).toBe(r2.totalFrames);
+    expect(r1.p1Stats).toEqual(r2.p1Stats);
+    expect(r1.p2Stats).toEqual(r2.p2Stats);
+    expect(r1.rounds).toEqual(r2.rounds);
+  });
+
+  it('produces different results with different seeds', () => {
+    // Use a balanced matchup (similar stats) so both sides can win
+    const results = [];
+    for (let seed = 0; seed < 20; seed++) {
+      results.push(runMatch('simon', 'alv', seed * 7919));
+    }
+    // With similar fighters and 20 seeds, we should see variation
+    const p1Wins = results.filter((r) => r.winnerIndex === 0).length;
+    expect(p1Wins).toBeGreaterThan(0);
+    expect(p1Wins).toBeLessThan(20);
+  });
+
+  it('collects hit and damage stats', () => {
+    const result = runMatch('simon', 'chicha', 123);
+    // Both fighters should land some hits in a full match
+    expect(result.p1Stats.hitsLanded).toBeGreaterThan(0);
+    expect(result.p2Stats.hitsLanded).toBeGreaterThan(0);
+    expect(result.p1Stats.damageDealt).toBeGreaterThan(0);
+    expect(result.p2Stats.damageDealt).toBeGreaterThan(0);
+  });
+
+  it('handles all fighter IDs without crashing', () => {
+    const fighters = [
+      'simon',
+      'jeka',
+      'chicha',
+      'cata',
+      'carito',
+      'mao',
+      'peks',
+      'lini',
+      'alv',
+      'sun',
+      'gartner',
+      'richi',
+      'cami',
+      'migue',
+      'bozzi',
+      'angy',
+    ];
+    for (const id of fighters) {
+      const result = runMatch(id, 'simon', 1);
+      expect(result.winnerId).toBeDefined();
+    }
+  });
+
+  it('records round results with KO or timeup type', () => {
+    const result = runMatch('simon', 'jeka', 42);
+    for (const round of result.rounds) {
+      expect(round.type).toBeOneOf(['ko', 'timeup']);
+      expect(round.winnerIndex).toBeOneOf([0, 1]);
+      expect(round.frames).toBeGreaterThan(0);
+      expect(round.p1HpRemaining).toBeGreaterThanOrEqual(0);
+      expect(round.p2HpRemaining).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('mirror match converges toward 50% over many fights', () => {
+    let p1Wins = 0;
+    const N = 50;
+    for (let i = 0; i < N; i++) {
+      const result = runMatch('simon', 'simon', i * 31);
+      if (result.winnerIndex === 0) p1Wins++;
+    }
+    const winRate = p1Wins / N;
+    // Mirror match should be roughly balanced (allow wide margin for small N)
+    expect(winRate).toBeGreaterThan(0.2);
+    expect(winRate).toBeLessThan(0.8);
+  });
+});
+
+describe('runMatchup', () => {
+  it('aggregates multiple fights into a matchup result', () => {
+    const result = runMatchup('simon', 'jeka', 10);
+    expect(result.totalFights).toBe(10);
+    expect(result.p1Wins + result.p2Wins).toBe(10);
+    expect(result.p1WinRate).toBeGreaterThanOrEqual(0);
+    expect(result.p1WinRate).toBeLessThanOrEqual(1);
+    expect(result.avgP1DamageDealt).toBeGreaterThan(0);
+    expect(result.avgTotalFrames).toBeGreaterThan(0);
+  });
+});

--- a/tests/systems/combat-math.test.js
+++ b/tests/systems/combat-math.test.js
@@ -5,25 +5,25 @@ import { calculateDamage } from '../../src/systems/combat-math.js';
 
 describe('calculateDamage', () => {
   it('neutral stats (power=3, defense=3) returns damage close to base', () => {
-    // powerMod = 0.7 + 0.3 = 1.0, defMod = 1.1 - 0.12 = 0.98
+    // powerMod = 0.85 + 0.15 = 1.00, defMod = 1.20 - 0.18 = 1.02
     const result = calculateDamage(10, 3, 3);
-    expect(result).toBe(Math.round(10 * 1.0 * 0.98)); // 10
+    expect(result).toBe(Math.round(10 * 1.0 * 1.02)); // 10
   });
 
   it('high power (5) + low defense (1) gives significant damage boost', () => {
-    // powerMod = 1.2, defMod = 1.06
+    // powerMod = 1.10, defMod = 1.14
     const result = calculateDamage(10, 5, 1);
     const neutral = calculateDamage(10, 3, 3);
     expect(result).toBeGreaterThan(neutral);
-    expect(result).toBe(Math.round(10 * 1.2 * 1.06)); // 13
+    expect(result).toBe(Math.round(10 * 1.1 * 1.14)); // 13
   });
 
   it('low power (1) + high defense (5) gives significant damage reduction', () => {
-    // powerMod = 0.8, defMod = 0.90
+    // powerMod = 0.90, defMod = 0.90
     const result = calculateDamage(10, 1, 5);
     const neutral = calculateDamage(10, 3, 3);
     expect(result).toBeLessThan(neutral);
-    expect(result).toBe(Math.round(10 * 0.8 * 0.9)); // 7
+    expect(result).toBe(Math.round(10 * 0.9 * 0.9)); // 8
   });
 
   it('always returns a rounded integer', () => {

--- a/tests/systems/hitbox-data.test.js
+++ b/tests/systems/hitbox-data.test.js
@@ -104,7 +104,7 @@ describe('per-character hitbox data', () => {
     const richi = fighters.find((f) => f.id === 'richi');
 
     expect(richi.moves.lightPunch.height).toBe(55);
-    expect(richi.moves.lightPunch.reach).toBe(35);
+    expect(richi.moves.lightPunch.reach).toBe(45);
 
     const f = createFighter(richi);
     f.currentAttack = { type: 'lightPunch', ...richi.moves.lightPunch };
@@ -112,7 +112,7 @@ describe('per-character hitbox data', () => {
 
     const hitbox = getAttackHitbox(f);
     expect(hitbox.h).toBe(55 * FP_SCALE);
-    expect(Math.abs(hitbox.w)).toBe(35 * FP_SCALE);
+    expect(Math.abs(hitbox.w)).toBe(45 * FP_SCALE);
   });
 
   it('bozzi (elastic) has extended reach', () => {


### PR DESCRIPTION
## Summary

Built a headless AI-vs-AI balance simulation pipeline, then used it iteratively to rebalance all 16 fighters from a 63% win rate spread down to 12%.

## The Balance Engine

### Problem
Players reported some fighters felt too strong and others too weak, but we had no data to confirm which ones or by how much.

### Approach
The game's simulation layer (`FighterSim`, `CombatSim`, `SimulationEngine`) is already fully headless — zero Phaser dependencies. We built a pipeline on top of it that:

1. **Adapts AI inputs** (`ai-input-adapter.js`): Reads `AIController.decision` and converts to encoded input integers for `tick()`, bridging the gap between AI decision-making and the simulation's input format
2. **Runs headless matches** (`match-runner.js`): Executes full AI-vs-AI fights using `SimulationEngine.tick()`, collecting hit/block/damage/KO stats from the events array
3. **Generates reports** (`report.js`): Produces tier lists, 16×16 matchup heatmaps, and outlier detection in both JSON and markdown
4. **CLI** (`run.js`): `bun run balance` runs the full 25,600-fight matrix in ~18 seconds

Both AIs use `hard` difficulty with seeded PRNG (mulberry32) for fully deterministic, reproducible results. Fights alternate which fighter is P1/P2 to eliminate positional bias from `tick()` processing order.

## The Balancing Process

### Iteration 0: Baseline (original game)
```
S-tier (>57%): Simo 79%, Camilo 78%, Sun 77%, Alv 76%, Mao 67%, Cata 62%, Bozz 60%, Migue 57%
D-tier (<43%): Panchito 36%, Angy 36%, Peks 22%, Chicha 21%, Carito 18%, LinaPcmn 17%
Spread: 16.5% → 79.2% (62.7% range)
```

**Root cause identified**: Power stat multiplier range was too wide (0.8x–1.2x = 50% damage swing) while defense was nearly meaningless (0.9x–1.06x = 16% swing). Power-4 fighters dominated everything; power-2 fighters couldn't compete.

Also discovered: `stats.special` (ranges 2-5) is a **dead stat** — never read by any code. Fighters with special 5 (Chicha, Peks, Carito) got zero benefit from it. Filed as issue #96.

### Iteration 1: Formula rebalance
Changed `combat-math.js`:
- Power: `700 + power*100` → `850 + power*50` (0.8x–1.2x narrowed to 0.9x–1.1x)  
- Defense: `1100 - def*40` → `1200 - def*60` (0.9x–1.06x widened to 0.9x–1.14x)

```
Result: Top came down slightly (Simo 79→77%), but bottom barely moved (LinaPcmn 17→21%)
Spread: 20.5% → 77.3% (56.8% range)
```

**Insight**: The formula change alone wasn't enough because D-tier fighters had **both** low power stat AND low base damage values in their moves — double penalized.

### Iteration 2: Base damage buffs for weak fighters
Increased normal attack base damage by +1–3 for Jeka, Chicha, Carito, Peks, Lini, Gartner, Angy. Also fixed Ric (who crashed to 26% after the power nerf) by reducing his startup frames and increasing reach.

```
Result: All fighters now 38–65%
Spread: 38.4% → 66.7% (28.3% range)
```

**Insight**: Fast fighters (Jecat, Lini) with 1-frame LP startup overshot to S-tier (65–66%) because their damage buff + speed was too much. Simo still dominated at 67%.

### Iteration 3: Pull back overtuned fast fighters
Reduced LP damage 5→4 for fighters with 1-frame startup (Jecat, Lini, Panchito). Buffed Migue's HK startup and special damage. Panchito's defense-1 fragility required restoring some heavy damage.

```
Result: All fighters now 34–67%
Spread: 34.1% → 66.7% (32.6% range)
```

**Insight**: Panchito's defense 1 combined with the LP nerf was too much. Needed partial rollback.

### Iteration 4: Final fine-tuning
Targeted the remaining outliers:
- Nerfed Simo/Camilo heavy damage, Ric HP/HK startup
- Buffed Panchito/Angy/LinaPcmn/Carito

```
Final result: All 16 fighters between 44.9% and 56.8%
Spread: 44.9% → 56.8% (11.9% range)
```

### Final Tier List

| Tier | Fighters | Win Rate |
|------|----------|----------|
| **A** | Simo, Camilo, Carito, Sun | 53–57% |
| **B** | Alv, Ric, Migue, LinaPcmn, Cata, Mao, Chicha | 48–53% |
| **C** | Panchito, Angy, Bozz, Peks, Jecat | 45–47% |

No S-tier. No D-tier. Every fighter is competitively viable.

### Spread comparison

| Phase | Min | Max | Range |
|-------|-----|-----|-------|
| Original | 16.5% | 79.2% | 62.7% |
| Formula fix | 20.5% | 77.3% | 56.8% |
| Base damage buffs | 38.4% | 66.7% | 28.3% |
| Fine-tuning | **44.9%** | **56.8%** | **11.9%** |

## Files Changed

### New files (balance engine)
- `scripts/balance-sim/` — AI adapter, match runner, report generator, CLI
- `tests/balance-sim/` — 14 tests for adapter and match runner
- `docs/rfcs/0013-fighter-balance-simulation.md` — RFC

### Modified files (balance changes)
- `src/systems/combat-math.js` — Power/defense multiplier formula
- `src/data/fighters.json` — Base damage and frame data for 10 fighters
- `tests/systems/combat-math.test.js` — Updated expected values
- `tests/systems/hitbox-data.test.js` — Updated Ric's reach value
- `package.json` — Added `balance` script
- `CLAUDE.md` — Documented pipeline

## Test plan

- [x] 840 tests pass (`bun run test:run`)
- [x] Lint clean (`bun run lint`)
- [x] Balance simulation produces deterministic results (same seed = same output)
- [x] Mirror matches converge to ~50% (verified with 300 fights/matchup)
- [x] All 16 fighters within 45–57% win rate range
- [x] Only 5 outlier matchups above 70% (down from 100+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)