### PR TITLE
feat(ui): add stage selection confirmation and fix mouse-hover auto-selection

### DIFF
--- a/src/data/stages.json
+++ b/src/data/stages.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "beach",
-    "name": "Pareo y Bogatell",
+    "name": "Bogatell y Pareo",
     "bgColor": "#1a3a5a",
     "groundColor": "#c4a84a",
     "description": "Cerveza beer pareo mojito fresh",

--- a/src/scenes/StageSelectScene.js
+++ b/src/scenes/StageSelectScene.js
@@ -98,17 +98,26 @@ export class StageSelectScene extends Phaser.Scene {
         rect.on('pointerdown', () => {
           this.selectedIndex = i;
           this.updateSelection();
-          this.confirmSelection();
-        });
-        rect.on('pointerover', () => {
-          this.selectedIndex = i;
-          this.updateSelection();
         });
       }
     }
 
+    // LISTO Button (Only for P1 or local)
+    if (this.isP1) {
+      this.listoBtn = createButton(
+        this,
+        GAME_WIDTH / 2,
+        GAME_HEIGHT - 25,
+        'LISTO',
+        () => {
+          this.confirmSelection();
+        },
+        { width: 100, height: 25, fontSize: '12px' },
+      );
+    }
+
     // Selection Info
-    this.infoContainer = this.add.container(GAME_WIDTH / 2, GAME_HEIGHT - 60);
+    this.infoContainer = this.add.container(GAME_WIDTH / 2, GAME_HEIGHT - 75);
     this.stageNameText = this.add
       .text(0, 0, '', {
         fontFamily: 'Arial Black',


### PR DESCRIPTION
This PR improves the stage selection flow by introducing a confirmation step (#92) and fixing an issue with mouse-based navigation on PC.

### Key Changes:
- **Confirmation Step:** Added a "LISTO" (Done) button to `StageSelectScene`. Stage selection is no longer immediate upon clicking or hovering; players must now confirm their choice.
- **PC Navigation Fix:** Removed the `pointerover` auto-selection from the stage grid. This allows PC players to move their mouse toward the "LISTO" button without accidentally changing their selected stage.
- **Keyboard Support:** Updated keyboard controls to support confirmation via `KeyZ`, `Enter`, or `Space`.
- **Code Quality:** Applied project-wide formatting using Biome to ensure consistency and resolved line-ending issues.

### Verification:
- Verified that the "LISTO" button works on both touch and mouse-enabled devices.
- Confirmed that mouse hover no longer triggers selection changes in `StageSelectScene`.
- Ran `bun run lint` and `bun run build` successfully.

<img width="1915" height="1079" alt="Captura de pantalla 2026-04-06 180726" src="https://github.com/user-attachments/assets/04bca211-2eba-4dca-88e3-d2b388a78c01" />
