### PR TITLE
feat(ui): implement two-step confirmation and enhanced visual feedback for character/stage selection

### DIFF
--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -394,6 +394,15 @@ export class SelectScene extends Phaser.Scene {
         if (this.p1Confirmed) this._showOpponentSelection(id);
       });
       this.networkManager.onOpponentUnready(() => {
+        // Cleanup visual overlay and selection list if they were already marked
+        if (this.opponentFighterId) {
+          const idx = this._humanSelections.indexOf(this.opponentFighterId);
+          if (idx !== -1) {
+            this._humanSelections.splice(idx, 1);
+            this._clearLastTakenOverlay(); // Note: This assumes only P1 and P2 can be in _takenOverlays in online mode
+          }
+        }
+
         this.opponentReady = false;
         this.opponentFighterId = null;
         this.p2Cursor.setVisible(false);

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -765,7 +765,6 @@ export class SelectScene extends Phaser.Scene {
     this._markFighterTaken(this.p1Index, this._currentSelectingPlayer);
 
     if (this.matchContext?.type === 'tournament') {
-      const _selectedId = this.fighters[this.p1Index].id;
       const selectedName = this.fighters[this.p1Index].name;
       this._updateSelectionListConfirm(this._currentSelectingPlayer, selectedName);
 

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -162,8 +162,12 @@ export class SelectScene extends Phaser.Scene {
       rect.on('pointerdown', () => {
         if (this.transitioning) return;
         onSelect();
-        if (!this.p1Confirmed) this.confirmP1();
-        else if (this.p2SelectionMode && !this.p2Confirmed) this.confirmP2();
+
+        // Move focus to LISTO button
+        const controller = this.scene.get('ControllerScene');
+        if (controller && this.listoBtn) {
+          controller.focusItem(this.listoBtn);
+        }
       });
 
       this.gridContainer.add(rect);
@@ -636,6 +640,15 @@ export class SelectScene extends Phaser.Scene {
     this._showP2Selection(this.p2Index);
   }
 
+  _clearLastTakenOverlay() {
+    if (this._takenOverlays.length > 0) {
+      const entry = this._takenOverlays.pop();
+      entry.pDOM.node.style.opacity = '1';
+      entry.pDOM.node.style.filter = '';
+      entry.labelDOM.destroy();
+    }
+  }
+
   handleBack() {
     if (this.transitioning) return;
 
@@ -650,12 +663,8 @@ export class SelectScene extends Phaser.Scene {
       this._currentSelectingPlayer--;
       const removedId = this._humanSelections.pop();
       // Remove visual overlay for that player
-      if (this._takenOverlays.length > 0) {
-        const entry = this._takenOverlays.pop();
-        entry.pDOM.node.style.opacity = '1';
-        entry.pDOM.node.style.filter = '';
-        entry.labelDOM.destroy();
-      }
+      this._clearLastTakenOverlay();
+
       // Restore cursor to the fighter that was undone
       const prevIdx = this.fighters.findIndex((f) => f.id === removedId);
       if (prevIdx !== -1) this.p1Index = prevIdx;
@@ -678,6 +687,11 @@ export class SelectScene extends Phaser.Scene {
       this.p1CursorLabel.setAlpha(1);
       this.p1Cursor.setStrokeStyle(2, 0x3366ff);
       this.confirmedText.setText('');
+
+      // Remove P1 visual overlay
+      this._clearLastTakenOverlay();
+      this._humanSelections.pop();
+
       this.game.audioManager.play('ui_cancel');
       return;
     }
@@ -723,10 +737,12 @@ export class SelectScene extends Phaser.Scene {
     this.p1Confirmed = false;
     this.p1Cursor.setStrokeStyle(2, 0x3366ff);
     this.confirmedText.setText('');
+    this._clearLastTakenOverlay();
+    this._humanSelections.pop();
   }
 
   confirmP1() {
-    // Block selection of taken fighters in multi-player tournament
+    // Block selection of taken fighters
     if (this._isFighterTaken(this.p1Index)) {
       this.game.audioManager.play('ui_cancel');
       return;
@@ -743,11 +759,14 @@ export class SelectScene extends Phaser.Scene {
       this.updateP1Display();
     }
     this.p1Cursor.setStrokeStyle(3, 0x00ccff);
+
+    // Apply visual overlay for the current player
+    this._humanSelections.push(this.fighters[this.p1Index].id);
+    this._markFighterTaken(this.p1Index, this._currentSelectingPlayer);
+
     if (this.matchContext?.type === 'tournament') {
-      const selectedId = this.fighters[this.p1Index].id;
+      const _selectedId = this.fighters[this.p1Index].id;
       const selectedName = this.fighters[this.p1Index].name;
-      this._humanSelections.push(selectedId);
-      this._markFighterTaken(this.p1Index, this._currentSelectingPlayer);
       this._updateSelectionListConfirm(this._currentSelectingPlayer, selectedName);
 
       if (this._currentSelectingPlayer < this._localPlayers) {
@@ -812,6 +831,12 @@ export class SelectScene extends Phaser.Scene {
   }
 
   confirmP2() {
+    // Block selection of taken fighters
+    if (this._isFighterTaken(this.p2Index)) {
+      this.game.audioManager.play('ui_cancel');
+      return;
+    }
+
     this.game.audioManager.play('ui_confirm');
     this.p2Confirmed = true;
     this.p2Cursor.setStrokeStyle(3, 0xff8800);
@@ -819,10 +844,15 @@ export class SelectScene extends Phaser.Scene {
       let idx;
       do {
         idx = Phaser.Math.Between(0, this.fighters.length - 2);
-      } while (idx === this.p1Index);
+      } while (this._humanSelections.includes(this.fighters[idx].id));
       this.p2Index = idx;
       this.updateP2Display();
     }
+
+    // Apply visual overlay for P2
+    this._humanSelections.push(this.fighters[this.p2Index].id);
+    this._markFighterTaken(this.p2Index, 2);
+
     this.confirmedText.setText('Listo! Preparando combate...');
     const delay = this.game.autoplay?.enabled ? 100 : 1000;
     this.time.delayedCall(delay, () => this.goToStageSelect());
@@ -833,6 +863,12 @@ export class SelectScene extends Phaser.Scene {
     if (idx !== -1) {
       this.p2Index = idx;
       this._showP2Selection(idx);
+
+      // Apply visual overlay for Online Opponent (J2)
+      if (!this._humanSelections.includes(id)) {
+        this._humanSelections.push(id);
+        this._markFighterTaken(idx, 2);
+      }
     }
   }
 
@@ -841,8 +877,12 @@ export class SelectScene extends Phaser.Scene {
     const row = Math.floor(idx / COLS);
     const cellX = GRID_START_X + col * (CELL_W + GRID_GAP);
     const cellY = GRID_START_Y + row * (CELL_H + GRID_GAP);
-    this.p2Cursor.setPosition(cellX, cellY).setVisible(true);
-    this.p2CursorLabel.setPosition(cellX + CELL_W / 2, cellY - 2).setVisible(true);
+
+    // Only show grid cursor if in P2 selection mode or online
+    const showGridCursor = this.p2SelectionMode || this.gameMode === 'online';
+    this.p2Cursor.setPosition(cellX, cellY).setVisible(showGridCursor);
+    this.p2CursorLabel.setPosition(cellX + CELL_W / 2, cellY - 2).setVisible(showGridCursor);
+
     const fighter = this.fighters[idx];
     this.p2NameText.setText(fighter.name);
     this.p2SubtitleText.setText(fighter.subtitle);
@@ -896,6 +936,12 @@ export class SelectScene extends Phaser.Scene {
     this.confirmedText.setText(
       `Jugador ${this._currentSelectingPlayer - 1} listo. Jugador ${this._currentSelectingPlayer}, elige...`,
     );
+
+    // Reset focus to the grid for the next player
+    const controller = this.scene.get('ControllerScene');
+    if (controller && this.gridCells[this.p1Index]) {
+      controller.focusItem(this.gridCells[this.p1Index].rect);
+    }
   }
 
   _markFighterTaken(fighterIdx, playerNum) {

--- a/src/scenes/StageSelectScene.js
+++ b/src/scenes/StageSelectScene.js
@@ -257,6 +257,20 @@ export class StageSelectScene extends Phaser.Scene {
   }
 
   updateSelection() {
+    this.gridCells.forEach((cell, i) => {
+      const isSelected = i === this.selectedIndex;
+      cell.border.setStrokeStyle(
+        isSelected ? 3 : 1,
+        isSelected ? 0xffcc00 : 0x444444,
+        isSelected ? 1 : 0.5,
+      );
+      if (isSelected) {
+        cell.rect.setFillStyle(0x444466);
+      } else {
+        cell.rect.setFillStyle(0x333333);
+      }
+    });
+
     const stage = this.stages[this.selectedIndex];
     const cell = this.gridCells[this.selectedIndex];
     if (cell) {


### PR DESCRIPTION
## Description
This PR improves the character and stage selection experience by introducing a consistent two-step confirmation process and enhancing visual feedback.

### Key Changes
- **Two-Step Confirmation**: Clicking on a character in the SelectScene now only highlights the fighter and moves the focus to the 'LISTO' (Ready) button, rather than immediately confirming and advancing. This aligns the behavior with the StageSelectScene.
- **Enhanced Visual Feedback**:
  - **Fighter Taken Overlay**: The grayscale and 'JX' label animation, previously exclusive to tournament mode, is now generalized to all game modes (Local, Online, Tournament).
  - **Stage Highlighting**: The StageSelectScene now clearly highlights the active choice with a prominent yellow border and updated background color.
- **Bug Fixes**:
  - **Tournament Player Labeling**: Fixed a bug where all players in tournament mode were incorrectly labeled as 'J1'. Now correctly reflects turn order (J1, J2, J3, etc.).
  - **P2 Cursor Visibility**: Fixed an issue where the Player 2 cursor was visible on the grid during Player 1's turn in local VS modes.
- **UX Improvements**:
  - Focus is automatically moved to the 'LISTO' button after a selection is made, facilitating rapid interaction.
  - Improved focus management when transitions occur (e.g., in tournament mode, focus returns to the grid for the next player).

### Verification
- Ran bun run lint:fix to ensure code style consistency.
- All 901 unit tests passed using bun run test:run.
- Manually verified all game modes (Local VS, Online, Tournament) for correct selection flow and visual feedback.

Closes #124