### PR TITLE
fix: block click-through on join room overlay (#104)

### DIFF
--- a/src/scenes/MultiplayerMenuScene.js
+++ b/src/scenes/MultiplayerMenuScene.js
@@ -104,6 +104,7 @@ export class MultiplayerMenuScene extends Phaser.Scene {
       0x000000,
       0.85,
     );
+    bg.setInteractive();
     this._joinOverlay.add(bg);
 
     const title = this.add


### PR DESCRIPTION
The overlay background rectangle in _showJoinOverlay() was not set as interactive, so pointer events passed through to menu buttons behind it. Adding setInteractive() makes the background consume clicks.

https://claude.ai/code/session_016PeEsKsF9FXS8amXPfg6qr