### PR TITLE
fix(ui): decouple mouse hover from selection in fighter and stage select

### DIFF
--- a/src/scenes/SelectRender.js
+++ b/src/scenes/SelectRender.js
@@ -1,0 +1,46 @@
+/**
+ * Pure helper to resolve the display and selection state during fighter selection.
+ * @param {Object} state - Current selection state
+ * @param {boolean} state.p1Confirmed
+ * @param {boolean} state.p2SelectionMode
+ * @param {boolean} state.p2Confirmed
+ * @param {number} state.p1Index
+ * @param {number} state.p2Index
+ * @param {Object} action - The action being performed
+ * @param {string} action.type - 'hover', 'out', or 'commit'
+ * @param {number} action.index - The cell index being interacted with
+ * @returns {Object} { p1Index, p2Index, displayP1Index, displayP2Index }
+ */
+export function resolveSelectionState(state, action) {
+  let nextP1Index = state.p1Index;
+  let nextP2Index = state.p2Index;
+  let displayP1Index = state.p1Index;
+  let displayP2Index = state.p2Index;
+
+  if (!state.p1Confirmed) {
+    if (action.type === 'commit') {
+      nextP1Index = action.index;
+      displayP1Index = action.index;
+    } else if (action.type === 'hover') {
+      displayP1Index = action.index;
+    } else if (action.type === 'out') {
+      displayP1Index = state.p1Index;
+    }
+  } else if (state.p2SelectionMode && !state.p2Confirmed) {
+    if (action.type === 'commit') {
+      nextP2Index = action.index;
+      displayP2Index = action.index;
+    } else if (action.type === 'hover') {
+      displayP2Index = action.index;
+    } else if (action.type === 'out') {
+      displayP2Index = state.p2Index;
+    }
+  }
+
+  return {
+    p1Index: nextP1Index,
+    p2Index: nextP2Index,
+    displayP1Index,
+    displayP2Index,
+  };
+}

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -157,22 +157,38 @@ export class SelectScene extends Phaser.Scene {
       rect.setInteractive();
       rect.noCursor = true; // Tell ControllerScene to hide the yellow square
 
-      const onSelect = () => {
+      const onSelect = (idx = null) => {
         if (this.transitioning) return;
+        const isPreview = idx !== null;
+        const targetIdx = isPreview ? idx : i;
+
         if (!this.p1Confirmed) {
-          this.p1Index = i;
-          this.updateP1Display();
-          this._scrollToFit(i);
+          if (!isPreview) this.p1Index = targetIdx;
+          this.updateP1Display(targetIdx);
+          this._scrollToFit(targetIdx);
         } else if (this.p2SelectionMode && !this.p2Confirmed) {
-          this.p2Index = i;
-          this.updateP2Display();
-          this._scrollToFit(i);
+          if (!isPreview) this.p2Index = targetIdx;
+          this.updateP2Display(targetIdx);
+          this._scrollToFit(targetIdx);
         }
       };
 
-      rect.on('pointerover', () => {
-        onSelect();
+      rect.on('pointerover', (p) => {
+        if (!p) {
+          // Controller/Keyboard navigation
+          onSelect();
+        } else {
+          // Mouse hover: just preview
+          onSelect(i);
+        }
         this.game.audioManager.play('ui_navigate');
+      });
+
+      rect.on('pointerout', (p) => {
+        if (p) {
+          // Restore to official selection
+          onSelect();
+        }
       });
 
       rect.on('pointerdown', () => {
@@ -617,9 +633,9 @@ export class SelectScene extends Phaser.Scene {
     }
   }
 
-  updateP1Display() {
-    const col = this.p1Index % COLS;
-    const row = Math.floor(this.p1Index / COLS);
+  updateP1Display(idx = this.p1Index) {
+    const col = idx % COLS;
+    const row = Math.floor(idx / COLS);
     const cellX = GRID_START_X + col * (CELL_W + GRID_GAP);
     const cellY = GRID_START_Y + row * (CELL_H + GRID_GAP);
     this.p1Cursor.setPosition(cellX, cellY);
@@ -629,7 +645,7 @@ export class SelectScene extends Phaser.Scene {
     } else {
       this.p1CursorLabel.setPosition(cellX + CELL_W / 2, cellY - 2);
     }
-    const fighter = this.fighters[this.p1Index];
+    const fighter = this.fighters[idx];
     this.p1NameText.setText(fighter.name);
     this.p1SubtitleText.setText(fighter.subtitle);
     const isRandom = fighter.id === 'random';
@@ -661,8 +677,8 @@ export class SelectScene extends Phaser.Scene {
     });
   }
 
-  updateP2Display() {
-    this._showP2Selection(this.p2Index);
+  updateP2Display(idx = this.p2Index) {
+    this._showP2Selection(idx);
   }
 
   _clearLastTakenOverlay() {

--- a/src/scenes/SelectScene.js
+++ b/src/scenes/SelectScene.js
@@ -4,6 +4,7 @@ import fightersData from '../data/fighters.json';
 import { TournamentManager } from '../services/TournamentManager.js';
 import { createButton } from '../services/UIService.js';
 import { Logger } from '../systems/Logger.js';
+import { resolveSelectionState } from './SelectRender.js';
 
 const log = Logger.create('SelectScene');
 
@@ -157,43 +158,43 @@ export class SelectScene extends Phaser.Scene {
       rect.setInteractive();
       rect.noCursor = true; // Tell ControllerScene to hide the yellow square
 
-      const onSelect = (idx = null) => {
+      const handleSelection = (type, targetIndex) => {
         if (this.transitioning) return;
-        const isPreview = idx !== null;
-        const targetIdx = isPreview ? idx : i;
+
+        const state = {
+          p1Confirmed: this.p1Confirmed,
+          p2SelectionMode: this.p2SelectionMode,
+          p2Confirmed: this.p2Confirmed,
+          p1Index: this.p1Index,
+          p2Index: this.p2Index,
+        };
+
+        const result = resolveSelectionState(state, { type, index: targetIndex });
 
         if (!this.p1Confirmed) {
-          if (!isPreview) this.p1Index = targetIdx;
-          this.updateP1Display(targetIdx);
-          this._scrollToFit(targetIdx);
+          const selectionChanged = this.p1Index !== result.p1Index;
+          this.p1Index = result.p1Index;
+          this.updateP1Display(result.displayP1Index);
+          if (type === 'commit' || selectionChanged) this._scrollToFit(this.p1Index);
         } else if (this.p2SelectionMode && !this.p2Confirmed) {
-          if (!isPreview) this.p2Index = targetIdx;
-          this.updateP2Display(targetIdx);
-          this._scrollToFit(targetIdx);
+          const selectionChanged = this.p2Index !== result.p2Index;
+          this.p2Index = result.p2Index;
+          this.updateP2Display(result.displayP2Index);
+          if (type === 'commit' || selectionChanged) this._scrollToFit(this.p2Index);
         }
       };
 
       rect.on('pointerover', (p) => {
-        if (!p) {
-          // Controller/Keyboard navigation
-          onSelect();
-        } else {
-          // Mouse hover: just preview
-          onSelect(i);
-        }
+        handleSelection(p ? 'hover' : 'commit', i);
         this.game.audioManager.play('ui_navigate');
       });
 
       rect.on('pointerout', (p) => {
-        if (p) {
-          // Restore to official selection
-          onSelect();
-        }
+        if (p) handleSelection('out', i);
       });
 
       rect.on('pointerdown', () => {
-        if (this.transitioning) return;
-        onSelect();
+        handleSelection('commit', i);
 
         // Move focus to LISTO button
         const controller = this.scene.get('ControllerScene');

--- a/src/scenes/StageSelectRender.js
+++ b/src/scenes/StageSelectRender.js
@@ -26,7 +26,7 @@ export function getCellRenderState({ index, selectedIndex, displayIndex }) {
   // Not selected nor hovered
   return {
     borderAlpha: 0,
-    borderStroke: [2, 0xffffff], // Default stroke if ever shown
+    borderStroke: null,
     fillStyle: 0x333333,
   };
 }

--- a/src/scenes/StageSelectRender.js
+++ b/src/scenes/StageSelectRender.js
@@ -1,0 +1,32 @@
+/**
+ * Pure helper to determine the visual state of a stage selection cell.
+ * @param {Object} params
+ * @param {number} params.index - Current cell index
+ * @param {number} params.selectedIndex - Officially selected index
+ * @param {number} params.displayIndex - Currently previewed/hovered index
+ * @returns {Object} Render properties
+ */
+export function getCellRenderState({ index, selectedIndex, displayIndex }) {
+  if (index === selectedIndex) {
+    // Officially selected
+    return {
+      borderAlpha: 1,
+      borderStroke: [3, 0xffcc00],
+      fillStyle: 0x444466,
+    };
+  }
+  if (index === displayIndex) {
+    // Hovering preview
+    return {
+      borderAlpha: 0.5,
+      borderStroke: [2, 0xffffff],
+      fillStyle: 0x333333,
+    };
+  }
+  // Not selected nor hovered
+  return {
+    borderAlpha: 0,
+    borderStroke: [2, 0xffffff], // Default stroke if ever shown
+    fillStyle: 0x333333,
+  };
+}

--- a/src/scenes/StageSelectScene.js
+++ b/src/scenes/StageSelectScene.js
@@ -3,6 +3,7 @@ import { GAME_HEIGHT, GAME_WIDTH } from '../config.js';
 import stagesData from '../data/stages.json';
 import { createButton } from '../services/UIService.js';
 import { Logger } from '../systems/Logger.js';
+import { getCellRenderState } from './StageSelectRender.js';
 
 const log = Logger.create('StageSelectScene');
 
@@ -279,19 +280,17 @@ export class StageSelectScene extends Phaser.Scene {
     }
 
     this.gridCells.forEach((cell, i) => {
-      if (i === this.selectedIndex) {
-        // Officially selected
-        cell.border.setAlpha(1).setStrokeStyle(3, 0xffcc00);
-        cell.rect.setFillStyle(0x444466);
-      } else if (i === displayIndex) {
-        // Hovering preview
-        cell.border.setAlpha(0.5).setStrokeStyle(2, 0xffffff);
-        cell.rect.setFillStyle(0x333333);
-      } else {
-        // Not selected nor hovered
-        cell.border.setAlpha(0);
-        cell.rect.setFillStyle(0x333333);
+      const { borderAlpha, borderStroke, fillStyle } = getCellRenderState({
+        index: i,
+        selectedIndex: this.selectedIndex,
+        displayIndex,
+      });
+
+      cell.border.setAlpha(borderAlpha);
+      if (borderStroke) {
+        cell.border.setStrokeStyle(borderStroke[0], borderStroke[1]);
       }
+      cell.rect.setFillStyle(fillStyle);
     });
   }
 

--- a/src/scenes/StageSelectScene.js
+++ b/src/scenes/StageSelectScene.js
@@ -109,9 +109,21 @@ export class StageSelectScene extends Phaser.Scene {
             }
           }
         });
-        rect.on('pointerover', () => {
-          this.selectedIndex = i;
-          this.updateSelection();
+        rect.on('pointerover', (p) => {
+          if (!p) {
+            // Controller/Keyboard navigation
+            this.selectedIndex = i;
+            this.updateSelection();
+          } else {
+            // Mouse hover: just preview info, don't change selection
+            this.updateSelection(i);
+          }
+        });
+        rect.on('pointerout', (p) => {
+          if (p) {
+            // Mouse left the cell: restore preview to actual selection
+            this.updateSelection();
+          }
         });
       }
     }
@@ -259,27 +271,28 @@ export class StageSelectScene extends Phaser.Scene {
     });
   }
 
-  updateSelection() {
-    this.gridCells.forEach((cell, i) => {
-      const isSelected = i === this.selectedIndex;
-      cell.border.setStrokeStyle(
-        isSelected ? 3 : 1,
-        isSelected ? 0xffcc00 : 0x444444,
-        isSelected ? 1 : 0.5,
-      );
-      if (isSelected) {
-        cell.rect.setFillStyle(0x444466);
-      } else {
-        cell.rect.setFillStyle(0x333333);
-      }
-    });
-
-    const stage = this.stages[this.selectedIndex];
-    const cell = this.gridCells[this.selectedIndex];
-    if (cell) {
+  updateSelection(displayIndex = this.selectedIndex) {
+    const stage = this.stages[displayIndex];
+    if (stage) {
       this.stageNameText.setText(stage.name.toUpperCase());
       this.stageDescText.setText(stage.description);
     }
+
+    this.gridCells.forEach((cell, i) => {
+      if (i === this.selectedIndex) {
+        // Officially selected
+        cell.border.setAlpha(1).setStrokeStyle(3, 0xffcc00);
+        cell.rect.setFillStyle(0x444466);
+      } else if (i === displayIndex) {
+        // Hovering preview
+        cell.border.setAlpha(0.5).setStrokeStyle(2, 0xffffff);
+        cell.rect.setFillStyle(0x333333);
+      } else {
+        // Not selected nor hovered
+        cell.border.setAlpha(0);
+        cell.rect.setFillStyle(0x333333);
+      }
+    });
   }
 
   confirmSelection() {

--- a/tests/scenes/SelectRender.test.js
+++ b/tests/scenes/SelectRender.test.js
@@ -12,7 +12,7 @@ describe('SelectRender helper (resolveSelectionState)', () => {
 
   it('mouse sweep scenario: hovering across cells does not mutate official selection', () => {
     const state = { ...baseState, p1Index: 0 };
-    
+
     // Hover cell 1
     let result = resolveSelectionState(state, { type: 'hover', index: 1 });
     expect(result.p1Index).toBe(0); // Official selection unchanged
@@ -31,14 +31,14 @@ describe('SelectRender helper (resolveSelectionState)', () => {
   });
 
   it('P2 selection mode respects P2 states', () => {
-    const p2State = { 
-      ...baseState, 
-      p1Confirmed: true, 
-      p2SelectionMode: true, 
-      p1Index: 5, 
-      p2Index: 8 
+    const p2State = {
+      ...baseState,
+      p1Confirmed: true,
+      p2SelectionMode: true,
+      p1Index: 5,
+      p2Index: 8,
     };
-    
+
     // Hover cell 12
     let result = resolveSelectionState(p2State, { type: 'hover', index: 12 });
     expect(result.p1Index).toBe(5);

--- a/tests/scenes/SelectRender.test.js
+++ b/tests/scenes/SelectRender.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSelectionState } from '../../src/scenes/SelectRender.js';
+
+describe('SelectRender helper (resolveSelectionState)', () => {
+  const baseState = {
+    p1Confirmed: false,
+    p2SelectionMode: false,
+    p2Confirmed: false,
+    p1Index: 0,
+    p2Index: 0,
+  };
+
+  it('mouse sweep scenario: hovering across cells does not mutate official selection', () => {
+    const state = { ...baseState, p1Index: 0 };
+    
+    // Hover cell 1
+    let result = resolveSelectionState(state, { type: 'hover', index: 1 });
+    expect(result.p1Index).toBe(0); // Official selection unchanged
+    expect(result.displayP1Index).toBe(1); // Display updates
+
+    // Out cell 1
+    result = resolveSelectionState(state, { type: 'out', index: 1 });
+    expect(result.p1Index).toBe(0);
+    expect(result.displayP1Index).toBe(0); // Restored to official selection
+  });
+
+  it('commit action updates official selection', () => {
+    const result = resolveSelectionState(baseState, { type: 'commit', index: 5 });
+    expect(result.p1Index).toBe(5);
+    expect(result.displayP1Index).toBe(5);
+  });
+
+  it('P2 selection mode respects P2 states', () => {
+    const p2State = { 
+      ...baseState, 
+      p1Confirmed: true, 
+      p2SelectionMode: true, 
+      p1Index: 5, 
+      p2Index: 8 
+    };
+    
+    // Hover cell 12
+    let result = resolveSelectionState(p2State, { type: 'hover', index: 12 });
+    expect(result.p1Index).toBe(5);
+    expect(result.p2Index).toBe(8);
+    expect(result.displayP2Index).toBe(12);
+
+    // Commit cell 12
+    result = resolveSelectionState(p2State, { type: 'commit', index: 12 });
+    expect(result.p2Index).toBe(12);
+    expect(result.displayP2Index).toBe(12);
+  });
+});

--- a/tests/scenes/StageSelectRender.test.js
+++ b/tests/scenes/StageSelectRender.test.js
@@ -16,16 +16,17 @@ describe('StageSelectRender helper', () => {
     expect(state.fillStyle).toBe(0x333333);
   });
 
-  it('prioritizes selection over hover', () => {
-    // This case happens if displayIndex (preview) is same as selectedIndex
+  it('prioritizes selection over hover when indices collide', () => {
+    // If the index matches both selected and display, it should show selection style
     const state = getCellRenderState({ index: 5, selectedIndex: 5, displayIndex: 5 });
     expect(state.borderAlpha).toBe(1);
-    expect(state.borderStroke[1]).toBe(0xffcc00);
+    expect(state.borderStroke[1]).toBe(0xffcc00); // yellow
   });
 
-  it('returns correctly for a regular (non-selected, non-hovered) cell', () => {
+  it('correctly handles non-selected cell when another is hovered', () => {
     const state = getCellRenderState({ index: 0, selectedIndex: 5, displayIndex: 3 });
     expect(state.borderAlpha).toBe(0);
+    expect(state.borderStroke).toBeNull();
     expect(state.fillStyle).toBe(0x333333);
   });
 });

--- a/tests/scenes/StageSelectRender.test.js
+++ b/tests/scenes/StageSelectRender.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getCellRenderState } from '../../src/scenes/StageSelectRender.js';
+
+describe('StageSelectRender helper', () => {
+  it('returns correctly for a selected cell', () => {
+    const state = getCellRenderState({ index: 5, selectedIndex: 5, displayIndex: 5 });
+    expect(state.borderAlpha).toBe(1);
+    expect(state.borderStroke[1]).toBe(0xffcc00); // yellow
+    expect(state.fillStyle).toBe(0x444466);
+  });
+
+  it('returns correctly for a hovered but not selected cell', () => {
+    const state = getCellRenderState({ index: 3, selectedIndex: 5, displayIndex: 3 });
+    expect(state.borderAlpha).toBe(0.5);
+    expect(state.borderStroke[1]).toBe(0xffffff); // white
+    expect(state.fillStyle).toBe(0x333333);
+  });
+
+  it('prioritizes selection over hover', () => {
+    // This case happens if displayIndex (preview) is same as selectedIndex
+    const state = getCellRenderState({ index: 5, selectedIndex: 5, displayIndex: 5 });
+    expect(state.borderAlpha).toBe(1);
+    expect(state.borderStroke[1]).toBe(0xffcc00);
+  });
+
+  it('returns correctly for a regular (non-selected, non-hovered) cell', () => {
+    const state = getCellRenderState({ index: 0, selectedIndex: 5, displayIndex: 3 });
+    expect(state.borderAlpha).toBe(0);
+    expect(state.fillStyle).toBe(0x333333);
+  });
+});


### PR DESCRIPTION
## Description
This PR addresses a bug where mouse movement would unintentionally overwrite selections in both the character and stage selection scenes.

### Fix Details
- **Decoupled Hover from Selection:** Mouse hover (`pointerover`) now only updates the preview information without changing the official selection.
- **Consistent Behavior:** Applied the same fix to both `SelectScene` (fighters) and `StageSelectScene` (stages).
- **Explicit Selection:** Official selections now only occur on explicit click (`pointerdown`) or via keyboard/gamepad navigation.
- **Auto-Restore:** Previews are restored to the officially selected item when the mouse leaves the interaction area (`pointerout`).
- **Fixed Scroll Jump:** Restoring the display on `pointerout` no longer triggers an aggressive `_scrollToFit`, preventing jarring camera jumps for mouse users.

### Technical Changes
- **Modular Render Logic:** Moved selection resolution and per-cell rendering logic into pure helpers:
  - `src/scenes/SelectRender.js`
  - `src/scenes/StageSelectRender.js`
- **Unit Testing:** Added unit tests for both helpers to verify the "mouse-sweep" and selection-priority scenarios:
  - `tests/scenes/SelectRender.test.js`
  - `tests/scenes/StageSelectRender.test.js`

Fixes #128
