### PR TITLE
feat: single-command local multiplayer dev setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,8 @@ DATABASE_URL=postgres://localhost:5432/postgres
 # DATABASE_URL=postgres://postgres:[YOUR-PASSWORD]@[YOUR-HOST]:6543/postgres?pgbouncer=true
 # Your Supabase Project ID (the part between https:// and .supabase.co)
 SUPABASE_PROJECT_ID=your-project-id
+
+# Multiplayer local dev (bun run dev:mp) — set automatically, no need to configure:
+# VITE_SUPABASE_URL=http://localhost:54321
+# VITE_SUPABASE_ANON_KEY=dev-anon-key
+# SUPABASE_JWT_SECRET=dev-jwt-secret-at-least-32-characters-long!!

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ Decoupled architecture: Supabase for Auth (JWT) + Vercel Functions for data pers
 ## Build & Run
 
 ```bash
+bun run dev:mp       # Full multiplayer dev (fake auth + PGLite + Vite + Vercel Dev + PartyKit)
+                     # Log in as p1@test.local or p2@test.local (password: password)
 bun run dev:all      # Run both Vite and Vercel Dev (recommended)
 bun run dev          # Vite dev server only
 bun run party:dev    # PartyKit dev server (port 1999)

--- a/db/seed-dev.sql
+++ b/db/seed-dev.sql
@@ -1,0 +1,6 @@
+-- Dev seed data: test profiles for local multiplayer testing (bun run dev:mp)
+-- UUIDs match the pre-seeded users in scripts/dev-auth.js
+INSERT INTO profiles (id, nickname, wins, losses, is_admin) VALUES
+  ('11111111-0000-0000-0000-000000000001', 'DevP1', 0, 0, true),
+  ('22222222-0000-0000-0000-000000000002', 'DevP2', 0, 0, false)
+ON CONFLICT (id) DO NOTHING;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "vite",
     "dev:db": "node scripts/dev-db.js",
     "dev:all": "concurrently \"node scripts/dev-db.js\" \"vite\" \"vercel dev --yes\"",
+    "dev:mp": "node scripts/dev-multiplayer.js",
     "build": "vite build",
     "preview": "vite preview",
     "party:dev": "bunx partykit dev",

--- a/scripts/dev-auth.js
+++ b/scripts/dev-auth.js
@@ -1,0 +1,227 @@
+/**
+ * Fake GoTrue auth server for local multiplayer development.
+ *
+ * Implements the minimal Supabase Auth REST API so the @supabase/supabase-js
+ * client can talk to it transparently. Issues HS256 JWTs verified by the
+ * backend via SUPABASE_JWT_SECRET.
+ *
+ * Pre-seeded test accounts:
+ *   p1@test.local / password  (DevP1)
+ *   p2@test.local / password  (DevP2)
+ */
+
+import { createServer } from 'node:http';
+import { jwtVerify, SignJWT } from 'jose';
+
+const PORT = 54321;
+const JWT_SECRET =
+  process.env.SUPABASE_JWT_SECRET || 'dev-jwt-secret-at-least-32-characters-long!!';
+const SECRET_KEY = new TextEncoder().encode(JWT_SECRET);
+
+// In-memory user store
+const users = new Map();
+const refreshTokens = new Map(); // refreshToken -> userId
+
+// Pre-seed test users
+const SEED_USERS = [
+  {
+    id: '11111111-0000-0000-0000-000000000001',
+    email: 'p1@test.local',
+    password: 'password',
+    nickname: 'DevP1',
+  },
+  {
+    id: '22222222-0000-0000-0000-000000000002',
+    email: 'p2@test.local',
+    password: 'password',
+    nickname: 'DevP2',
+  },
+];
+
+for (const u of SEED_USERS) {
+  users.set(u.email, { ...u, created_at: new Date().toISOString() });
+}
+
+async function signJwt(user) {
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({
+    sub: user.id,
+    email: user.email,
+    aud: 'authenticated',
+    role: 'authenticated',
+    user_metadata: { nickname: user.nickname },
+  })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600)
+    .setIssuer(`http://localhost:${PORT}/auth/v1`)
+    .sign(SECRET_KEY);
+}
+
+function userPayload(user) {
+  return {
+    id: user.id,
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: user.email,
+    email_confirmed_at: user.created_at,
+    phone: '',
+    last_sign_in_at: new Date().toISOString(),
+    app_metadata: { provider: 'email', providers: ['email'] },
+    user_metadata: { nickname: user.nickname },
+    identities: [],
+    created_at: user.created_at,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+async function sessionResponse(user) {
+  const accessToken = await signJwt(user);
+  const refreshToken = crypto.randomUUID();
+  refreshTokens.set(refreshToken, user.id);
+
+  return {
+    access_token: accessToken,
+    token_type: 'bearer',
+    expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    refresh_token: refreshToken,
+    user: userPayload(user),
+  };
+}
+
+function json(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function cors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'authorization, apikey, content-type, x-client-info, x-supabase-api-version',
+  );
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+const server = createServer(async (req, res) => {
+  cors(res);
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const path = url.pathname;
+
+  // POST /auth/v1/token
+  if (req.method === 'POST' && path === '/auth/v1/token') {
+    const grantType = url.searchParams.get('grant_type');
+    const body = await readBody(req);
+
+    if (grantType === 'password') {
+      const user = users.get(body.email);
+      if (!user || user.password !== body.password) {
+        return json(res, 400, {
+          error: 'invalid_grant',
+          error_description: 'Invalid login credentials',
+        });
+      }
+      return json(res, 200, await sessionResponse(user));
+    }
+
+    if (grantType === 'refresh_token') {
+      const userId = refreshTokens.get(body.refresh_token);
+      if (!userId) {
+        return json(res, 400, {
+          error: 'invalid_grant',
+          error_description: 'Invalid refresh token',
+        });
+      }
+      const user = [...users.values()].find((u) => u.id === userId);
+      if (!user) {
+        return json(res, 400, { error: 'invalid_grant', error_description: 'User not found' });
+      }
+      refreshTokens.delete(body.refresh_token);
+      return json(res, 200, await sessionResponse(user));
+    }
+
+    return json(res, 400, { error: 'unsupported_grant_type' });
+  }
+
+  // POST /auth/v1/signup
+  if (req.method === 'POST' && path === '/auth/v1/signup') {
+    const body = await readBody(req);
+    const { email, password } = body;
+    const nickname = body.data?.nickname || email?.split('@')[0] || 'Player';
+
+    if (!email || !password) {
+      return json(res, 400, {
+        error: 'validation_failed',
+        error_description: 'Email and password required',
+      });
+    }
+    if (users.has(email)) {
+      return json(res, 422, {
+        error: 'user_already_exists',
+        error_description: 'User already registered',
+      });
+    }
+
+    const user = {
+      id: crypto.randomUUID(),
+      email,
+      password,
+      nickname,
+      created_at: new Date().toISOString(),
+    };
+    users.set(email, user);
+    return json(res, 200, await sessionResponse(user));
+  }
+
+  // POST /auth/v1/logout
+  if (req.method === 'POST' && path === '/auth/v1/logout') {
+    res.writeHead(200);
+    res.end();
+    return;
+  }
+
+  // GET /auth/v1/user
+  if (req.method === 'GET' && path === '/auth/v1/user') {
+    const auth = req.headers.authorization;
+    if (!auth?.startsWith('Bearer ')) {
+      return json(res, 401, { error: 'unauthorized', error_description: 'Missing token' });
+    }
+    try {
+      const token = auth.split(' ')[1];
+      const { payload } = await jwtVerify(token, SECRET_KEY);
+      const user = [...users.values()].find((u) => u.id === payload.sub);
+      if (!user) return json(res, 404, { error: 'user_not_found' });
+      return json(res, 200, userPayload(user));
+    } catch {
+      return json(res, 401, { error: 'unauthorized', error_description: 'Invalid token' });
+    }
+  }
+
+  // Catch-all
+  json(res, 404, { error: 'not_found' });
+});
+
+server.listen(PORT, () => {
+  console.log(`Fake GoTrue auth server on http://localhost:${PORT}`);
+  console.log('Test accounts: p1@test.local / p2@test.local (password: password)');
+});

--- a/scripts/dev-multiplayer.js
+++ b/scripts/dev-multiplayer.js
@@ -1,0 +1,77 @@
+/**
+ * Single-command orchestrator for local multiplayer development.
+ *
+ * Starts: PGLite (in-process) + fake auth + Vite + Vercel Dev + PartyKit
+ * Usage:  bun run dev:mp
+ *
+ * Test accounts: p1@test.local / p2@test.local (password: password)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { PGlite } from '@electric-sql/pglite';
+import { PGLiteSocketServer } from '@electric-sql/pglite-socket';
+import { concurrently } from 'concurrently';
+
+const JWT_SECRET = 'dev-jwt-secret-at-least-32-characters-long!!';
+
+// 1. Set env vars — inherited by all child processes.
+//    process.env takes precedence over .env files in both Vite and Vercel Dev.
+process.env.VITE_SUPABASE_URL = 'http://localhost:54321';
+process.env.VITE_SUPABASE_ANON_KEY = 'dev-anon-key';
+process.env.SUPABASE_JWT_SECRET = JWT_SECRET;
+process.env.DATABASE_URL = 'postgres://localhost:5432/postgres';
+
+// 2. Start PGLite in-process
+const db = await PGlite.create('.pglite');
+const dbServer = new PGLiteSocketServer({ db, port: 5432, host: '127.0.0.1' });
+await dbServer.start();
+console.log('[db] PGLite running on localhost:5432');
+
+// 3. Run migrations
+const migrationsDir = path.resolve('db/migrations');
+const migrationFiles = fs
+  .readdirSync(migrationsDir)
+  .filter((f) => f.endsWith('.sql'))
+  .sort();
+
+for (const file of migrationFiles) {
+  const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf-8');
+  // Extract the -- migrate:up section (everything before -- migrate:down)
+  const upSection = sql.split('-- migrate:down')[0].replace('-- migrate:up', '').trim();
+  try {
+    await db.exec(upSection);
+    console.log(`[db] Migration applied: ${file}`);
+  } catch (e) {
+    // Ignore "already exists" errors for idempotent re-runs
+    if (e.message?.includes('already exists')) {
+      console.log(`[db] Migration skipped (already applied): ${file}`);
+    } else {
+      throw e;
+    }
+  }
+}
+
+// 4. Run seed data
+const seedFile = path.resolve('db/seed-dev.sql');
+if (fs.existsSync(seedFile)) {
+  await db.exec(fs.readFileSync(seedFile, 'utf-8'));
+  console.log('[db] Seed data applied (DevP1, DevP2)');
+}
+
+// 5. Start remaining services
+console.log('\n[dev:mp] Starting services...\n');
+
+concurrently(
+  [
+    { command: 'node scripts/dev-auth.js', name: 'auth', prefixColor: 'magenta' },
+    { command: 'npx vite', name: 'vite', prefixColor: 'green' },
+    { command: 'npx vercel dev --yes', name: 'api', prefixColor: 'yellow' },
+    { command: 'npx partykit dev', name: 'party', prefixColor: 'cyan' },
+  ],
+  {
+    prefix: 'name',
+    padPrefix: true,
+    killOthers: ['failure'],
+  },
+);


### PR DESCRIPTION
## Summary

- Adds `bun run dev:mp` — a single command that starts everything needed for local multiplayer testing: PGLite (with auto-migrate + seed), fake GoTrue auth server, Vite, Vercel Dev, and PartyKit
- Fake auth server implements the minimal Supabase Auth REST API so the existing `@supabase/supabase-js` client works transparently — no frontend changes needed
- Pre-seeded test accounts (`p1@test.local` / `p2@test.local`) with matching DB profiles, so two browser tabs can log in as different authenticated users
- Zero external dependencies or API keys required

## Test plan

- [ ] Run `bun run dev:mp` — all 5 services start
- [ ] Open two tabs, log in as `p1@test.local` and `p2@test.local` (password: `password`)
- [ ] Create online room in tab 1, join from tab 2 — full multiplayer flow works
- [ ] Verify `bun run dev` and `bun run dev:all` still work unchanged
- [ ] `bun run test:run` passes (849 tests)
- [ ] `bun run lint` clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)