### PR TITLE
feat: human pose estimation pipeline for fighter sprites

### DIFF
--- a/.claude/skills/generate-poses/SKILL.md
+++ b/.claude/skills/generate-poses/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: generate-poses
+description: Extract per-frame pose keypoints (head, hands, feet + orientations) from a fighter's sprite animations in the A Los Traques repo. Use this skill whenever the user wants to generate, regenerate, or refresh pose data for a fighter — including phrases like "generate poses for X", "run pose estimation", "extract keypoints", "rebuild poses.json", "add hat anchor points", or any request to enrich an existing fighter's animations with body-part positions. Also trigger when the user adds a new fighter sprite set and wants attachment anchors for runtime effects. The pipeline runs MediaPipe on every animation frame and writes a consolidated `poses.json` alongside the sprite strips.
+---
+
+# Generate Pose Keypoints
+
+End-to-end pipeline for extracting per-frame pose keypoints from a fighter's sprite animations. Writes one `poses.json` per fighter, colocated with the sprite strips, describing head/hand/foot positions plus derived orientation angles. Consumed at runtime to attach visual elements (hats, weapons, effects) to body parts with correct rotation.
+
+## When to use
+
+Run this after a fighter's sprites have been fully generated and had their facing direction corrected via `/generate-fighter`. Don't run it before Phase 4 of that skill — the post-hoc `-flop` fixes will swap `left*` and `right*` keypoints across animations and invalidate every derived angle.
+
+## Prerequisites
+
+- `assets/manifests/poses_{id}.json` exists. If not, copy `poses_simon.json` and change `output` + `fighter`.
+- All 13 animation PNG strips exist at `public/assets/fighters/{id}/{anim}.png`. Check with `ls public/assets/fighters/{id}/`.
+- `uv` is on the PATH. First invocation installs MediaPipe + OpenCV into an isolated cache under `scripts/asset-pipeline/pose/.venv`.
+- ImageMagick (`magick`) is on the PATH — same dependency as the fighter pipeline.
+
+## Workflow
+
+### 1. Smoke-test with debug previews
+
+Run the pipeline with `--debug` so skeleton overlays are written to `assets/_raw/poses/{id}/{anim}_debug.png`:
+
+```bash
+node scripts/asset-pipeline/cli.js poses assets/manifests/poses_{id}.json --debug
+```
+
+First run downloads MediaPipe model weights (~30 MB) and can take up to a minute. Subsequent runs complete in ~10s for all 13 animations.
+
+The pipeline prints a per-animation summary at the end. Example:
+
+```
+  - simon/idle: 4/4 frames detected
+  - simon/block: 1/2 frames detected (review debug strip)
+  - simon/knockdown: 2/4 frames detected (review debug strip)
+```
+
+Partial detection in `block`, `hurt`, and `knockdown` is expected — the character's pose is ambiguous (arms over face, body horizontal) and the affected frames are stored as `detected: false`.
+
+### 2. Review debug strips
+
+Open the debug strips for three representative animations and show them to the user:
+
+```bash
+open assets/_raw/poses/{id}/idle_debug.png
+open assets/_raw/poses/{id}/light_punch_debug.png
+open assets/_raw/poses/{id}/knockdown_debug.png
+```
+
+Ask: "Does the skeleton track the character's actual body — head on head, wrists on wrists?"
+
+- If yes, proceed.
+- If the skeleton is consistently mirrored (left/right swapped) across a whole animation, that usually means Phase 4 of `/generate-fighter` wasn't run for that animation. Confirm with the user and re-run the fighter pipeline's facing fixes before regenerating poses.
+- If detection is wrong only for specific frames inside `block`/`hurt`/`knockdown`, leave as-is — these are marked `detected: false` and runtime code should skip attachment for those frames.
+
+### 3. Verify JSON output
+
+Confirm the output file exists and has all 13 animations:
+
+```bash
+jq '.animations | keys' public/assets/fighters/{id}/poses.json
+```
+
+Sanity-check a derived block for a character standing upright and facing right:
+
+```bash
+jq '.animations.idle.frames[0].derived' public/assets/fighters/{id}/poses.json
+```
+
+Expect `head.roll` near 0 and `torso.angle` near 90. Large deviations on the very first idle frame usually indicate a detection problem worth investigating.
+
+### 4. Commit
+
+Stage the manifest (if new) and the generated JSON:
+
+```bash
+git add assets/manifests/poses_{id}.json public/assets/fighters/{id}/poses.json
+```
+
+The `assets/_raw/poses/{id}/` directory holds intermediate frame splits and debug previews — it's regeneratable and should not be committed.
+
+## Output shape
+
+One JSON file per fighter, colocated with sprites:
+
+```
+public/assets/fighters/{id}/poses.json
+```
+
+Top-level fields: `version`, `fighter`, `frameSize` (128), `model`, `generatedAt`, `animations`.
+
+Each animation has `frameCount` and a `frames` array. Each frame has:
+
+- `index`, `detected`, `avgVisibility`
+- `keypoints` — 23 named landmarks as `{x, y, v}`. Coordinates are **pixel-space relative to the 128×128 frame**, top-left origin, y down (matches Phaser sprite-child coords).
+- `derived` — `head {center, roll, yaw, pitch}`, `torso {center, angle}`, `{left,right}Hand {anchor, angle}`, `{left,right}Foot {anchor, angle}`. Angles are **degrees, counter-clockwise from +x axis**. Phaser rotates clockwise, so renderer code must negate.
+
+When `detected: false`, both `keypoints` and `derived` are `null`.
+
+## Key lessons
+
+- **Run after `/generate-fighter` Phase 4.** Facing fixes (`magick -flop`) happen post-hoc and swap left/right semantics. Run poses before that, and the JSON is wrong.
+- **Transparent backgrounds break pose models.** `detect.py` composites each RGBA frame over mid-gray `(128,128,128)` before inference. Never composite over green — some sprites have green flames that would bleed.
+- **`static_image_mode=True`** is required so MediaPipe doesn't try to track state across unrelated animations.
+- **`model_complexity=2`** (heavy) is more tolerant of limbs at the frame edge (common in `heavy_kick`, `special`). Still <2 minutes total for 800 frames.
+- **Cached frame splits** in `assets/_raw/poses/{id}/{anim}/frame_*.png` are reused across runs. Delete the directory to force re-split if a sprite strip changed.
+- **`poses.json` is consolidated per fighter** — one file holds all 13 animations. Regenerating a single animation rewrites the whole file.

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ test-results/
 # Terraform
 infra/.terraform/
 infra/*.tfvars
+
+# Pose estimation pipeline (Python/MediaPipe)
+scripts/asset-pipeline/pose/.venv/
+scripts/asset-pipeline/pose/__pycache__/
+scripts/asset-pipeline/pose/models/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ node scripts/asset-pipeline/cli.js reference <config.json>  # Golden reference (
 node scripts/asset-pipeline/cli.js fighter <config.json>     # Animation frames
 node scripts/asset-pipeline/cli.js portrait <config.json>    # Character portrait
 node scripts/asset-pipeline/cli.js stage <config.json>       # Stage background
+node scripts/asset-pipeline/cli.js poses <config.json>       # Pose keypoints per frame
 ```
 
 ### Fighter generation workflow
@@ -138,6 +139,16 @@ Use the `/generate-animated-stage` skill for the full workflow. Key points:
 
 ### Animation frame counts
 idle(4), walk(4), light_punch(4), heavy_punch(5), light_kick(4), heavy_kick(5), special(5), block(2), hurt(3), knockdown(4), victory(4), defeat(3), jump(3)
+
+### Pose estimation
+Use the `/generate-poses` skill to extract per-frame keypoints for attaching runtime effects (hats, weapons, VFX) to body parts. Key points:
+- **Model**: MediaPipe PoseLandmarker heavy (BlazePose GHUM) via Python + `uv`. Managed in `scripts/asset-pipeline/pose/` with its own `pyproject.toml`.
+- **Must run AFTER `/generate-fighter` Phase 4** (facing fixes). Running before swaps `left*`/`right*` keypoints across an animation.
+- **Frame splitting gotcha**: strips have a `128x128+0+0` page geometry from `+append`; split must use `+repage -crop 128x128 +repage` or only the first frame is produced.
+- **Output**: `public/assets/fighters/{id}/poses.json` — one consolidated file per fighter with all 13 animations. 23 named keypoints per frame (pixel-space, top-left origin) + derived `head/torso/leftHand/rightHand/leftFoot/rightFoot` angles (degrees, CCW from +x).
+- **Low-vis frames**: `block`, `hurt`, `knockdown` sometimes have contorted poses MediaPipe can't read — stored as `detected: false`, runtime code should skip attachment or interpolate.
+- **`--debug`**: writes skeleton-overlay strips to `assets/_raw/poses/{id}/{anim}_debug.png` for QA.
+- **Model file** (~30 MB) auto-downloads to `scripts/asset-pipeline/pose/models/` on first run. Gitignored.
 
 ## Fighter Entity
 

--- a/assets/manifests/poses_alv.json
+++ b/assets/manifests/poses_alv.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/alv/",
+  "fighter": "alv",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_angy.json
+++ b/assets/manifests/poses_angy.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/angy/",
+  "fighter": "angy",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_bozzi.json
+++ b/assets/manifests/poses_bozzi.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/bozzi/",
+  "fighter": "bozzi",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_cami.json
+++ b/assets/manifests/poses_cami.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/cami/",
+  "fighter": "cami",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_carito.json
+++ b/assets/manifests/poses_carito.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/carito/",
+  "fighter": "carito",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_cata.json
+++ b/assets/manifests/poses_cata.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/cata/",
+  "fighter": "cata",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_chicha.json
+++ b/assets/manifests/poses_chicha.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/chicha/",
+  "fighter": "chicha",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_gartner.json
+++ b/assets/manifests/poses_gartner.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/gartner/",
+  "fighter": "gartner",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_jeka.json
+++ b/assets/manifests/poses_jeka.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/jeka/",
+  "fighter": "jeka",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_lini.json
+++ b/assets/manifests/poses_lini.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/lini/",
+  "fighter": "lini",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_mao.json
+++ b/assets/manifests/poses_mao.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/mao/",
+  "fighter": "mao",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_migue.json
+++ b/assets/manifests/poses_migue.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/migue/",
+  "fighter": "migue",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_peks.json
+++ b/assets/manifests/poses_peks.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/peks/",
+  "fighter": "peks",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_richi.json
+++ b/assets/manifests/poses_richi.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/richi/",
+  "fighter": "richi",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_simon.json
+++ b/assets/manifests/poses_simon.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/simon/",
+  "fighter": "simon",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/assets/manifests/poses_sun.json
+++ b/assets/manifests/poses_sun.json
@@ -1,0 +1,21 @@
+{
+  "output": "public/assets/fighters/sun/",
+  "fighter": "sun",
+  "animations": [
+    "idle",
+    "walk",
+    "light_punch",
+    "heavy_punch",
+    "light_kick",
+    "heavy_kick",
+    "special",
+    "block",
+    "hurt",
+    "knockdown",
+    "victory",
+    "defeat",
+    "jump"
+  ],
+  "rawDir": "assets/_raw/poses",
+  "minVisibility": 0.3
+}

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,17 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
   "files": {
-    "includes": ["src/**", "tests/**", "party/**", "scripts/**", "*.json", "*.js"]
+    "includes": [
+      "src/**",
+      "tests/**",
+      "party/**",
+      "scripts/**",
+      "*.json",
+      "*.js",
+      "!scripts/asset-pipeline/pose/.venv",
+      "!scripts/asset-pipeline/pose/models",
+      "!scripts/asset-pipeline/pose/__pycache__"
+    ]
   },
   "formatter": {
     "indentStyle": "space",

--- a/public/assets/fighters/alv/poses.json
+++ b/public/assets/fighters/alv/poses.json
@@ -1,0 +1,1837 @@
+{
+  "version": 1,
+  "fighter": "alv",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:41:00.117Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.761,
+          "keypoints": {
+            "nose": {
+              "x": 50.2,
+              "y": 37.6,
+              "v": 0.99
+            },
+            "leftEye": {
+              "x": 50.9,
+              "y": 34.9,
+              "v": 0.977
+            },
+            "rightEye": {
+              "x": 48.1,
+              "y": 36.5,
+              "v": 0.987
+            },
+            "leftEar": {
+              "x": 52.9,
+              "y": 35.1,
+              "v": 0.992
+            },
+            "rightEar": {
+              "x": 47.2,
+              "y": 37.9,
+              "v": 0.975
+            },
+            "leftShoulder": {
+              "x": 62.2,
+              "y": 44,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 47.3,
+              "y": 47.5,
+              "v": 0.997
+            },
+            "leftElbow": {
+              "x": 72.8,
+              "y": 45.4,
+              "v": 0.138
+            },
+            "rightElbow": {
+              "x": 46.5,
+              "y": 44.2,
+              "v": 0.399
+            },
+            "leftWrist": {
+              "x": 73.4,
+              "y": 41.9,
+              "v": 0.125
+            },
+            "rightWrist": {
+              "x": 49.6,
+              "y": 38.6,
+              "v": 0.204
+            },
+            "leftIndex": {
+              "x": 72.2,
+              "y": 39.7,
+              "v": 0.163
+            },
+            "rightIndex": {
+              "x": 51,
+              "y": 36.7,
+              "v": 0.173
+            },
+            "leftHip": {
+              "x": 68,
+              "y": 78.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.1,
+              "y": 79.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.6,
+              "y": 86.9,
+              "v": 0.88
+            },
+            "rightKnee": {
+              "x": 38.2,
+              "y": 91.7,
+              "v": 0.927
+            },
+            "leftAnkle": {
+              "x": 76.6,
+              "y": 109.2,
+              "v": 0.956
+            },
+            "rightAnkle": {
+              "x": 27.9,
+              "y": 114.3,
+              "v": 0.976
+            },
+            "leftHeel": {
+              "x": 72.4,
+              "y": 114.4,
+              "v": 0.914
+            },
+            "rightHeel": {
+              "x": 27.7,
+              "y": 117.3,
+              "v": 0.871
+            },
+            "leftFootIndex": {
+              "x": 87.8,
+              "y": 114.6,
+              "v": 0.92
+            },
+            "rightFootIndex": {
+              "x": 23,
+              "y": 125.6,
+              "v": 0.946
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 49.5,
+                "y": 35.7
+              },
+              "roll": -150.3,
+              "yaw": 0.217,
+              "pitch": 0.589
+            },
+            "torso": {
+              "center": {
+                "x": 54.8,
+                "y": 45.8
+              },
+              "angle": 103.4
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 72.4,
+                "y": 114.4
+              },
+              "angle": -0.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27.7,
+                "y": 117.3
+              },
+              "angle": -119.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 4,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.7,
+          "keypoints": {
+            "nose": {
+              "x": 54.4,
+              "y": 38.7,
+              "v": 0.857
+            },
+            "leftEye": {
+              "x": 55.3,
+              "y": 36.9,
+              "v": 0.629
+            },
+            "rightEye": {
+              "x": 52.9,
+              "y": 37.6,
+              "v": 0.801
+            },
+            "leftEar": {
+              "x": 56.8,
+              "y": 37.5,
+              "v": 0.849
+            },
+            "rightEar": {
+              "x": 51.8,
+              "y": 38.7,
+              "v": 0.742
+            },
+            "leftShoulder": {
+              "x": 65.1,
+              "y": 46.7,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 48.7,
+              "y": 48.2,
+              "v": 0.998
+            },
+            "leftElbow": {
+              "x": 74.6,
+              "y": 50.3,
+              "v": 0.065
+            },
+            "rightElbow": {
+              "x": 45.6,
+              "y": 47.3,
+              "v": 0.429
+            },
+            "leftWrist": {
+              "x": 73.5,
+              "y": 52.9,
+              "v": 0.033
+            },
+            "rightWrist": {
+              "x": 48.7,
+              "y": 44.2,
+              "v": 0.332
+            },
+            "leftIndex": {
+              "x": 71.9,
+              "y": 53,
+              "v": 0.045
+            },
+            "rightIndex": {
+              "x": 50.4,
+              "y": 43.1,
+              "v": 0.294
+            },
+            "leftHip": {
+              "x": 67.4,
+              "y": 79,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.4,
+              "y": 78.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.7,
+              "y": 88.1,
+              "v": 0.847
+            },
+            "rightKnee": {
+              "x": 39.9,
+              "y": 90.2,
+              "v": 0.896
+            },
+            "leftAnkle": {
+              "x": 77,
+              "y": 108.2,
+              "v": 0.929
+            },
+            "rightAnkle": {
+              "x": 27.1,
+              "y": 114.5,
+              "v": 0.962
+            },
+            "leftHeel": {
+              "x": 72.7,
+              "y": 113.3,
+              "v": 0.865
+            },
+            "rightHeel": {
+              "x": 26.3,
+              "y": 118,
+              "v": 0.747
+            },
+            "leftFootIndex": {
+              "x": 87.7,
+              "y": 114.9,
+              "v": 0.873
+            },
+            "rightFootIndex": {
+              "x": 24.1,
+              "y": 124,
+              "v": 0.917
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.1,
+                "y": 37.3
+              },
+              "roll": -163.7,
+              "yaw": 0.12,
+              "pitch": 0.58
+            },
+            "torso": {
+              "center": {
+                "x": 56.9,
+                "y": 47.5
+              },
+              "angle": 98.1
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 48.7,
+                "y": 44.2
+              },
+              "angle": 45
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.7,
+                "y": 113.3
+              },
+              "angle": -6.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 26.3,
+                "y": 118
+              },
+              "angle": -110.1
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.55,
+          "keypoints": {
+            "nose": {
+              "x": 27.5,
+              "y": 30.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 27.4,
+              "y": 28.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 26,
+              "y": 30.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 29.6,
+              "y": 28.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 26.6,
+              "y": 32.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 37.6,
+              "y": 34.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 33.2,
+              "y": 38.3,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 36.6,
+              "y": 43.4,
+              "v": 0.218
+            },
+            "rightElbow": {
+              "x": 32.5,
+              "y": 43.5,
+              "v": 0.15
+            },
+            "leftWrist": {
+              "x": 30.4,
+              "y": 43.6,
+              "v": 0.112
+            },
+            "rightWrist": {
+              "x": 27.8,
+              "y": 41.9,
+              "v": 0.187
+            },
+            "leftIndex": {
+              "x": 28.4,
+              "y": 42.6,
+              "v": 0.124
+            },
+            "rightIndex": {
+              "x": 26.6,
+              "y": 40.8,
+              "v": 0.205
+            },
+            "leftHip": {
+              "x": 54.8,
+              "y": 51.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.4,
+              "y": 53.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 54.6,
+              "y": 64.6,
+              "v": 0.311
+            },
+            "rightKnee": {
+              "x": 49.2,
+              "y": 63.1,
+              "v": 0.188
+            },
+            "leftAnkle": {
+              "x": 52.8,
+              "y": 81.2,
+              "v": 0.436
+            },
+            "rightAnkle": {
+              "x": 52.3,
+              "y": 80,
+              "v": 0.339
+            },
+            "leftHeel": {
+              "x": 53.4,
+              "y": 83.3,
+              "v": 0.382
+            },
+            "rightHeel": {
+              "x": 55,
+              "y": 82.2,
+              "v": 0.308
+            },
+            "leftFootIndex": {
+              "x": 49.9,
+              "y": 87.3,
+              "v": 0.398
+            },
+            "rightFootIndex": {
+              "x": 49.2,
+              "y": 86.9,
+              "v": 0.3
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 26.7,
+                "y": 29.9
+              },
+              "roll": -123.7,
+              "yaw": 0.317,
+              "pitch": 0.376
+            },
+            "torso": {
+              "center": {
+                "x": 35.4,
+                "y": 36.2
+              },
+              "angle": 136.5
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 53.4,
+                "y": 83.3
+              },
+              "angle": -131.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 55,
+                "y": 82.2
+              },
+              "angle": -141
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.704,
+          "keypoints": {
+            "nose": {
+              "x": 42.2,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 42.7,
+              "y": 8.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 40.7,
+              "y": 9.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 43.2,
+              "y": 9.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 39.4,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 49.3,
+              "y": 19,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.7,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 54.3,
+              "y": 29,
+              "v": 0.331
+            },
+            "rightElbow": {
+              "x": 38.4,
+              "y": 38.1,
+              "v": 0.904
+            },
+            "leftWrist": {
+              "x": 55.1,
+              "y": 34,
+              "v": 0.524
+            },
+            "rightWrist": {
+              "x": 36.8,
+              "y": 40.6,
+              "v": 0.948
+            },
+            "leftIndex": {
+              "x": 54.8,
+              "y": 34.7,
+              "v": 0.594
+            },
+            "rightIndex": {
+              "x": 36.3,
+              "y": 39.7,
+              "v": 0.948
+            },
+            "leftHip": {
+              "x": 56.6,
+              "y": 44.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.2,
+              "y": 47.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 59.3,
+              "y": 50.2,
+              "v": 0.45
+            },
+            "rightKnee": {
+              "x": 52.9,
+              "y": 61.2,
+              "v": 0.417
+            },
+            "leftAnkle": {
+              "x": 49.4,
+              "y": 68.9,
+              "v": 0.366
+            },
+            "rightAnkle": {
+              "x": 46.1,
+              "y": 71.8,
+              "v": 0.312
+            },
+            "leftHeel": {
+              "x": 48,
+              "y": 71.8,
+              "v": 0.294
+            },
+            "rightHeel": {
+              "x": 46.5,
+              "y": 74.1,
+              "v": 0.295
+            },
+            "leftFootIndex": {
+              "x": 46,
+              "y": 73.1,
+              "v": 0.439
+            },
+            "rightFootIndex": {
+              "x": 40.5,
+              "y": 73.5,
+              "v": 0.378
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 41.7,
+                "y": 9
+              },
+              "roll": -166,
+              "yaw": 0.243,
+              "pitch": 0.655
+            },
+            "torso": {
+              "center": {
+                "x": 44,
+                "y": 21.6
+              },
+              "angle": 110.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 55.1,
+                "y": 34
+              },
+              "angle": -113.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.8,
+                "y": 40.6
+              },
+              "angle": 119.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 49.4,
+                "y": 68.9
+              },
+              "angle": -129
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 46.1,
+                "y": 71.8
+              },
+              "angle": -163.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 4,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.841,
+          "keypoints": {
+            "nose": {
+              "x": 36.5,
+              "y": 30.3,
+              "v": 0.992
+            },
+            "leftEye": {
+              "x": 39.3,
+              "y": 26.9,
+              "v": 0.978
+            },
+            "rightEye": {
+              "x": 33.6,
+              "y": 28.8,
+              "v": 0.986
+            },
+            "leftEar": {
+              "x": 45.2,
+              "y": 26.9,
+              "v": 0.99
+            },
+            "rightEar": {
+              "x": 36,
+              "y": 28,
+              "v": 0.976
+            },
+            "leftShoulder": {
+              "x": 59.2,
+              "y": 33.5,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 37.4,
+              "y": 41.7,
+              "v": 0.998
+            },
+            "leftElbow": {
+              "x": 72.1,
+              "y": 38.5,
+              "v": 0.67
+            },
+            "rightElbow": {
+              "x": 35.3,
+              "y": 45.2,
+              "v": 0.54
+            },
+            "leftWrist": {
+              "x": 77.4,
+              "y": 26.7,
+              "v": 0.576
+            },
+            "rightWrist": {
+              "x": 34.2,
+              "y": 42.9,
+              "v": 0.328
+            },
+            "leftIndex": {
+              "x": 78.2,
+              "y": 23,
+              "v": 0.585
+            },
+            "rightIndex": {
+              "x": 34.3,
+              "y": 41.4,
+              "v": 0.281
+            },
+            "leftHip": {
+              "x": 56.1,
+              "y": 78.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 41.4,
+              "y": 79.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.6,
+              "y": 86,
+              "v": 0.921
+            },
+            "rightKnee": {
+              "x": 31.9,
+              "y": 94.9,
+              "v": 0.982
+            },
+            "leftAnkle": {
+              "x": 69.1,
+              "y": 108.9,
+              "v": 0.964
+            },
+            "rightAnkle": {
+              "x": 19.7,
+              "y": 114.7,
+              "v": 0.975
+            },
+            "leftHeel": {
+              "x": 65.6,
+              "y": 113.2,
+              "v": 0.902
+            },
+            "rightHeel": {
+              "x": 18.5,
+              "y": 118,
+              "v": 0.835
+            },
+            "leftFootIndex": {
+              "x": 80.2,
+              "y": 114.7,
+              "v": 0.934
+            },
+            "rightFootIndex": {
+              "x": 16.5,
+              "y": 124.7,
+              "v": 0.94
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 36.5,
+                "y": 27.9
+              },
+              "roll": -161.6,
+              "yaw": 0.008,
+              "pitch": 0.408
+            },
+            "torso": {
+              "center": {
+                "x": 48.3,
+                "y": 37.6
+              },
+              "angle": 90.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 77.4,
+                "y": 26.7
+              },
+              "angle": 77.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.2,
+                "y": 42.9
+              },
+              "angle": 115.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 65.6,
+                "y": 113.2
+              },
+              "angle": -5.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 18.5,
+                "y": 118
+              },
+              "angle": -106.6
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 4,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.877,
+          "keypoints": {
+            "nose": {
+              "x": 90,
+              "y": 24,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 93.2,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 88.2,
+              "y": 19.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 93.4,
+              "y": 21.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 84.6,
+              "y": 16.4,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 95.3,
+              "y": 31.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 70,
+              "y": 24.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 100.8,
+              "y": 49.4,
+              "v": 0.577
+            },
+            "rightElbow": {
+              "x": 52.4,
+              "y": 33,
+              "v": 0.894
+            },
+            "leftWrist": {
+              "x": 102,
+              "y": 53.8,
+              "v": 0.69
+            },
+            "rightWrist": {
+              "x": 36.1,
+              "y": 35.8,
+              "v": 0.876
+            },
+            "leftIndex": {
+              "x": 102.7,
+              "y": 51.5,
+              "v": 0.688
+            },
+            "rightIndex": {
+              "x": 30.1,
+              "y": 35.5,
+              "v": 0.828
+            },
+            "leftHip": {
+              "x": 85.5,
+              "y": 65.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 70.4,
+              "y": 65.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 103.1,
+              "y": 85.6,
+              "v": 0.957
+            },
+            "rightKnee": {
+              "x": 55.4,
+              "y": 93.6,
+              "v": 0.965
+            },
+            "leftAnkle": {
+              "x": 85.1,
+              "y": 97.2,
+              "v": 0.754
+            },
+            "rightAnkle": {
+              "x": 42.6,
+              "y": 113.9,
+              "v": 0.963
+            },
+            "leftHeel": {
+              "x": 78.8,
+              "y": 96.9,
+              "v": 0.655
+            },
+            "rightHeel": {
+              "x": 40.3,
+              "y": 117.1,
+              "v": 0.655
+            },
+            "leftFootIndex": {
+              "x": 83.7,
+              "y": 111,
+              "v": 0.761
+            },
+            "rightFootIndex": {
+              "x": 39.5,
+              "y": 124.6,
+              "v": 0.903
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 90.7,
+                "y": 20.6
+              },
+              "roll": 156.3,
+              "yaw": -0.128,
+              "pitch": 0.622
+            },
+            "torso": {
+              "center": {
+                "x": 82.7,
+                "y": 28
+              },
+              "angle": 82.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 102,
+                "y": 53.8
+              },
+              "angle": 73.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.1,
+                "y": 35.8
+              },
+              "angle": 177.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.8,
+                "y": 96.9
+              },
+              "angle": -70.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.3,
+                "y": 117.1
+              },
+              "angle": -96.1
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.98,
+          "keypoints": {
+            "nose": {
+              "x": 80.6,
+              "y": 18.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 82,
+              "y": 16,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 78,
+              "y": 14.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 82.3,
+              "y": 15.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 73.4,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 85.2,
+              "y": 26.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61.3,
+              "y": 24.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 92.2,
+              "y": 40.4,
+              "v": 0.765
+            },
+            "rightElbow": {
+              "x": 50.4,
+              "y": 34.9,
+              "v": 0.984
+            },
+            "leftWrist": {
+              "x": 101.2,
+              "y": 29.6,
+              "v": 0.965
+            },
+            "rightWrist": {
+              "x": 53.3,
+              "y": 27.5,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 104,
+              "y": 23.3,
+              "v": 0.965
+            },
+            "rightIndex": {
+              "x": 54.7,
+              "y": 23.7,
+              "v": 0.99
+            },
+            "leftHip": {
+              "x": 81.2,
+              "y": 62.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.9,
+              "y": 63.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 97.9,
+              "y": 84.7,
+              "v": 0.991
+            },
+            "rightKnee": {
+              "x": 52.3,
+              "y": 91.6,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 89.9,
+              "y": 108.3,
+              "v": 0.99
+            },
+            "rightAnkle": {
+              "x": 41.4,
+              "y": 113.8,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 86.1,
+              "y": 114.1,
+              "v": 0.98
+            },
+            "rightHeel": {
+              "x": 41,
+              "y": 116.8,
+              "v": 0.941
+            },
+            "leftFootIndex": {
+              "x": 100.9,
+              "y": 115,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 38.4,
+              "y": 123.9,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 80,
+                "y": 15.5
+              },
+              "roll": 164.6,
+              "yaw": 0.145,
+              "pitch": 0.783
+            },
+            "torso": {
+              "center": {
+                "x": 73.3,
+                "y": 25.8
+              },
+              "angle": 91.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 101.2,
+                "y": 29.6
+              },
+              "angle": 66
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 53.3,
+                "y": 27.5
+              },
+              "angle": 69.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 86.1,
+                "y": 114.1
+              },
+              "angle": -3.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41,
+                "y": 116.8
+              },
+              "angle": -110.1
+            }
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.781,
+          "keypoints": {
+            "nose": {
+              "x": 68.5,
+              "y": 57.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.8,
+              "y": 56.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68,
+              "y": 56.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68,
+              "y": 56.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.7,
+              "y": 56.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.6,
+              "y": 64.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 77.7,
+              "y": 58.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 67.5,
+              "y": 72.8,
+              "v": 0.026
+            },
+            "rightElbow": {
+              "x": 90.7,
+              "y": 60.8,
+              "v": 0.901
+            },
+            "leftWrist": {
+              "x": 69.7,
+              "y": 77.2,
+              "v": 0.061
+            },
+            "rightWrist": {
+              "x": 102.2,
+              "y": 60.1,
+              "v": 0.965
+            },
+            "leftIndex": {
+              "x": 70.3,
+              "y": 77.7,
+              "v": 0.09
+            },
+            "rightIndex": {
+              "x": 104.1,
+              "y": 59.7,
+              "v": 0.94
+            },
+            "leftHip": {
+              "x": 77.1,
+              "y": 83,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 83.6,
+              "y": 79.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.9,
+              "y": 94,
+              "v": 0.14
+            },
+            "rightKnee": {
+              "x": 84.8,
+              "y": 87.9,
+              "v": 0.808
+            },
+            "leftAnkle": {
+              "x": 79.2,
+              "y": 105.6,
+              "v": 0.782
+            },
+            "rightAnkle": {
+              "x": 79.4,
+              "y": 102.8,
+              "v": 0.91
+            },
+            "leftHeel": {
+              "x": 80.3,
+              "y": 107,
+              "v": 0.896
+            },
+            "rightHeel": {
+              "x": 78.2,
+              "y": 104.1,
+              "v": 0.869
+            },
+            "leftFootIndex": {
+              "x": 80.8,
+              "y": 109.3,
+              "v": 0.716
+            },
+            "rightFootIndex": {
+              "x": 79.6,
+              "y": 109.4,
+              "v": 0.854
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.9,
+                "y": 56.1
+              },
+              "roll": 0,
+              "yaw": 3,
+              "pitch": 6
+            },
+            "torso": {
+              "center": {
+                "x": 71.7,
+                "y": 61.3
+              },
+              "angle": 113.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 102.2,
+                "y": 60.1
+              },
+              "angle": 11.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80.3,
+                "y": 107
+              },
+              "angle": -77.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 78.2,
+                "y": 104.1
+              },
+              "angle": -75.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.751,
+          "keypoints": {
+            "nose": {
+              "x": 69.2,
+              "y": 35.9,
+              "v": 0.979
+            },
+            "leftEye": {
+              "x": 70,
+              "y": 32.9,
+              "v": 0.943
+            },
+            "rightEye": {
+              "x": 65.9,
+              "y": 32.8,
+              "v": 0.965
+            },
+            "leftEar": {
+              "x": 68.5,
+              "y": 33.8,
+              "v": 0.978
+            },
+            "rightEar": {
+              "x": 60.2,
+              "y": 33.4,
+              "v": 0.94
+            },
+            "leftShoulder": {
+              "x": 69.8,
+              "y": 45,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 47.5,
+              "y": 46.4,
+              "v": 0.994
+            },
+            "leftElbow": {
+              "x": 83.7,
+              "y": 41.5,
+              "v": 0.409
+            },
+            "rightElbow": {
+              "x": 39.7,
+              "y": 46.1,
+              "v": 0.578
+            },
+            "leftWrist": {
+              "x": 88.3,
+              "y": 24.7,
+              "v": 0.555
+            },
+            "rightWrist": {
+              "x": 40.9,
+              "y": 37.9,
+              "v": 0.314
+            },
+            "leftIndex": {
+              "x": 88.6,
+              "y": 21.8,
+              "v": 0.595
+            },
+            "rightIndex": {
+              "x": 42.7,
+              "y": 34.5,
+              "v": 0.279
+            },
+            "leftHip": {
+              "x": 60.6,
+              "y": 88,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 46.4,
+              "y": 89.1,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 83.2,
+              "y": 89.2,
+              "v": 0.537
+            },
+            "rightKnee": {
+              "x": 37.6,
+              "y": 93.4,
+              "v": 0.797
+            },
+            "leftAnkle": {
+              "x": 76.3,
+              "y": 107.8,
+              "v": 0.798
+            },
+            "rightAnkle": {
+              "x": 26.1,
+              "y": 115.7,
+              "v": 0.87
+            },
+            "leftHeel": {
+              "x": 72.3,
+              "y": 113.8,
+              "v": 0.742
+            },
+            "rightHeel": {
+              "x": 25.4,
+              "y": 119.3,
+              "v": 0.581
+            },
+            "leftFootIndex": {
+              "x": 88.3,
+              "y": 114.4,
+              "v": 0.7
+            },
+            "rightFootIndex": {
+              "x": 23.9,
+              "y": 125,
+              "v": 0.715
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68,
+                "y": 32.8
+              },
+              "roll": 178.6,
+              "yaw": 0.305,
+              "pitch": 0.744
+            },
+            "torso": {
+              "center": {
+                "x": 58.7,
+                "y": 45.7
+              },
+              "angle": 83.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.3,
+                "y": 24.7
+              },
+              "angle": 84.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40.9,
+                "y": 37.9
+              },
+              "angle": 81.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.3,
+                "y": 113.8
+              },
+              "angle": -2.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25.4,
+                "y": 119.3
+              },
+              "angle": -104.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/angy/poses.json
+++ b/public/assets/fighters/angy/poses.json
@@ -1,0 +1,8271 @@
+{
+  "version": 1,
+  "fighter": "angy",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:42:12.634Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 69,
+              "y": 13.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.9,
+              "y": 11,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.2,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.2,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.8,
+              "y": 11,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.4,
+              "y": 23.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.4,
+              "y": 24.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.5,
+              "y": 39.3,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 45.5,
+              "y": 35.7,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 86.8,
+              "y": 46.1,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 62.4,
+              "y": 32.6,
+              "v": 0.992
+            },
+            "leftIndex": {
+              "x": 86.2,
+              "y": 48.1,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 68.7,
+              "y": 30.3,
+              "v": 0.981
+            },
+            "leftHip": {
+              "x": 71.6,
+              "y": 60.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.2,
+              "y": 60.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.2,
+              "y": 86.4,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 48.2,
+              "y": 86.1,
+              "v": 0.985
+            },
+            "leftAnkle": {
+              "x": 91.2,
+              "y": 113.6,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 40.1,
+              "y": 114.8,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 92.7,
+              "y": 117.9,
+              "v": 0.963
+            },
+            "rightHeel": {
+              "x": 41.7,
+              "y": 120.2,
+              "v": 0.956
+            },
+            "leftFootIndex": {
+              "x": 91.2,
+              "y": 125.8,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 32.4,
+              "y": 124.3,
+              "v": 0.994
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.1,
+                "y": 11
+              },
+              "roll": 178.5,
+              "yaw": 0.257,
+              "pitch": 0.689
+            },
+            "torso": {
+              "center": {
+                "x": 63.9,
+                "y": 24.2
+              },
+              "angle": 90.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.8,
+                "y": 46.1
+              },
+              "angle": -106.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 62.4,
+                "y": 32.6
+              },
+              "angle": 20.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.7,
+                "y": 117.9
+              },
+              "angle": -100.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.7,
+                "y": 120.2
+              },
+              "angle": -156.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.968,
+          "keypoints": {
+            "nose": {
+              "x": 69,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.6,
+              "y": 10,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.7,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.4,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.1,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.5,
+              "y": 23.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.4,
+              "y": 24.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.5,
+              "y": 40.2,
+              "v": 0.993
+            },
+            "rightElbow": {
+              "x": 46.4,
+              "y": 36.6,
+              "v": 0.94
+            },
+            "leftWrist": {
+              "x": 85.6,
+              "y": 46.7,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 50.5,
+              "y": 36.2,
+              "v": 0.844
+            },
+            "leftIndex": {
+              "x": 85.7,
+              "y": 48.4,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 53.3,
+              "y": 34.9,
+              "v": 0.818
+            },
+            "leftHip": {
+              "x": 71.1,
+              "y": 58.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57,
+              "y": 58.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.7,
+              "y": 85.5,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 48.9,
+              "y": 85.7,
+              "v": 0.966
+            },
+            "leftAnkle": {
+              "x": 91.4,
+              "y": 114.4,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 40,
+              "y": 114.7,
+              "v": 0.989
+            },
+            "leftHeel": {
+              "x": 92.5,
+              "y": 118.5,
+              "v": 0.879
+            },
+            "rightHeel": {
+              "x": 41.6,
+              "y": 120.3,
+              "v": 0.9
+            },
+            "leftFootIndex": {
+              "x": 90.8,
+              "y": 126.5,
+              "v": 0.986
+            },
+            "rightFootIndex": {
+              "x": 31.6,
+              "y": 124.1,
+              "v": 0.983
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.7,
+                "y": 10.1
+              },
+              "roll": -177.1,
+              "yaw": 0.346,
+              "pitch": 0.64
+            },
+            "torso": {
+              "center": {
+                "x": 64,
+                "y": 24
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.6,
+                "y": 46.7
+              },
+              "angle": -86.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.5,
+                "y": 36.2
+              },
+              "angle": 24.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.5,
+                "y": 118.5
+              },
+              "angle": -102
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.6,
+                "y": 120.3
+              },
+              "angle": -159.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.964,
+          "keypoints": {
+            "nose": {
+              "x": 68,
+              "y": 13.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.5,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.1,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.3,
+              "y": 12,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.5,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.7,
+              "y": 25.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.8,
+              "y": 40.6,
+              "v": 0.995
+            },
+            "rightElbow": {
+              "x": 45.2,
+              "y": 36.1,
+              "v": 0.905
+            },
+            "leftWrist": {
+              "x": 84.1,
+              "y": 47.1,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 57,
+              "y": 35.5,
+              "v": 0.786
+            },
+            "leftIndex": {
+              "x": 85.8,
+              "y": 48.1,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 61.6,
+              "y": 33.9,
+              "v": 0.759
+            },
+            "leftHip": {
+              "x": 70.9,
+              "y": 59.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.6,
+              "y": 58.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.8,
+              "y": 86.1,
+              "v": 0.986
+            },
+            "rightKnee": {
+              "x": 48.7,
+              "y": 85.4,
+              "v": 0.943
+            },
+            "leftAnkle": {
+              "x": 91,
+              "y": 115,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 40.3,
+              "y": 115.3,
+              "v": 0.987
+            },
+            "leftHeel": {
+              "x": 92.3,
+              "y": 118.7,
+              "v": 0.925
+            },
+            "rightHeel": {
+              "x": 41.6,
+              "y": 120.8,
+              "v": 0.924
+            },
+            "leftFootIndex": {
+              "x": 91.2,
+              "y": 125.9,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 32.9,
+              "y": 123.5,
+              "v": 0.983
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.3,
+                "y": 10.8
+              },
+              "roll": 177.4,
+              "yaw": 0.159,
+              "pitch": 0.59
+            },
+            "torso": {
+              "center": {
+                "x": 64.1,
+                "y": 24.4
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.1,
+                "y": 47.1
+              },
+              "angle": -30.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 57,
+                "y": 35.5
+              },
+              "angle": 19.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.3,
+                "y": 118.7
+              },
+              "angle": -98.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.6,
+                "y": 120.8
+              },
+              "angle": -162.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.974,
+          "keypoints": {
+            "nose": {
+              "x": 69.1,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.6,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.9,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.9,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.1,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.9,
+              "y": 24.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.8,
+              "y": 24.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.8,
+              "y": 40.3,
+              "v": 0.994
+            },
+            "rightElbow": {
+              "x": 44.9,
+              "y": 36.2,
+              "v": 0.963
+            },
+            "leftWrist": {
+              "x": 86.1,
+              "y": 46.5,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 56,
+              "y": 34.4,
+              "v": 0.926
+            },
+            "leftIndex": {
+              "x": 85.7,
+              "y": 47.9,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 60.9,
+              "y": 32,
+              "v": 0.899
+            },
+            "leftHip": {
+              "x": 72,
+              "y": 59.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.5,
+              "y": 58.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.3,
+              "y": 86.5,
+              "v": 0.983
+            },
+            "rightKnee": {
+              "x": 48.5,
+              "y": 86.5,
+              "v": 0.939
+            },
+            "leftAnkle": {
+              "x": 91.7,
+              "y": 114.1,
+              "v": 0.988
+            },
+            "rightAnkle": {
+              "x": 40.2,
+              "y": 114.8,
+              "v": 0.985
+            },
+            "leftHeel": {
+              "x": 92.4,
+              "y": 118,
+              "v": 0.883
+            },
+            "rightHeel": {
+              "x": 41.5,
+              "y": 120.5,
+              "v": 0.897
+            },
+            "leftFootIndex": {
+              "x": 91.4,
+              "y": 126,
+              "v": 0.981
+            },
+            "rightFootIndex": {
+              "x": 31.7,
+              "y": 123.9,
+              "v": 0.977
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.8,
+                "y": 10.3
+              },
+              "roll": 178.5,
+              "yaw": 0.365,
+              "pitch": 0.608
+            },
+            "torso": {
+              "center": {
+                "x": 64.4,
+                "y": 24.3
+              },
+              "angle": 90.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.1,
+                "y": 46.5
+              },
+              "angle": -105.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 56,
+                "y": 34.4
+              },
+              "angle": 26.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.4,
+                "y": 118
+              },
+              "angle": -97.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.5,
+                "y": 120.5
+              },
+              "angle": -160.9
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.957,
+          "keypoints": {
+            "nose": {
+              "x": 70.6,
+              "y": 13,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.8,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.4,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.5,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.2,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.4,
+              "y": 23.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.2,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.5,
+              "y": 40.6,
+              "v": 0.992
+            },
+            "rightElbow": {
+              "x": 43.5,
+              "y": 37.3,
+              "v": 0.807
+            },
+            "leftWrist": {
+              "x": 83.1,
+              "y": 46,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 39.2,
+              "y": 43.8,
+              "v": 0.662
+            },
+            "leftIndex": {
+              "x": 82.1,
+              "y": 47.5,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 36.3,
+              "y": 44.3,
+              "v": 0.68
+            },
+            "leftHip": {
+              "x": 67.9,
+              "y": 57.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.7,
+              "y": 58.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.9,
+              "y": 86,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 52.6,
+              "y": 88.2,
+              "v": 0.981
+            },
+            "leftAnkle": {
+              "x": 82.6,
+              "y": 114.5,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 47.1,
+              "y": 115.4,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 83.4,
+              "y": 117.6,
+              "v": 0.958
+            },
+            "rightHeel": {
+              "x": 48.9,
+              "y": 119.8,
+              "v": 0.966
+            },
+            "leftFootIndex": {
+              "x": 80.5,
+              "y": 124.7,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 39.3,
+              "y": 123.7,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.1,
+                "y": 10.6
+              },
+              "roll": 178.3,
+              "yaw": 0.441,
+              "pitch": 0.691
+            },
+            "torso": {
+              "center": {
+                "x": 63.8,
+                "y": 23.5
+              },
+              "angle": 86.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 83.1,
+                "y": 46
+              },
+              "angle": -123.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.2,
+                "y": 43.8
+              },
+              "angle": -170.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.4,
+                "y": 117.6
+              },
+              "angle": -112.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.9,
+                "y": 119.8
+              },
+              "angle": -157.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.977,
+          "keypoints": {
+            "nose": {
+              "x": 68.9,
+              "y": 13.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.1,
+              "y": 10.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.7,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.8,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.8,
+              "y": 11,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.3,
+              "y": 23,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.1,
+              "y": 24.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.6,
+              "y": 40,
+              "v": 0.991
+            },
+            "rightElbow": {
+              "x": 46.8,
+              "y": 35.8,
+              "v": 0.97
+            },
+            "leftWrist": {
+              "x": 85,
+              "y": 46.6,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 63.2,
+              "y": 30.3,
+              "v": 0.937
+            },
+            "leftIndex": {
+              "x": 85.8,
+              "y": 48.3,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 69.3,
+              "y": 27.8,
+              "v": 0.895
+            },
+            "leftHip": {
+              "x": 71.7,
+              "y": 58.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.9,
+              "y": 59,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.4,
+              "y": 85.8,
+              "v": 0.981
+            },
+            "rightKnee": {
+              "x": 48.4,
+              "y": 85.9,
+              "v": 0.941
+            },
+            "leftAnkle": {
+              "x": 91.1,
+              "y": 113.5,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 39.9,
+              "y": 114.8,
+              "v": 0.986
+            },
+            "leftHeel": {
+              "x": 92.7,
+              "y": 117,
+              "v": 0.902
+            },
+            "rightHeel": {
+              "x": 41.7,
+              "y": 121.2,
+              "v": 0.923
+            },
+            "leftFootIndex": {
+              "x": 91.3,
+              "y": 124.2,
+              "v": 0.984
+            },
+            "rightFootIndex": {
+              "x": 31.7,
+              "y": 124.3,
+              "v": 0.981
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.9,
+                "y": 10.5
+              },
+              "roll": 172.2,
+              "yaw": 0.225,
+              "pitch": 0.653
+            },
+            "torso": {
+              "center": {
+                "x": 64.2,
+                "y": 23.7
+              },
+              "angle": 91
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85,
+                "y": 46.6
+              },
+              "angle": -64.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 63.2,
+                "y": 30.3
+              },
+              "angle": 22.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.7,
+                "y": 117
+              },
+              "angle": -101
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.7,
+                "y": 121.2
+              },
+              "angle": -162.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.979,
+          "keypoints": {
+            "nose": {
+              "x": 69.7,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70,
+              "y": 10,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.6,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.3,
+              "y": 10.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.8,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.4,
+              "y": 23.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.3,
+              "y": 24.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80,
+              "y": 37.4,
+              "v": 0.995
+            },
+            "rightElbow": {
+              "x": 46,
+              "y": 38.4,
+              "v": 0.956
+            },
+            "leftWrist": {
+              "x": 85.8,
+              "y": 46.3,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 39.9,
+              "y": 41.1,
+              "v": 0.905
+            },
+            "leftIndex": {
+              "x": 86.2,
+              "y": 47.7,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 35.7,
+              "y": 41.3,
+              "v": 0.889
+            },
+            "leftHip": {
+              "x": 70.9,
+              "y": 58.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.6,
+              "y": 58.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.4,
+              "y": 85.4,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 48.9,
+              "y": 85.4,
+              "v": 0.986
+            },
+            "leftAnkle": {
+              "x": 91.4,
+              "y": 113.8,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 40.4,
+              "y": 114.4,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 92.5,
+              "y": 117.4,
+              "v": 0.903
+            },
+            "rightHeel": {
+              "x": 41.9,
+              "y": 120.7,
+              "v": 0.933
+            },
+            "leftFootIndex": {
+              "x": 91.4,
+              "y": 124,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 31.7,
+              "y": 124.2,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.3,
+                "y": 10.1
+              },
+              "roll": -178.3,
+              "yaw": 0.412,
+              "pitch": 0.75
+            },
+            "torso": {
+              "center": {
+                "x": 63.9,
+                "y": 23.9
+              },
+              "angle": 89.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.8,
+                "y": 46.3
+              },
+              "angle": -74.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.9,
+                "y": 41.1
+              },
+              "angle": -177.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.5,
+                "y": 117.4
+              },
+              "angle": -99.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.9,
+                "y": 120.7
+              },
+              "angle": -161.1
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.962,
+          "keypoints": {
+            "nose": {
+              "x": 68.9,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69,
+              "y": 10.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.1,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.5,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.1,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.9,
+              "y": 24.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.1,
+              "y": 25.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82,
+              "y": 42.2,
+              "v": 0.989
+            },
+            "rightElbow": {
+              "x": 47.1,
+              "y": 38.2,
+              "v": 0.907
+            },
+            "leftWrist": {
+              "x": 85.5,
+              "y": 47.2,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 58.6,
+              "y": 36,
+              "v": 0.736
+            },
+            "leftIndex": {
+              "x": 85.6,
+              "y": 48.2,
+              "v": 0.993
+            },
+            "rightIndex": {
+              "x": 63.7,
+              "y": 34,
+              "v": 0.707
+            },
+            "leftHip": {
+              "x": 71.8,
+              "y": 59.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.8,
+              "y": 59.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.7,
+              "y": 86.2,
+              "v": 0.994
+            },
+            "rightKnee": {
+              "x": 48.5,
+              "y": 85.9,
+              "v": 0.974
+            },
+            "leftAnkle": {
+              "x": 91.2,
+              "y": 114.9,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 40.2,
+              "y": 114.6,
+              "v": 0.992
+            },
+            "leftHeel": {
+              "x": 92.5,
+              "y": 119.1,
+              "v": 0.927
+            },
+            "rightHeel": {
+              "x": 41.6,
+              "y": 120.1,
+              "v": 0.937
+            },
+            "leftFootIndex": {
+              "x": 91,
+              "y": 126.4,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 32.6,
+              "y": 123.6,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.6,
+                "y": 10.2
+              },
+              "roll": -176.1,
+              "yaw": 0.464,
+              "pitch": 0.757
+            },
+            "torso": {
+              "center": {
+                "x": 64,
+                "y": 24.8
+              },
+              "angle": 91.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.5,
+                "y": 47.2
+              },
+              "angle": -84.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 58.6,
+                "y": 36
+              },
+              "angle": 21.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.5,
+                "y": 119.1
+              },
+              "angle": -101.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.6,
+                "y": 120.1
+              },
+              "angle": -158.7
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.917,
+          "keypoints": {
+            "nose": {
+              "x": 68.8,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.9,
+              "y": 10.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.5,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.9,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.7,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.4,
+              "y": 23.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.9,
+              "y": 23.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.2,
+              "y": 26.5,
+              "v": 0.989
+            },
+            "rightElbow": {
+              "x": 43.6,
+              "y": 33.5,
+              "v": 0.724
+            },
+            "leftWrist": {
+              "x": 103.6,
+              "y": 26.6,
+              "v": 0.992
+            },
+            "rightWrist": {
+              "x": 52.3,
+              "y": 34.8,
+              "v": 0.475
+            },
+            "leftIndex": {
+              "x": 108.9,
+              "y": 26.9,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 56.2,
+              "y": 33.9,
+              "v": 0.477
+            },
+            "leftHip": {
+              "x": 70,
+              "y": 56.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.3,
+              "y": 57.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.4,
+              "y": 85.1,
+              "v": 0.978
+            },
+            "rightKnee": {
+              "x": 49,
+              "y": 86.2,
+              "v": 0.89
+            },
+            "leftAnkle": {
+              "x": 91.2,
+              "y": 113.5,
+              "v": 0.977
+            },
+            "rightAnkle": {
+              "x": 39.9,
+              "y": 115.4,
+              "v": 0.972
+            },
+            "leftHeel": {
+              "x": 92.6,
+              "y": 117,
+              "v": 0.821
+            },
+            "rightHeel": {
+              "x": 41.8,
+              "y": 121.7,
+              "v": 0.871
+            },
+            "leftFootIndex": {
+              "x": 91.9,
+              "y": 124.5,
+              "v": 0.971
+            },
+            "rightFootIndex": {
+              "x": 31.3,
+              "y": 124.2,
+              "v": 0.967
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.2,
+                "y": 10.5
+              },
+              "roll": 168.4,
+              "yaw": 0.173,
+              "pitch": 0.706
+            },
+            "torso": {
+              "center": {
+                "x": 63.2,
+                "y": 23.2
+              },
+              "angle": 90.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.6,
+                "y": 26.6
+              },
+              "angle": -3.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52.3,
+                "y": 34.8
+              },
+              "angle": 13
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.6,
+                "y": 117
+              },
+              "angle": -95.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.8,
+                "y": 121.7
+              },
+              "angle": -166.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.973,
+          "keypoints": {
+            "nose": {
+              "x": 71.8,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.8,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.4,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.9,
+              "y": 11,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.6,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.6,
+              "y": 22.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.7,
+              "y": 24.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.7,
+              "y": 23.6,
+              "v": 0.991
+            },
+            "rightElbow": {
+              "x": 41.4,
+              "y": 35,
+              "v": 0.99
+            },
+            "leftWrist": {
+              "x": 102.3,
+              "y": 22.3,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 44.9,
+              "y": 33.1,
+              "v": 0.952
+            },
+            "leftIndex": {
+              "x": 106.7,
+              "y": 22.2,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 49.5,
+              "y": 29.5,
+              "v": 0.93
+            },
+            "leftHip": {
+              "x": 68.6,
+              "y": 55.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54.9,
+              "y": 56.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.3,
+              "y": 84.6,
+              "v": 0.984
+            },
+            "rightKnee": {
+              "x": 43.8,
+              "y": 85.8,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 93.8,
+              "y": 112.6,
+              "v": 0.978
+            },
+            "rightAnkle": {
+              "x": 30.9,
+              "y": 114.9,
+              "v": 0.99
+            },
+            "leftHeel": {
+              "x": 94.3,
+              "y": 116.8,
+              "v": 0.814
+            },
+            "rightHeel": {
+              "x": 30.3,
+              "y": 119.3,
+              "v": 0.825
+            },
+            "leftFootIndex": {
+              "x": 95.2,
+              "y": 124,
+              "v": 0.975
+            },
+            "rightFootIndex": {
+              "x": 29.1,
+              "y": 125.7,
+              "v": 0.982
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.1,
+                "y": 10.5
+              },
+              "roll": 160.3,
+              "yaw": 1.144,
+              "pitch": 1.581
+            },
+            "torso": {
+              "center": {
+                "x": 62.7,
+                "y": 23.4
+              },
+              "angle": 88.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 102.3,
+                "y": 22.3
+              },
+              "angle": 1.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.9,
+                "y": 33.1
+              },
+              "angle": 38
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 94.3,
+                "y": 116.8
+              },
+              "angle": -82.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.3,
+                "y": 119.3
+              },
+              "angle": -100.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.976,
+          "keypoints": {
+            "nose": {
+              "x": 68.5,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.1,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.1,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.9,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.4,
+              "y": 10,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.3,
+              "y": 23.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.2,
+              "y": 23.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.5,
+              "y": 24.1,
+              "v": 0.995
+            },
+            "rightElbow": {
+              "x": 43.3,
+              "y": 34.1,
+              "v": 0.919
+            },
+            "leftWrist": {
+              "x": 100.6,
+              "y": 23.6,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 36.1,
+              "y": 37.9,
+              "v": 0.871
+            },
+            "leftIndex": {
+              "x": 105.4,
+              "y": 23.8,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 33.9,
+              "y": 39.5,
+              "v": 0.825
+            },
+            "leftHip": {
+              "x": 69.7,
+              "y": 57.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.9,
+              "y": 58.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.5,
+              "y": 86.2,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 49.1,
+              "y": 86.3,
+              "v": 0.98
+            },
+            "leftAnkle": {
+              "x": 91.5,
+              "y": 114.1,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 40.1,
+              "y": 115.1,
+              "v": 0.99
+            },
+            "leftHeel": {
+              "x": 93.1,
+              "y": 118.5,
+              "v": 0.95
+            },
+            "rightHeel": {
+              "x": 41.9,
+              "y": 121.2,
+              "v": 0.95
+            },
+            "leftFootIndex": {
+              "x": 90.2,
+              "y": 124.1,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 32.1,
+              "y": 124.4,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.6,
+                "y": 10.1
+              },
+              "roll": 159.9,
+              "yaw": 0.282,
+              "pitch": 0.861
+            },
+            "torso": {
+              "center": {
+                "x": 62.3,
+                "y": 23.5
+              },
+              "angle": 91.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.6,
+                "y": 23.6
+              },
+              "angle": -2.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.1,
+                "y": 37.9
+              },
+              "angle": -144
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.1,
+                "y": 118.5
+              },
+              "angle": -117.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.9,
+                "y": 121.2
+              },
+              "angle": -161.9
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.946,
+          "keypoints": {
+            "nose": {
+              "x": 70,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.4,
+              "y": 9.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.7,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.4,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.2,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.4,
+              "y": 21.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.8,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.4,
+              "y": 24.4,
+              "v": 0.988
+            },
+            "rightElbow": {
+              "x": 43.7,
+              "y": 35.7,
+              "v": 0.865
+            },
+            "leftWrist": {
+              "x": 100.6,
+              "y": 24.5,
+              "v": 0.981
+            },
+            "rightWrist": {
+              "x": 35.2,
+              "y": 39.5,
+              "v": 0.636
+            },
+            "leftIndex": {
+              "x": 105.5,
+              "y": 24.2,
+              "v": 0.97
+            },
+            "rightIndex": {
+              "x": 33.2,
+              "y": 42.1,
+              "v": 0.562
+            },
+            "leftHip": {
+              "x": 69.3,
+              "y": 55.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.5,
+              "y": 56.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80,
+              "y": 85.1,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 48.9,
+              "y": 86.3,
+              "v": 0.963
+            },
+            "leftAnkle": {
+              "x": 91.4,
+              "y": 114.6,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 40.1,
+              "y": 114.1,
+              "v": 0.987
+            },
+            "leftHeel": {
+              "x": 93,
+              "y": 118.2,
+              "v": 0.927
+            },
+            "rightHeel": {
+              "x": 41.8,
+              "y": 119.7,
+              "v": 0.918
+            },
+            "leftFootIndex": {
+              "x": 90.9,
+              "y": 125.3,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 31.7,
+              "y": 124.2,
+              "v": 0.983
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.6,
+                "y": 9.7
+              },
+              "roll": 166.8,
+              "yaw": 0.83,
+              "pitch": 1.374
+            },
+            "torso": {
+              "center": {
+                "x": 62.6,
+                "y": 22.9
+              },
+              "angle": 90.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.6,
+                "y": 24.5
+              },
+              "angle": 3.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.2,
+                "y": 39.5
+              },
+              "angle": -127.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93,
+                "y": 118.2
+              },
+              "angle": -106.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.8,
+                "y": 119.7
+              },
+              "angle": -156
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.978,
+          "keypoints": {
+            "nose": {
+              "x": 61.6,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 60.3,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.6,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 56.8,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.6,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 61.9,
+              "y": 23.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.9,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.6,
+              "y": 26,
+              "v": 0.99
+            },
+            "rightElbow": {
+              "x": 29.6,
+              "y": 36.2,
+              "v": 0.982
+            },
+            "leftWrist": {
+              "x": 95.8,
+              "y": 25.5,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 34.4,
+              "y": 38.5,
+              "v": 0.905
+            },
+            "leftIndex": {
+              "x": 101.7,
+              "y": 24,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 39.8,
+              "y": 36.2,
+              "v": 0.883
+            },
+            "leftHip": {
+              "x": 58.5,
+              "y": 58.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.5,
+              "y": 58.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.5,
+              "y": 83.5,
+              "v": 0.986
+            },
+            "rightKnee": {
+              "x": 34.1,
+              "y": 87,
+              "v": 0.993
+            },
+            "leftAnkle": {
+              "x": 80.8,
+              "y": 114.7,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 20.6,
+              "y": 114.6,
+              "v": 0.992
+            },
+            "leftHeel": {
+              "x": 78.2,
+              "y": 120.7,
+              "v": 0.953
+            },
+            "rightHeel": {
+              "x": 18.8,
+              "y": 118.8,
+              "v": 0.862
+            },
+            "leftFootIndex": {
+              "x": 89.5,
+              "y": 124.5,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 19.8,
+              "y": 125.2,
+              "v": 0.985
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.5,
+                "y": 11.4
+              },
+              "roll": -160.6,
+              "yaw": 1.193,
+              "pitch": 1.498
+            },
+            "torso": {
+              "center": {
+                "x": 51.9,
+                "y": 24.2
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.8,
+                "y": 25.5
+              },
+              "angle": 14.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.4,
+                "y": 38.5
+              },
+              "angle": 23.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.2,
+                "y": 120.7
+              },
+              "angle": -18.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 18.8,
+                "y": 118.8
+              },
+              "angle": -81.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.981,
+          "keypoints": {
+            "nose": {
+              "x": 67.7,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.9,
+              "y": 10,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.2,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.1,
+              "y": 10.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.4,
+              "y": 22.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.1,
+              "y": 23.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.4,
+              "y": 25,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 41.6,
+              "y": 34.5,
+              "v": 0.967
+            },
+            "leftWrist": {
+              "x": 98.7,
+              "y": 24.5,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 43.9,
+              "y": 38.1,
+              "v": 0.893
+            },
+            "leftIndex": {
+              "x": 103.7,
+              "y": 23.6,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 44.9,
+              "y": 38.1,
+              "v": 0.884
+            },
+            "leftHip": {
+              "x": 70.2,
+              "y": 57.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.8,
+              "y": 58.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.7,
+              "y": 84.3,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 48.7,
+              "y": 85.2,
+              "v": 0.991
+            },
+            "leftAnkle": {
+              "x": 90.2,
+              "y": 113.3,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 40.2,
+              "y": 115,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 91.5,
+              "y": 116.6,
+              "v": 0.912
+            },
+            "rightHeel": {
+              "x": 41.6,
+              "y": 120.2,
+              "v": 0.95
+            },
+            "leftFootIndex": {
+              "x": 88.4,
+              "y": 126.3,
+              "v": 0.992
+            },
+            "rightFootIndex": {
+              "x": 32.4,
+              "y": 124.4,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.6,
+                "y": 9.8
+              },
+              "roll": 171.6,
+              "yaw": 0.421,
+              "pitch": 0.953
+            },
+            "torso": {
+              "center": {
+                "x": 62.3,
+                "y": 22.9
+              },
+              "angle": 91.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.7,
+                "y": 24.5
+              },
+              "angle": 10.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.9,
+                "y": 38.1
+              },
+              "angle": 0
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 91.5,
+                "y": 116.6
+              },
+              "angle": -107.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.6,
+                "y": 120.2
+              },
+              "angle": -155.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.826,
+          "keypoints": {
+            "nose": {
+              "x": 63.6,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.8,
+              "y": 9.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 60.8,
+              "y": 8.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.5,
+              "y": 10.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.7,
+              "y": 9.7,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 67.5,
+              "y": 22.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.4,
+              "y": 22.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.5,
+              "y": 31.1,
+              "v": 0.756
+            },
+            "rightElbow": {
+              "x": 45.1,
+              "y": 34.7,
+              "v": 0.27
+            },
+            "leftWrist": {
+              "x": 68.2,
+              "y": 31.5,
+              "v": 0.631
+            },
+            "rightWrist": {
+              "x": 49.1,
+              "y": 34.3,
+              "v": 0.246
+            },
+            "leftIndex": {
+              "x": 66.5,
+              "y": 27.3,
+              "v": 0.66
+            },
+            "rightIndex": {
+              "x": 51.1,
+              "y": 32.9,
+              "v": 0.326
+            },
+            "leftHip": {
+              "x": 66.7,
+              "y": 57.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54.4,
+              "y": 57.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.9,
+              "y": 86.4,
+              "v": 0.955
+            },
+            "rightKnee": {
+              "x": 45.1,
+              "y": 86.7,
+              "v": 0.843
+            },
+            "leftAnkle": {
+              "x": 87.2,
+              "y": 115.6,
+              "v": 0.962
+            },
+            "rightAnkle": {
+              "x": 35.8,
+              "y": 115.3,
+              "v": 0.955
+            },
+            "leftHeel": {
+              "x": 88.8,
+              "y": 119.1,
+              "v": 0.698
+            },
+            "rightHeel": {
+              "x": 38,
+              "y": 120.7,
+              "v": 0.794
+            },
+            "leftFootIndex": {
+              "x": 87.7,
+              "y": 126.4,
+              "v": 0.951
+            },
+            "rightFootIndex": {
+              "x": 27.7,
+              "y": 124.8,
+              "v": 0.942
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.8,
+                "y": 9
+              },
+              "roll": 175.7,
+              "yaw": 0.199,
+              "pitch": 0.686
+            },
+            "torso": {
+              "center": {
+                "x": 59,
+                "y": 22.4
+              },
+              "angle": 92.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 68.2,
+                "y": 31.5
+              },
+              "angle": 112
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 88.8,
+                "y": 119.1
+              },
+              "angle": -98.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38,
+                "y": 120.7
+              },
+              "angle": -158.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.841,
+          "keypoints": {
+            "nose": {
+              "x": 61.6,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62,
+              "y": 9.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.6,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.4,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 55,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.3,
+              "y": 23.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.4,
+              "y": 23,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.5,
+              "y": 32.6,
+              "v": 0.816
+            },
+            "rightElbow": {
+              "x": 41,
+              "y": 33.9,
+              "v": 0.264
+            },
+            "leftWrist": {
+              "x": 64.9,
+              "y": 31.6,
+              "v": 0.766
+            },
+            "rightWrist": {
+              "x": 41.1,
+              "y": 34.6,
+              "v": 0.146
+            },
+            "leftIndex": {
+              "x": 64.6,
+              "y": 26.5,
+              "v": 0.808
+            },
+            "rightIndex": {
+              "x": 42.1,
+              "y": 34.1,
+              "v": 0.201
+            },
+            "leftHip": {
+              "x": 62.7,
+              "y": 57,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.9,
+              "y": 58.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.9,
+              "y": 86.1,
+              "v": 0.947
+            },
+            "rightKnee": {
+              "x": 42.1,
+              "y": 87.2,
+              "v": 0.858
+            },
+            "leftAnkle": {
+              "x": 84.2,
+              "y": 114.9,
+              "v": 0.976
+            },
+            "rightAnkle": {
+              "x": 33.4,
+              "y": 115.7,
+              "v": 0.972
+            },
+            "leftHeel": {
+              "x": 86.1,
+              "y": 118.4,
+              "v": 0.795
+            },
+            "rightHeel": {
+              "x": 35.2,
+              "y": 120.9,
+              "v": 0.863
+            },
+            "leftFootIndex": {
+              "x": 84.7,
+              "y": 125.3,
+              "v": 0.969
+            },
+            "rightFootIndex": {
+              "x": 25.9,
+              "y": 124.2,
+              "v": 0.963
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.3,
+                "y": 9.6
+              },
+              "roll": 178.3,
+              "yaw": 0.382,
+              "pitch": 0.867
+            },
+            "torso": {
+              "center": {
+                "x": 56.4,
+                "y": 23.1
+              },
+              "angle": 90.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 64.9,
+                "y": 31.6
+              },
+              "angle": 93.4
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 86.1,
+                "y": 118.4
+              },
+              "angle": -101.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.2,
+                "y": 120.9
+              },
+              "angle": -160.5
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.971,
+          "keypoints": {
+            "nose": {
+              "x": 69.3,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.8,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.4,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.4,
+              "y": 21.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.9,
+              "y": 24.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.7,
+              "y": 24.5,
+              "v": 0.981
+            },
+            "rightElbow": {
+              "x": 46.8,
+              "y": 33.4,
+              "v": 0.963
+            },
+            "leftWrist": {
+              "x": 97.3,
+              "y": 24.6,
+              "v": 0.993
+            },
+            "rightWrist": {
+              "x": 63.1,
+              "y": 29.7,
+              "v": 0.944
+            },
+            "leftIndex": {
+              "x": 101.9,
+              "y": 24.3,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 70,
+              "y": 28.3,
+              "v": 0.921
+            },
+            "leftHip": {
+              "x": 71.1,
+              "y": 58.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58,
+              "y": 58.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.2,
+              "y": 85.3,
+              "v": 0.982
+            },
+            "rightKnee": {
+              "x": 48.5,
+              "y": 85.6,
+              "v": 0.886
+            },
+            "leftAnkle": {
+              "x": 90.7,
+              "y": 114.4,
+              "v": 0.984
+            },
+            "rightAnkle": {
+              "x": 40.4,
+              "y": 114.5,
+              "v": 0.969
+            },
+            "leftHeel": {
+              "x": 92.2,
+              "y": 118.1,
+              "v": 0.891
+            },
+            "rightHeel": {
+              "x": 42.3,
+              "y": 119.8,
+              "v": 0.872
+            },
+            "leftFootIndex": {
+              "x": 91,
+              "y": 126.1,
+              "v": 0.979
+            },
+            "rightFootIndex": {
+              "x": 32.3,
+              "y": 124.2,
+              "v": 0.967
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.1,
+                "y": 10.3
+              },
+              "roll": 178.3,
+              "yaw": 0.353,
+              "pitch": 0.779
+            },
+            "torso": {
+              "center": {
+                "x": 63.2,
+                "y": 23
+              },
+              "angle": 92.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.3,
+                "y": 24.6
+              },
+              "angle": 3.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 63.1,
+                "y": 29.7
+              },
+              "angle": 11.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.2,
+                "y": 118.1
+              },
+              "angle": -98.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.3,
+                "y": 119.8
+              },
+              "angle": -156.3
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.899,
+          "keypoints": {
+            "nose": {
+              "x": 74.4,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.5,
+              "y": 9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.9,
+              "y": 9.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.4,
+              "y": 10.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.2,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.9,
+              "y": 25.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63,
+              "y": 23.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75,
+              "y": 44.2,
+              "v": 0.148
+            },
+            "rightElbow": {
+              "x": 66.1,
+              "y": 36.4,
+              "v": 0.994
+            },
+            "leftWrist": {
+              "x": 83.8,
+              "y": 58.4,
+              "v": 0.335
+            },
+            "rightWrist": {
+              "x": 77.4,
+              "y": 53.6,
+              "v": 0.973
+            },
+            "leftIndex": {
+              "x": 87.1,
+              "y": 60.3,
+              "v": 0.438
+            },
+            "rightIndex": {
+              "x": 80.3,
+              "y": 58.7,
+              "v": 0.958
+            },
+            "leftHip": {
+              "x": 67.1,
+              "y": 59.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.3,
+              "y": 60.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 97.7,
+              "y": 60.9,
+              "v": 0.955
+            },
+            "rightKnee": {
+              "x": 56.7,
+              "y": 87,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 84,
+              "y": 84.4,
+              "v": 0.96
+            },
+            "rightAnkle": {
+              "x": 47.5,
+              "y": 114.3,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 78.9,
+              "y": 87.5,
+              "v": 0.954
+            },
+            "rightHeel": {
+              "x": 44.2,
+              "y": 118,
+              "v": 0.993
+            },
+            "leftFootIndex": {
+              "x": 88.1,
+              "y": 96.5,
+              "v": 0.969
+            },
+            "rightFootIndex": {
+              "x": 51.9,
+              "y": 125.5,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.2,
+                "y": 9.1
+              },
+              "roll": -170.5,
+              "yaw": 3.617,
+              "pitch": 3.699
+            },
+            "torso": {
+              "center": {
+                "x": 67.5,
+                "y": 24.5
+              },
+              "angle": 82.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 83.8,
+                "y": 58.4
+              },
+              "angle": -29.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 77.4,
+                "y": 53.6
+              },
+              "angle": -60.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.9,
+                "y": 87.5
+              },
+              "angle": -44.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.2,
+                "y": 118
+              },
+              "angle": -44.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.977,
+          "keypoints": {
+            "nose": {
+              "x": 60.8,
+              "y": 15.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 60.1,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.1,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.4,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.9,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 58.3,
+              "y": 27.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.5,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 68.6,
+              "y": 38.4,
+              "v": 0.816
+            },
+            "rightElbow": {
+              "x": 38.6,
+              "y": 29.8,
+              "v": 0.977
+            },
+            "leftWrist": {
+              "x": 79.7,
+              "y": 45.6,
+              "v": 0.955
+            },
+            "rightWrist": {
+              "x": 39.6,
+              "y": 32.3,
+              "v": 0.989
+            },
+            "leftIndex": {
+              "x": 82.9,
+              "y": 47.6,
+              "v": 0.95
+            },
+            "rightIndex": {
+              "x": 42.3,
+              "y": 30.8,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 52.8,
+              "y": 60.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.5,
+              "y": 57.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 53.5,
+              "y": 89.4,
+              "v": 0.938
+            },
+            "rightKnee": {
+              "x": 82.6,
+              "y": 56.9,
+              "v": 0.937
+            },
+            "leftAnkle": {
+              "x": 46.4,
+              "y": 115.8,
+              "v": 0.985
+            },
+            "rightAnkle": {
+              "x": 110.4,
+              "y": 60.7,
+              "v": 0.984
+            },
+            "leftHeel": {
+              "x": 43.2,
+              "y": 121,
+              "v": 0.991
+            },
+            "rightHeel": {
+              "x": 114,
+              "y": 64.3,
+              "v": 0.985
+            },
+            "leftFootIndex": {
+              "x": 55.3,
+              "y": 125.6,
+              "v": 0.987
+            },
+            "rightFootIndex": {
+              "x": 123.3,
+              "y": 55.3,
+              "v": 0.986
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.1,
+                "y": 12.3
+              },
+              "roll": -180,
+              "yaw": 0.85,
+              "pitch": 1.45
+            },
+            "torso": {
+              "center": {
+                "x": 52.4,
+                "y": 26
+              },
+              "angle": 89.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 79.7,
+                "y": 45.6
+              },
+              "angle": -32
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.6,
+                "y": 32.3
+              },
+              "angle": 29.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 43.2,
+                "y": 121
+              },
+              "angle": -20.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 114,
+                "y": 64.3
+              },
+              "angle": 44.1
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.979,
+          "keypoints": {
+            "nose": {
+              "x": 69.5,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.8,
+              "y": 10.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.4,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.2,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.6,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.6,
+              "y": 23.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.4,
+              "y": 25,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.5,
+              "y": 38,
+              "v": 0.993
+            },
+            "rightElbow": {
+              "x": 45,
+              "y": 37.8,
+              "v": 0.974
+            },
+            "leftWrist": {
+              "x": 85.8,
+              "y": 46.1,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 47.2,
+              "y": 38.1,
+              "v": 0.927
+            },
+            "leftIndex": {
+              "x": 85.8,
+              "y": 48.5,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 49.4,
+              "y": 37,
+              "v": 0.904
+            },
+            "leftHip": {
+              "x": 71.5,
+              "y": 57.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.1,
+              "y": 58.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.7,
+              "y": 84.7,
+              "v": 0.994
+            },
+            "rightKnee": {
+              "x": 48.9,
+              "y": 85.2,
+              "v": 0.976
+            },
+            "leftAnkle": {
+              "x": 91.4,
+              "y": 113.1,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 40.2,
+              "y": 113.8,
+              "v": 0.991
+            },
+            "leftHeel": {
+              "x": 92.5,
+              "y": 116.9,
+              "v": 0.891
+            },
+            "rightHeel": {
+              "x": 42,
+              "y": 119,
+              "v": 0.902
+            },
+            "leftFootIndex": {
+              "x": 91.5,
+              "y": 124.5,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 32.2,
+              "y": 124,
+              "v": 0.985
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.1,
+                "y": 10.5
+              },
+              "roll": -180,
+              "yaw": 0.412,
+              "pitch": 0.794
+            },
+            "torso": {
+              "center": {
+                "x": 63.5,
+                "y": 24.5
+              },
+              "angle": 91.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.8,
+                "y": 46.1
+              },
+              "angle": -90
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.2,
+                "y": 38.1
+              },
+              "angle": 26.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.5,
+                "y": 116.9
+              },
+              "angle": -97.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42,
+                "y": 119
+              },
+              "angle": -153
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.976,
+          "keypoints": {
+            "nose": {
+              "x": 68.6,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.4,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.8,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.1,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.5,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.7,
+              "y": 23.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.4,
+              "y": 25.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.1,
+              "y": 39.2,
+              "v": 0.997
+            },
+            "rightElbow": {
+              "x": 44.5,
+              "y": 36.3,
+              "v": 0.968
+            },
+            "leftWrist": {
+              "x": 86.2,
+              "y": 45.9,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 57,
+              "y": 34.1,
+              "v": 0.864
+            },
+            "leftIndex": {
+              "x": 85.9,
+              "y": 47.9,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 62.3,
+              "y": 32,
+              "v": 0.808
+            },
+            "leftHip": {
+              "x": 71.4,
+              "y": 60.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.7,
+              "y": 60.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.8,
+              "y": 86.1,
+              "v": 0.994
+            },
+            "rightKnee": {
+              "x": 48.4,
+              "y": 86.7,
+              "v": 0.976
+            },
+            "leftAnkle": {
+              "x": 91,
+              "y": 114.8,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 40,
+              "y": 115.9,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 92.7,
+              "y": 119,
+              "v": 0.935
+            },
+            "rightHeel": {
+              "x": 41.2,
+              "y": 121.4,
+              "v": 0.949
+            },
+            "leftFootIndex": {
+              "x": 91.3,
+              "y": 126,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 32.3,
+              "y": 124.3,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.6,
+                "y": 10.7
+              },
+              "roll": -176.8,
+              "yaw": 0.277,
+              "pitch": 0.693
+            },
+            "torso": {
+              "center": {
+                "x": 64.1,
+                "y": 24.4
+              },
+              "angle": 90.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.2,
+                "y": 45.9
+              },
+              "angle": -98.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 57,
+                "y": 34.1
+              },
+              "angle": 21.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.7,
+                "y": 119
+              },
+              "angle": -101.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.2,
+                "y": 121.4
+              },
+              "angle": -162
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.992,
+          "keypoints": {
+            "nose": {
+              "x": 52.7,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 52.6,
+              "y": 13.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49.5,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 50.9,
+              "y": 14.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 45.8,
+              "y": 14.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 54.8,
+              "y": 28.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.3,
+              "y": 25,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 64,
+              "y": 36.5,
+              "v": 0.92
+            },
+            "rightElbow": {
+              "x": 35.9,
+              "y": 29.2,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 76.5,
+              "y": 34.1,
+              "v": 0.991
+            },
+            "rightWrist": {
+              "x": 34.3,
+              "y": 33.8,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 80.3,
+              "y": 33.2,
+              "v": 0.989
+            },
+            "rightIndex": {
+              "x": 35.5,
+              "y": 35.8,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 55.4,
+              "y": 54.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.4,
+              "y": 56.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80,
+              "y": 38.6,
+              "v": 0.982
+            },
+            "rightKnee": {
+              "x": 48.9,
+              "y": 84.7,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 108.6,
+              "y": 28.5,
+              "v": 0.978
+            },
+            "rightAnkle": {
+              "x": 41.5,
+              "y": 114.7,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 112.8,
+              "y": 30.5,
+              "v": 0.968
+            },
+            "rightHeel": {
+              "x": 38.6,
+              "y": 119.7,
+              "v": 0.994
+            },
+            "leftFootIndex": {
+              "x": 116.6,
+              "y": 18.5,
+              "v": 0.99
+            },
+            "rightFootIndex": {
+              "x": 45.8,
+              "y": 125.5,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.1,
+                "y": 14
+              },
+              "roll": -172.6,
+              "yaw": 0.528,
+              "pitch": 0.736
+            },
+            "torso": {
+              "center": {
+                "x": 48.1,
+                "y": 26.9
+              },
+              "angle": 99.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76.5,
+                "y": 34.1
+              },
+              "angle": 13.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.3,
+                "y": 33.8
+              },
+              "angle": -59
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 112.8,
+                "y": 30.5
+              },
+              "angle": 72.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.6,
+                "y": 119.7
+              },
+              "angle": -38.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 54,
+              "y": 17.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.1,
+              "y": 14.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51.2,
+              "y": 14.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52.5,
+              "y": 15.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 47,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 54.4,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.1,
+              "y": 26.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 64.6,
+              "y": 37.2,
+              "v": 0.947
+            },
+            "rightElbow": {
+              "x": 30.3,
+              "y": 38.2,
+              "v": 0.986
+            },
+            "leftWrist": {
+              "x": 77.5,
+              "y": 34.3,
+              "v": 0.991
+            },
+            "rightWrist": {
+              "x": 39.7,
+              "y": 35.6,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 80.7,
+              "y": 33.2,
+              "v": 0.99
+            },
+            "rightIndex": {
+              "x": 42.5,
+              "y": 33.3,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 51.2,
+              "y": 61.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.8,
+              "y": 54.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 46.1,
+              "y": 87.9,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 76.4,
+              "y": 40.7,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 37.1,
+              "y": 115.4,
+              "v": 1
+            },
+            "rightAnkle": {
+              "x": 106.1,
+              "y": 28.2,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 33.9,
+              "y": 119.1,
+              "v": 1
+            },
+            "rightHeel": {
+              "x": 103.9,
+              "y": 38.6,
+              "v": 0.999
+            },
+            "leftFootIndex": {
+              "x": 41.6,
+              "y": 124.7,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 114.2,
+              "y": 17.8,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 52.7,
+                "y": 14.7
+              },
+              "roll": 178,
+              "yaw": 0.465,
+              "pitch": 0.844
+            },
+            "torso": {
+              "center": {
+                "x": 47.8,
+                "y": 28.2
+              },
+              "angle": 93.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 77.5,
+                "y": 34.3
+              },
+              "angle": 19
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.7,
+                "y": 35.6
+              },
+              "angle": 39.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 33.9,
+                "y": 119.1
+              },
+              "angle": -36
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 103.9,
+                "y": 38.6
+              },
+              "angle": 63.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.999,
+          "keypoints": {
+            "nose": {
+              "x": 55.7,
+              "y": 15.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.4,
+              "y": 13.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 52.9,
+              "y": 13.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 51.9,
+              "y": 14.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.9,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 54.3,
+              "y": 29.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42.3,
+              "y": 26,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 64.6,
+              "y": 37.6,
+              "v": 0.994
+            },
+            "rightElbow": {
+              "x": 33.3,
+              "y": 36.7,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 77.7,
+              "y": 33.7,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 42.2,
+              "y": 38.3,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 81.8,
+              "y": 32.5,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 46.8,
+              "y": 38,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 52.9,
+              "y": 60.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.1,
+              "y": 54,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 47.7,
+              "y": 86.4,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 80.6,
+              "y": 39.8,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 38.4,
+              "y": 113.3,
+              "v": 1
+            },
+            "rightAnkle": {
+              "x": 107.3,
+              "y": 27.8,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 34.7,
+              "y": 117.8,
+              "v": 1
+            },
+            "rightHeel": {
+              "x": 111.2,
+              "y": 29.4,
+              "v": 1
+            },
+            "leftFootIndex": {
+              "x": 42,
+              "y": 123.8,
+              "v": 1
+            },
+            "rightFootIndex": {
+              "x": 115,
+              "y": 16.4,
+              "v": 1
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.7,
+                "y": 13.4
+              },
+              "roll": -180,
+              "yaw": 1.367,
+              "pitch": 1.2
+            },
+            "torso": {
+              "center": {
+                "x": 48.3,
+                "y": 27.6
+              },
+              "angle": 97.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 77.7,
+                "y": 33.7
+              },
+              "angle": 16.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 42.2,
+                "y": 38.3
+              },
+              "angle": 3.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 34.7,
+                "y": 117.8
+              },
+              "angle": -39.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 111.2,
+                "y": 29.4
+              },
+              "angle": 73.7
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 56.3,
+              "y": 20.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.6,
+              "y": 18.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.3,
+              "y": 19,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52.7,
+              "y": 18.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.2,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 54,
+              "y": 30.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42.6,
+              "y": 29.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 65.6,
+              "y": 35.1,
+              "v": 0.956
+            },
+            "rightElbow": {
+              "x": 28,
+              "y": 38,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 81.7,
+              "y": 36.2,
+              "v": 0.992
+            },
+            "rightWrist": {
+              "x": 38.2,
+              "y": 35.6,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 85.5,
+              "y": 35.9,
+              "v": 0.99
+            },
+            "rightIndex": {
+              "x": 41.8,
+              "y": 33.6,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 53.7,
+              "y": 60.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53,
+              "y": 57.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 55.2,
+              "y": 89.4,
+              "v": 0.986
+            },
+            "rightKnee": {
+              "x": 80.6,
+              "y": 43.2,
+              "v": 0.985
+            },
+            "leftAnkle": {
+              "x": 48.3,
+              "y": 116.5,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 108.3,
+              "y": 33.2,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 44.9,
+              "y": 120.4,
+              "v": 0.999
+            },
+            "rightHeel": {
+              "x": 110.9,
+              "y": 34.1,
+              "v": 0.998
+            },
+            "leftFootIndex": {
+              "x": 56.5,
+              "y": 126.4,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 117.5,
+              "y": 22.3,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55,
+                "y": 18.9
+              },
+              "roll": -167,
+              "yaw": 1.012,
+              "pitch": 1.462
+            },
+            "torso": {
+              "center": {
+                "x": 48.3,
+                "y": 30
+              },
+              "angle": 99.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 81.7,
+                "y": 36.2
+              },
+              "angle": 4.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.2,
+                "y": 35.6
+              },
+              "angle": 29.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 44.9,
+                "y": 120.4
+              },
+              "angle": -27.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 110.9,
+                "y": 34.1
+              },
+              "angle": 60.8
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.98,
+          "keypoints": {
+            "nose": {
+              "x": 74.5,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.7,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.2,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.8,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.9,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78.2,
+              "y": 23.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.2,
+              "y": 24.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.8,
+              "y": 40.5,
+              "v": 0.987
+            },
+            "rightElbow": {
+              "x": 49.2,
+              "y": 33.8,
+              "v": 0.981
+            },
+            "leftWrist": {
+              "x": 90.4,
+              "y": 50.3,
+              "v": 0.986
+            },
+            "rightWrist": {
+              "x": 56.7,
+              "y": 37.6,
+              "v": 0.92
+            },
+            "leftIndex": {
+              "x": 90.2,
+              "y": 51.1,
+              "v": 0.981
+            },
+            "rightIndex": {
+              "x": 59.9,
+              "y": 37.2,
+              "v": 0.872
+            },
+            "leftHip": {
+              "x": 74,
+              "y": 60.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.5,
+              "y": 59.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.2,
+              "y": 87.9,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 49,
+              "y": 85.8,
+              "v": 0.993
+            },
+            "leftAnkle": {
+              "x": 91.5,
+              "y": 113.4,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 39.5,
+              "y": 113.9,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 91.6,
+              "y": 116.5,
+              "v": 0.916
+            },
+            "rightHeel": {
+              "x": 41,
+              "y": 118.8,
+              "v": 0.923
+            },
+            "leftFootIndex": {
+              "x": 92.1,
+              "y": 124,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 35.5,
+              "y": 124.7,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.5,
+                "y": 10.8
+              },
+              "roll": 173.2,
+              "yaw": 0.417,
+              "pitch": 0.933
+            },
+            "torso": {
+              "center": {
+                "x": 68.7,
+                "y": 24.1
+              },
+              "angle": 86.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.4,
+                "y": 50.3
+              },
+              "angle": -104
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 56.7,
+                "y": 37.6
+              },
+              "angle": 7.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 91.6,
+                "y": 116.5
+              },
+              "angle": -86.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41,
+                "y": 118.8
+              },
+              "angle": -133
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.944,
+          "keypoints": {
+            "nose": {
+              "x": 64.1,
+              "y": 26.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.8,
+              "y": 23.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.6,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.7,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.3,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.1,
+              "y": 33.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.6,
+              "y": 35.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.3,
+              "y": 36.1,
+              "v": 0.971
+            },
+            "rightElbow": {
+              "x": 46.6,
+              "y": 42.9,
+              "v": 0.951
+            },
+            "leftWrist": {
+              "x": 93.7,
+              "y": 35.9,
+              "v": 0.981
+            },
+            "rightWrist": {
+              "x": 48,
+              "y": 38.4,
+              "v": 0.688
+            },
+            "leftIndex": {
+              "x": 96.6,
+              "y": 36.5,
+              "v": 0.972
+            },
+            "rightIndex": {
+              "x": 52.5,
+              "y": 38.7,
+              "v": 0.631
+            },
+            "leftHip": {
+              "x": 55.5,
+              "y": 63.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.3,
+              "y": 62.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.7,
+              "y": 87.7,
+              "v": 0.932
+            },
+            "rightKnee": {
+              "x": 32.5,
+              "y": 89.1,
+              "v": 0.99
+            },
+            "leftAnkle": {
+              "x": 78.6,
+              "y": 114.6,
+              "v": 0.968
+            },
+            "rightAnkle": {
+              "x": 20,
+              "y": 114.3,
+              "v": 0.988
+            },
+            "leftHeel": {
+              "x": 77,
+              "y": 119.5,
+              "v": 0.884
+            },
+            "rightHeel": {
+              "x": 17.4,
+              "y": 117,
+              "v": 0.815
+            },
+            "leftFootIndex": {
+              "x": 85.5,
+              "y": 123.8,
+              "v": 0.97
+            },
+            "rightFootIndex": {
+              "x": 19.6,
+              "y": 124.3,
+              "v": 0.977
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.2,
+                "y": 23.5
+              },
+              "roll": -170.5,
+              "yaw": 1.562,
+              "pitch": 2.137
+            },
+            "torso": {
+              "center": {
+                "x": 55.9,
+                "y": 34.7
+              },
+              "angle": 78.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.7,
+                "y": 35.9
+              },
+              "angle": -11.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48,
+                "y": 38.4
+              },
+              "angle": -3.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 77,
+                "y": 119.5
+              },
+              "angle": -26.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 17.4,
+                "y": 117
+              },
+              "angle": -73.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.981,
+          "keypoints": {
+            "nose": {
+              "x": 58.5,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 57.9,
+              "y": 19.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.7,
+              "y": 19.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.2,
+              "y": 20.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.3,
+              "y": 20.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.7,
+              "y": 31.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41,
+              "y": 30.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73,
+              "y": 37.1,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 30.9,
+              "y": 36.6,
+              "v": 0.99
+            },
+            "leftWrist": {
+              "x": 88.7,
+              "y": 37,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 24.9,
+              "y": 42.8,
+              "v": 0.965
+            },
+            "leftIndex": {
+              "x": 92.8,
+              "y": 36.7,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 22.6,
+              "y": 43.6,
+              "v": 0.936
+            },
+            "leftHip": {
+              "x": 58.4,
+              "y": 60.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.9,
+              "y": 61.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.6,
+              "y": 86.8,
+              "v": 0.994
+            },
+            "rightKnee": {
+              "x": 33.5,
+              "y": 87.9,
+              "v": 0.991
+            },
+            "leftAnkle": {
+              "x": 82.5,
+              "y": 113.9,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 20.8,
+              "y": 116.2,
+              "v": 0.992
+            },
+            "leftHeel": {
+              "x": 83.4,
+              "y": 118,
+              "v": 0.849
+            },
+            "rightHeel": {
+              "x": 21.7,
+              "y": 121.6,
+              "v": 0.902
+            },
+            "leftFootIndex": {
+              "x": 83.4,
+              "y": 124.1,
+              "v": 0.986
+            },
+            "rightFootIndex": {
+              "x": 14.9,
+              "y": 125,
+              "v": 0.988
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.8,
+                "y": 19.9
+              },
+              "roll": -180,
+              "yaw": 0.773,
+              "pitch": 1.045
+            },
+            "torso": {
+              "center": {
+                "x": 50.4,
+                "y": 31.4
+              },
+              "angle": 92.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.7,
+                "y": 37
+              },
+              "angle": 4.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 24.9,
+                "y": 42.8
+              },
+              "angle": -160.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.4,
+                "y": 118
+              },
+              "angle": -90
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 21.7,
+                "y": 121.6
+              },
+              "angle": -153.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.971,
+          "keypoints": {
+            "nose": {
+              "x": 64,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.3,
+              "y": 10,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.5,
+              "y": 9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.9,
+              "y": 11,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.6,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.1,
+              "y": 22.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.7,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.6,
+              "y": 37.6,
+              "v": 0.972
+            },
+            "rightElbow": {
+              "x": 40.8,
+              "y": 38.1,
+              "v": 0.949
+            },
+            "leftWrist": {
+              "x": 81.6,
+              "y": 46.7,
+              "v": 0.973
+            },
+            "rightWrist": {
+              "x": 50.4,
+              "y": 34.6,
+              "v": 0.873
+            },
+            "leftIndex": {
+              "x": 82.1,
+              "y": 48.4,
+              "v": 0.967
+            },
+            "rightIndex": {
+              "x": 54.9,
+              "y": 32,
+              "v": 0.833
+            },
+            "leftHip": {
+              "x": 66.7,
+              "y": 57.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.1,
+              "y": 58,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.1,
+              "y": 84.4,
+              "v": 0.993
+            },
+            "rightKnee": {
+              "x": 44,
+              "y": 84.8,
+              "v": 0.976
+            },
+            "leftAnkle": {
+              "x": 87,
+              "y": 114.1,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 35.4,
+              "y": 115.1,
+              "v": 0.992
+            },
+            "leftHeel": {
+              "x": 88.5,
+              "y": 117.8,
+              "v": 0.909
+            },
+            "rightHeel": {
+              "x": 36.6,
+              "y": 120.5,
+              "v": 0.923
+            },
+            "leftFootIndex": {
+              "x": 86.7,
+              "y": 125.6,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 27.8,
+              "y": 124.2,
+              "v": 0.986
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.4,
+                "y": 9.5
+              },
+              "roll": 165.3,
+              "yaw": 0.153,
+              "pitch": 0.611
+            },
+            "torso": {
+              "center": {
+                "x": 57.9,
+                "y": 22.8
+              },
+              "angle": 92.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 81.6,
+                "y": 46.7
+              },
+              "angle": -73.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.4,
+                "y": 34.6
+              },
+              "angle": 30
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 88.5,
+                "y": 117.8
+              },
+              "angle": -103
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.6,
+                "y": 120.5
+              },
+              "angle": -157.2
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.957,
+          "keypoints": {
+            "nose": {
+              "x": 65.4,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.8,
+              "y": 9.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.7,
+              "y": 10.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 58.7,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72,
+              "y": 23.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.1,
+              "y": 25.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.3,
+              "y": 41.1,
+              "v": 0.962
+            },
+            "rightElbow": {
+              "x": 45.1,
+              "y": 38.2,
+              "v": 0.974
+            },
+            "leftWrist": {
+              "x": 81.2,
+              "y": 47.4,
+              "v": 0.969
+            },
+            "rightWrist": {
+              "x": 63.2,
+              "y": 32.5,
+              "v": 0.944
+            },
+            "leftIndex": {
+              "x": 81.9,
+              "y": 47.3,
+              "v": 0.967
+            },
+            "rightIndex": {
+              "x": 69.9,
+              "y": 29.6,
+              "v": 0.899
+            },
+            "leftHip": {
+              "x": 68.8,
+              "y": 57.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54.6,
+              "y": 58.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.6,
+              "y": 84.7,
+              "v": 0.961
+            },
+            "rightKnee": {
+              "x": 45.6,
+              "y": 86.2,
+              "v": 0.888
+            },
+            "leftAnkle": {
+              "x": 88.6,
+              "y": 114.2,
+              "v": 0.973
+            },
+            "rightAnkle": {
+              "x": 37.3,
+              "y": 114.4,
+              "v": 0.962
+            },
+            "leftHeel": {
+              "x": 89.3,
+              "y": 118.1,
+              "v": 0.814
+            },
+            "rightHeel": {
+              "x": 38.8,
+              "y": 119.8,
+              "v": 0.79
+            },
+            "leftFootIndex": {
+              "x": 88.6,
+              "y": 124.3,
+              "v": 0.964
+            },
+            "rightFootIndex": {
+              "x": 29.9,
+              "y": 123.8,
+              "v": 0.949
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.9,
+                "y": 9.6
+              },
+              "roll": -180,
+              "yaw": 0.395,
+              "pitch": 0.605
+            },
+            "torso": {
+              "center": {
+                "x": 61.6,
+                "y": 24.6
+              },
+              "angle": 90.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 81.2,
+                "y": 47.4
+              },
+              "angle": 8.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 63.2,
+                "y": 32.5
+              },
+              "angle": 23.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 89.3,
+                "y": 118.1
+              },
+              "angle": -96.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.8,
+                "y": 119.8
+              },
+              "angle": -155.8
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.95,
+          "keypoints": {
+            "nose": {
+              "x": 70.9,
+              "y": 13.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.9,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.1,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.2,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.3,
+              "y": 23,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.9,
+              "y": 25.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.6,
+              "y": 39.6,
+              "v": 0.987
+            },
+            "rightElbow": {
+              "x": 52.1,
+              "y": 39.6,
+              "v": 0.594
+            },
+            "leftWrist": {
+              "x": 88,
+              "y": 46.2,
+              "v": 0.987
+            },
+            "rightWrist": {
+              "x": 42.5,
+              "y": 41.4,
+              "v": 0.765
+            },
+            "leftIndex": {
+              "x": 89.3,
+              "y": 47.4,
+              "v": 0.982
+            },
+            "rightIndex": {
+              "x": 38.9,
+              "y": 40.9,
+              "v": 0.79
+            },
+            "leftHip": {
+              "x": 66.7,
+              "y": 55.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.6,
+              "y": 56.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.9,
+              "y": 78.5,
+              "v": 0.989
+            },
+            "rightKnee": {
+              "x": 50.2,
+              "y": 83.5,
+              "v": 0.975
+            },
+            "leftAnkle": {
+              "x": 76.8,
+              "y": 103.5,
+              "v": 0.981
+            },
+            "rightAnkle": {
+              "x": 42.3,
+              "y": 112.3,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 77.1,
+              "y": 106.6,
+              "v": 0.884
+            },
+            "rightHeel": {
+              "x": 43.4,
+              "y": 115.9,
+              "v": 0.956
+            },
+            "leftFootIndex": {
+              "x": 75,
+              "y": 114.1,
+              "v": 0.975
+            },
+            "rightFootIndex": {
+              "x": 39.2,
+              "y": 119.4,
+              "v": 0.987
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.5,
+                "y": 10.8
+              },
+              "roll": 175.9,
+              "yaw": 0.499,
+              "pitch": 0.962
+            },
+            "torso": {
+              "center": {
+                "x": 66.1,
+                "y": 24.4
+              },
+              "angle": 82
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88,
+                "y": 46.2
+              },
+              "angle": -42.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 42.5,
+                "y": 41.4
+              },
+              "angle": 172.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 77.1,
+                "y": 106.6
+              },
+              "angle": -105.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.4,
+                "y": 115.9
+              },
+              "angle": -140.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.978,
+          "keypoints": {
+            "nose": {
+              "x": 70.7,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.3,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.9,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.7,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.7,
+              "y": 23.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.4,
+              "y": 24.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.5,
+              "y": 39.3,
+              "v": 0.982
+            },
+            "rightElbow": {
+              "x": 50,
+              "y": 37.1,
+              "v": 0.993
+            },
+            "leftWrist": {
+              "x": 87.8,
+              "y": 46.3,
+              "v": 0.981
+            },
+            "rightWrist": {
+              "x": 62,
+              "y": 33.3,
+              "v": 0.974
+            },
+            "leftIndex": {
+              "x": 88.5,
+              "y": 47.3,
+              "v": 0.975
+            },
+            "rightIndex": {
+              "x": 67,
+              "y": 31.4,
+              "v": 0.946
+            },
+            "leftHip": {
+              "x": 72.4,
+              "y": 58,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.3,
+              "y": 57.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.9,
+              "y": 85.5,
+              "v": 0.98
+            },
+            "rightKnee": {
+              "x": 48.9,
+              "y": 85.1,
+              "v": 0.958
+            },
+            "leftAnkle": {
+              "x": 91.4,
+              "y": 113.5,
+              "v": 0.99
+            },
+            "rightAnkle": {
+              "x": 40.5,
+              "y": 114.6,
+              "v": 0.989
+            },
+            "leftHeel": {
+              "x": 92.6,
+              "y": 117.3,
+              "v": 0.873
+            },
+            "rightHeel": {
+              "x": 42.1,
+              "y": 120.6,
+              "v": 0.897
+            },
+            "leftFootIndex": {
+              "x": 91.6,
+              "y": 124.8,
+              "v": 0.983
+            },
+            "rightFootIndex": {
+              "x": 31.8,
+              "y": 124.6,
+              "v": 0.982
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.6,
+                "y": 10.5
+              },
+              "roll": -173.3,
+              "yaw": 0.613,
+              "pitch": 0.701
+            },
+            "torso": {
+              "center": {
+                "x": 64.6,
+                "y": 24.2
+              },
+              "angle": 90.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.8,
+                "y": 46.3
+              },
+              "angle": -55
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 62,
+                "y": 33.3
+              },
+              "angle": 20.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.6,
+                "y": 117.3
+              },
+              "angle": -97.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.1,
+                "y": 120.6
+              },
+              "angle": -158.8
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.903,
+          "keypoints": {
+            "nose": {
+              "x": 53.2,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.9,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51.3,
+              "y": 13,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.5,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.8,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.9,
+              "y": 20.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.9,
+              "y": 26,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.5,
+              "y": 36.9,
+              "v": 0.977
+            },
+            "rightElbow": {
+              "x": 42.1,
+              "y": 33.2,
+              "v": 0.638
+            },
+            "leftWrist": {
+              "x": 88.1,
+              "y": 53.2,
+              "v": 0.935
+            },
+            "rightWrist": {
+              "x": 50.6,
+              "y": 28.9,
+              "v": 0.46
+            },
+            "leftIndex": {
+              "x": 90.4,
+              "y": 57.9,
+              "v": 0.914
+            },
+            "rightIndex": {
+              "x": 53.1,
+              "y": 27,
+              "v": 0.42
+            },
+            "leftHip": {
+              "x": 70.7,
+              "y": 58.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.3,
+              "y": 59.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.1,
+              "y": 85.6,
+              "v": 0.974
+            },
+            "rightKnee": {
+              "x": 48.7,
+              "y": 85.1,
+              "v": 0.941
+            },
+            "leftAnkle": {
+              "x": 91.6,
+              "y": 113.4,
+              "v": 0.974
+            },
+            "rightAnkle": {
+              "x": 40,
+              "y": 115.2,
+              "v": 0.972
+            },
+            "leftHeel": {
+              "x": 92.8,
+              "y": 115.5,
+              "v": 0.744
+            },
+            "rightHeel": {
+              "x": 42,
+              "y": 120.4,
+              "v": 0.884
+            },
+            "leftFootIndex": {
+              "x": 89.9,
+              "y": 125.4,
+              "v": 0.955
+            },
+            "rightFootIndex": {
+              "x": 32.3,
+              "y": 123.8,
+              "v": 0.97
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.1,
+                "y": 12.3
+              },
+              "roll": -157.4,
+              "yaw": 0.026,
+              "pitch": 0.526
+            },
+            "torso": {
+              "center": {
+                "x": 59.9,
+                "y": 23.3
+              },
+              "angle": 97.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.1,
+                "y": 53.2
+              },
+              "angle": -63.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.6,
+                "y": 28.9
+              },
+              "angle": 37.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.8,
+                "y": 115.5
+              },
+              "angle": -106.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42,
+                "y": 120.4
+              },
+              "angle": -160.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.818,
+          "keypoints": {
+            "nose": {
+              "x": 96.8,
+              "y": 22.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 97.2,
+              "y": 20.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 94.3,
+              "y": 19.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 95.2,
+              "y": 20.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 90,
+              "y": 19.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 90.6,
+              "y": 30.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 79.5,
+              "y": 25.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 90.7,
+              "y": 33.6,
+              "v": 0.021
+            },
+            "rightElbow": {
+              "x": 68.4,
+              "y": 30.8,
+              "v": 0.966
+            },
+            "leftWrist": {
+              "x": 85.8,
+              "y": 31.4,
+              "v": 0.025
+            },
+            "rightWrist": {
+              "x": 73.7,
+              "y": 33.1,
+              "v": 0.951
+            },
+            "leftIndex": {
+              "x": 83.4,
+              "y": 30.3,
+              "v": 0.055
+            },
+            "rightIndex": {
+              "x": 76.7,
+              "y": 33.1,
+              "v": 0.946
+            },
+            "leftHip": {
+              "x": 77,
+              "y": 61.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.7,
+              "y": 59.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 93.8,
+              "y": 83,
+              "v": 0.629
+            },
+            "rightKnee": {
+              "x": 62.2,
+              "y": 86.7,
+              "v": 0.973
+            },
+            "leftAnkle": {
+              "x": 86.8,
+              "y": 112.1,
+              "v": 0.801
+            },
+            "rightAnkle": {
+              "x": 46.6,
+              "y": 112.8,
+              "v": 0.986
+            },
+            "leftHeel": {
+              "x": 83.8,
+              "y": 116.5,
+              "v": 0.743
+            },
+            "rightHeel": {
+              "x": 43.4,
+              "y": 114.5,
+              "v": 0.871
+            },
+            "leftFootIndex": {
+              "x": 96.1,
+              "y": 120.2,
+              "v": 0.869
+            },
+            "rightFootIndex": {
+              "x": 45.5,
+              "y": 125.9,
+              "v": 0.977
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 95.8,
+                "y": 19.9
+              },
+              "roll": 164.6,
+              "yaw": 0.349,
+              "pitch": 0.931
+            },
+            "torso": {
+              "center": {
+                "x": 85.1,
+                "y": 28.3
+              },
+              "angle": 67.7
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 73.7,
+                "y": 33.1
+              },
+              "angle": 0
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.8,
+                "y": 116.5
+              },
+              "angle": -16.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.4,
+                "y": 114.5
+              },
+              "angle": -79.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.873,
+          "keypoints": {
+            "nose": {
+              "x": 64.2,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.4,
+              "y": 10.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62.3,
+              "y": 8.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.2,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.5,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.8,
+              "y": 23.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.4,
+              "y": 24.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.4,
+              "y": 38.6,
+              "v": 0.91
+            },
+            "rightElbow": {
+              "x": 43.3,
+              "y": 38.4,
+              "v": 0.739
+            },
+            "leftWrist": {
+              "x": 68.5,
+              "y": 42.8,
+              "v": 0.625
+            },
+            "rightWrist": {
+              "x": 52.3,
+              "y": 45,
+              "v": 0.378
+            },
+            "leftIndex": {
+              "x": 64.8,
+              "y": 43.5,
+              "v": 0.613
+            },
+            "rightIndex": {
+              "x": 56.7,
+              "y": 45.9,
+              "v": 0.391
+            },
+            "leftHip": {
+              "x": 70.6,
+              "y": 57.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.4,
+              "y": 58.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.8,
+              "y": 84.9,
+              "v": 0.976
+            },
+            "rightKnee": {
+              "x": 49.1,
+              "y": 85.4,
+              "v": 0.914
+            },
+            "leftAnkle": {
+              "x": 91.1,
+              "y": 114.4,
+              "v": 0.967
+            },
+            "rightAnkle": {
+              "x": 40.5,
+              "y": 115,
+              "v": 0.983
+            },
+            "leftHeel": {
+              "x": 92.1,
+              "y": 118,
+              "v": 0.775
+            },
+            "rightHeel": {
+              "x": 42.1,
+              "y": 120.2,
+              "v": 0.879
+            },
+            "leftFootIndex": {
+              "x": 90.7,
+              "y": 122.2,
+              "v": 0.955
+            },
+            "rightFootIndex": {
+              "x": 32,
+              "y": 123,
+              "v": 0.971
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.4,
+                "y": 9.5
+              },
+              "roll": 162.4,
+              "yaw": -0.035,
+              "pitch": 0.43
+            },
+            "torso": {
+              "center": {
+                "x": 61.6,
+                "y": 24.1
+              },
+              "angle": 94
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 68.5,
+                "y": 42.8
+              },
+              "angle": -169.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52.3,
+                "y": 45
+              },
+              "angle": -11.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.1,
+                "y": 118
+              },
+              "angle": -108.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.1,
+                "y": 120.2
+              },
+              "angle": -164.5
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.98,
+          "keypoints": {
+            "nose": {
+              "x": 75.7,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.8,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.2,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.2,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.5,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.4,
+              "y": 27,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.1,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.2,
+              "y": 45.3,
+              "v": 0.945
+            },
+            "rightElbow": {
+              "x": 49,
+              "y": 42.5,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 81.5,
+              "y": 59.3,
+              "v": 0.993
+            },
+            "rightWrist": {
+              "x": 41.7,
+              "y": 60.1,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 83.6,
+              "y": 63.7,
+              "v": 0.99
+            },
+            "rightIndex": {
+              "x": 42,
+              "y": 65.6,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 70.5,
+              "y": 58.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.9,
+              "y": 57.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 85.8,
+              "y": 85.5,
+              "v": 0.979
+            },
+            "rightKnee": {
+              "x": 45.2,
+              "y": 86.7,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 94.3,
+              "y": 115.4,
+              "v": 0.982
+            },
+            "rightAnkle": {
+              "x": 30.7,
+              "y": 113.1,
+              "v": 0.989
+            },
+            "leftHeel": {
+              "x": 92.3,
+              "y": 121.1,
+              "v": 0.917
+            },
+            "rightHeel": {
+              "x": 29.5,
+              "y": 116.1,
+              "v": 0.785
+            },
+            "leftFootIndex": {
+              "x": 100.8,
+              "y": 124.5,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 29.5,
+              "y": 124.9,
+              "v": 0.987
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.5,
+                "y": 11.5
+              },
+              "roll": 169.1,
+              "yaw": 0.453,
+              "pitch": 1.076
+            },
+            "torso": {
+              "center": {
+                "x": 66.8,
+                "y": 25.6
+              },
+              "angle": 85.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 81.5,
+                "y": 59.3
+              },
+              "angle": -64.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.7,
+                "y": 60.1
+              },
+              "angle": -86.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.3,
+                "y": 121.1
+              },
+              "angle": -21.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29.5,
+                "y": 116.1
+              },
+              "angle": -90
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.988,
+          "keypoints": {
+            "nose": {
+              "x": 69.6,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.6,
+              "y": 9.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.5,
+              "y": 8.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.1,
+              "y": 10.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.2,
+              "y": 9.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.7,
+              "y": 23.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.7,
+              "y": 24.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85,
+              "y": 39.6,
+              "v": 0.999
+            },
+            "rightElbow": {
+              "x": 51.1,
+              "y": 39.9,
+              "v": 0.988
+            },
+            "leftWrist": {
+              "x": 87.8,
+              "y": 46.1,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 59.6,
+              "y": 45.5,
+              "v": 0.95
+            },
+            "leftIndex": {
+              "x": 86.8,
+              "y": 47.4,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 63.9,
+              "y": 46,
+              "v": 0.933
+            },
+            "leftHip": {
+              "x": 71.6,
+              "y": 59.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.5,
+              "y": 59.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.3,
+              "y": 86.8,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 49.5,
+              "y": 84.6,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 91.8,
+              "y": 114,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 41.5,
+              "y": 114.7,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 92.5,
+              "y": 117.2,
+              "v": 0.942
+            },
+            "rightHeel": {
+              "x": 42.8,
+              "y": 118.5,
+              "v": 0.94
+            },
+            "leftFootIndex": {
+              "x": 92.5,
+              "y": 127.6,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 36.2,
+              "y": 125.7,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.1,
+                "y": 9
+              },
+              "roll": 162.1,
+              "yaw": 0.476,
+              "pitch": 0.706
+            },
+            "torso": {
+              "center": {
+                "x": 64.7,
+                "y": 24
+              },
+              "angle": 89.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.8,
+                "y": 46.1
+              },
+              "angle": -127.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 59.6,
+                "y": 45.5
+              },
+              "angle": -6.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.5,
+                "y": 117.2
+              },
+              "angle": -90
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.8,
+                "y": 118.5
+              },
+              "angle": -132.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.959,
+          "keypoints": {
+            "nose": {
+              "x": 69.6,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70,
+              "y": 9.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.5,
+              "y": 9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.9,
+              "y": 10.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.4,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.7,
+              "y": 22.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.3,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.8,
+              "y": 36.9,
+              "v": 0.995
+            },
+            "rightElbow": {
+              "x": 47.8,
+              "y": 39.3,
+              "v": 0.946
+            },
+            "leftWrist": {
+              "x": 85.7,
+              "y": 46.8,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 55.4,
+              "y": 50.4,
+              "v": 0.696
+            },
+            "leftIndex": {
+              "x": 86.5,
+              "y": 48,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 59.3,
+              "y": 53.5,
+              "v": 0.64
+            },
+            "leftHip": {
+              "x": 71,
+              "y": 58.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.1,
+              "y": 58,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.8,
+              "y": 85.5,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 49,
+              "y": 85.5,
+              "v": 0.981
+            },
+            "leftAnkle": {
+              "x": 91.7,
+              "y": 114.3,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 40.2,
+              "y": 115.1,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 92.1,
+              "y": 118.7,
+              "v": 0.918
+            },
+            "rightHeel": {
+              "x": 41.7,
+              "y": 121,
+              "v": 0.933
+            },
+            "leftFootIndex": {
+              "x": 91.2,
+              "y": 126.1,
+              "v": 0.992
+            },
+            "rightFootIndex": {
+              "x": 31.7,
+              "y": 124.5,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.3,
+                "y": 9.3
+              },
+              "roll": 171.9,
+              "yaw": 0.382,
+              "pitch": 0.665
+            },
+            "torso": {
+              "center": {
+                "x": 64,
+                "y": 23.4
+              },
+              "angle": 90.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.7,
+                "y": 46.8
+              },
+              "angle": -56.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 55.4,
+                "y": 50.4
+              },
+              "angle": -38.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.1,
+                "y": 118.7
+              },
+              "angle": -96.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.7,
+                "y": 121
+              },
+              "angle": -160.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.962,
+          "keypoints": {
+            "nose": {
+              "x": 85.3,
+              "y": 22.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 85,
+              "y": 20.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 83,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 83.6,
+              "y": 20.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 79.1,
+              "y": 20.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 83.7,
+              "y": 33.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 73.2,
+              "y": 30.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.7,
+              "y": 48.9,
+              "v": 0.563
+            },
+            "rightElbow": {
+              "x": 71.7,
+              "y": 45.4,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 96,
+              "y": 41.9,
+              "v": 0.922
+            },
+            "rightWrist": {
+              "x": 72.3,
+              "y": 61.1,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 98.8,
+              "y": 39,
+              "v": 0.937
+            },
+            "rightIndex": {
+              "x": 73.6,
+              "y": 64.7,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 80,
+              "y": 63.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 73.4,
+              "y": 63.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 104.7,
+              "y": 63.5,
+              "v": 0.959
+            },
+            "rightKnee": {
+              "x": 86.7,
+              "y": 84.3,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 90.4,
+              "y": 86.9,
+              "v": 0.906
+            },
+            "rightAnkle": {
+              "x": 79.6,
+              "y": 113.5,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 85.3,
+              "y": 89.7,
+              "v": 0.916
+            },
+            "rightHeel": {
+              "x": 76,
+              "y": 116.6,
+              "v": 0.993
+            },
+            "leftFootIndex": {
+              "x": 93.6,
+              "y": 98.3,
+              "v": 0.937
+            },
+            "rightFootIndex": {
+              "x": 83.6,
+              "y": 120,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 84,
+                "y": 20.2
+              },
+              "roll": 174.3,
+              "yaw": 0.647,
+              "pitch": 1.045
+            },
+            "torso": {
+              "center": {
+                "x": 78.5,
+                "y": 32
+              },
+              "angle": 86.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96,
+                "y": 41.9
+              },
+              "angle": 46
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72.3,
+                "y": 61.1
+              },
+              "angle": -70.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85.3,
+                "y": 89.7
+              },
+              "angle": -46
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 76,
+                "y": 116.6
+              },
+              "angle": -24.1
+            }
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.975,
+          "keypoints": {
+            "nose": {
+              "x": 69.1,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.4,
+              "y": 10.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.2,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.7,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.2,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.3,
+              "y": 24.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.7,
+              "y": 25,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.9,
+              "y": 39.9,
+              "v": 0.97
+            },
+            "rightElbow": {
+              "x": 42.5,
+              "y": 35.3,
+              "v": 0.928
+            },
+            "leftWrist": {
+              "x": 86.1,
+              "y": 46.9,
+              "v": 0.993
+            },
+            "rightWrist": {
+              "x": 38.6,
+              "y": 22,
+              "v": 0.991
+            },
+            "leftIndex": {
+              "x": 86.1,
+              "y": 47.6,
+              "v": 0.993
+            },
+            "rightIndex": {
+              "x": 39.2,
+              "y": 16.3,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 71.6,
+              "y": 58.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.3,
+              "y": 59.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.5,
+              "y": 86.6,
+              "v": 0.972
+            },
+            "rightKnee": {
+              "x": 48.6,
+              "y": 86.8,
+              "v": 0.932
+            },
+            "leftAnkle": {
+              "x": 91.4,
+              "y": 113.7,
+              "v": 0.985
+            },
+            "rightAnkle": {
+              "x": 40.7,
+              "y": 114.7,
+              "v": 0.982
+            },
+            "leftHeel": {
+              "x": 92.8,
+              "y": 117.3,
+              "v": 0.837
+            },
+            "rightHeel": {
+              "x": 42.2,
+              "y": 119.9,
+              "v": 0.886
+            },
+            "leftFootIndex": {
+              "x": 91.5,
+              "y": 124.3,
+              "v": 0.983
+            },
+            "rightFootIndex": {
+              "x": 33,
+              "y": 124.2,
+              "v": 0.977
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.3,
+                "y": 10.3
+              },
+              "roll": 174.6,
+              "yaw": 0.19,
+              "pitch": 0.664
+            },
+            "torso": {
+              "center": {
+                "x": 64.5,
+                "y": 24.6
+              },
+              "angle": 89.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.1,
+                "y": 46.9
+              },
+              "angle": -90
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.6,
+                "y": 22
+              },
+              "angle": 84
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.8,
+                "y": 117.3
+              },
+              "angle": -100.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.2,
+                "y": 119.9
+              },
+              "angle": -154.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.985,
+          "keypoints": {
+            "nose": {
+              "x": 69.1,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.8,
+              "y": 10.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.8,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.4,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.9,
+              "y": 24.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.4,
+              "y": 24.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.1,
+              "y": 41,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 45.9,
+              "y": 36.6,
+              "v": 0.963
+            },
+            "leftWrist": {
+              "x": 87.6,
+              "y": 47.1,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 47.9,
+              "y": 37.8,
+              "v": 0.93
+            },
+            "leftIndex": {
+              "x": 86.2,
+              "y": 47.6,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 50,
+              "y": 37,
+              "v": 0.923
+            },
+            "leftHip": {
+              "x": 72.3,
+              "y": 60.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.6,
+              "y": 59.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.4,
+              "y": 86,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 49,
+              "y": 85.3,
+              "v": 0.986
+            },
+            "leftAnkle": {
+              "x": 91,
+              "y": 113.4,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 40.3,
+              "y": 115.5,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 92.5,
+              "y": 117.5,
+              "v": 0.935
+            },
+            "rightHeel": {
+              "x": 41.7,
+              "y": 121,
+              "v": 0.963
+            },
+            "leftFootIndex": {
+              "x": 91.5,
+              "y": 125,
+              "v": 0.992
+            },
+            "rightFootIndex": {
+              "x": 31.1,
+              "y": 124.4,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.9,
+                "y": 10.5
+              },
+              "roll": -172.5,
+              "yaw": 0.313,
+              "pitch": 0.613
+            },
+            "torso": {
+              "center": {
+                "x": 64.7,
+                "y": 24.6
+              },
+              "angle": 90.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.6,
+                "y": 47.1
+              },
+              "angle": -160.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.9,
+                "y": 37.8
+              },
+              "angle": 20.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.5,
+                "y": 117.5
+              },
+              "angle": -97.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.7,
+                "y": 121
+              },
+              "angle": -162.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.914,
+          "keypoints": {
+            "nose": {
+              "x": 68.9,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.7,
+              "y": 10.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.6,
+              "y": 11,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.8,
+              "y": 11,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75,
+              "y": 23.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54,
+              "y": 25.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.6,
+              "y": 40.6,
+              "v": 0.977
+            },
+            "rightElbow": {
+              "x": 48.7,
+              "y": 38.9,
+              "v": 0.77
+            },
+            "leftWrist": {
+              "x": 86,
+              "y": 46.3,
+              "v": 0.987
+            },
+            "rightWrist": {
+              "x": 57.7,
+              "y": 39.3,
+              "v": 0.384
+            },
+            "leftIndex": {
+              "x": 85.9,
+              "y": 48.1,
+              "v": 0.984
+            },
+            "rightIndex": {
+              "x": 62,
+              "y": 38,
+              "v": 0.37
+            },
+            "leftHip": {
+              "x": 71.7,
+              "y": 58.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.3,
+              "y": 58.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.3,
+              "y": 86.6,
+              "v": 0.983
+            },
+            "rightKnee": {
+              "x": 48.2,
+              "y": 86.2,
+              "v": 0.945
+            },
+            "leftAnkle": {
+              "x": 91.3,
+              "y": 114.3,
+              "v": 0.988
+            },
+            "rightAnkle": {
+              "x": 40,
+              "y": 114.6,
+              "v": 0.983
+            },
+            "leftHeel": {
+              "x": 92.3,
+              "y": 117.7,
+              "v": 0.829
+            },
+            "rightHeel": {
+              "x": 41.8,
+              "y": 120.1,
+              "v": 0.876
+            },
+            "leftFootIndex": {
+              "x": 91.8,
+              "y": 125.7,
+              "v": 0.98
+            },
+            "rightFootIndex": {
+              "x": 32.5,
+              "y": 124.4,
+              "v": 0.974
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.9,
+                "y": 10.1
+              },
+              "roll": -180,
+              "yaw": 0.284,
+              "pitch": 0.703
+            },
+            "torso": {
+              "center": {
+                "x": 64.5,
+                "y": 24.5
+              },
+              "angle": 90
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86,
+                "y": 46.3
+              },
+              "angle": -93.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 57.7,
+                "y": 39.3
+              },
+              "angle": 16.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.3,
+                "y": 117.7
+              },
+              "angle": -93.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.8,
+                "y": 120.1
+              },
+              "angle": -155.2
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.962,
+          "keypoints": {
+            "nose": {
+              "x": 72.4,
+              "y": 24.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.8,
+              "y": 23,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.8,
+              "y": 23.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.6,
+              "y": 23.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.4,
+              "y": 23.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.4,
+              "y": 34.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.4,
+              "y": 34.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.9,
+              "y": 31.2,
+              "v": 0.945
+            },
+            "rightElbow": {
+              "x": 47.7,
+              "y": 44.1,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 98.3,
+              "y": 24.1,
+              "v": 0.99
+            },
+            "rightWrist": {
+              "x": 54.2,
+              "y": 41.2,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 101,
+              "y": 21.1,
+              "v": 0.989
+            },
+            "rightIndex": {
+              "x": 57.1,
+              "y": 38.6,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 72.2,
+              "y": 63.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.6,
+              "y": 62.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.3,
+              "y": 89.9,
+              "v": 0.839
+            },
+            "rightKnee": {
+              "x": 50.6,
+              "y": 90.1,
+              "v": 0.972
+            },
+            "leftAnkle": {
+              "x": 84.2,
+              "y": 115.8,
+              "v": 0.949
+            },
+            "rightAnkle": {
+              "x": 41,
+              "y": 115.3,
+              "v": 0.97
+            },
+            "leftHeel": {
+              "x": 82.3,
+              "y": 121.2,
+              "v": 0.868
+            },
+            "rightHeel": {
+              "x": 39.3,
+              "y": 118.5,
+              "v": 0.712
+            },
+            "leftFootIndex": {
+              "x": 90.6,
+              "y": 123.9,
+              "v": 0.962
+            },
+            "rightFootIndex": {
+              "x": 40.7,
+              "y": 126.2,
+              "v": 0.96
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.3,
+                "y": 23.1
+              },
+              "roll": -174.3,
+              "yaw": 2.09,
+              "pitch": 1.841
+            },
+            "torso": {
+              "center": {
+                "x": 64.9,
+                "y": 34.4
+              },
+              "angle": 93
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.3,
+                "y": 24.1
+              },
+              "angle": 48
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 54.2,
+                "y": 41.2
+              },
+              "angle": 41.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 82.3,
+                "y": 121.2
+              },
+              "angle": -18
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.3,
+                "y": 118.5
+              },
+              "angle": -79.7
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.829,
+          "keypoints": {
+            "nose": {
+              "x": 54.2,
+              "y": 16.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.1,
+              "y": 13.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.9,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60.9,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.2,
+              "y": 13,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.6,
+              "y": 23,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.2,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.3,
+              "y": 46.5,
+              "v": 0.997
+            },
+            "rightElbow": {
+              "x": 57.7,
+              "y": 42.8,
+              "v": 0.182
+            },
+            "leftWrist": {
+              "x": 70.5,
+              "y": 62.2,
+              "v": 0.992
+            },
+            "rightWrist": {
+              "x": 57.7,
+              "y": 57.4,
+              "v": 0.105
+            },
+            "leftIndex": {
+              "x": 67.6,
+              "y": 66.6,
+              "v": 0.981
+            },
+            "rightIndex": {
+              "x": 58.2,
+              "y": 62.8,
+              "v": 0.107
+            },
+            "leftHip": {
+              "x": 77.7,
+              "y": 57.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.6,
+              "y": 57.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 85.6,
+              "y": 86.9,
+              "v": 0.912
+            },
+            "rightKnee": {
+              "x": 53.1,
+              "y": 83.3,
+              "v": 0.756
+            },
+            "leftAnkle": {
+              "x": 96.4,
+              "y": 114.4,
+              "v": 0.945
+            },
+            "rightAnkle": {
+              "x": 44.9,
+              "y": 112.5,
+              "v": 0.903
+            },
+            "leftHeel": {
+              "x": 97.8,
+              "y": 118.4,
+              "v": 0.607
+            },
+            "rightHeel": {
+              "x": 46.7,
+              "y": 118,
+              "v": 0.727
+            },
+            "leftFootIndex": {
+              "x": 95.3,
+              "y": 125.1,
+              "v": 0.939
+            },
+            "rightFootIndex": {
+              "x": 36.9,
+              "y": 120.6,
+              "v": 0.925
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55,
+                "y": 13.5
+              },
+              "roll": -174.8,
+              "yaw": -0.362,
+              "pitch": 1.449
+            },
+            "torso": {
+              "center": {
+                "x": 65.9,
+                "y": 23.8
+              },
+              "angle": 98.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 70.5,
+                "y": 62.2
+              },
+              "angle": -123.4
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 97.8,
+                "y": 118.4
+              },
+              "angle": -110.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 46.7,
+                "y": 118
+              },
+              "angle": -165.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.865,
+          "keypoints": {
+            "nose": {
+              "x": 31.4,
+              "y": 16.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 32.2,
+              "y": 14,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 31.3,
+              "y": 14.3,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 36.8,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 35.3,
+              "y": 12.8,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 52.1,
+              "y": 19.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.3,
+              "y": 24.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 56.8,
+              "y": 39.4,
+              "v": 0.998
+            },
+            "rightElbow": {
+              "x": 42.5,
+              "y": 42.9,
+              "v": 0.069
+            },
+            "leftWrist": {
+              "x": 59.2,
+              "y": 56.7,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 42.6,
+              "y": 56.8,
+              "v": 0.12
+            },
+            "leftIndex": {
+              "x": 59,
+              "y": 62.3,
+              "v": 0.99
+            },
+            "rightIndex": {
+              "x": 41.9,
+              "y": 60.5,
+              "v": 0.151
+            },
+            "leftHip": {
+              "x": 57.4,
+              "y": 57.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.8,
+              "y": 57.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 66,
+              "y": 84.5,
+              "v": 0.991
+            },
+            "rightKnee": {
+              "x": 44.6,
+              "y": 84.4,
+              "v": 0.901
+            },
+            "leftAnkle": {
+              "x": 75.1,
+              "y": 113.1,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 39.9,
+              "y": 111.5,
+              "v": 0.95
+            },
+            "leftHeel": {
+              "x": 76.8,
+              "y": 116.2,
+              "v": 0.928
+            },
+            "rightHeel": {
+              "x": 41.7,
+              "y": 116.2,
+              "v": 0.854
+            },
+            "leftFootIndex": {
+              "x": 73.6,
+              "y": 126,
+              "v": 0.992
+            },
+            "rightFootIndex": {
+              "x": 32,
+              "y": 119.6,
+              "v": 0.964
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 31.8,
+                "y": 14.2
+              },
+              "roll": -161.6,
+              "yaw": -0.369,
+              "pitch": 2.899
+            },
+            "torso": {
+              "center": {
+                "x": 45.7,
+                "y": 22
+              },
+              "angle": 99.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 59.2,
+                "y": 56.7
+              },
+              "angle": -92
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 76.8,
+                "y": 116.2
+              },
+              "angle": -108.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.7,
+                "y": 116.2
+              },
+              "angle": -160.7
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.698,
+          "keypoints": {
+            "nose": {
+              "x": 90.5,
+              "y": 29.1,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 91.7,
+              "y": 25.7,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 92,
+              "y": 25.7,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 88.8,
+              "y": 22.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 88.8,
+              "y": 22.6,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 74,
+              "y": 24.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 72.8,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 64.9,
+              "y": 41.4,
+              "v": 0.07
+            },
+            "rightElbow": {
+              "x": 69.4,
+              "y": 41.3,
+              "v": 0.957
+            },
+            "leftWrist": {
+              "x": 68,
+              "y": 61.1,
+              "v": 0.098
+            },
+            "rightWrist": {
+              "x": 68.3,
+              "y": 61.4,
+              "v": 0.784
+            },
+            "leftIndex": {
+              "x": 68,
+              "y": 66.9,
+              "v": 0.118
+            },
+            "rightIndex": {
+              "x": 69.3,
+              "y": 67.1,
+              "v": 0.667
+            },
+            "leftHip": {
+              "x": 52.5,
+              "y": 51,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.5,
+              "y": 50.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63.8,
+              "y": 79.8,
+              "v": 0.139
+            },
+            "rightKnee": {
+              "x": 60.2,
+              "y": 81.4,
+              "v": 0.83
+            },
+            "leftAnkle": {
+              "x": 61.5,
+              "y": 113.5,
+              "v": 0.278
+            },
+            "rightAnkle": {
+              "x": 58.6,
+              "y": 114.3,
+              "v": 0.856
+            },
+            "leftHeel": {
+              "x": 59,
+              "y": 117.7,
+              "v": 0.271
+            },
+            "rightHeel": {
+              "x": 56.1,
+              "y": 119,
+              "v": 0.733
+            },
+            "leftFootIndex": {
+              "x": 69.6,
+              "y": 122.8,
+              "v": 0.441
+            },
+            "rightFootIndex": {
+              "x": 66.1,
+              "y": 124.1,
+              "v": 0.819
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 91.9,
+                "y": 25.7
+              },
+              "roll": 0,
+              "yaw": -4.5,
+              "pitch": 11.333
+            },
+            "torso": {
+              "center": {
+                "x": 73.4,
+                "y": 24.2
+              },
+              "angle": 48.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 68.3,
+                "y": 61.4
+              },
+              "angle": -80
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 56.1,
+                "y": 119
+              },
+              "angle": -27
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.976,
+          "keypoints": {
+            "nose": {
+              "x": 73.6,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.3,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.5,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.7,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.6,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.1,
+              "y": 22.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.1,
+              "y": 36,
+              "v": 0.975
+            },
+            "rightElbow": {
+              "x": 52.9,
+              "y": 32.9,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 96.1,
+              "y": 40.5,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 58.6,
+              "y": 28.5,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 99.7,
+              "y": 40.5,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 60.4,
+              "y": 26.4,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 68.2,
+              "y": 57.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.1,
+              "y": 56.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 91.5,
+              "y": 63.7,
+              "v": 0.986
+            },
+            "rightKnee": {
+              "x": 52.9,
+              "y": 83.2,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 69.9,
+              "y": 80.1,
+              "v": 0.819
+            },
+            "rightAnkle": {
+              "x": 42.4,
+              "y": 108.4,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 64.2,
+              "y": 79.3,
+              "v": 0.84
+            },
+            "rightHeel": {
+              "x": 40,
+              "y": 109.8,
+              "v": 0.989
+            },
+            "leftFootIndex": {
+              "x": 64.3,
+              "y": 92,
+              "v": 0.864
+            },
+            "rightFootIndex": {
+              "x": 46.1,
+              "y": 117.4,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.9,
+                "y": 11.3
+              },
+              "roll": 172.9,
+              "yaw": 2.109,
+              "pitch": 2.419
+            },
+            "torso": {
+              "center": {
+                "x": 66.6,
+                "y": 24
+              },
+              "angle": 84.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.1,
+                "y": 40.5
+              },
+              "angle": 0
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 58.6,
+                "y": 28.5
+              },
+              "angle": 49.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 64.2,
+                "y": 79.3
+              },
+              "angle": -89.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40,
+                "y": 109.8
+              },
+              "angle": -51.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.963,
+          "keypoints": {
+            "nose": {
+              "x": 69.7,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.6,
+              "y": 13.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.7,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.5,
+              "y": 14.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.6,
+              "y": 15,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.6,
+              "y": 27.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.7,
+              "y": 24.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.2,
+              "y": 31.1,
+              "v": 0.993
+            },
+            "rightElbow": {
+              "x": 40.2,
+              "y": 30.3,
+              "v": 0.987
+            },
+            "leftWrist": {
+              "x": 100.3,
+              "y": 31.9,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 29.6,
+              "y": 26.2,
+              "v": 0.944
+            },
+            "leftIndex": {
+              "x": 103.9,
+              "y": 31.8,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 25.8,
+              "y": 23.2,
+              "v": 0.935
+            },
+            "leftHip": {
+              "x": 66.9,
+              "y": 58.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.3,
+              "y": 58.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 87.9,
+              "y": 63.5,
+              "v": 0.975
+            },
+            "rightKnee": {
+              "x": 53.8,
+              "y": 84.1,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 66.1,
+              "y": 77.8,
+              "v": 0.768
+            },
+            "rightAnkle": {
+              "x": 47,
+              "y": 109.8,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 61.3,
+              "y": 76.8,
+              "v": 0.786
+            },
+            "rightHeel": {
+              "x": 44.7,
+              "y": 112.3,
+              "v": 0.962
+            },
+            "leftFootIndex": {
+              "x": 60.2,
+              "y": 88.6,
+              "v": 0.833
+            },
+            "rightFootIndex": {
+              "x": 46.6,
+              "y": 117.2,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.2,
+                "y": 13.7
+              },
+              "roll": -180,
+              "yaw": 2.833,
+              "pitch": 1.889
+            },
+            "torso": {
+              "center": {
+                "x": 62.2,
+                "y": 26.1
+              },
+              "angle": 89.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.3,
+                "y": 31.9
+              },
+              "angle": 1.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.6,
+                "y": 26.2
+              },
+              "angle": 141.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.3,
+                "y": 76.8
+              },
+              "angle": -95.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.7,
+                "y": 112.3
+              },
+              "angle": -68.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.938,
+          "keypoints": {
+            "nose": {
+              "x": 73.4,
+              "y": 35.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.4,
+              "y": 32.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.6,
+              "y": 31.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70,
+              "y": 32.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.2,
+              "y": 32.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.9,
+              "y": 45.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.5,
+              "y": 42.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.1,
+              "y": 50.4,
+              "v": 0.967
+            },
+            "rightElbow": {
+              "x": 47.4,
+              "y": 47.6,
+              "v": 0.807
+            },
+            "leftWrist": {
+              "x": 102.7,
+              "y": 51.1,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 54.1,
+              "y": 47.9,
+              "v": 0.721
+            },
+            "leftIndex": {
+              "x": 107.5,
+              "y": 50.3,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 56.4,
+              "y": 47.2,
+              "v": 0.756
+            },
+            "leftHip": {
+              "x": 61.8,
+              "y": 73.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51,
+              "y": 68.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.5,
+              "y": 78.1,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 44.2,
+              "y": 57.5,
+              "v": 0.914
+            },
+            "leftAnkle": {
+              "x": 66.7,
+              "y": 99,
+              "v": 0.955
+            },
+            "rightAnkle": {
+              "x": 34.2,
+              "y": 70.6,
+              "v": 0.912
+            },
+            "leftHeel": {
+              "x": 61.6,
+              "y": 101,
+              "v": 0.916
+            },
+            "rightHeel": {
+              "x": 33.8,
+              "y": 73.9,
+              "v": 0.85
+            },
+            "leftFootIndex": {
+              "x": 64.5,
+              "y": 112.7,
+              "v": 0.926
+            },
+            "rightFootIndex": {
+              "x": 28.5,
+              "y": 72.6,
+              "v": 0.881
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.5,
+                "y": 32.1
+              },
+              "roll": 167.5,
+              "yaw": 1.03,
+              "pitch": 1.627
+            },
+            "torso": {
+              "center": {
+                "x": 65.2,
+                "y": 43.9
+              },
+              "angle": 71.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 102.7,
+                "y": 51.1
+              },
+              "angle": 9.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 54.1,
+                "y": 47.9
+              },
+              "angle": 16.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.6,
+                "y": 101
+              },
+              "angle": -76.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33.8,
+                "y": 73.9
+              },
+              "angle": 166.2
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/bozzi/poses.json
+++ b/public/assets/fighters/bozzi/poses.json
@@ -1,0 +1,8432 @@
+{
+  "version": 1,
+  "fighter": "bozzi",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:42:02.152Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 70.2,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.5,
+              "y": 16.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.1,
+              "y": 15.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.6,
+              "y": 16.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.2,
+              "y": 16.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.1,
+              "y": 31.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47,
+              "y": 27.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.4,
+              "y": 49.4,
+              "v": 0.979
+            },
+            "rightElbow": {
+              "x": 31.8,
+              "y": 41,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 94.9,
+              "y": 44.8,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 27.9,
+              "y": 53.1,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 98.5,
+              "y": 39.8,
+              "v": 0.993
+            },
+            "rightIndex": {
+              "x": 29.4,
+              "y": 53,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 64.3,
+              "y": 65.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.9,
+              "y": 65.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.8,
+              "y": 87.1,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 44.2,
+              "y": 91.4,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74.3,
+              "y": 111,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 34.1,
+              "y": 118,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 70.4,
+              "y": 116.1,
+              "v": 0.993
+            },
+            "rightHeel": {
+              "x": 32.1,
+              "y": 121.4,
+              "v": 0.99
+            },
+            "leftFootIndex": {
+              "x": 85.6,
+              "y": 118.3,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 35.3,
+              "y": 125.3,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.8,
+                "y": 15.9
+              },
+              "roll": 171.6,
+              "yaw": 0.407,
+              "pitch": 0.858
+            },
+            "torso": {
+              "center": {
+                "x": 60.1,
+                "y": 29.4
+              },
+              "angle": 86.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.9,
+                "y": 44.8
+              },
+              "angle": 54.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 27.9,
+                "y": 53.1
+              },
+              "angle": 3.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.4,
+                "y": 116.1
+              },
+              "angle": -8.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.1,
+                "y": 121.4
+              },
+              "angle": -50.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 70.4,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.9,
+              "y": 15.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.4,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.8,
+              "y": 15.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.7,
+              "y": 16.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.5,
+              "y": 30.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.5,
+              "y": 27.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79,
+              "y": 49.3,
+              "v": 0.968
+            },
+            "rightElbow": {
+              "x": 31.1,
+              "y": 40.2,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 94.1,
+              "y": 45.3,
+              "v": 0.993
+            },
+            "rightWrist": {
+              "x": 26,
+              "y": 51.9,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 98.5,
+              "y": 40.3,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 28,
+              "y": 53.5,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 64.5,
+              "y": 64.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.6,
+              "y": 64.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.6,
+              "y": 87.1,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 43.5,
+              "y": 92.2,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74,
+              "y": 111.7,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 33.8,
+              "y": 118.6,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 70.3,
+              "y": 116.8,
+              "v": 0.996
+            },
+            "rightHeel": {
+              "x": 32,
+              "y": 122.4,
+              "v": 0.992
+            },
+            "leftFootIndex": {
+              "x": 84.7,
+              "y": 118.2,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 34.4,
+              "y": 126.4,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.2,
+                "y": 15.8
+              },
+              "roll": -178.4,
+              "yaw": 0.357,
+              "pitch": 0.871
+            },
+            "torso": {
+              "center": {
+                "x": 60,
+                "y": 28.9
+              },
+              "angle": 86.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.1,
+                "y": 45.3
+              },
+              "angle": 48.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 26,
+                "y": 51.9
+              },
+              "angle": -38.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.3,
+                "y": 116.8
+              },
+              "angle": -5.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32,
+                "y": 122.4
+              },
+              "angle": -59
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.958,
+          "keypoints": {
+            "nose": {
+              "x": 66.7,
+              "y": 19.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67,
+              "y": 16.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.7,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.3,
+              "y": 16.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 58,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.9,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.4,
+              "y": 28,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.2,
+              "y": 36.4,
+              "v": 0.95
+            },
+            "rightElbow": {
+              "x": 29.6,
+              "y": 41.5,
+              "v": 0.976
+            },
+            "leftWrist": {
+              "x": 98.8,
+              "y": 33.2,
+              "v": 0.96
+            },
+            "rightWrist": {
+              "x": 24.5,
+              "y": 53,
+              "v": 0.771
+            },
+            "leftIndex": {
+              "x": 102.9,
+              "y": 28.4,
+              "v": 0.948
+            },
+            "rightIndex": {
+              "x": 23.6,
+              "y": 54.1,
+              "v": 0.691
+            },
+            "leftHip": {
+              "x": 60.4,
+              "y": 63.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.1,
+              "y": 63.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.2,
+              "y": 87.3,
+              "v": 0.948
+            },
+            "rightKnee": {
+              "x": 40.1,
+              "y": 90.5,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 69.8,
+              "y": 111.7,
+              "v": 0.971
+            },
+            "rightAnkle": {
+              "x": 30.3,
+              "y": 117.6,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 65.9,
+              "y": 116.7,
+              "v": 0.931
+            },
+            "rightHeel": {
+              "x": 27.2,
+              "y": 121.3,
+              "v": 0.921
+            },
+            "leftFootIndex": {
+              "x": 81.6,
+              "y": 118.2,
+              "v": 0.977
+            },
+            "rightFootIndex": {
+              "x": 31.7,
+              "y": 128,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.4,
+                "y": 16.3
+              },
+              "roll": -178.3,
+              "yaw": 0.409,
+              "pitch": 0.863
+            },
+            "torso": {
+              "center": {
+                "x": 56.2,
+                "y": 28.8
+              },
+              "angle": 86
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.8,
+                "y": 33.2
+              },
+              "angle": 49.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 24.5,
+                "y": 53
+              },
+              "angle": -129.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 65.9,
+                "y": 116.7
+              },
+              "angle": -5.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27.2,
+                "y": 121.3
+              },
+              "angle": -56.1
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.998,
+          "keypoints": {
+            "nose": {
+              "x": 70.4,
+              "y": 18.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.9,
+              "y": 15.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.4,
+              "y": 15.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.2,
+              "y": 16.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.6,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.4,
+              "y": 31.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47,
+              "y": 27.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.7,
+              "y": 50.2,
+              "v": 0.982
+            },
+            "rightElbow": {
+              "x": 31.5,
+              "y": 40.7,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 94.8,
+              "y": 44.8,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 27.1,
+              "y": 52.8,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 98.2,
+              "y": 39.9,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 29.2,
+              "y": 53,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 64.1,
+              "y": 65,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.6,
+              "y": 65.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.5,
+              "y": 86.8,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 43.6,
+              "y": 91.4,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74.1,
+              "y": 111,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 33.8,
+              "y": 118.2,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 70.2,
+              "y": 116.1,
+              "v": 0.994
+            },
+            "rightHeel": {
+              "x": 32.5,
+              "y": 121.9,
+              "v": 0.99
+            },
+            "leftFootIndex": {
+              "x": 84.8,
+              "y": 118,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 33.7,
+              "y": 125,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.2,
+                "y": 15.6
+              },
+              "roll": 170.3,
+              "yaw": 0.352,
+              "pitch": 0.817
+            },
+            "torso": {
+              "center": {
+                "x": 60.2,
+                "y": 29.3
+              },
+              "angle": 85.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.8,
+                "y": 44.8
+              },
+              "angle": 55.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 27.1,
+                "y": 52.8
+              },
+              "angle": -5.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.2,
+                "y": 116.1
+              },
+              "angle": -7.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.5,
+                "y": 121.9
+              },
+              "angle": -68.8
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.982,
+          "keypoints": {
+            "nose": {
+              "x": 63.2,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.9,
+              "y": 15.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.1,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.9,
+              "y": 16.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 55.5,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.3,
+              "y": 31.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.7,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.8,
+              "y": 36.9,
+              "v": 0.947
+            },
+            "rightElbow": {
+              "x": 24.1,
+              "y": 39.8,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 93.2,
+              "y": 35.3,
+              "v": 0.985
+            },
+            "rightWrist": {
+              "x": 24.4,
+              "y": 52.4,
+              "v": 0.957
+            },
+            "leftIndex": {
+              "x": 99.4,
+              "y": 32.8,
+              "v": 0.979
+            },
+            "rightIndex": {
+              "x": 30.2,
+              "y": 56.2,
+              "v": 0.935
+            },
+            "leftHip": {
+              "x": 56.9,
+              "y": 64.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46,
+              "y": 65,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.6,
+              "y": 88,
+              "v": 0.938
+            },
+            "rightKnee": {
+              "x": 40.4,
+              "y": 92,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 64.7,
+              "y": 112.1,
+              "v": 0.969
+            },
+            "rightAnkle": {
+              "x": 24.7,
+              "y": 117,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 60.7,
+              "y": 116.3,
+              "v": 0.951
+            },
+            "rightHeel": {
+              "x": 20.9,
+              "y": 118.3,
+              "v": 0.968
+            },
+            "leftFootIndex": {
+              "x": 75.9,
+              "y": 118.3,
+              "v": 0.974
+            },
+            "rightFootIndex": {
+              "x": 24.5,
+              "y": 127.1,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62,
+                "y": 15.8
+              },
+              "roll": 176.8,
+              "yaw": 0.666,
+              "pitch": 1.414
+            },
+            "torso": {
+              "center": {
+                "x": 52.5,
+                "y": 29.8
+              },
+              "angle": 88.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.2,
+                "y": 35.3
+              },
+              "angle": 22
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 24.4,
+                "y": 52.4
+              },
+              "angle": -33.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.7,
+                "y": 116.3
+              },
+              "angle": -7.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 20.9,
+                "y": 118.3
+              },
+              "angle": -67.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.99,
+          "keypoints": {
+            "nose": {
+              "x": 70.9,
+              "y": 19.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.8,
+              "y": 16.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.9,
+              "y": 16.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68,
+              "y": 16.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62,
+              "y": 16.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.1,
+              "y": 31,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.8,
+              "y": 28,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77,
+              "y": 48.6,
+              "v": 0.892
+            },
+            "rightElbow": {
+              "x": 30.1,
+              "y": 42.1,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 89.6,
+              "y": 49.3,
+              "v": 0.959
+            },
+            "rightWrist": {
+              "x": 26.9,
+              "y": 52.6,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 93.8,
+              "y": 47.1,
+              "v": 0.962
+            },
+            "rightIndex": {
+              "x": 28,
+              "y": 54.2,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 64.9,
+              "y": 65.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.1,
+              "y": 65.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.6,
+              "y": 87.5,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 44.1,
+              "y": 92.7,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 74.2,
+              "y": 112.1,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 34.3,
+              "y": 118,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 70.2,
+              "y": 117.4,
+              "v": 0.991
+            },
+            "rightHeel": {
+              "x": 31.9,
+              "y": 122.2,
+              "v": 0.974
+            },
+            "leftFootIndex": {
+              "x": 85,
+              "y": 119.3,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 34.9,
+              "y": 127.3,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.4,
+                "y": 16.5
+              },
+              "roll": -166.4,
+              "yaw": 0.52,
+              "pitch": 0.955
+            },
+            "torso": {
+              "center": {
+                "x": 60,
+                "y": 29.5
+              },
+              "angle": 86.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.6,
+                "y": 49.3
+              },
+              "angle": 27.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 26.9,
+                "y": 52.6
+              },
+              "angle": -55.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.2,
+                "y": 117.4
+              },
+              "angle": -7.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.9,
+                "y": 122.2
+              },
+              "angle": -59.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 70.4,
+              "y": 19,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.1,
+              "y": 16,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.5,
+              "y": 16,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.2,
+              "y": 16.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61,
+              "y": 16.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.7,
+              "y": 30.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.9,
+              "y": 28.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.2,
+              "y": 48.6,
+              "v": 0.986
+            },
+            "rightElbow": {
+              "x": 32.2,
+              "y": 40.9,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 93.3,
+              "y": 46.3,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 26.1,
+              "y": 51.1,
+              "v": 0.991
+            },
+            "leftIndex": {
+              "x": 98.3,
+              "y": 40.8,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 27.1,
+              "y": 53.1,
+              "v": 0.986
+            },
+            "leftHip": {
+              "x": 63.6,
+              "y": 63.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.7,
+              "y": 64,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.5,
+              "y": 86.2,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 43.4,
+              "y": 91.4,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74,
+              "y": 111.7,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 34.1,
+              "y": 117.7,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 70.6,
+              "y": 116.5,
+              "v": 0.996
+            },
+            "rightHeel": {
+              "x": 32.8,
+              "y": 122,
+              "v": 0.99
+            },
+            "leftFootIndex": {
+              "x": 84.5,
+              "y": 118.3,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 33.8,
+              "y": 125.8,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.3,
+                "y": 16
+              },
+              "roll": -180,
+              "yaw": 0.306,
+              "pitch": 0.833
+            },
+            "torso": {
+              "center": {
+                "x": 60.3,
+                "y": 29.8
+              },
+              "angle": 84.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.3,
+                "y": 46.3
+              },
+              "angle": 47.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 26.1,
+                "y": 51.1
+              },
+              "angle": -63.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.6,
+                "y": 116.5
+              },
+              "angle": -7.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.8,
+                "y": 122
+              },
+              "angle": -75.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 70.5,
+              "y": 19.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.7,
+              "y": 16.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.5,
+              "y": 16.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.7,
+              "y": 16.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.4,
+              "y": 16.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73,
+              "y": 30.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.7,
+              "y": 27.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.1,
+              "y": 49.3,
+              "v": 0.968
+            },
+            "rightElbow": {
+              "x": 31,
+              "y": 41.1,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 94.3,
+              "y": 45.2,
+              "v": 0.991
+            },
+            "rightWrist": {
+              "x": 27.1,
+              "y": 52.8,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 98.3,
+              "y": 39.6,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 28.5,
+              "y": 53.6,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 64,
+              "y": 64.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.6,
+              "y": 65.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79,
+              "y": 87.2,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 43.6,
+              "y": 91.3,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74,
+              "y": 111.5,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 34,
+              "y": 119.2,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 69.8,
+              "y": 117.1,
+              "v": 0.991
+            },
+            "rightHeel": {
+              "x": 32.1,
+              "y": 122.4,
+              "v": 0.989
+            },
+            "leftFootIndex": {
+              "x": 84.6,
+              "y": 118.3,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 34.4,
+              "y": 125.8,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.1,
+                "y": 16.6
+              },
+              "roll": -178.2,
+              "yaw": 0.437,
+              "pitch": 0.984
+            },
+            "torso": {
+              "center": {
+                "x": 59.9,
+                "y": 29.3
+              },
+              "angle": 85.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.3,
+                "y": 45.2
+              },
+              "angle": 54.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 27.1,
+                "y": 52.8
+              },
+              "angle": -29.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.8,
+                "y": 117.1
+              },
+              "angle": -4.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.1,
+                "y": 122.4
+              },
+              "angle": -55.9
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.915,
+          "keypoints": {
+            "nose": {
+              "x": 61.5,
+              "y": 18.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.9,
+              "y": 15,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.5,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.4,
+              "y": 15.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.3,
+              "y": 16.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.3,
+              "y": 28.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.7,
+              "y": 28.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.7,
+              "y": 30.9,
+              "v": 0.979
+            },
+            "rightElbow": {
+              "x": 25.7,
+              "y": 41.7,
+              "v": 0.861
+            },
+            "leftWrist": {
+              "x": 100.3,
+              "y": 29.7,
+              "v": 0.989
+            },
+            "rightWrist": {
+              "x": 17.6,
+              "y": 49.5,
+              "v": 0.366
+            },
+            "leftIndex": {
+              "x": 107.3,
+              "y": 27.9,
+              "v": 0.981
+            },
+            "rightIndex": {
+              "x": 15.2,
+              "y": 51,
+              "v": 0.285
+            },
+            "leftHip": {
+              "x": 55.1,
+              "y": 63.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 41.3,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.7,
+              "y": 87.2,
+              "v": 0.933
+            },
+            "rightKnee": {
+              "x": 34.5,
+              "y": 91.7,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 64.5,
+              "y": 111.1,
+              "v": 0.958
+            },
+            "rightAnkle": {
+              "x": 24,
+              "y": 117.1,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 60.5,
+              "y": 115.8,
+              "v": 0.874
+            },
+            "rightHeel": {
+              "x": 21.2,
+              "y": 120,
+              "v": 0.884
+            },
+            "leftFootIndex": {
+              "x": 74.9,
+              "y": 118.2,
+              "v": 0.961
+            },
+            "rightFootIndex": {
+              "x": 24.1,
+              "y": 128.6,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.2,
+                "y": 15.4
+              },
+              "roll": -166.8,
+              "yaw": 0.372,
+              "pitch": 1.002
+            },
+            "torso": {
+              "center": {
+                "x": 52,
+                "y": 28.6
+              },
+              "angle": 83.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.3,
+                "y": 29.7
+              },
+              "angle": 14.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 17.6,
+                "y": 49.5
+              },
+              "angle": -136.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.5,
+                "y": 115.8
+              },
+              "angle": -9.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 21.2,
+                "y": 120
+              },
+              "angle": -71.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 62.6,
+              "y": 19.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63.6,
+              "y": 15.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 60,
+              "y": 15.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60.6,
+              "y": 16.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 54.2,
+              "y": 16,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.3,
+              "y": 30.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.3,
+              "y": 27.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.1,
+              "y": 35.5,
+              "v": 0.972
+            },
+            "rightElbow": {
+              "x": 23.7,
+              "y": 41.1,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 90.6,
+              "y": 35.7,
+              "v": 0.987
+            },
+            "rightWrist": {
+              "x": 19.2,
+              "y": 52,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 96.1,
+              "y": 33.6,
+              "v": 0.985
+            },
+            "rightIndex": {
+              "x": 19.7,
+              "y": 53.8,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 56.5,
+              "y": 64.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43,
+              "y": 64.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.7,
+              "y": 87.8,
+              "v": 0.991
+            },
+            "rightKnee": {
+              "x": 35.4,
+              "y": 91.2,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 65.7,
+              "y": 112.5,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 26.3,
+              "y": 117.3,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 61.7,
+              "y": 116.9,
+              "v": 0.982
+            },
+            "rightHeel": {
+              "x": 23.7,
+              "y": 121.1,
+              "v": 0.966
+            },
+            "leftFootIndex": {
+              "x": 76.8,
+              "y": 118.7,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 26.7,
+              "y": 127,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 61.8,
+                "y": 15.9
+              },
+              "roll": -180,
+              "yaw": 0.222,
+              "pitch": 0.972
+            },
+            "torso": {
+              "center": {
+                "x": 52.3,
+                "y": 28.9
+              },
+              "angle": 85.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.6,
+                "y": 35.7
+              },
+              "angle": 20.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 19.2,
+                "y": 52
+              },
+              "angle": -74.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.7,
+                "y": 116.9
+              },
+              "angle": -6.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.7,
+                "y": 121.1
+              },
+              "angle": -63
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.99,
+          "keypoints": {
+            "nose": {
+              "x": 62.1,
+              "y": 18.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.5,
+              "y": 15.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 59.1,
+              "y": 15.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60,
+              "y": 16.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.3,
+              "y": 16.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.9,
+              "y": 29.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.4,
+              "y": 27.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.3,
+              "y": 33.3,
+              "v": 0.975
+            },
+            "rightElbow": {
+              "x": 24.1,
+              "y": 39.6,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 91.2,
+              "y": 35.8,
+              "v": 0.977
+            },
+            "rightWrist": {
+              "x": 19,
+              "y": 49.9,
+              "v": 0.981
+            },
+            "leftIndex": {
+              "x": 95.7,
+              "y": 33.6,
+              "v": 0.972
+            },
+            "rightIndex": {
+              "x": 18.4,
+              "y": 51.2,
+              "v": 0.969
+            },
+            "leftHip": {
+              "x": 55.7,
+              "y": 62.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.1,
+              "y": 62.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.2,
+              "y": 85.4,
+              "v": 0.994
+            },
+            "rightKnee": {
+              "x": 35.3,
+              "y": 90.6,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 65.5,
+              "y": 109.1,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 25.2,
+              "y": 115.9,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 61.3,
+              "y": 114.3,
+              "v": 0.977
+            },
+            "rightHeel": {
+              "x": 23.1,
+              "y": 119.5,
+              "v": 0.949
+            },
+            "leftFootIndex": {
+              "x": 76.8,
+              "y": 117,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 26.2,
+              "y": 125.8,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.8,
+                "y": 15.5
+              },
+              "roll": -176.6,
+              "yaw": 0.382,
+              "pitch": 0.881
+            },
+            "torso": {
+              "center": {
+                "x": 52.2,
+                "y": 28.5
+              },
+              "angle": 84.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.2,
+                "y": 35.8
+              },
+              "angle": 26.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 19,
+                "y": 49.9
+              },
+              "angle": -114.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.3,
+                "y": 114.3
+              },
+              "angle": -9.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.1,
+                "y": 119.5
+              },
+              "angle": -63.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.889,
+          "keypoints": {
+            "nose": {
+              "x": 61.8,
+              "y": 19.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63.1,
+              "y": 15.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.8,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 62,
+              "y": 15.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.2,
+              "y": 15.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.3,
+              "y": 27,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41,
+              "y": 28.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.2,
+              "y": 32.2,
+              "v": 0.946
+            },
+            "rightElbow": {
+              "x": 28.9,
+              "y": 42.7,
+              "v": 0.665
+            },
+            "leftWrist": {
+              "x": 100.4,
+              "y": 31.2,
+              "v": 0.974
+            },
+            "rightWrist": {
+              "x": 22.6,
+              "y": 51.5,
+              "v": 0.113
+            },
+            "leftIndex": {
+              "x": 107.2,
+              "y": 30.4,
+              "v": 0.964
+            },
+            "rightIndex": {
+              "x": 19.7,
+              "y": 51.4,
+              "v": 0.086
+            },
+            "leftHip": {
+              "x": 55.3,
+              "y": 60.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.4,
+              "y": 62.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.2,
+              "y": 85,
+              "v": 0.944
+            },
+            "rightKnee": {
+              "x": 35.5,
+              "y": 89.8,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 67.3,
+              "y": 109.7,
+              "v": 0.979
+            },
+            "rightAnkle": {
+              "x": 26,
+              "y": 115.1,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 62.9,
+              "y": 114.8,
+              "v": 0.937
+            },
+            "rightHeel": {
+              "x": 23.1,
+              "y": 118,
+              "v": 0.9
+            },
+            "leftFootIndex": {
+              "x": 78.3,
+              "y": 116,
+              "v": 0.98
+            },
+            "rightFootIndex": {
+              "x": 26.3,
+              "y": 124.9,
+              "v": 0.987
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 61,
+                "y": 15.7
+              },
+              "roll": -177.3,
+              "yaw": 0.197,
+              "pitch": 0.79
+            },
+            "torso": {
+              "center": {
+                "x": 53.2,
+                "y": 27.7
+              },
+              "angle": 82.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.4,
+                "y": 31.2
+              },
+              "angle": 6.7
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 62.9,
+                "y": 114.8
+              },
+              "angle": -4.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.1,
+                "y": 118
+              },
+              "angle": -65.1
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.964,
+          "keypoints": {
+            "nose": {
+              "x": 65.3,
+              "y": 18.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.2,
+              "y": 15.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62.4,
+              "y": 15.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.9,
+              "y": 15.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.2,
+              "y": 27.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.5,
+              "y": 27.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.1,
+              "y": 31.3,
+              "v": 0.99
+            },
+            "rightElbow": {
+              "x": 34.4,
+              "y": 42.9,
+              "v": 0.94
+            },
+            "leftWrist": {
+              "x": 98.1,
+              "y": 31.2,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 25.2,
+              "y": 46.1,
+              "v": 0.665
+            },
+            "leftIndex": {
+              "x": 105,
+              "y": 31.4,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 21.5,
+              "y": 44,
+              "v": 0.635
+            },
+            "leftHip": {
+              "x": 59.4,
+              "y": 62.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.5,
+              "y": 64,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.9,
+              "y": 86.7,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 40,
+              "y": 90.3,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 70,
+              "y": 111.3,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 30.1,
+              "y": 115.8,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 65.7,
+              "y": 116.5,
+              "v": 0.987
+            },
+            "rightHeel": {
+              "x": 27.1,
+              "y": 120.3,
+              "v": 0.972
+            },
+            "leftFootIndex": {
+              "x": 81.6,
+              "y": 118.1,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 30.9,
+              "y": 126.1,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.3,
+                "y": 15.2
+              },
+              "roll": -178.5,
+              "yaw": 0.263,
+              "pitch": 0.881
+            },
+            "torso": {
+              "center": {
+                "x": 55.4,
+                "y": 27.5
+              },
+              "angle": 86.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.1,
+                "y": 31.2
+              },
+              "angle": -1.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 25.2,
+                "y": 46.1
+              },
+              "angle": 150.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 65.7,
+                "y": 116.5
+              },
+              "angle": -5.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27.1,
+                "y": 120.3
+              },
+              "angle": -56.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.952,
+          "keypoints": {
+            "nose": {
+              "x": 63,
+              "y": 20.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63.8,
+              "y": 16.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 59.5,
+              "y": 17.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 62,
+              "y": 17.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.3,
+              "y": 17.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.1,
+              "y": 28.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.4,
+              "y": 31.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.2,
+              "y": 33.8,
+              "v": 0.966
+            },
+            "rightElbow": {
+              "x": 26.5,
+              "y": 49.7,
+              "v": 0.977
+            },
+            "leftWrist": {
+              "x": 106.7,
+              "y": 33.3,
+              "v": 0.958
+            },
+            "rightWrist": {
+              "x": 41.6,
+              "y": 44.7,
+              "v": 0.793
+            },
+            "leftIndex": {
+              "x": 114,
+              "y": 31.9,
+              "v": 0.943
+            },
+            "rightIndex": {
+              "x": 47.4,
+              "y": 39.1,
+              "v": 0.67
+            },
+            "leftHip": {
+              "x": 56.2,
+              "y": 65.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.7,
+              "y": 67.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.9,
+              "y": 85.3,
+              "v": 0.961
+            },
+            "rightKnee": {
+              "x": 31.6,
+              "y": 91.3,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 69.7,
+              "y": 108.9,
+              "v": 0.961
+            },
+            "rightAnkle": {
+              "x": 18.9,
+              "y": 116.2,
+              "v": 0.988
+            },
+            "leftHeel": {
+              "x": 65.5,
+              "y": 114.1,
+              "v": 0.929
+            },
+            "rightHeel": {
+              "x": 15.5,
+              "y": 120.1,
+              "v": 0.822
+            },
+            "leftFootIndex": {
+              "x": 80.4,
+              "y": 116.1,
+              "v": 0.961
+            },
+            "rightFootIndex": {
+              "x": 21.3,
+              "y": 124.4,
+              "v": 0.972
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 61.7,
+                "y": 17.3
+              },
+              "roll": -168.2,
+              "yaw": 0.307,
+              "pitch": 0.785
+            },
+            "torso": {
+              "center": {
+                "x": 53.8,
+                "y": 30.3
+              },
+              "angle": 83.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 106.7,
+                "y": 33.3
+              },
+              "angle": 10.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.6,
+                "y": 44.7
+              },
+              "angle": 44
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 65.5,
+                "y": 114.1
+              },
+              "angle": -7.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 15.5,
+                "y": 120.1
+              },
+              "angle": -36.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.918,
+          "keypoints": {
+            "nose": {
+              "x": 57.7,
+              "y": 20.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.5,
+              "y": 16.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.5,
+              "y": 17.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57,
+              "y": 17,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.3,
+              "y": 17.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 61.1,
+              "y": 29.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 36.1,
+              "y": 31,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.3,
+              "y": 32.8,
+              "v": 0.992
+            },
+            "rightElbow": {
+              "x": 23,
+              "y": 45.9,
+              "v": 0.89
+            },
+            "leftWrist": {
+              "x": 100.7,
+              "y": 32.7,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 18.5,
+              "y": 51.8,
+              "v": 0.214
+            },
+            "leftIndex": {
+              "x": 108.3,
+              "y": 31.6,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 16.8,
+              "y": 50.8,
+              "v": 0.165
+            },
+            "leftHip": {
+              "x": 50.3,
+              "y": 63.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 37.1,
+              "y": 65.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.8,
+              "y": 85.2,
+              "v": 0.985
+            },
+            "rightKnee": {
+              "x": 29.1,
+              "y": 90.8,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 62.6,
+              "y": 109.6,
+              "v": 0.99
+            },
+            "rightAnkle": {
+              "x": 19.2,
+              "y": 116.4,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 58,
+              "y": 115,
+              "v": 0.976
+            },
+            "rightHeel": {
+              "x": 16.5,
+              "y": 119.8,
+              "v": 0.944
+            },
+            "leftFootIndex": {
+              "x": 74.8,
+              "y": 116.9,
+              "v": 0.99
+            },
+            "rightFootIndex": {
+              "x": 19.3,
+              "y": 125.3,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.5,
+                "y": 17
+              },
+              "roll": -177.1,
+              "yaw": 0.3,
+              "pitch": 0.924
+            },
+            "torso": {
+              "center": {
+                "x": 48.6,
+                "y": 30.1
+              },
+              "angle": 81.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.7,
+                "y": 32.7
+              },
+              "angle": 8.2
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 58,
+                "y": 115
+              },
+              "angle": -6.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 16.5,
+                "y": 119.8
+              },
+              "angle": -63
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.942,
+          "keypoints": {
+            "nose": {
+              "x": 58.8,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.4,
+              "y": 15.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.9,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 56.8,
+              "y": 15.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.3,
+              "y": 15.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.2,
+              "y": 27.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 36,
+              "y": 27.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.5,
+              "y": 31.2,
+              "v": 0.979
+            },
+            "rightElbow": {
+              "x": 24,
+              "y": 44.1,
+              "v": 0.918
+            },
+            "leftWrist": {
+              "x": 101,
+              "y": 30.4,
+              "v": 0.985
+            },
+            "rightWrist": {
+              "x": 31.8,
+              "y": 40.3,
+              "v": 0.512
+            },
+            "leftIndex": {
+              "x": 108.4,
+              "y": 29.5,
+              "v": 0.975
+            },
+            "rightIndex": {
+              "x": 34.6,
+              "y": 35,
+              "v": 0.443
+            },
+            "leftHip": {
+              "x": 54.2,
+              "y": 62.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 41,
+              "y": 65.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71,
+              "y": 85.1,
+              "v": 0.994
+            },
+            "rightKnee": {
+              "x": 32.7,
+              "y": 89.6,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 65.5,
+              "y": 109.1,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 23.7,
+              "y": 114.4,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 61.3,
+              "y": 113.9,
+              "v": 0.972
+            },
+            "rightHeel": {
+              "x": 22.8,
+              "y": 117.6,
+              "v": 0.92
+            },
+            "leftFootIndex": {
+              "x": 77,
+              "y": 116.3,
+              "v": 0.99
+            },
+            "rightFootIndex": {
+              "x": 22.6,
+              "y": 124.8,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.7,
+                "y": 15.7
+              },
+              "roll": -178.4,
+              "yaw": 0.328,
+              "pitch": 0.9
+            },
+            "torso": {
+              "center": {
+                "x": 49.1,
+                "y": 27.3
+              },
+              "angle": 87.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 101,
+                "y": 30.4
+              },
+              "angle": 6.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31.8,
+                "y": 40.3
+              },
+              "angle": 62.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.3,
+                "y": 113.9
+              },
+              "angle": -8.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 22.8,
+                "y": 117.6
+              },
+              "angle": -91.6
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.89,
+          "keypoints": {
+            "nose": {
+              "x": 61,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.6,
+              "y": 14.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.8,
+              "y": 15.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.3,
+              "y": 14.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.7,
+              "y": 15.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.8,
+              "y": 27.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.9,
+              "y": 30.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.4,
+              "y": 30.7,
+              "v": 0.969
+            },
+            "rightElbow": {
+              "x": 25.5,
+              "y": 44.5,
+              "v": 0.665
+            },
+            "leftWrist": {
+              "x": 100,
+              "y": 30.4,
+              "v": 0.985
+            },
+            "rightWrist": {
+              "x": 20.1,
+              "y": 54.6,
+              "v": 0.104
+            },
+            "leftIndex": {
+              "x": 107.3,
+              "y": 29.1,
+              "v": 0.977
+            },
+            "rightIndex": {
+              "x": 17.9,
+              "y": 54.8,
+              "v": 0.089
+            },
+            "leftHip": {
+              "x": 53.4,
+              "y": 62.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 39.7,
+              "y": 63.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.2,
+              "y": 86.8,
+              "v": 0.95
+            },
+            "rightKnee": {
+              "x": 33.2,
+              "y": 90.1,
+              "v": 0.992
+            },
+            "leftAnkle": {
+              "x": 63.7,
+              "y": 110.3,
+              "v": 0.975
+            },
+            "rightAnkle": {
+              "x": 22.4,
+              "y": 116.6,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 59.5,
+              "y": 115.1,
+              "v": 0.918
+            },
+            "rightHeel": {
+              "x": 19.6,
+              "y": 120,
+              "v": 0.884
+            },
+            "leftFootIndex": {
+              "x": 75.7,
+              "y": 117.2,
+              "v": 0.977
+            },
+            "rightFootIndex": {
+              "x": 23.8,
+              "y": 126.3,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.7,
+                "y": 14.9
+              },
+              "roll": -169.6,
+              "yaw": 0.336,
+              "pitch": 0.919
+            },
+            "torso": {
+              "center": {
+                "x": 50.8,
+                "y": 28.7
+              },
+              "angle": 82.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100,
+                "y": 30.4
+              },
+              "angle": 10.1
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 59.5,
+                "y": 115.1
+              },
+              "angle": -7.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 19.6,
+                "y": 120
+              },
+              "angle": -56.3
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.999,
+          "keypoints": {
+            "nose": {
+              "x": 65.6,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.5,
+              "y": 15.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62.3,
+              "y": 15.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 62.8,
+              "y": 15.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56,
+              "y": 16.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.6,
+              "y": 30.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.1,
+              "y": 28,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.5,
+              "y": 49.9,
+              "v": 0.992
+            },
+            "rightElbow": {
+              "x": 25.7,
+              "y": 41.9,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 85.2,
+              "y": 49.7,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 21.7,
+              "y": 52.2,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 91.4,
+              "y": 44.4,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 22.2,
+              "y": 53.3,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 59,
+              "y": 65.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.5,
+              "y": 66.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.3,
+              "y": 64,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 38.1,
+              "y": 92.2,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 99.2,
+              "y": 73.7,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 28.8,
+              "y": 119.1,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 100.1,
+              "y": 78.8,
+              "v": 1
+            },
+            "rightHeel": {
+              "x": 27,
+              "y": 122,
+              "v": 0.999
+            },
+            "leftFootIndex": {
+              "x": 110.2,
+              "y": 63.9,
+              "v": 1
+            },
+            "rightFootIndex": {
+              "x": 28.8,
+              "y": 126.3,
+              "v": 1
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.9,
+                "y": 15.4
+              },
+              "roll": -172.9,
+              "yaw": 0.527,
+              "pitch": 0.93
+            },
+            "torso": {
+              "center": {
+                "x": 54.9,
+                "y": 29.2
+              },
+              "angle": 86
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.2,
+                "y": 49.7
+              },
+              "angle": 40.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 21.7,
+                "y": 52.2
+              },
+              "angle": -65.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 100.1,
+                "y": 78.8
+              },
+              "angle": 55.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27,
+                "y": 122
+              },
+              "angle": -67.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.991,
+          "keypoints": {
+            "nose": {
+              "x": 64.3,
+              "y": 18.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.5,
+              "y": 15.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.3,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.3,
+              "y": 15.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 55.2,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.7,
+              "y": 31.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42.2,
+              "y": 28.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.9,
+              "y": 49.5,
+              "v": 0.89
+            },
+            "rightElbow": {
+              "x": 26.7,
+              "y": 40.6,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 86.2,
+              "y": 48.4,
+              "v": 0.97
+            },
+            "rightWrist": {
+              "x": 21.1,
+              "y": 50.8,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 91.2,
+              "y": 43.6,
+              "v": 0.975
+            },
+            "rightIndex": {
+              "x": 21.6,
+              "y": 52.9,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 58.1,
+              "y": 65.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.5,
+              "y": 66.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.1,
+              "y": 65.3,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 38.8,
+              "y": 91.3,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 99.5,
+              "y": 74.2,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 29,
+              "y": 118.2,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 102.1,
+              "y": 78.9,
+              "v": 0.994
+            },
+            "rightHeel": {
+              "x": 27.1,
+              "y": 121.1,
+              "v": 0.987
+            },
+            "leftFootIndex": {
+              "x": 108.8,
+              "y": 64.7,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 30.4,
+              "y": 123.1,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.4,
+                "y": 15.1
+              },
+              "roll": 170.5,
+              "yaw": 0.211,
+              "pitch": 0.74
+            },
+            "torso": {
+              "center": {
+                "x": 55,
+                "y": 30
+              },
+              "angle": 85
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.2,
+                "y": 48.4
+              },
+              "angle": 43.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 21.1,
+                "y": 50.8
+              },
+              "angle": -76.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 102.1,
+                "y": 78.9
+              },
+              "angle": 64.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27.1,
+                "y": 121.1
+              },
+              "angle": -31.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.977,
+          "keypoints": {
+            "nose": {
+              "x": 58.9,
+              "y": 19.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.4,
+              "y": 15.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.6,
+              "y": 16.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 56.4,
+              "y": 16.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.1,
+              "y": 16.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.6,
+              "y": 28.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 33,
+              "y": 28.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.5,
+              "y": 30,
+              "v": 0.997
+            },
+            "rightElbow": {
+              "x": 8.9,
+              "y": 36.7,
+              "v": 0.973
+            },
+            "leftWrist": {
+              "x": 106.9,
+              "y": 28.9,
+              "v": 0.993
+            },
+            "rightWrist": {
+              "x": 8.9,
+              "y": 44.3,
+              "v": 0.816
+            },
+            "leftIndex": {
+              "x": 113.5,
+              "y": 28.2,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 11.2,
+              "y": 44,
+              "v": 0.862
+            },
+            "leftHip": {
+              "x": 45.3,
+              "y": 59.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 38.1,
+              "y": 61.5,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 39.3,
+              "y": 91.1,
+              "v": 0.923
+            },
+            "rightKnee": {
+              "x": 76.3,
+              "y": 58.5,
+              "v": 0.95
+            },
+            "leftAnkle": {
+              "x": 21.8,
+              "y": 117.9,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 106.3,
+              "y": 64.3,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 17.7,
+              "y": 121.8,
+              "v": 0.995
+            },
+            "rightHeel": {
+              "x": 110,
+              "y": 69.5,
+              "v": 0.989
+            },
+            "leftFootIndex": {
+              "x": 25.4,
+              "y": 126,
+              "v": 0.992
+            },
+            "rightFootIndex": {
+              "x": 115.2,
+              "y": 54,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.5,
+                "y": 16.1
+              },
+              "roll": -175.5,
+              "yaw": 0.367,
+              "pitch": 0.905
+            },
+            "torso": {
+              "center": {
+                "x": 46.3,
+                "y": 28.2
+              },
+              "angle": 81.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 106.9,
+                "y": 28.9
+              },
+              "angle": 6.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 8.9,
+                "y": 44.3
+              },
+              "angle": 7.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 17.7,
+                "y": 121.8
+              },
+              "angle": -28.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 110,
+                "y": 69.5
+              },
+              "angle": 71.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.916,
+          "keypoints": {
+            "nose": {
+              "x": 58.9,
+              "y": 20.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.8,
+              "y": 16.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56,
+              "y": 17.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.2,
+              "y": 16.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.7,
+              "y": 16.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 60.3,
+              "y": 28.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 34.7,
+              "y": 31,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.1,
+              "y": 31.4,
+              "v": 0.946
+            },
+            "rightElbow": {
+              "x": 21.5,
+              "y": 44.1,
+              "v": 0.856
+            },
+            "leftWrist": {
+              "x": 105,
+              "y": 29.8,
+              "v": 0.975
+            },
+            "rightWrist": {
+              "x": 30.7,
+              "y": 42.5,
+              "v": 0.308
+            },
+            "leftIndex": {
+              "x": 112.4,
+              "y": 29,
+              "v": 0.974
+            },
+            "rightIndex": {
+              "x": 35.1,
+              "y": 38.3,
+              "v": 0.301
+            },
+            "leftHip": {
+              "x": 44.9,
+              "y": 56.7,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 35.9,
+              "y": 60.1,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 73.4,
+              "y": 58.6,
+              "v": 0.916
+            },
+            "rightKnee": {
+              "x": 39.8,
+              "y": 89.9,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 102.1,
+              "y": 64.9,
+              "v": 0.964
+            },
+            "rightAnkle": {
+              "x": 23.5,
+              "y": 117.6,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 104.8,
+              "y": 70.8,
+              "v": 0.932
+            },
+            "rightHeel": {
+              "x": 19.1,
+              "y": 121.2,
+              "v": 0.933
+            },
+            "leftFootIndex": {
+              "x": 111.8,
+              "y": 54,
+              "v": 0.977
+            },
+            "rightFootIndex": {
+              "x": 25.9,
+              "y": 125.5,
+              "v": 0.988
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.9,
+                "y": 17
+              },
+              "roll": -174,
+              "yaw": 0.262,
+              "pitch": 1.021
+            },
+            "torso": {
+              "center": {
+                "x": 47.5,
+                "y": 30
+              },
+              "angle": 76
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 105,
+                "y": 29.8
+              },
+              "angle": 6.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 30.7,
+                "y": 42.5
+              },
+              "angle": 43.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 104.8,
+                "y": 70.8
+              },
+              "angle": 67.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 19.1,
+                "y": 121.2
+              },
+              "angle": -32.3
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.897,
+          "keypoints": {
+            "nose": {
+              "x": 44.8,
+              "y": 20.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 45.4,
+              "y": 17.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 41.2,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 43.2,
+              "y": 17.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 35.3,
+              "y": 19.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 50.6,
+              "y": 28,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 23.7,
+              "y": 35.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.9,
+              "y": 28.6,
+              "v": 0.94
+            },
+            "rightElbow": {
+              "x": 8.9,
+              "y": 54.8,
+              "v": 0.944
+            },
+            "leftWrist": {
+              "x": 90.3,
+              "y": 24,
+              "v": 0.916
+            },
+            "rightWrist": {
+              "x": 20.6,
+              "y": 65.4,
+              "v": 0.141
+            },
+            "leftIndex": {
+              "x": 96.7,
+              "y": 22.5,
+              "v": 0.924
+            },
+            "rightIndex": {
+              "x": 23.5,
+              "y": 64.7,
+              "v": 0.111
+            },
+            "leftHip": {
+              "x": 53.8,
+              "y": 58.3,
+              "v": 0.996
+            },
+            "rightHip": {
+              "x": 44.7,
+              "y": 65.7,
+              "v": 0.997
+            },
+            "leftKnee": {
+              "x": 82.7,
+              "y": 41.5,
+              "v": 0.96
+            },
+            "rightKnee": {
+              "x": 53.9,
+              "y": 89.9,
+              "v": 0.983
+            },
+            "leftAnkle": {
+              "x": 112.3,
+              "y": 34.6,
+              "v": 0.956
+            },
+            "rightAnkle": {
+              "x": 42.9,
+              "y": 115.2,
+              "v": 0.98
+            },
+            "leftHeel": {
+              "x": 118.1,
+              "y": 37.3,
+              "v": 0.988
+            },
+            "rightHeel": {
+              "x": 38.8,
+              "y": 120.3,
+              "v": 0.851
+            },
+            "leftFootIndex": {
+              "x": 117.8,
+              "y": 19.6,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 52,
+              "y": 124.2,
+              "v": 0.949
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 43.3,
+                "y": 17.9
+              },
+              "roll": -165.3,
+              "yaw": 0.345,
+              "pitch": 0.679
+            },
+            "torso": {
+              "center": {
+                "x": 37.2,
+                "y": 31.8
+              },
+              "angle": 111.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.3,
+                "y": 24
+              },
+              "angle": 13.2
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 118.1,
+                "y": 37.3
+              },
+              "angle": 91
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.8,
+                "y": 120.3
+              },
+              "angle": -16.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.843,
+          "keypoints": {
+            "nose": {
+              "x": 55.2,
+              "y": 18.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.6,
+              "y": 15.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 52.3,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 53.1,
+              "y": 16.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46.4,
+              "y": 16.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 55.6,
+              "y": 29.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.5,
+              "y": 27.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 58.8,
+              "y": 50.1,
+              "v": 0.329
+            },
+            "rightElbow": {
+              "x": 27.5,
+              "y": 44,
+              "v": 0.835
+            },
+            "leftWrist": {
+              "x": 55.6,
+              "y": 45.5,
+              "v": 0.477
+            },
+            "rightWrist": {
+              "x": 42.3,
+              "y": 37.6,
+              "v": 0.179
+            },
+            "leftIndex": {
+              "x": 55.1,
+              "y": 40.6,
+              "v": 0.545
+            },
+            "rightIndex": {
+              "x": 46.9,
+              "y": 32.6,
+              "v": 0.135
+            },
+            "leftHip": {
+              "x": 54.2,
+              "y": 57.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.1,
+              "y": 63,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.9,
+              "y": 53.5,
+              "v": 0.98
+            },
+            "rightKnee": {
+              "x": 42.8,
+              "y": 89.2,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 88.1,
+              "y": 53.8,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 31.3,
+              "y": 117.2,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 89.8,
+              "y": 56.7,
+              "v": 0.98
+            },
+            "rightHeel": {
+              "x": 29.8,
+              "y": 121.4,
+              "v": 0.962
+            },
+            "leftFootIndex": {
+              "x": 91.8,
+              "y": 48.7,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 32.4,
+              "y": 123.6,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54,
+                "y": 15.5
+              },
+              "roll": -171.4,
+              "yaw": 0.375,
+              "pitch": 0.914
+            },
+            "torso": {
+              "center": {
+                "x": 46.6,
+                "y": 28.8
+              },
+              "angle": 96.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 55.6,
+                "y": 45.5
+              },
+              "angle": 95.8
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 89.8,
+                "y": 56.7
+              },
+              "angle": 76
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29.8,
+                "y": 121.4
+              },
+              "angle": -40.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.844,
+          "keypoints": {
+            "nose": {
+              "x": 50.6,
+              "y": 17.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 51.1,
+              "y": 14.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 47.5,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 49.5,
+              "y": 14.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 42.5,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 56.1,
+              "y": 25.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 29.8,
+              "y": 27.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.5,
+              "y": 29.2,
+              "v": 0.567
+            },
+            "rightElbow": {
+              "x": 16.9,
+              "y": 42,
+              "v": 0.903
+            },
+            "leftWrist": {
+              "x": 89.7,
+              "y": 26.4,
+              "v": 0.418
+            },
+            "rightWrist": {
+              "x": 30.9,
+              "y": 39.2,
+              "v": 0.158
+            },
+            "leftIndex": {
+              "x": 93.7,
+              "y": 22.2,
+              "v": 0.447
+            },
+            "rightIndex": {
+              "x": 35.4,
+              "y": 35.9,
+              "v": 0.125
+            },
+            "leftHip": {
+              "x": 53.6,
+              "y": 54.9,
+              "v": 0.998
+            },
+            "rightHip": {
+              "x": 42.7,
+              "y": 61,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 78.8,
+              "y": 38.8,
+              "v": 0.983
+            },
+            "rightKnee": {
+              "x": 39.2,
+              "y": 88.5,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 107.7,
+              "y": 29.6,
+              "v": 0.981
+            },
+            "rightAnkle": {
+              "x": 29,
+              "y": 116.2,
+              "v": 0.989
+            },
+            "leftHeel": {
+              "x": 112.8,
+              "y": 31.8,
+              "v": 0.977
+            },
+            "rightHeel": {
+              "x": 26.8,
+              "y": 120.2,
+              "v": 0.927
+            },
+            "leftFootIndex": {
+              "x": 112.4,
+              "y": 15.4,
+              "v": 0.987
+            },
+            "rightFootIndex": {
+              "x": 30,
+              "y": 124.9,
+              "v": 0.969
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 49.3,
+                "y": 14.3
+              },
+              "roll": -176.8,
+              "yaw": 0.361,
+              "pitch": 0.804
+            },
+            "torso": {
+              "center": {
+                "x": 43,
+                "y": 26.4
+              },
+              "angle": 99.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.7,
+                "y": 26.4
+              },
+              "angle": 46.4
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 112.8,
+                "y": 31.8
+              },
+              "angle": 91.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 26.8,
+                "y": 120.2
+              },
+              "angle": -55.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.84,
+          "keypoints": {
+            "nose": {
+              "x": 50.1,
+              "y": 17.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 50.3,
+              "y": 14.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 46.4,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 48,
+              "y": 15.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 41.4,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 54.2,
+              "y": 25.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 30.5,
+              "y": 30.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.9,
+              "y": 29.1,
+              "v": 0.672
+            },
+            "rightElbow": {
+              "x": 20,
+              "y": 45.1,
+              "v": 0.75
+            },
+            "leftWrist": {
+              "x": 82.7,
+              "y": 23.7,
+              "v": 0.696
+            },
+            "rightWrist": {
+              "x": 29.9,
+              "y": 37.2,
+              "v": 0.067
+            },
+            "leftIndex": {
+              "x": 87,
+              "y": 23.5,
+              "v": 0.732
+            },
+            "rightIndex": {
+              "x": 32.6,
+              "y": 31.9,
+              "v": 0.063
+            },
+            "leftHip": {
+              "x": 52.4,
+              "y": 54.9,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 41.9,
+              "y": 61.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.4,
+              "y": 39.1,
+              "v": 0.895
+            },
+            "rightKnee": {
+              "x": 39.4,
+              "y": 88.1,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 108.8,
+              "y": 29.3,
+              "v": 0.82
+            },
+            "rightAnkle": {
+              "x": 29.3,
+              "y": 115.7,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 112.9,
+              "y": 31.5,
+              "v": 0.822
+            },
+            "rightHeel": {
+              "x": 26.2,
+              "y": 120.3,
+              "v": 0.92
+            },
+            "leftFootIndex": {
+              "x": 112.9,
+              "y": 15.7,
+              "v": 0.91
+            },
+            "rightFootIndex": {
+              "x": 28.5,
+              "y": 125.3,
+              "v": 0.979
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 48.3,
+                "y": 15.1
+              },
+              "roll": -169.8,
+              "yaw": 0.442,
+              "pitch": 0.719
+            },
+            "torso": {
+              "center": {
+                "x": 42.4,
+                "y": 28
+              },
+              "angle": 99
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.7,
+                "y": 23.7
+              },
+              "angle": 2.7
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 112.9,
+                "y": 31.5
+              },
+              "angle": 90
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 26.2,
+                "y": 120.3
+              },
+              "angle": -65.3
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.904,
+          "keypoints": {
+            "nose": {
+              "x": 46.5,
+              "y": 17,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 47.2,
+              "y": 13.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 42.9,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 45.7,
+              "y": 14.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 38,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 51.8,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 30.7,
+              "y": 31.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.7,
+              "y": 27.4,
+              "v": 0.641
+            },
+            "rightElbow": {
+              "x": 29.7,
+              "y": 45.4,
+              "v": 0.97
+            },
+            "leftWrist": {
+              "x": 85.9,
+              "y": 24.3,
+              "v": 0.7
+            },
+            "rightWrist": {
+              "x": 47.5,
+              "y": 32.8,
+              "v": 0.547
+            },
+            "leftIndex": {
+              "x": 90.3,
+              "y": 21.3,
+              "v": 0.756
+            },
+            "rightIndex": {
+              "x": 52.8,
+              "y": 26.4,
+              "v": 0.402
+            },
+            "leftHip": {
+              "x": 51.6,
+              "y": 54.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.2,
+              "y": 62.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.2,
+              "y": 39.6,
+              "v": 0.944
+            },
+            "rightKnee": {
+              "x": 40.2,
+              "y": 89.2,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 107.3,
+              "y": 28.7,
+              "v": 0.943
+            },
+            "rightAnkle": {
+              "x": 29.7,
+              "y": 118.3,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 111.5,
+              "y": 30.3,
+              "v": 0.956
+            },
+            "rightHeel": {
+              "x": 26.8,
+              "y": 123.2,
+              "v": 0.976
+            },
+            "leftFootIndex": {
+              "x": 114.1,
+              "y": 15.1,
+              "v": 0.974
+            },
+            "rightFootIndex": {
+              "x": 32,
+              "y": 125.4,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 45.1,
+                "y": 13.7
+              },
+              "roll": -168.2,
+              "yaw": 0.33,
+              "pitch": 0.763
+            },
+            "torso": {
+              "center": {
+                "x": 41.3,
+                "y": 28.4
+              },
+              "angle": 101.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.9,
+                "y": 24.3
+              },
+              "angle": 34.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.5,
+                "y": 32.8
+              },
+              "angle": 50.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 111.5,
+                "y": 30.3
+              },
+              "angle": 80.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 26.8,
+                "y": 123.2
+              },
+              "angle": -22.9
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 56.2,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.8,
+              "y": 16,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.6,
+              "y": 16.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52.1,
+              "y": 16.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 47.7,
+              "y": 16.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 57.4,
+              "y": 30.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 31.6,
+              "y": 28.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.4,
+              "y": 38.2,
+              "v": 0.997
+            },
+            "rightElbow": {
+              "x": 17,
+              "y": 40.4,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 94,
+              "y": 39.6,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 10.3,
+              "y": 51.4,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 99.4,
+              "y": 39.3,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 9.8,
+              "y": 53.7,
+              "v": 0.993
+            },
+            "leftHip": {
+              "x": 48.2,
+              "y": 64.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 35.1,
+              "y": 64.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63.5,
+              "y": 86.6,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 28.1,
+              "y": 91.5,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 58.7,
+              "y": 111,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 18,
+              "y": 118.7,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 54.4,
+              "y": 116.3,
+              "v": 0.988
+            },
+            "rightHeel": {
+              "x": 16.8,
+              "y": 121.7,
+              "v": 0.981
+            },
+            "leftFootIndex": {
+              "x": 69.9,
+              "y": 118.6,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 16.4,
+              "y": 125.4,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.7,
+                "y": 16.1
+              },
+              "roll": -174.8,
+              "yaw": 0.679,
+              "pitch": 1.403
+            },
+            "torso": {
+              "center": {
+                "x": 44.5,
+                "y": 29.7
+              },
+              "angle": 85.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94,
+                "y": 39.6
+              },
+              "angle": 3.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 10.3,
+                "y": 51.4
+              },
+              "angle": -102.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 54.4,
+                "y": 116.3
+              },
+              "angle": -8.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 16.8,
+                "y": 121.7
+              },
+              "angle": -96.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.984,
+          "keypoints": {
+            "nose": {
+              "x": 54.6,
+              "y": 19.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.3,
+              "y": 16.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 52.2,
+              "y": 16.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 53.3,
+              "y": 16.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46.1,
+              "y": 16.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 57,
+              "y": 30.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 31.6,
+              "y": 28,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.8,
+              "y": 36.7,
+              "v": 0.988
+            },
+            "rightElbow": {
+              "x": 16.1,
+              "y": 38.9,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 94.4,
+              "y": 37.6,
+              "v": 0.982
+            },
+            "rightWrist": {
+              "x": 10.2,
+              "y": 50.4,
+              "v": 0.97
+            },
+            "leftIndex": {
+              "x": 100.6,
+              "y": 37.8,
+              "v": 0.966
+            },
+            "rightIndex": {
+              "x": 9.7,
+              "y": 53,
+              "v": 0.936
+            },
+            "leftHip": {
+              "x": 47.4,
+              "y": 64.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 35.1,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 61.7,
+              "y": 86.8,
+              "v": 0.978
+            },
+            "rightKnee": {
+              "x": 26.3,
+              "y": 91.1,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 56.7,
+              "y": 112,
+              "v": 0.979
+            },
+            "rightAnkle": {
+              "x": 16.3,
+              "y": 117.8,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 52.7,
+              "y": 116.6,
+              "v": 0.956
+            },
+            "rightHeel": {
+              "x": 13.9,
+              "y": 121.9,
+              "v": 0.919
+            },
+            "leftFootIndex": {
+              "x": 67.7,
+              "y": 118.1,
+              "v": 0.984
+            },
+            "rightFootIndex": {
+              "x": 17.3,
+              "y": 125.6,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.8,
+                "y": 16.3
+              },
+              "roll": 176.3,
+              "yaw": 0.274,
+              "pitch": 0.966
+            },
+            "torso": {
+              "center": {
+                "x": 44.3,
+                "y": 29.2
+              },
+              "angle": 85
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.4,
+                "y": 37.6
+              },
+              "angle": -1.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 10.2,
+                "y": 50.4
+              },
+              "angle": -100.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 52.7,
+                "y": 116.6
+              },
+              "angle": -5.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 13.9,
+                "y": 121.9
+              },
+              "angle": -47.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.982,
+          "keypoints": {
+            "nose": {
+              "x": 51.9,
+              "y": 19.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 52.2,
+              "y": 16.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 48.9,
+              "y": 16.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 49.4,
+              "y": 16.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 42.4,
+              "y": 16.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 54.4,
+              "y": 29.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 27.6,
+              "y": 30.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.5,
+              "y": 33.9,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 11.5,
+              "y": 46.1,
+              "v": 0.977
+            },
+            "leftWrist": {
+              "x": 94.7,
+              "y": 33.5,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 10.7,
+              "y": 51.8,
+              "v": 0.858
+            },
+            "leftIndex": {
+              "x": 102.1,
+              "y": 32.7,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 10.5,
+              "y": 51.1,
+              "v": 0.816
+            },
+            "leftHip": {
+              "x": 44.1,
+              "y": 62.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 30.3,
+              "y": 64.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 59.4,
+              "y": 85.5,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 23.2,
+              "y": 90.5,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 53.9,
+              "y": 109.6,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 15.2,
+              "y": 113.4,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 49.7,
+              "y": 114.1,
+              "v": 0.99
+            },
+            "rightHeel": {
+              "x": 13.6,
+              "y": 116.1,
+              "v": 0.972
+            },
+            "leftFootIndex": {
+              "x": 64.6,
+              "y": 115.9,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 14.2,
+              "y": 124.1,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 50.6,
+                "y": 16.3
+              },
+              "roll": -173.1,
+              "yaw": 0.406,
+              "pitch": 0.933
+            },
+            "torso": {
+              "center": {
+                "x": 41,
+                "y": 30.1
+              },
+              "angle": 83.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.7,
+                "y": 33.5
+              },
+              "angle": 6.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 10.7,
+                "y": 51.8
+              },
+              "angle": 105.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 49.7,
+                "y": 114.1
+              },
+              "angle": -6.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 13.6,
+                "y": 116.1
+              },
+              "angle": -85.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.977,
+          "keypoints": {
+            "nose": {
+              "x": 52.7,
+              "y": 19,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.2,
+              "y": 15.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 50.1,
+              "y": 15.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52.6,
+              "y": 16.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 44.3,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 56,
+              "y": 30.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 31,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.4,
+              "y": 35.7,
+              "v": 0.994
+            },
+            "rightElbow": {
+              "x": 16,
+              "y": 39.6,
+              "v": 0.986
+            },
+            "leftWrist": {
+              "x": 90.2,
+              "y": 35.4,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 11,
+              "y": 49.4,
+              "v": 0.847
+            },
+            "leftIndex": {
+              "x": 96.6,
+              "y": 34,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 10.5,
+              "y": 51.4,
+              "v": 0.768
+            },
+            "leftHip": {
+              "x": 46.7,
+              "y": 64.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 33.6,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 61.1,
+              "y": 86,
+              "v": 0.991
+            },
+            "rightKnee": {
+              "x": 27.2,
+              "y": 90.6,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 56.6,
+              "y": 111.4,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 17.4,
+              "y": 119.4,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 52.5,
+              "y": 116.4,
+              "v": 0.973
+            },
+            "rightHeel": {
+              "x": 15.2,
+              "y": 122.6,
+              "v": 0.952
+            },
+            "leftFootIndex": {
+              "x": 68.1,
+              "y": 117.8,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 18,
+              "y": 127.5,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 52.2,
+                "y": 15.5
+              },
+              "roll": 173,
+              "yaw": 0.133,
+              "pitch": 0.859
+            },
+            "torso": {
+              "center": {
+                "x": 43.5,
+                "y": 29.2
+              },
+              "angle": 84.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.2,
+                "y": 35.4
+              },
+              "angle": 12.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 11,
+                "y": 49.4
+              },
+              "angle": -104
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 52.5,
+                "y": 116.4
+              },
+              "angle": -5.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 15.2,
+                "y": 122.6
+              },
+              "angle": -60.3
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.939,
+          "keypoints": {
+            "nose": {
+              "x": 47.2,
+              "y": 19.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 47.9,
+              "y": 16.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 43.9,
+              "y": 16.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 46.8,
+              "y": 16.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 38.4,
+              "y": 16.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 50.6,
+              "y": 30.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 26.4,
+              "y": 30.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 66,
+              "y": 36.9,
+              "v": 0.943
+            },
+            "rightElbow": {
+              "x": 16.3,
+              "y": 50.9,
+              "v": 0.904
+            },
+            "leftWrist": {
+              "x": 84.6,
+              "y": 38.5,
+              "v": 0.93
+            },
+            "rightWrist": {
+              "x": 24.4,
+              "y": 46.3,
+              "v": 0.542
+            },
+            "leftIndex": {
+              "x": 90.7,
+              "y": 36.4,
+              "v": 0.911
+            },
+            "rightIndex": {
+              "x": 27.8,
+              "y": 41,
+              "v": 0.483
+            },
+            "leftHip": {
+              "x": 40.8,
+              "y": 64.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 28.2,
+              "y": 65.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 56.3,
+              "y": 86.3,
+              "v": 0.994
+            },
+            "rightKnee": {
+              "x": 21.5,
+              "y": 90,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 51.6,
+              "y": 110.1,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 12.4,
+              "y": 113.5,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 47.5,
+              "y": 115.1,
+              "v": 0.982
+            },
+            "rightHeel": {
+              "x": 11.2,
+              "y": 116.8,
+              "v": 0.94
+            },
+            "leftFootIndex": {
+              "x": 62.9,
+              "y": 117.2,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 11.5,
+              "y": 123.9,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 45.9,
+                "y": 16.4
+              },
+              "roll": -172.9,
+              "yaw": 0.322,
+              "pitch": 0.781
+            },
+            "torso": {
+              "center": {
+                "x": 38.5,
+                "y": 30.2
+              },
+              "angle": 83.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.6,
+                "y": 38.5
+              },
+              "angle": 19
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 24.4,
+                "y": 46.3
+              },
+              "angle": 57.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 47.5,
+                "y": 115.1
+              },
+              "angle": -7.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 11.2,
+                "y": 116.8
+              },
+              "angle": -87.6
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.987,
+          "keypoints": {
+            "nose": {
+              "x": 62.1,
+              "y": 18.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.3,
+              "y": 15.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 59.1,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.6,
+              "y": 15.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.2,
+              "y": 15.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.9,
+              "y": 29,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.1,
+              "y": 27.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.7,
+              "y": 32.5,
+              "v": 0.944
+            },
+            "rightElbow": {
+              "x": 24.6,
+              "y": 40.6,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 93.8,
+              "y": 31.7,
+              "v": 0.936
+            },
+            "rightWrist": {
+              "x": 19.1,
+              "y": 52.2,
+              "v": 0.975
+            },
+            "leftIndex": {
+              "x": 98.9,
+              "y": 28.6,
+              "v": 0.929
+            },
+            "rightIndex": {
+              "x": 19.1,
+              "y": 53.6,
+              "v": 0.962
+            },
+            "leftHip": {
+              "x": 56.7,
+              "y": 63.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43,
+              "y": 64.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.2,
+              "y": 86.5,
+              "v": 0.994
+            },
+            "rightKnee": {
+              "x": 36,
+              "y": 91.1,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 65.2,
+              "y": 111.6,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 25.8,
+              "y": 116.9,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 61.3,
+              "y": 116.5,
+              "v": 0.992
+            },
+            "rightHeel": {
+              "x": 23.3,
+              "y": 120.6,
+              "v": 0.984
+            },
+            "leftFootIndex": {
+              "x": 76.6,
+              "y": 118.4,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 26.2,
+              "y": 127.7,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.7,
+                "y": 15.6
+              },
+              "roll": -174.6,
+              "yaw": 0.436,
+              "pitch": 0.825
+            },
+            "torso": {
+              "center": {
+                "x": 51.5,
+                "y": 28.2
+              },
+              "angle": 87.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.8,
+                "y": 31.7
+              },
+              "angle": 31.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 19.1,
+                "y": 52.2
+              },
+              "angle": -90
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.3,
+                "y": 116.5
+              },
+              "angle": -7.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.3,
+                "y": 120.6
+              },
+              "angle": -67.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.969,
+          "keypoints": {
+            "nose": {
+              "x": 56.7,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 57,
+              "y": 15.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.6,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.5,
+              "y": 15.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.1,
+              "y": 15.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.2,
+              "y": 29.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 33.4,
+              "y": 27.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 68.2,
+              "y": 38,
+              "v": 0.921
+            },
+            "rightElbow": {
+              "x": 18.6,
+              "y": 41.2,
+              "v": 0.979
+            },
+            "leftWrist": {
+              "x": 76.9,
+              "y": 27.8,
+              "v": 0.936
+            },
+            "rightWrist": {
+              "x": 15.6,
+              "y": 52.3,
+              "v": 0.865
+            },
+            "leftIndex": {
+              "x": 80.3,
+              "y": 19.9,
+              "v": 0.922
+            },
+            "rightIndex": {
+              "x": 15.8,
+              "y": 53.4,
+              "v": 0.813
+            },
+            "leftHip": {
+              "x": 49.7,
+              "y": 62.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 35.6,
+              "y": 62.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 64.5,
+              "y": 85.5,
+              "v": 0.984
+            },
+            "rightKnee": {
+              "x": 28.2,
+              "y": 89.8,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 59.3,
+              "y": 109.4,
+              "v": 0.988
+            },
+            "rightAnkle": {
+              "x": 18.2,
+              "y": 115.7,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 55.1,
+              "y": 114.4,
+              "v": 0.969
+            },
+            "rightHeel": {
+              "x": 16.6,
+              "y": 118.8,
+              "v": 0.936
+            },
+            "leftFootIndex": {
+              "x": 70.9,
+              "y": 117.1,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 18.1,
+              "y": 124.9,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55.3,
+                "y": 15.4
+              },
+              "roll": -180,
+              "yaw": 0.412,
+              "pitch": 0.882
+            },
+            "torso": {
+              "center": {
+                "x": 46.3,
+                "y": 28.2
+              },
+              "angle": 83.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76.9,
+                "y": 27.8
+              },
+              "angle": 66.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 15.6,
+                "y": 52.3
+              },
+              "angle": -79.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 55.1,
+                "y": 114.4
+              },
+              "angle": -9.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 16.6,
+                "y": 118.8
+              },
+              "angle": -76.2
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.977,
+          "keypoints": {
+            "nose": {
+              "x": 81,
+              "y": 25.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 83,
+              "y": 22.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 80.1,
+              "y": 21.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 80.4,
+              "y": 20.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 74.4,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.3,
+              "y": 35.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.3,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82,
+              "y": 53.2,
+              "v": 0.887
+            },
+            "rightElbow": {
+              "x": 33.2,
+              "y": 34.8,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 94.4,
+              "y": 46.6,
+              "v": 0.966
+            },
+            "rightWrist": {
+              "x": 26.6,
+              "y": 47.3,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 98.1,
+              "y": 40.9,
+              "v": 0.955
+            },
+            "rightIndex": {
+              "x": 28.4,
+              "y": 52.4,
+              "v": 0.981
+            },
+            "leftHip": {
+              "x": 58.4,
+              "y": 63,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.2,
+              "y": 61.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.8,
+              "y": 83.3,
+              "v": 0.914
+            },
+            "rightKnee": {
+              "x": 40.7,
+              "y": 90.2,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 73,
+              "y": 110.2,
+              "v": 0.933
+            },
+            "rightAnkle": {
+              "x": 30.3,
+              "y": 120,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 68.2,
+              "y": 115.7,
+              "v": 0.915
+            },
+            "rightHeel": {
+              "x": 26.5,
+              "y": 124.6,
+              "v": 0.98
+            },
+            "leftFootIndex": {
+              "x": 86,
+              "y": 116.9,
+              "v": 0.954
+            },
+            "rightFootIndex": {
+              "x": 32.2,
+              "y": 130.5,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 81.6,
+                "y": 21.8
+              },
+              "roll": 155.9,
+              "yaw": -0.173,
+              "pitch": 1.18
+            },
+            "torso": {
+              "center": {
+                "x": 65.3,
+                "y": 29.1
+              },
+              "angle": 68.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.4,
+                "y": 46.6
+              },
+              "angle": 57
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 26.6,
+                "y": 47.3
+              },
+              "angle": -70.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.2,
+                "y": 115.7
+              },
+              "angle": -3.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 26.5,
+                "y": 124.6
+              },
+              "angle": -46
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.968,
+          "keypoints": {
+            "nose": {
+              "x": 81.7,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 82.7,
+              "y": 20.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 80.9,
+              "y": 19.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 79.4,
+              "y": 18.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 75.8,
+              "y": 17.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.5,
+              "y": 33.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.5,
+              "y": 21.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.1,
+              "y": 52.4,
+              "v": 0.95
+            },
+            "rightElbow": {
+              "x": 33.9,
+              "y": 31.5,
+              "v": 0.985
+            },
+            "leftWrist": {
+              "x": 94,
+              "y": 44.3,
+              "v": 0.974
+            },
+            "rightWrist": {
+              "x": 27.3,
+              "y": 45.4,
+              "v": 0.907
+            },
+            "leftIndex": {
+              "x": 98.5,
+              "y": 38.1,
+              "v": 0.961
+            },
+            "rightIndex": {
+              "x": 28.7,
+              "y": 50.6,
+              "v": 0.853
+            },
+            "leftHip": {
+              "x": 56.8,
+              "y": 61,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.6,
+              "y": 58.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78,
+              "y": 82.8,
+              "v": 0.938
+            },
+            "rightKnee": {
+              "x": 40.7,
+              "y": 89.5,
+              "v": 0.993
+            },
+            "leftAnkle": {
+              "x": 72,
+              "y": 110.3,
+              "v": 0.94
+            },
+            "rightAnkle": {
+              "x": 29.4,
+              "y": 119.8,
+              "v": 0.992
+            },
+            "leftHeel": {
+              "x": 67.9,
+              "y": 115.7,
+              "v": 0.916
+            },
+            "rightHeel": {
+              "x": 26.4,
+              "y": 123.2,
+              "v": 0.918
+            },
+            "leftFootIndex": {
+              "x": 85.2,
+              "y": 117.2,
+              "v": 0.953
+            },
+            "rightFootIndex": {
+              "x": 32,
+              "y": 127.9,
+              "v": 0.979
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 81.8,
+                "y": 20.3
+              },
+              "roll": 150.9,
+              "yaw": -0.049,
+              "pitch": 1.505
+            },
+            "torso": {
+              "center": {
+                "x": 66.5,
+                "y": 27.7
+              },
+              "angle": 63.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94,
+                "y": 44.3
+              },
+              "angle": 54
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 27.3,
+                "y": 45.4
+              },
+              "angle": -74.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.9,
+                "y": 115.7
+              },
+              "angle": -5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 26.4,
+                "y": 123.2
+              },
+              "angle": -40
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.982,
+          "keypoints": {
+            "nose": {
+              "x": 75.2,
+              "y": 20.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.8,
+              "y": 18,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.6,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 76.2,
+              "y": 18.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.3,
+              "y": 14.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.3,
+              "y": 32.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.6,
+              "y": 22.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.3,
+              "y": 49.2,
+              "v": 0.927
+            },
+            "rightElbow": {
+              "x": 31.9,
+              "y": 35.9,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 94.8,
+              "y": 45.1,
+              "v": 0.974
+            },
+            "rightWrist": {
+              "x": 26.1,
+              "y": 52.9,
+              "v": 0.977
+            },
+            "leftIndex": {
+              "x": 98.7,
+              "y": 39,
+              "v": 0.967
+            },
+            "rightIndex": {
+              "x": 28.8,
+              "y": 59.4,
+              "v": 0.959
+            },
+            "leftHip": {
+              "x": 59.9,
+              "y": 61.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.1,
+              "y": 61.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.7,
+              "y": 83.9,
+              "v": 0.93
+            },
+            "rightKnee": {
+              "x": 42.7,
+              "y": 89.2,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 73.4,
+              "y": 110.4,
+              "v": 0.967
+            },
+            "rightAnkle": {
+              "x": 32.2,
+              "y": 118.7,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 68.9,
+              "y": 115.8,
+              "v": 0.943
+            },
+            "rightHeel": {
+              "x": 29.3,
+              "y": 123,
+              "v": 0.974
+            },
+            "leftFootIndex": {
+              "x": 85.3,
+              "y": 117.1,
+              "v": 0.977
+            },
+            "rightFootIndex": {
+              "x": 34.3,
+              "y": 128.7,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 75.7,
+                "y": 16.9
+              },
+              "roll": 151.3,
+              "yaw": -0.104,
+              "pitch": 0.7
+            },
+            "torso": {
+              "center": {
+                "x": 62.5,
+                "y": 27.5
+              },
+              "angle": 75.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.8,
+                "y": 45.1
+              },
+              "angle": 57.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 26.1,
+                "y": 52.9
+              },
+              "angle": -67.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.9,
+                "y": 115.8
+              },
+              "angle": -4.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29.3,
+                "y": 123
+              },
+              "angle": -48.7
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.967,
+          "keypoints": {
+            "nose": {
+              "x": 70.9,
+              "y": 18.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.1,
+              "y": 15.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.9,
+              "y": 15.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69,
+              "y": 15.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.7,
+              "y": 16.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73,
+              "y": 31,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.3,
+              "y": 28.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77,
+              "y": 51.5,
+              "v": 0.786
+            },
+            "rightElbow": {
+              "x": 34.3,
+              "y": 44,
+              "v": 0.993
+            },
+            "leftWrist": {
+              "x": 84,
+              "y": 66.6,
+              "v": 0.834
+            },
+            "rightWrist": {
+              "x": 30.9,
+              "y": 59.1,
+              "v": 0.981
+            },
+            "leftIndex": {
+              "x": 88,
+              "y": 70.6,
+              "v": 0.832
+            },
+            "rightIndex": {
+              "x": 32.3,
+              "y": 63.2,
+              "v": 0.973
+            },
+            "leftHip": {
+              "x": 64.4,
+              "y": 62.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.4,
+              "y": 63,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.5,
+              "y": 87,
+              "v": 0.964
+            },
+            "rightKnee": {
+              "x": 44.6,
+              "y": 89.8,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 74.2,
+              "y": 110.9,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 34.6,
+              "y": 116.3,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 70.5,
+              "y": 116.1,
+              "v": 0.974
+            },
+            "rightHeel": {
+              "x": 32.5,
+              "y": 121.1,
+              "v": 0.926
+            },
+            "leftFootIndex": {
+              "x": 86.7,
+              "y": 118.1,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 35.2,
+              "y": 125.1,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.5,
+                "y": 15.7
+              },
+              "roll": -172.9,
+              "yaw": 0.434,
+              "pitch": 0.93
+            },
+            "torso": {
+              "center": {
+                "x": 60.7,
+                "y": 29.7
+              },
+              "angle": 85.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84,
+                "y": 66.6
+              },
+              "angle": -45
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 30.9,
+                "y": 59.1
+              },
+              "angle": -71.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.5,
+                "y": 116.1
+              },
+              "angle": -7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.5,
+                "y": 121.1
+              },
+              "angle": -56
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 61,
+              "y": 16.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 60.5,
+              "y": 13.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.3,
+              "y": 14.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.6,
+              "y": 15.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.1,
+              "y": 17.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 69.4,
+              "y": 26.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44.5,
+              "y": 34.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.5,
+              "y": 32.3,
+              "v": 0.966
+            },
+            "rightElbow": {
+              "x": 42.1,
+              "y": 54.8,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 98.2,
+              "y": 23.7,
+              "v": 0.969
+            },
+            "rightWrist": {
+              "x": 41.7,
+              "y": 73.2,
+              "v": 0.983
+            },
+            "leftIndex": {
+              "x": 101.3,
+              "y": 20.7,
+              "v": 0.956
+            },
+            "rightIndex": {
+              "x": 42.6,
+              "y": 79.7,
+              "v": 0.958
+            },
+            "leftHip": {
+              "x": 75.3,
+              "y": 61.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.2,
+              "y": 64.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 93.6,
+              "y": 82.6,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 58.8,
+              "y": 90.4,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 89.9,
+              "y": 107.1,
+              "v": 0.983
+            },
+            "rightAnkle": {
+              "x": 50.6,
+              "y": 115.5,
+              "v": 0.988
+            },
+            "leftHeel": {
+              "x": 86.8,
+              "y": 111.1,
+              "v": 0.964
+            },
+            "rightHeel": {
+              "x": 49.5,
+              "y": 119.7,
+              "v": 0.904
+            },
+            "leftFootIndex": {
+              "x": 101.9,
+              "y": 113.2,
+              "v": 0.983
+            },
+            "rightFootIndex": {
+              "x": 50.3,
+              "y": 124.2,
+              "v": 0.982
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58.9,
+                "y": 14.3
+              },
+              "roll": -159.4,
+              "yaw": 0.614,
+              "pitch": 0.614
+            },
+            "torso": {
+              "center": {
+                "x": 57,
+                "y": 30.6
+              },
+              "angle": 110.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.2,
+                "y": 23.7
+              },
+              "angle": 44.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.7,
+                "y": 73.2
+              },
+              "angle": -82.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 86.8,
+                "y": 111.1
+              },
+              "angle": -7.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 49.5,
+                "y": 119.7
+              },
+              "angle": -79.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.923,
+          "keypoints": {
+            "nose": {
+              "x": 50.4,
+              "y": 25.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 48.8,
+              "y": 24,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 46.4,
+              "y": 25.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 47.4,
+              "y": 26.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 42.2,
+              "y": 29.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.3,
+              "y": 36.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.4,
+              "y": 45.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75,
+              "y": 40.1,
+              "v": 0.349
+            },
+            "rightElbow": {
+              "x": 37.4,
+              "y": 64,
+              "v": 0.99
+            },
+            "leftWrist": {
+              "x": 80.5,
+              "y": 26.6,
+              "v": 0.6
+            },
+            "rightWrist": {
+              "x": 41.9,
+              "y": 80.8,
+              "v": 0.948
+            },
+            "leftIndex": {
+              "x": 80.4,
+              "y": 22.1,
+              "v": 0.592
+            },
+            "rightIndex": {
+              "x": 43.6,
+              "y": 86.3,
+              "v": 0.897
+            },
+            "leftHip": {
+              "x": 77.7,
+              "y": 56.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 70.4,
+              "y": 66.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 98,
+              "y": 42.3,
+              "v": 0.97
+            },
+            "rightKnee": {
+              "x": 78.5,
+              "y": 89.2,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 112.9,
+              "y": 59.9,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 70.8,
+              "y": 111.4,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 114.8,
+              "y": 65.6,
+              "v": 0.989
+            },
+            "rightHeel": {
+              "x": 67.1,
+              "y": 113.7,
+              "v": 0.932
+            },
+            "leftFootIndex": {
+              "x": 124.1,
+              "y": 53.7,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 74.9,
+              "y": 124.3,
+              "v": 0.988
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 47.6,
+                "y": 24.8
+              },
+              "roll": -146.3,
+              "yaw": 0.971,
+              "pitch": 0.243
+            },
+            "torso": {
+              "center": {
+                "x": 50.3,
+                "y": 40.8
+              },
+              "angle": 139.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.5,
+                "y": 26.6
+              },
+              "angle": 91.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.9,
+                "y": 80.8
+              },
+              "angle": -72.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 114.8,
+                "y": 65.6
+              },
+              "angle": 52
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 67.1,
+                "y": 113.7
+              },
+              "angle": -53.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.969,
+          "keypoints": {
+            "nose": {
+              "x": 72.8,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74,
+              "y": 20.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.6,
+              "y": 20.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.2,
+              "y": 21.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.2,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.4,
+              "y": 35.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.2,
+              "y": 31.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.8,
+              "y": 55.5,
+              "v": 0.923
+            },
+            "rightElbow": {
+              "x": 37.9,
+              "y": 48.4,
+              "v": 0.979
+            },
+            "leftWrist": {
+              "x": 90.3,
+              "y": 64.3,
+              "v": 0.987
+            },
+            "rightWrist": {
+              "x": 36.1,
+              "y": 65.6,
+              "v": 0.911
+            },
+            "leftIndex": {
+              "x": 96,
+              "y": 65.8,
+              "v": 0.983
+            },
+            "rightIndex": {
+              "x": 37,
+              "y": 70,
+              "v": 0.853
+            },
+            "leftHip": {
+              "x": 65.9,
+              "y": 65.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.1,
+              "y": 65.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.2,
+              "y": 88.6,
+              "v": 0.937
+            },
+            "rightKnee": {
+              "x": 45.9,
+              "y": 91.7,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 70.9,
+              "y": 109.3,
+              "v": 0.972
+            },
+            "rightAnkle": {
+              "x": 37.4,
+              "y": 115.9,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 66.5,
+              "y": 113.5,
+              "v": 0.922
+            },
+            "rightHeel": {
+              "x": 35.4,
+              "y": 118.8,
+              "v": 0.871
+            },
+            "leftFootIndex": {
+              "x": 80.3,
+              "y": 119.2,
+              "v": 0.977
+            },
+            "rightFootIndex": {
+              "x": 37.4,
+              "y": 125.4,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.3,
+                "y": 20.6
+              },
+              "roll": 173.3,
+              "yaw": 0.146,
+              "pitch": 1.022
+            },
+            "torso": {
+              "center": {
+                "x": 62.3,
+                "y": 33.6
+              },
+              "angle": 85
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.3,
+                "y": 64.3
+              },
+              "angle": -14.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.1,
+                "y": 65.6
+              },
+              "angle": -78.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 66.5,
+                "y": 113.5
+              },
+              "angle": -22.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.4,
+                "y": 118.8
+              },
+              "angle": -73.1
+            }
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.973,
+          "keypoints": {
+            "nose": {
+              "x": 70.7,
+              "y": 18.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.6,
+              "y": 15.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.1,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.5,
+              "y": 15.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.6,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73,
+              "y": 30.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.3,
+              "y": 27.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.5,
+              "y": 46.7,
+              "v": 0.831
+            },
+            "rightElbow": {
+              "x": 35,
+              "y": 41.4,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 90.2,
+              "y": 45.5,
+              "v": 0.86
+            },
+            "rightWrist": {
+              "x": 29.6,
+              "y": 52.7,
+              "v": 0.935
+            },
+            "leftIndex": {
+              "x": 94.2,
+              "y": 41.8,
+              "v": 0.867
+            },
+            "rightIndex": {
+              "x": 26.6,
+              "y": 53.3,
+              "v": 0.906
+            },
+            "leftHip": {
+              "x": 65.3,
+              "y": 63.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.5,
+              "y": 63.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.7,
+              "y": 86.7,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 44.5,
+              "y": 90.3,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74.2,
+              "y": 111.3,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 34.6,
+              "y": 117.1,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 70.4,
+              "y": 116.3,
+              "v": 0.995
+            },
+            "rightHeel": {
+              "x": 32.8,
+              "y": 121.6,
+              "v": 0.992
+            },
+            "leftFootIndex": {
+              "x": 85.6,
+              "y": 117.7,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 35.2,
+              "y": 127.2,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.9,
+                "y": 15.9
+              },
+              "roll": 178.4,
+              "yaw": 0.243,
+              "pitch": 0.871
+            },
+            "torso": {
+              "center": {
+                "x": 60.7,
+                "y": 28.9
+              },
+              "angle": 86.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.2,
+                "y": 45.5
+              },
+              "angle": 42.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.6,
+                "y": 52.7
+              },
+              "angle": -168.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.4,
+                "y": 116.3
+              },
+              "angle": -5.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.8,
+                "y": 121.6
+              },
+              "angle": -66.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.909,
+          "keypoints": {
+            "nose": {
+              "x": 70.2,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.6,
+              "y": 15.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.3,
+              "y": 15,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.5,
+              "y": 15.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.2,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.7,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46,
+              "y": 27.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.4,
+              "y": 45.9,
+              "v": 0.312
+            },
+            "rightElbow": {
+              "x": 31.2,
+              "y": 45.5,
+              "v": 0.965
+            },
+            "leftWrist": {
+              "x": 85.9,
+              "y": 47.7,
+              "v": 0.401
+            },
+            "rightWrist": {
+              "x": 32.6,
+              "y": 50.8,
+              "v": 0.854
+            },
+            "leftIndex": {
+              "x": 89.6,
+              "y": 44.9,
+              "v": 0.553
+            },
+            "rightIndex": {
+              "x": 34.5,
+              "y": 49.2,
+              "v": 0.874
+            },
+            "leftHip": {
+              "x": 64.2,
+              "y": 64.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.9,
+              "y": 65,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80,
+              "y": 87.2,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 43.2,
+              "y": 90.6,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 74,
+              "y": 110.7,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 34.5,
+              "y": 115.9,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 69.8,
+              "y": 116.1,
+              "v": 0.991
+            },
+            "rightHeel": {
+              "x": 32,
+              "y": 119.6,
+              "v": 0.977
+            },
+            "leftFootIndex": {
+              "x": 85.9,
+              "y": 117.9,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 35.5,
+              "y": 125.7,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.9,
+                "y": 15.1
+              },
+              "roll": 176.5,
+              "yaw": 0.378,
+              "pitch": 0.968
+            },
+            "torso": {
+              "center": {
+                "x": 58.9,
+                "y": 28.4
+              },
+              "angle": 88
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.9,
+                "y": 47.7
+              },
+              "angle": 37.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.6,
+                "y": 50.8
+              },
+              "angle": 40.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.8,
+                "y": 116.1
+              },
+              "angle": -6.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32,
+                "y": 119.6
+              },
+              "angle": -60.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.952,
+          "keypoints": {
+            "nose": {
+              "x": 70.6,
+              "y": 19.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.2,
+              "y": 15.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.8,
+              "y": 16,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69,
+              "y": 16.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.3,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.9,
+              "y": 30.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.6,
+              "y": 27.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.4,
+              "y": 47.3,
+              "v": 0.699
+            },
+            "rightElbow": {
+              "x": 36.3,
+              "y": 45.1,
+              "v": 0.967
+            },
+            "leftWrist": {
+              "x": 89.6,
+              "y": 51.3,
+              "v": 0.794
+            },
+            "rightWrist": {
+              "x": 29.3,
+              "y": 52.1,
+              "v": 0.819
+            },
+            "leftIndex": {
+              "x": 94.6,
+              "y": 47.6,
+              "v": 0.836
+            },
+            "rightIndex": {
+              "x": 27.7,
+              "y": 52.5,
+              "v": 0.827
+            },
+            "leftHip": {
+              "x": 65,
+              "y": 63.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.3,
+              "y": 64.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.9,
+              "y": 87.5,
+              "v": 0.987
+            },
+            "rightKnee": {
+              "x": 44.6,
+              "y": 91.1,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74.1,
+              "y": 111.3,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 34.4,
+              "y": 116.4,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 70.3,
+              "y": 116.6,
+              "v": 0.992
+            },
+            "rightHeel": {
+              "x": 31.6,
+              "y": 121.2,
+              "v": 0.988
+            },
+            "leftFootIndex": {
+              "x": 85.7,
+              "y": 118.1,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 34.6,
+              "y": 125.9,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.5,
+                "y": 16
+              },
+              "roll": -178.3,
+              "yaw": 0.323,
+              "pitch": 0.926
+            },
+            "torso": {
+              "center": {
+                "x": 60.8,
+                "y": 29.1
+              },
+              "angle": 85.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.6,
+                "y": 51.3
+              },
+              "angle": 36.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.3,
+                "y": 52.1
+              },
+              "angle": -166
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.3,
+                "y": 116.6
+              },
+              "angle": -5.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.6,
+                "y": 121.2
+              },
+              "angle": -57.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.944,
+          "keypoints": {
+            "nose": {
+              "x": 55.7,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.1,
+              "y": 15.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.2,
+              "y": 15.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 53.8,
+              "y": 15.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46.9,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.5,
+              "y": 29.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 33.3,
+              "y": 28.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.4,
+              "y": 35.6,
+              "v": 0.991
+            },
+            "rightElbow": {
+              "x": 24.5,
+              "y": 46.5,
+              "v": 0.907
+            },
+            "leftWrist": {
+              "x": 100.2,
+              "y": 35.7,
+              "v": 0.992
+            },
+            "rightWrist": {
+              "x": 15.4,
+              "y": 53.6,
+              "v": 0.48
+            },
+            "leftIndex": {
+              "x": 107.5,
+              "y": 33.8,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 11,
+              "y": 52.4,
+              "v": 0.42
+            },
+            "leftHip": {
+              "x": 49.8,
+              "y": 63.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 35.8,
+              "y": 64.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 64.9,
+              "y": 87.8,
+              "v": 0.993
+            },
+            "rightKnee": {
+              "x": 29,
+              "y": 90.4,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 59.4,
+              "y": 111.4,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 21.5,
+              "y": 114.4,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 54.4,
+              "y": 116.4,
+              "v": 0.986
+            },
+            "rightHeel": {
+              "x": 19.5,
+              "y": 118.3,
+              "v": 0.97
+            },
+            "leftFootIndex": {
+              "x": 71.3,
+              "y": 117.9,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 20.4,
+              "y": 125.3,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.7,
+                "y": 15.6
+              },
+              "roll": 178,
+              "yaw": 0.362,
+              "pitch": 1.12
+            },
+            "torso": {
+              "center": {
+                "x": 46.4,
+                "y": 29.1
+              },
+              "angle": 84.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.2,
+                "y": 35.7
+              },
+              "angle": 14.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 15.4,
+                "y": 53.6
+              },
+              "angle": 164.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 54.4,
+                "y": 116.4
+              },
+              "angle": -5.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 19.5,
+                "y": 118.3
+              },
+              "angle": -82.7
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 77.8,
+              "y": 18.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 78.5,
+              "y": 15.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 74.7,
+              "y": 15.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 76.5,
+              "y": 15.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 69,
+              "y": 15.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 81.3,
+              "y": 30.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.8,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.6,
+              "y": 49.2,
+              "v": 0.993
+            },
+            "rightElbow": {
+              "x": 37.5,
+              "y": 42.5,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 91.4,
+              "y": 64.6,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 35.2,
+              "y": 53.1,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 92.7,
+              "y": 70.3,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 36.6,
+              "y": 53.9,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 71.5,
+              "y": 63.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.2,
+              "y": 64.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86.1,
+              "y": 87,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 51.8,
+              "y": 90.9,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 82,
+              "y": 111.7,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 42.3,
+              "y": 115.9,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 78.1,
+              "y": 116.6,
+              "v": 0.975
+            },
+            "rightHeel": {
+              "x": 41.1,
+              "y": 120.1,
+              "v": 0.929
+            },
+            "leftFootIndex": {
+              "x": 92.8,
+              "y": 118.3,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 41.9,
+              "y": 124.3,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 76.6,
+                "y": 15.6
+              },
+              "roll": -178.5,
+              "yaw": 0.316,
+              "pitch": 0.802
+            },
+            "torso": {
+              "center": {
+                "x": 68.1,
+                "y": 29.2
+              },
+              "angle": 84.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.4,
+                "y": 64.6
+              },
+              "angle": -77.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.2,
+                "y": 53.1
+              },
+              "angle": -29.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.1,
+                "y": 116.6
+              },
+              "angle": -6.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.1,
+                "y": 120.1
+              },
+              "angle": -79.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.886,
+          "keypoints": {
+            "nose": {
+              "x": 81.4,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 82.3,
+              "y": 18.8,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 80.2,
+              "y": 18.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 79.7,
+              "y": 17.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 74.6,
+              "y": 16.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.2,
+              "y": 30.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.9,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.6,
+              "y": 53.8,
+              "v": 0.849
+            },
+            "rightElbow": {
+              "x": 37,
+              "y": 46.1,
+              "v": 0.993
+            },
+            "leftWrist": {
+              "x": 90.3,
+              "y": 74.9,
+              "v": 0.497
+            },
+            "rightWrist": {
+              "x": 33.7,
+              "y": 72.7,
+              "v": 0.809
+            },
+            "leftIndex": {
+              "x": 91.5,
+              "y": 80.2,
+              "v": 0.475
+            },
+            "rightIndex": {
+              "x": 35.6,
+              "y": 79.8,
+              "v": 0.716
+            },
+            "leftHip": {
+              "x": 64.8,
+              "y": 59.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.1,
+              "y": 57.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.5,
+              "y": 83.9,
+              "v": 0.573
+            },
+            "rightKnee": {
+              "x": 52.9,
+              "y": 86.5,
+              "v": 0.99
+            },
+            "leftAnkle": {
+              "x": 76.6,
+              "y": 109.4,
+              "v": 0.841
+            },
+            "rightAnkle": {
+              "x": 44.8,
+              "y": 115,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 72.2,
+              "y": 114.7,
+              "v": 0.81
+            },
+            "rightHeel": {
+              "x": 42.5,
+              "y": 117,
+              "v": 0.937
+            },
+            "leftFootIndex": {
+              "x": 88.7,
+              "y": 116.4,
+              "v": 0.913
+            },
+            "rightFootIndex": {
+              "x": 47.5,
+              "y": 126,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 81.3,
+                "y": 18.7
+              },
+              "roll": 174.6,
+              "yaw": 0.071,
+              "pitch": 1.659
+            },
+            "torso": {
+              "center": {
+                "x": 67.1,
+                "y": 27.7
+              },
+              "angle": 73.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.3,
+                "y": 74.9
+              },
+              "angle": -77.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.7,
+                "y": 72.7
+              },
+              "angle": -75
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.2,
+                "y": 114.7
+              },
+              "angle": -5.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.5,
+                "y": 117
+              },
+              "angle": -60.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.942,
+          "keypoints": {
+            "nose": {
+              "x": 78.9,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 82.3,
+              "y": 21.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 77.2,
+              "y": 18.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 81.1,
+              "y": 19.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 73.3,
+              "y": 16.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78.9,
+              "y": 26,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.8,
+              "y": 20.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.2,
+              "y": 47.9,
+              "v": 0.842
+            },
+            "rightElbow": {
+              "x": 35.5,
+              "y": 41.4,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 90.6,
+              "y": 69.2,
+              "v": 0.715
+            },
+            "rightWrist": {
+              "x": 33.1,
+              "y": 67.9,
+              "v": 0.895
+            },
+            "leftIndex": {
+              "x": 92.3,
+              "y": 75.6,
+              "v": 0.697
+            },
+            "rightIndex": {
+              "x": 35.5,
+              "y": 74.1,
+              "v": 0.8
+            },
+            "leftHip": {
+              "x": 63.4,
+              "y": 54.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.3,
+              "y": 53.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.9,
+              "y": 79.6,
+              "v": 0.917
+            },
+            "rightKnee": {
+              "x": 49.1,
+              "y": 83.6,
+              "v": 0.992
+            },
+            "leftAnkle": {
+              "x": 77.7,
+              "y": 107.9,
+              "v": 0.966
+            },
+            "rightAnkle": {
+              "x": 41.4,
+              "y": 111,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 73.8,
+              "y": 112.9,
+              "v": 0.93
+            },
+            "rightHeel": {
+              "x": 40.4,
+              "y": 112.1,
+              "v": 0.947
+            },
+            "leftFootIndex": {
+              "x": 89.2,
+              "y": 114.9,
+              "v": 0.974
+            },
+            "rightFootIndex": {
+              "x": 44.7,
+              "y": 116.1,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 79.8,
+                "y": 20
+              },
+              "roll": 152.1,
+              "yaw": -0.147,
+              "pitch": 0.719
+            },
+            "torso": {
+              "center": {
+                "x": 66.4,
+                "y": 23.2
+              },
+              "angle": 72
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.6,
+                "y": 69.2
+              },
+              "angle": -75.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.1,
+                "y": 67.9
+              },
+              "angle": -68.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.8,
+                "y": 112.9
+              },
+              "angle": -7.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.4,
+                "y": 112.1
+              },
+              "angle": -42.9
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.985,
+          "keypoints": {
+            "nose": {
+              "x": 70.5,
+              "y": 19.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.4,
+              "y": 16.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.9,
+              "y": 16.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.2,
+              "y": 16.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.9,
+              "y": 16.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.4,
+              "y": 31.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.2,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78,
+              "y": 48.6,
+              "v": 0.862
+            },
+            "rightElbow": {
+              "x": 33.2,
+              "y": 40.5,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 88.3,
+              "y": 49.9,
+              "v": 0.952
+            },
+            "rightWrist": {
+              "x": 26.5,
+              "y": 50.6,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 93.2,
+              "y": 46.5,
+              "v": 0.959
+            },
+            "rightIndex": {
+              "x": 27.8,
+              "y": 51.9,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 63.8,
+              "y": 64.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.5,
+              "y": 64.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.7,
+              "y": 83.3,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 44.6,
+              "y": 90.6,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 65.2,
+              "y": 96.6,
+              "v": 0.972
+            },
+            "rightAnkle": {
+              "x": 36,
+              "y": 115.1,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 60.1,
+              "y": 96.7,
+              "v": 0.961
+            },
+            "rightHeel": {
+              "x": 34.7,
+              "y": 116.5,
+              "v": 0.99
+            },
+            "leftFootIndex": {
+              "x": 66.3,
+              "y": 109.5,
+              "v": 0.972
+            },
+            "rightFootIndex": {
+              "x": 33.2,
+              "y": 124.8,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.7,
+                "y": 16.6
+              },
+              "roll": 176.7,
+              "yaw": 0.242,
+              "pitch": 0.856
+            },
+            "torso": {
+              "center": {
+                "x": 60.8,
+                "y": 29.8
+              },
+              "angle": 84.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.3,
+                "y": 49.9
+              },
+              "angle": 34.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 26.5,
+                "y": 50.6
+              },
+              "angle": -45
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.1,
+                "y": 96.7
+              },
+              "angle": -64.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 34.7,
+                "y": 116.5
+              },
+              "angle": -100.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.898,
+          "keypoints": {
+            "nose": {
+              "x": 65.5,
+              "y": 18.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.6,
+              "y": 15.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62.7,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.5,
+              "y": 16,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.8,
+              "y": 15.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.8,
+              "y": 29.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.8,
+              "y": 28.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.1,
+              "y": 35.9,
+              "v": 0.922
+            },
+            "rightElbow": {
+              "x": 33.8,
+              "y": 46.9,
+              "v": 0.877
+            },
+            "leftWrist": {
+              "x": 95.8,
+              "y": 35.8,
+              "v": 0.824
+            },
+            "rightWrist": {
+              "x": 25,
+              "y": 53.1,
+              "v": 0.623
+            },
+            "leftIndex": {
+              "x": 100.3,
+              "y": 36.7,
+              "v": 0.813
+            },
+            "rightIndex": {
+              "x": 22.2,
+              "y": 52.7,
+              "v": 0.61
+            },
+            "leftHip": {
+              "x": 59.2,
+              "y": 63.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.7,
+              "y": 63.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.7,
+              "y": 83,
+              "v": 0.962
+            },
+            "rightKnee": {
+              "x": 40.3,
+              "y": 90.7,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 61.1,
+              "y": 95.1,
+              "v": 0.709
+            },
+            "rightAnkle": {
+              "x": 30.7,
+              "y": 116.6,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 55.4,
+              "y": 95,
+              "v": 0.68
+            },
+            "rightHeel": {
+              "x": 27.6,
+              "y": 120.3,
+              "v": 0.927
+            },
+            "leftFootIndex": {
+              "x": 60.9,
+              "y": 109,
+              "v": 0.737
+            },
+            "rightFootIndex": {
+              "x": 32.7,
+              "y": 124.8,
+              "v": 0.987
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.7,
+                "y": 15.7
+              },
+              "roll": -177.1,
+              "yaw": 0.218,
+              "pitch": 0.743
+            },
+            "torso": {
+              "center": {
+                "x": 56.3,
+                "y": 29.2
+              },
+              "angle": 84.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.8,
+                "y": 35.8
+              },
+              "angle": -11.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 25,
+                "y": 53.1
+              },
+              "angle": 171.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 55.4,
+                "y": 95
+              },
+              "angle": -68.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27.6,
+                "y": 120.3
+              },
+              "angle": -41.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.955,
+          "keypoints": {
+            "nose": {
+              "x": 60.9,
+              "y": 19.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.2,
+              "y": 16.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.4,
+              "y": 16.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60.7,
+              "y": 17.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.6,
+              "y": 16.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.7,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.7,
+              "y": 26.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.2,
+              "y": 33,
+              "v": 0.955
+            },
+            "rightElbow": {
+              "x": 27.5,
+              "y": 37,
+              "v": 0.95
+            },
+            "leftWrist": {
+              "x": 97.7,
+              "y": 32,
+              "v": 0.97
+            },
+            "rightWrist": {
+              "x": 22.2,
+              "y": 46,
+              "v": 0.791
+            },
+            "leftIndex": {
+              "x": 104.1,
+              "y": 30.8,
+              "v": 0.958
+            },
+            "rightIndex": {
+              "x": 22.7,
+              "y": 47.2,
+              "v": 0.748
+            },
+            "leftHip": {
+              "x": 54.4,
+              "y": 61.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.7,
+              "y": 62.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.4,
+              "y": 70.4,
+              "v": 0.973
+            },
+            "rightKnee": {
+              "x": 37.3,
+              "y": 87.7,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 59.6,
+              "y": 82.8,
+              "v": 0.885
+            },
+            "rightAnkle": {
+              "x": 27.4,
+              "y": 112.1,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 54.4,
+              "y": 82.9,
+              "v": 0.882
+            },
+            "rightHeel": {
+              "x": 25.5,
+              "y": 115.2,
+              "v": 0.969
+            },
+            "leftFootIndex": {
+              "x": 59.5,
+              "y": 95.2,
+              "v": 0.908
+            },
+            "rightFootIndex": {
+              "x": 27.6,
+              "y": 122.9,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.3,
+                "y": 16.6
+              },
+              "roll": 174,
+              "yaw": 0.157,
+              "pitch": 0.785
+            },
+            "torso": {
+              "center": {
+                "x": 52.7,
+                "y": 28.1
+              },
+              "angle": 83.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.7,
+                "y": 32
+              },
+              "angle": 10.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 22.2,
+                "y": 46
+              },
+              "angle": -67.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 54.4,
+                "y": 82.9
+              },
+              "angle": -67.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25.5,
+                "y": 115.2
+              },
+              "angle": -74.7
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/cami/poses.json
+++ b/public/assets/fighters/cami/poses.json
@@ -1,0 +1,4061 @@
+{
+  "version": 1,
+  "fighter": "cami",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:41:41.219Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.847,
+          "keypoints": {
+            "nose": {
+              "x": 67.6,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.9,
+              "y": 18.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.1,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.1,
+              "y": 19.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.2,
+              "y": 19.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.5,
+              "y": 29.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.4,
+              "y": 29,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76,
+              "y": 41.4,
+              "v": 0.485
+            },
+            "rightElbow": {
+              "x": 50.7,
+              "y": 28.7,
+              "v": 0.964
+            },
+            "leftWrist": {
+              "x": 78.8,
+              "y": 50.2,
+              "v": 0.688
+            },
+            "rightWrist": {
+              "x": 41.9,
+              "y": 20.4,
+              "v": 0.955
+            },
+            "leftIndex": {
+              "x": 79.5,
+              "y": 52.3,
+              "v": 0.718
+            },
+            "rightIndex": {
+              "x": 38.5,
+              "y": 15.6,
+              "v": 0.945
+            },
+            "leftHip": {
+              "x": 71.1,
+              "y": 53.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63,
+              "y": 53.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.9,
+              "y": 71.1,
+              "v": 0.912
+            },
+            "rightKnee": {
+              "x": 63,
+              "y": 70.4,
+              "v": 0.848
+            },
+            "leftAnkle": {
+              "x": 76.9,
+              "y": 87.2,
+              "v": 0.946
+            },
+            "rightAnkle": {
+              "x": 61.8,
+              "y": 75.3,
+              "v": 0.478
+            },
+            "leftHeel": {
+              "x": 76.3,
+              "y": 90.3,
+              "v": 0.822
+            },
+            "rightHeel": {
+              "x": 61.9,
+              "y": 76.3,
+              "v": 0.272
+            },
+            "leftFootIndex": {
+              "x": 79.5,
+              "y": 91.2,
+              "v": 0.935
+            },
+            "rightFootIndex": {
+              "x": 62.5,
+              "y": 77.8,
+              "v": 0.506
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67,
+                "y": 18.8
+              },
+              "roll": -180,
+              "yaw": 0.158,
+              "pitch": 0.342
+            },
+            "torso": {
+              "center": {
+                "x": 66.5,
+                "y": 29.4
+              },
+              "angle": 91.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 78.8,
+                "y": 50.2
+              },
+              "angle": -71.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.9,
+                "y": 20.4
+              },
+              "angle": 125.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.3,
+                "y": 90.3
+              },
+              "angle": -15.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 61.8,
+                "y": 75.3
+              },
+              "angle": -74.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.969,
+          "keypoints": {
+            "nose": {
+              "x": 67.4,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.5,
+              "y": 17.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.8,
+              "y": 17.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.7,
+              "y": 18.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.1,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.2,
+              "y": 31.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.6,
+              "y": 30.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.2,
+              "y": 47,
+              "v": 0.851
+            },
+            "rightElbow": {
+              "x": 47.6,
+              "y": 44.2,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 84.1,
+              "y": 58.2,
+              "v": 0.952
+            },
+            "rightWrist": {
+              "x": 46.6,
+              "y": 58.5,
+              "v": 0.992
+            },
+            "leftIndex": {
+              "x": 86.3,
+              "y": 62.5,
+              "v": 0.951
+            },
+            "rightIndex": {
+              "x": 47.1,
+              "y": 62.9,
+              "v": 0.985
+            },
+            "leftHip": {
+              "x": 70.3,
+              "y": 63.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.7,
+              "y": 63.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.6,
+              "y": 86.3,
+              "v": 0.9
+            },
+            "rightKnee": {
+              "x": 52.1,
+              "y": 86.4,
+              "v": 0.985
+            },
+            "leftAnkle": {
+              "x": 74.9,
+              "y": 107.5,
+              "v": 0.985
+            },
+            "rightAnkle": {
+              "x": 46.9,
+              "y": 107.2,
+              "v": 0.987
+            },
+            "leftHeel": {
+              "x": 73.3,
+              "y": 111.3,
+              "v": 0.925
+            },
+            "rightHeel": {
+              "x": 45.6,
+              "y": 108.4,
+              "v": 0.815
+            },
+            "leftFootIndex": {
+              "x": 82.7,
+              "y": 113.2,
+              "v": 0.987
+            },
+            "rightFootIndex": {
+              "x": 46.1,
+              "y": 115.4,
+              "v": 0.981
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.2,
+                "y": 17.6
+              },
+              "roll": -180,
+              "yaw": 0.053,
+              "pitch": 0.34
+            },
+            "torso": {
+              "center": {
+                "x": 65.9,
+                "y": 31.1
+              },
+              "angle": 87.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.1,
+                "y": 58.2
+              },
+              "angle": -62.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 46.6,
+                "y": 58.5
+              },
+              "angle": -83.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.3,
+                "y": 111.3
+              },
+              "angle": -11.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45.6,
+                "y": 108.4
+              },
+              "angle": -85.9
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.988,
+          "keypoints": {
+            "nose": {
+              "x": 69,
+              "y": 19,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.2,
+              "y": 17.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.1,
+              "y": 17,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.1,
+              "y": 18.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.3,
+              "y": 17.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.4,
+              "y": 30.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.9,
+              "y": 30,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.4,
+              "y": 46.3,
+              "v": 0.943
+            },
+            "rightElbow": {
+              "x": 46.6,
+              "y": 43.7,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 85.5,
+              "y": 58.8,
+              "v": 0.985
+            },
+            "rightWrist": {
+              "x": 47.4,
+              "y": 58.7,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 87.3,
+              "y": 62.9,
+              "v": 0.981
+            },
+            "rightIndex": {
+              "x": 49.2,
+              "y": 63.5,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 71.7,
+              "y": 63.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.6,
+              "y": 64.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.1,
+              "y": 85.9,
+              "v": 0.974
+            },
+            "rightKnee": {
+              "x": 53.1,
+              "y": 86.2,
+              "v": 0.992
+            },
+            "leftAnkle": {
+              "x": 75.4,
+              "y": 107.2,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 47.9,
+              "y": 106.9,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 73,
+              "y": 111.3,
+              "v": 0.968
+            },
+            "rightHeel": {
+              "x": 47.2,
+              "y": 109.3,
+              "v": 0.916
+            },
+            "leftFootIndex": {
+              "x": 84.2,
+              "y": 113.1,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 47.3,
+              "y": 117.9,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.2,
+                "y": 17.1
+              },
+              "roll": 178.6,
+              "yaw": 0.207,
+              "pitch": 0.475
+            },
+            "torso": {
+              "center": {
+                "x": 64.7,
+                "y": 30.1
+              },
+              "angle": 91.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.5,
+                "y": 58.8
+              },
+              "angle": -66.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.4,
+                "y": 58.7
+              },
+              "angle": -69.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73,
+                "y": 111.3
+              },
+              "angle": -9.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.2,
+                "y": 109.3
+              },
+              "angle": -89.3
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.902,
+          "keypoints": {
+            "nose": {
+              "x": 56.7,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.1,
+              "y": 17.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.8,
+              "y": 16.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.6,
+              "y": 18.4,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 51.1,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.7,
+              "y": 30.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.4,
+              "y": 30.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 68.9,
+              "y": 30.9,
+              "v": 0.377
+            },
+            "rightElbow": {
+              "x": 36.6,
+              "y": 42.8,
+              "v": 0.963
+            },
+            "leftWrist": {
+              "x": 65.8,
+              "y": 16.9,
+              "v": 0.613
+            },
+            "rightWrist": {
+              "x": 35.3,
+              "y": 57.9,
+              "v": 0.948
+            },
+            "leftIndex": {
+              "x": 65.2,
+              "y": 14.4,
+              "v": 0.64
+            },
+            "rightIndex": {
+              "x": 36.5,
+              "y": 62.3,
+              "v": 0.916
+            },
+            "leftHip": {
+              "x": 60.4,
+              "y": 62.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.7,
+              "y": 63.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 64.6,
+              "y": 84.4,
+              "v": 0.78
+            },
+            "rightKnee": {
+              "x": 41.6,
+              "y": 85.6,
+              "v": 0.96
+            },
+            "leftAnkle": {
+              "x": 64.4,
+              "y": 107.4,
+              "v": 0.958
+            },
+            "rightAnkle": {
+              "x": 35.8,
+              "y": 107.7,
+              "v": 0.98
+            },
+            "leftHeel": {
+              "x": 62.3,
+              "y": 112.1,
+              "v": 0.875
+            },
+            "rightHeel": {
+              "x": 35,
+              "y": 109.7,
+              "v": 0.808
+            },
+            "leftFootIndex": {
+              "x": 73.2,
+              "y": 113.4,
+              "v": 0.961
+            },
+            "rightFootIndex": {
+              "x": 34.3,
+              "y": 117.7,
+              "v": 0.966
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56,
+                "y": 17
+              },
+              "roll": 173.4,
+              "yaw": 0.173,
+              "pitch": 0.427
+            },
+            "torso": {
+              "center": {
+                "x": 54.1,
+                "y": 30.4
+              },
+              "angle": 90.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 65.8,
+                "y": 16.9
+              },
+              "angle": 103.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.3,
+                "y": 57.9
+              },
+              "angle": -74.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 62.3,
+                "y": 112.1
+              },
+              "angle": -6.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35,
+                "y": 109.7
+              },
+              "angle": -95
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.966,
+          "keypoints": {
+            "nose": {
+              "x": 56.6,
+              "y": 20,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.4,
+              "y": 18.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.1,
+              "y": 17.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.8,
+              "y": 19.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.7,
+              "y": 18,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.7,
+              "y": 29.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44.8,
+              "y": 30.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.3,
+              "y": 35.6,
+              "v": 0.879
+            },
+            "rightElbow": {
+              "x": 35.9,
+              "y": 42.7,
+              "v": 0.994
+            },
+            "leftWrist": {
+              "x": 88.4,
+              "y": 37.3,
+              "v": 0.914
+            },
+            "rightWrist": {
+              "x": 36.9,
+              "y": 57.7,
+              "v": 0.987
+            },
+            "leftIndex": {
+              "x": 93.8,
+              "y": 36.4,
+              "v": 0.914
+            },
+            "rightIndex": {
+              "x": 36.7,
+              "y": 62.1,
+              "v": 0.974
+            },
+            "leftHip": {
+              "x": 60.7,
+              "y": 62.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.3,
+              "y": 63,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63.1,
+              "y": 85.6,
+              "v": 0.889
+            },
+            "rightKnee": {
+              "x": 42.3,
+              "y": 85.5,
+              "v": 0.977
+            },
+            "leftAnkle": {
+              "x": 62.4,
+              "y": 107.1,
+              "v": 0.978
+            },
+            "rightAnkle": {
+              "x": 36.9,
+              "y": 107.6,
+              "v": 0.985
+            },
+            "leftHeel": {
+              "x": 60.4,
+              "y": 111.2,
+              "v": 0.93
+            },
+            "rightHeel": {
+              "x": 35.8,
+              "y": 109.7,
+              "v": 0.841
+            },
+            "leftFootIndex": {
+              "x": 70.1,
+              "y": 113.7,
+              "v": 0.981
+            },
+            "rightFootIndex": {
+              "x": 36.2,
+              "y": 117.8,
+              "v": 0.978
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.3,
+                "y": 17.9
+              },
+              "roll": 169.5,
+              "yaw": 0.08,
+              "pitch": 0.48
+            },
+            "torso": {
+              "center": {
+                "x": 53.8,
+                "y": 30
+              },
+              "angle": 92.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.4,
+                "y": 37.3
+              },
+              "angle": 9.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.9,
+                "y": 57.7
+              },
+              "angle": -92.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.4,
+                "y": 111.2
+              },
+              "angle": -14.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.8,
+                "y": 109.7
+              },
+              "angle": -87.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.657,
+          "keypoints": {
+            "nose": {
+              "x": 29.5,
+              "y": 39.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 26.6,
+              "y": 38.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 26.9,
+              "y": 42.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 24.8,
+              "y": 38,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 27.1,
+              "y": 43.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 33,
+              "y": 34.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 34.6,
+              "y": 45.4,
+              "v": 0.998
+            },
+            "leftElbow": {
+              "x": 39.6,
+              "y": 29.3,
+              "v": 0.107
+            },
+            "rightElbow": {
+              "x": 40.6,
+              "y": 40.8,
+              "v": 0.259
+            },
+            "leftWrist": {
+              "x": 44.8,
+              "y": 28.5,
+              "v": 0.077
+            },
+            "rightWrist": {
+              "x": 35.2,
+              "y": 35.7,
+              "v": 0.07
+            },
+            "leftIndex": {
+              "x": 46.3,
+              "y": 28.9,
+              "v": 0.101
+            },
+            "rightIndex": {
+              "x": 33.3,
+              "y": 34.6,
+              "v": 0.088
+            },
+            "leftHip": {
+              "x": 51.2,
+              "y": 48.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.8,
+              "y": 55.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.9,
+              "y": 46.5,
+              "v": 0.224
+            },
+            "rightKnee": {
+              "x": 50.2,
+              "y": 67.3,
+              "v": 0.553
+            },
+            "leftAnkle": {
+              "x": 81.2,
+              "y": 59,
+              "v": 0.748
+            },
+            "rightAnkle": {
+              "x": 59.3,
+              "y": 96.5,
+              "v": 0.912
+            },
+            "leftHeel": {
+              "x": 83,
+              "y": 62,
+              "v": 0.671
+            },
+            "rightHeel": {
+              "x": 61.2,
+              "y": 100.2,
+              "v": 0.699
+            },
+            "leftFootIndex": {
+              "x": 87.9,
+              "y": 59.5,
+              "v": 0.729
+            },
+            "rightFootIndex": {
+              "x": 64.1,
+              "y": 105.4,
+              "v": 0.875
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 26.8,
+                "y": 40.4
+              },
+              "roll": -85.9,
+              "yaw": 0.653,
+              "pitch": -0.166
+            },
+            "torso": {
+              "center": {
+                "x": 33.8,
+                "y": 39.9
+              },
+              "angle": 142.4
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 83,
+                "y": 62
+              },
+              "angle": 27
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 61.2,
+                "y": 100.2
+              },
+              "angle": -60.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.979,
+          "keypoints": {
+            "nose": {
+              "x": 58.6,
+              "y": 19.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.7,
+              "y": 18.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.4,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.1,
+              "y": 19,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 54.3,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.5,
+              "y": 30.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.2,
+              "y": 30,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.8,
+              "y": 34,
+              "v": 0.942
+            },
+            "rightElbow": {
+              "x": 40.2,
+              "y": 29.1,
+              "v": 0.967
+            },
+            "leftWrist": {
+              "x": 87.4,
+              "y": 35.7,
+              "v": 0.973
+            },
+            "rightWrist": {
+              "x": 33,
+              "y": 22,
+              "v": 0.987
+            },
+            "leftIndex": {
+              "x": 91.1,
+              "y": 34.2,
+              "v": 0.982
+            },
+            "rightIndex": {
+              "x": 30.9,
+              "y": 19.1,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 62.5,
+              "y": 59.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.3,
+              "y": 58.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.4,
+              "y": 80.6,
+              "v": 0.941
+            },
+            "rightKnee": {
+              "x": 45.7,
+              "y": 79.3,
+              "v": 0.941
+            },
+            "leftAnkle": {
+              "x": 64.1,
+              "y": 104.4,
+              "v": 0.987
+            },
+            "rightAnkle": {
+              "x": 38.3,
+              "y": 102.1,
+              "v": 0.988
+            },
+            "leftHeel": {
+              "x": 61.9,
+              "y": 105.7,
+              "v": 0.951
+            },
+            "rightHeel": {
+              "x": 38.4,
+              "y": 105.2,
+              "v": 0.898
+            },
+            "leftFootIndex": {
+              "x": 66.7,
+              "y": 111,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 35.7,
+              "y": 108.8,
+              "v": 0.983
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.6,
+                "y": 18.3
+              },
+              "roll": -180,
+              "yaw": 0.457,
+              "pitch": 0.522
+            },
+            "torso": {
+              "center": {
+                "x": 55.9,
+                "y": 30.3
+              },
+              "angle": 93.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.4,
+                "y": 35.7
+              },
+              "angle": 22.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33,
+                "y": 22
+              },
+              "angle": 125.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.9,
+                "y": 105.7
+              },
+              "angle": -47.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.4,
+                "y": 105.2
+              },
+              "angle": -126.9
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.95,
+          "keypoints": {
+            "nose": {
+              "x": 58.2,
+              "y": 19,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.5,
+              "y": 17.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.5,
+              "y": 17.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60.4,
+              "y": 18.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.5,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65,
+              "y": 30.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.9,
+              "y": 30,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.2,
+              "y": 34.8,
+              "v": 0.882
+            },
+            "rightElbow": {
+              "x": 38.9,
+              "y": 40.1,
+              "v": 0.961
+            },
+            "leftWrist": {
+              "x": 88.1,
+              "y": 35.1,
+              "v": 0.894
+            },
+            "rightWrist": {
+              "x": 42.5,
+              "y": 48,
+              "v": 0.914
+            },
+            "leftIndex": {
+              "x": 92.3,
+              "y": 34.5,
+              "v": 0.912
+            },
+            "rightIndex": {
+              "x": 46,
+              "y": 47.8,
+              "v": 0.908
+            },
+            "leftHip": {
+              "x": 63.4,
+              "y": 60.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.9,
+              "y": 59.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.7,
+              "y": 82,
+              "v": 0.868
+            },
+            "rightKnee": {
+              "x": 45.3,
+              "y": 81.7,
+              "v": 0.965
+            },
+            "leftAnkle": {
+              "x": 65.1,
+              "y": 106.3,
+              "v": 0.953
+            },
+            "rightAnkle": {
+              "x": 38.5,
+              "y": 106.4,
+              "v": 0.984
+            },
+            "leftHeel": {
+              "x": 62.8,
+              "y": 108.7,
+              "v": 0.853
+            },
+            "rightHeel": {
+              "x": 38.3,
+              "y": 109.3,
+              "v": 0.839
+            },
+            "leftFootIndex": {
+              "x": 68.7,
+              "y": 113.5,
+              "v": 0.949
+            },
+            "rightFootIndex": {
+              "x": 35.4,
+              "y": 111.7,
+              "v": 0.972
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.5,
+                "y": 17.5
+              },
+              "roll": 172.9,
+              "yaw": 0.174,
+              "pitch": 0.385
+            },
+            "torso": {
+              "center": {
+                "x": 57,
+                "y": 30.3
+              },
+              "angle": 92.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.1,
+                "y": 35.1
+              },
+              "angle": 8.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 42.5,
+                "y": 48
+              },
+              "angle": 3.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 62.8,
+                "y": 108.7
+              },
+              "angle": -39.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.3,
+                "y": 109.3
+              },
+              "angle": -140.4
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.977,
+          "keypoints": {
+            "nose": {
+              "x": 57.1,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.7,
+              "y": 17.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.7,
+              "y": 17.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.7,
+              "y": 18.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.6,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.1,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.1,
+              "y": 30.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.9,
+              "y": 33.8,
+              "v": 0.976
+            },
+            "rightElbow": {
+              "x": 38.8,
+              "y": 43.6,
+              "v": 0.99
+            },
+            "leftWrist": {
+              "x": 93,
+              "y": 33.9,
+              "v": 0.985
+            },
+            "rightWrist": {
+              "x": 45.5,
+              "y": 44,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 98.7,
+              "y": 33.1,
+              "v": 0.98
+            },
+            "rightIndex": {
+              "x": 48.3,
+              "y": 42.3,
+              "v": 0.982
+            },
+            "leftHip": {
+              "x": 62.3,
+              "y": 59.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.5,
+              "y": 58.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.9,
+              "y": 80.2,
+              "v": 0.975
+            },
+            "rightKnee": {
+              "x": 43.1,
+              "y": 80.3,
+              "v": 0.98
+            },
+            "leftAnkle": {
+              "x": 64.4,
+              "y": 105.8,
+              "v": 0.973
+            },
+            "rightAnkle": {
+              "x": 35.3,
+              "y": 104.3,
+              "v": 0.981
+            },
+            "leftHeel": {
+              "x": 62,
+              "y": 107.8,
+              "v": 0.924
+            },
+            "rightHeel": {
+              "x": 34.6,
+              "y": 107.6,
+              "v": 0.812
+            },
+            "leftFootIndex": {
+              "x": 68.1,
+              "y": 113,
+              "v": 0.966
+            },
+            "rightFootIndex": {
+              "x": 33,
+              "y": 110.9,
+              "v": 0.966
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.7,
+                "y": 17.2
+              },
+              "roll": -177.1,
+              "yaw": 0.1,
+              "pitch": 0.499
+            },
+            "torso": {
+              "center": {
+                "x": 55.6,
+                "y": 30.2
+              },
+              "angle": 92.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93,
+                "y": 33.9
+              },
+              "angle": 8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 45.5,
+                "y": 44
+              },
+              "angle": 31.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 62,
+                "y": 107.8
+              },
+              "angle": -40.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 34.6,
+                "y": 107.6
+              },
+              "angle": -115.9
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.999,
+          "keypoints": {
+            "nose": {
+              "x": 53.7,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.8,
+              "y": 17,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51.2,
+              "y": 16.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.5,
+              "y": 18,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.6,
+              "y": 17.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 58.5,
+              "y": 29.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.8,
+              "y": 29.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70,
+              "y": 33.6,
+              "v": 0.993
+            },
+            "rightElbow": {
+              "x": 33.5,
+              "y": 42.8,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 83,
+              "y": 33.8,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 34.1,
+              "y": 56.1,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 86.8,
+              "y": 33.5,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 34.8,
+              "y": 60.2,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 58.1,
+              "y": 57.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.7,
+              "y": 60.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.7,
+              "y": 65,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 43.6,
+              "y": 81.6,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 93.1,
+              "y": 79.7,
+              "v": 1
+            },
+            "rightAnkle": {
+              "x": 38.3,
+              "y": 102.6,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 93.9,
+              "y": 84.4,
+              "v": 0.998
+            },
+            "rightHeel": {
+              "x": 36.6,
+              "y": 106.4,
+              "v": 0.991
+            },
+            "leftFootIndex": {
+              "x": 103,
+              "y": 77.2,
+              "v": 1
+            },
+            "rightFootIndex": {
+              "x": 36.3,
+              "y": 108.5,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53,
+                "y": 16.9
+              },
+              "roll": 175.2,
+              "yaw": 0.194,
+              "pitch": 0.429
+            },
+            "torso": {
+              "center": {
+                "x": 49.7,
+                "y": 29.6
+              },
+              "angle": 95.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 83,
+                "y": 33.8
+              },
+              "angle": 4.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.1,
+                "y": 56.1
+              },
+              "angle": -80.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.9,
+                "y": 84.4
+              },
+              "angle": 38.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.6,
+                "y": 106.4
+              },
+              "angle": -98.1
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.947,
+          "keypoints": {
+            "nose": {
+              "x": 48.9,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 49.5,
+              "y": 18.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 46.2,
+              "y": 18.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 49.1,
+              "y": 19.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 42.5,
+              "y": 20.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 51.5,
+              "y": 30.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.5,
+              "y": 31.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 58.5,
+              "y": 39.8,
+              "v": 0.198
+            },
+            "rightElbow": {
+              "x": 32.4,
+              "y": 42.1,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 65.7,
+              "y": 38.4,
+              "v": 0.749
+            },
+            "rightWrist": {
+              "x": 35.4,
+              "y": 56.3,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 67.9,
+              "y": 37.7,
+              "v": 0.867
+            },
+            "rightIndex": {
+              "x": 37.3,
+              "y": 60.2,
+              "v": 0.994
+            },
+            "leftHip": {
+              "x": 55.8,
+              "y": 58.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47,
+              "y": 62.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.4,
+              "y": 49.2,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 47.4,
+              "y": 85,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 96,
+              "y": 48.7,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 40.3,
+              "y": 107.3,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 97.3,
+              "y": 53,
+              "v": 0.998
+            },
+            "rightHeel": {
+              "x": 37.6,
+              "y": 111.5,
+              "v": 0.991
+            },
+            "leftFootIndex": {
+              "x": 102.8,
+              "y": 39.5,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 46.8,
+              "y": 114.6,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 47.9,
+                "y": 18.5
+              },
+              "roll": -173.1,
+              "yaw": 0.316,
+              "pitch": 0.481
+            },
+            "torso": {
+              "center": {
+                "x": 45.5,
+                "y": 31
+              },
+              "angle": 101.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 65.7,
+                "y": 38.4
+              },
+              "angle": 17.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.4,
+                "y": 56.3
+              },
+              "angle": -64
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 97.3,
+                "y": 53
+              },
+              "angle": 67.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.6,
+                "y": 111.5
+              },
+              "angle": -18.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.483,
+          "keypoints": {
+            "nose": {
+              "x": 35,
+              "y": 53.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 34.2,
+              "y": 53.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 33.8,
+              "y": 53.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 33.7,
+              "y": 54,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 32.4,
+              "y": 55.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 33.9,
+              "y": 58.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 35.8,
+              "y": 58.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 35.8,
+              "y": 61.8,
+              "v": 0.009
+            },
+            "rightElbow": {
+              "x": 39,
+              "y": 63.2,
+              "v": 0.128
+            },
+            "leftWrist": {
+              "x": 37,
+              "y": 61.9,
+              "v": 0.042
+            },
+            "rightWrist": {
+              "x": 39.3,
+              "y": 61.8,
+              "v": 0.207
+            },
+            "leftIndex": {
+              "x": 37.2,
+              "y": 61.4,
+              "v": 0.08
+            },
+            "rightIndex": {
+              "x": 38.9,
+              "y": 60.8,
+              "v": 0.23
+            },
+            "leftHip": {
+              "x": 38.1,
+              "y": 69.5,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 38.4,
+              "y": 69.4,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 41.9,
+              "y": 70.5,
+              "v": 0.056
+            },
+            "rightKnee": {
+              "x": 42.4,
+              "y": 71.3,
+              "v": 0.306
+            },
+            "leftAnkle": {
+              "x": 33.8,
+              "y": 76.1,
+              "v": 0.046
+            },
+            "rightAnkle": {
+              "x": 41,
+              "y": 79.1,
+              "v": 0.323
+            },
+            "leftHeel": {
+              "x": 32.5,
+              "y": 76.7,
+              "v": 0.118
+            },
+            "rightHeel": {
+              "x": 40.5,
+              "y": 80.7,
+              "v": 0.282
+            },
+            "leftFootIndex": {
+              "x": 32.5,
+              "y": 77.3,
+              "v": 0.054
+            },
+            "rightFootIndex": {
+              "x": 41.9,
+              "y": 79.9,
+              "v": 0.235
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 34,
+                "y": 53.5
+              },
+              "roll": -135,
+              "yaw": 1.768,
+              "pitch": 0.354
+            },
+            "torso": {
+              "center": {
+                "x": 34.8,
+                "y": 58.3
+              },
+              "angle": 107
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.797,
+          "keypoints": {
+            "nose": {
+              "x": 48.6,
+              "y": 18.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 50.2,
+              "y": 17.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 46.1,
+              "y": 17.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 50.9,
+              "y": 18.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 43.7,
+              "y": 17.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 55,
+              "y": 29.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.9,
+              "y": 29.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 62.2,
+              "y": 40.3,
+              "v": 0.653
+            },
+            "rightElbow": {
+              "x": 30.2,
+              "y": 42.9,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 75.6,
+              "y": 43.5,
+              "v": 0.774
+            },
+            "rightWrist": {
+              "x": 29.2,
+              "y": 57.5,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 79.7,
+              "y": 43,
+              "v": 0.783
+            },
+            "rightIndex": {
+              "x": 29.7,
+              "y": 61.7,
+              "v": 0.99
+            },
+            "leftHip": {
+              "x": 51.5,
+              "y": 56.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 41.9,
+              "y": 57,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 54.9,
+              "y": 76.9,
+              "v": 0.563
+            },
+            "rightKnee": {
+              "x": 40.5,
+              "y": 74.8,
+              "v": 0.622
+            },
+            "leftAnkle": {
+              "x": 55.5,
+              "y": 93.5,
+              "v": 0.68
+            },
+            "rightAnkle": {
+              "x": 40.2,
+              "y": 88.8,
+              "v": 0.443
+            },
+            "leftHeel": {
+              "x": 54.6,
+              "y": 96.3,
+              "v": 0.486
+            },
+            "rightHeel": {
+              "x": 40.6,
+              "y": 90.7,
+              "v": 0.226
+            },
+            "leftFootIndex": {
+              "x": 57.8,
+              "y": 98.8,
+              "v": 0.705
+            },
+            "rightFootIndex": {
+              "x": 41,
+              "y": 94.8,
+              "v": 0.421
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 48.2,
+                "y": 17.3
+              },
+              "roll": 175.8,
+              "yaw": 0.109,
+              "pitch": 0.401
+            },
+            "torso": {
+              "center": {
+                "x": 46.5,
+                "y": 29.6
+              },
+              "angle": 90.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 75.6,
+                "y": 43.5
+              },
+              "angle": 7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.2,
+                "y": 57.5
+              },
+              "angle": -83.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 54.6,
+                "y": 96.3
+              },
+              "angle": -38
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.2,
+                "y": 88.8
+              },
+              "angle": -82.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 4,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.927,
+          "keypoints": {
+            "nose": {
+              "x": 61.2,
+              "y": 19.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.6,
+              "y": 18,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 59.1,
+              "y": 17.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 62.6,
+              "y": 19.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.4,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.5,
+              "y": 31.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.5,
+              "y": 29.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.1,
+              "y": 40.6,
+              "v": 0.495
+            },
+            "rightElbow": {
+              "x": 50.9,
+              "y": 36.1,
+              "v": 0.903
+            },
+            "leftWrist": {
+              "x": 77.7,
+              "y": 40.3,
+              "v": 0.783
+            },
+            "rightWrist": {
+              "x": 51.3,
+              "y": 33.6,
+              "v": 0.915
+            },
+            "leftIndex": {
+              "x": 80.7,
+              "y": 41,
+              "v": 0.855
+            },
+            "rightIndex": {
+              "x": 51.4,
+              "y": 32.2,
+              "v": 0.926
+            },
+            "leftHip": {
+              "x": 67.1,
+              "y": 60.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.9,
+              "y": 60,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70,
+              "y": 82.6,
+              "v": 0.913
+            },
+            "rightKnee": {
+              "x": 47.8,
+              "y": 82.9,
+              "v": 0.966
+            },
+            "leftAnkle": {
+              "x": 69.5,
+              "y": 106.6,
+              "v": 0.964
+            },
+            "rightAnkle": {
+              "x": 42.2,
+              "y": 106.5,
+              "v": 0.98
+            },
+            "leftHeel": {
+              "x": 67.9,
+              "y": 110.8,
+              "v": 0.879
+            },
+            "rightHeel": {
+              "x": 42.8,
+              "y": 109.4,
+              "v": 0.813
+            },
+            "leftFootIndex": {
+              "x": 76.7,
+              "y": 111.2,
+              "v": 0.964
+            },
+            "rightFootIndex": {
+              "x": 38.8,
+              "y": 112.4,
+              "v": 0.97
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.9,
+                "y": 17.8
+              },
+              "roll": 171.9,
+              "yaw": 0.099,
+              "pitch": 0.552
+            },
+            "torso": {
+              "center": {
+                "x": 58.5,
+                "y": 30.2
+              },
+              "angle": 96.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 77.7,
+                "y": 40.3
+              },
+              "angle": -13.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 51.3,
+                "y": 33.6
+              },
+              "angle": 85.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.9,
+                "y": 110.8
+              },
+              "angle": -2.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.8,
+                "y": 109.4
+              },
+              "angle": -143.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.823,
+          "keypoints": {
+            "nose": {
+              "x": 62.8,
+              "y": 19.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.4,
+              "y": 18.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.3,
+              "y": 16.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 66.6,
+              "y": 19.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.1,
+              "y": 17.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.1,
+              "y": 30.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.4,
+              "y": 27.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.1,
+              "y": 41.1,
+              "v": 0.388
+            },
+            "rightElbow": {
+              "x": 47.5,
+              "y": 32,
+              "v": 0.872
+            },
+            "leftWrist": {
+              "x": 75.8,
+              "y": 40.5,
+              "v": 0.676
+            },
+            "rightWrist": {
+              "x": 46.2,
+              "y": 30.9,
+              "v": 0.945
+            },
+            "leftIndex": {
+              "x": 74.9,
+              "y": 39.9,
+              "v": 0.801
+            },
+            "rightIndex": {
+              "x": 47.5,
+              "y": 31.5,
+              "v": 0.961
+            },
+            "leftHip": {
+              "x": 67.4,
+              "y": 60.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.9,
+              "y": 60.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.3,
+              "y": 83.7,
+              "v": 0.373
+            },
+            "rightKnee": {
+              "x": 49.1,
+              "y": 84.1,
+              "v": 0.731
+            },
+            "leftAnkle": {
+              "x": 69.9,
+              "y": 107.1,
+              "v": 0.726
+            },
+            "rightAnkle": {
+              "x": 42,
+              "y": 107.9,
+              "v": 0.871
+            },
+            "leftHeel": {
+              "x": 68,
+              "y": 111,
+              "v": 0.549
+            },
+            "rightHeel": {
+              "x": 41.1,
+              "y": 109.2,
+              "v": 0.404
+            },
+            "leftFootIndex": {
+              "x": 77.1,
+              "y": 112.6,
+              "v": 0.799
+            },
+            "rightFootIndex": {
+              "x": 41.2,
+              "y": 116.1,
+              "v": 0.837
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.4,
+                "y": 17.5
+              },
+              "roll": 162.4,
+              "yaw": -0.128,
+              "pitch": 0.453
+            },
+            "torso": {
+              "center": {
+                "x": 61.3,
+                "y": 29.2
+              },
+              "angle": 90.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 75.8,
+                "y": 40.5
+              },
+              "angle": 146.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 46.2,
+                "y": 30.9
+              },
+              "angle": -24.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68,
+                "y": 111
+              },
+              "angle": -10
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.1,
+                "y": 109.2
+              },
+              "angle": -89.2
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.719,
+          "keypoints": {
+            "nose": {
+              "x": 59,
+              "y": 18.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 60.3,
+              "y": 16.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.3,
+              "y": 17.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 62.1,
+              "y": 16.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 54.8,
+              "y": 19.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 69.5,
+              "y": 25.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.5,
+              "y": 30.7,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 78.9,
+              "y": 24.8,
+              "v": 0.721
+            },
+            "rightElbow": {
+              "x": 47.3,
+              "y": 35,
+              "v": 0.794
+            },
+            "leftWrist": {
+              "x": 79,
+              "y": 16.9,
+              "v": 0.884
+            },
+            "rightWrist": {
+              "x": 36.5,
+              "y": 29.2,
+              "v": 0.849
+            },
+            "leftIndex": {
+              "x": 78.3,
+              "y": 13.4,
+              "v": 0.892
+            },
+            "rightIndex": {
+              "x": 33.2,
+              "y": 26.6,
+              "v": 0.839
+            },
+            "leftHip": {
+              "x": 76,
+              "y": 53.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.4,
+              "y": 55.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.1,
+              "y": 74,
+              "v": 0.47
+            },
+            "rightKnee": {
+              "x": 60.5,
+              "y": 73.5,
+              "v": 0.379
+            },
+            "leftAnkle": {
+              "x": 83.9,
+              "y": 87.1,
+              "v": 0.46
+            },
+            "rightAnkle": {
+              "x": 63.7,
+              "y": 80.8,
+              "v": 0.136
+            },
+            "leftHeel": {
+              "x": 83.5,
+              "y": 89.2,
+              "v": 0.399
+            },
+            "rightHeel": {
+              "x": 65.1,
+              "y": 81.4,
+              "v": 0.124
+            },
+            "leftFootIndex": {
+              "x": 85.3,
+              "y": 92.3,
+              "v": 0.462
+            },
+            "rightFootIndex": {
+              "x": 64.1,
+              "y": 85.6,
+              "v": 0.139
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58.3,
+                "y": 17
+              },
+              "roll": -157,
+              "yaw": 0.161,
+              "pitch": 0.334
+            },
+            "torso": {
+              "center": {
+                "x": 62,
+                "y": 28
+              },
+              "angle": 109.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 79,
+                "y": 16.9
+              },
+              "angle": 101.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.5,
+                "y": 29.2
+              },
+              "angle": 141.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.5,
+                "y": 89.2
+              },
+              "angle": -59.9
+            },
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.552,
+          "keypoints": {
+            "nose": {
+              "x": 59.5,
+              "y": 98.3,
+              "v": 0.996
+            },
+            "leftEye": {
+              "x": 60.2,
+              "y": 98.7,
+              "v": 0.992
+            },
+            "rightEye": {
+              "x": 60.5,
+              "y": 98.9,
+              "v": 0.996
+            },
+            "leftEar": {
+              "x": 62.7,
+              "y": 98.4,
+              "v": 0.996
+            },
+            "rightEar": {
+              "x": 63,
+              "y": 98.5,
+              "v": 0.988
+            },
+            "leftShoulder": {
+              "x": 63.6,
+              "y": 91.6,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 66.3,
+              "y": 96.7,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 64,
+              "y": 86.1,
+              "v": 0.012
+            },
+            "rightElbow": {
+              "x": 65.6,
+              "y": 96.8,
+              "v": 0.79
+            },
+            "leftWrist": {
+              "x": 61.4,
+              "y": 87.4,
+              "v": 0.031
+            },
+            "rightWrist": {
+              "x": 59.9,
+              "y": 98.1,
+              "v": 0.195
+            },
+            "leftIndex": {
+              "x": 60.4,
+              "y": 88.8,
+              "v": 0.052
+            },
+            "rightIndex": {
+              "x": 58.4,
+              "y": 98.7,
+              "v": 0.132
+            },
+            "leftHip": {
+              "x": 69.8,
+              "y": 78.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 72.5,
+              "y": 80,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.2,
+              "y": 65.2,
+              "v": 0.042
+            },
+            "rightKnee": {
+              "x": 76.4,
+              "y": 66.7,
+              "v": 0.433
+            },
+            "leftAnkle": {
+              "x": 80.4,
+              "y": 53.5,
+              "v": 0.165
+            },
+            "rightAnkle": {
+              "x": 82.6,
+              "y": 54.4,
+              "v": 0.532
+            },
+            "leftHeel": {
+              "x": 82.4,
+              "y": 51.9,
+              "v": 0.325
+            },
+            "rightHeel": {
+              "x": 84.4,
+              "y": 52.7,
+              "v": 0.353
+            },
+            "leftFootIndex": {
+              "x": 77.5,
+              "y": 49.4,
+              "v": 0.237
+            },
+            "rightFootIndex": {
+              "x": 81.4,
+              "y": 49.8,
+              "v": 0.427
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.4,
+                "y": 98.8
+              },
+              "roll": -33.7,
+              "yaw": -2.357,
+              "pitch": -1.387
+            },
+            "torso": {
+              "center": {
+                "x": 65,
+                "y": 94.2
+              },
+              "angle": -112.5
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 84.4,
+                "y": 52.7
+              },
+              "angle": 136
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.838,
+          "keypoints": {
+            "nose": {
+              "x": 54.1,
+              "y": 19,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 55.2,
+              "y": 16.7,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 52.2,
+              "y": 18.6,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 58,
+              "y": 17.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.2,
+              "y": 20.6,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 68.2,
+              "y": 27.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.4,
+              "y": 32.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75,
+              "y": 36.2,
+              "v": 0.346
+            },
+            "rightElbow": {
+              "x": 56.4,
+              "y": 42.3,
+              "v": 0.441
+            },
+            "leftWrist": {
+              "x": 71.5,
+              "y": 32.9,
+              "v": 0.352
+            },
+            "rightWrist": {
+              "x": 59.2,
+              "y": 37.8,
+              "v": 0.52
+            },
+            "leftIndex": {
+              "x": 69.8,
+              "y": 30.8,
+              "v": 0.429
+            },
+            "rightIndex": {
+              "x": 59.7,
+              "y": 35.6,
+              "v": 0.564
+            },
+            "leftHip": {
+              "x": 74.6,
+              "y": 57.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64,
+              "y": 58.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95,
+              "y": 66.3,
+              "v": 0.987
+            },
+            "rightKnee": {
+              "x": 56.1,
+              "y": 78,
+              "v": 0.991
+            },
+            "leftAnkle": {
+              "x": 83.9,
+              "y": 86.8,
+              "v": 0.934
+            },
+            "rightAnkle": {
+              "x": 49.1,
+              "y": 100.1,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 80.1,
+              "y": 88.6,
+              "v": 0.879
+            },
+            "rightHeel": {
+              "x": 49.4,
+              "y": 103.1,
+              "v": 0.935
+            },
+            "leftFootIndex": {
+              "x": 89.2,
+              "y": 96.5,
+              "v": 0.92
+            },
+            "rightFootIndex": {
+              "x": 46.8,
+              "y": 109,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.7,
+                "y": 17.7
+              },
+              "roll": -147.7,
+              "yaw": 0.113,
+              "pitch": 0.38
+            },
+            "torso": {
+              "center": {
+                "x": 61.3,
+                "y": 29.9
+              },
+              "angle": 105.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 71.5,
+                "y": 32.9
+              },
+              "angle": 129
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 59.2,
+                "y": 37.8
+              },
+              "angle": 77.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80.1,
+                "y": 88.6
+              },
+              "angle": -41
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 49.4,
+                "y": 103.1
+              },
+              "angle": -113.8
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.953,
+          "keypoints": {
+            "nose": {
+              "x": 53.6,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.1,
+              "y": 17.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51.4,
+              "y": 17.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.7,
+              "y": 19.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.9,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 60.5,
+              "y": 30.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.2,
+              "y": 30.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.6,
+              "y": 37.9,
+              "v": 0.758
+            },
+            "rightElbow": {
+              "x": 29.5,
+              "y": 38.2,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 76.4,
+              "y": 41.7,
+              "v": 0.841
+            },
+            "rightWrist": {
+              "x": 26.2,
+              "y": 51.6,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 77.1,
+              "y": 42.3,
+              "v": 0.849
+            },
+            "rightIndex": {
+              "x": 26.7,
+              "y": 55.9,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 57.2,
+              "y": 59.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.9,
+              "y": 58.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 67.2,
+              "y": 79.4,
+              "v": 0.986
+            },
+            "rightKnee": {
+              "x": 39.3,
+              "y": 76.1,
+              "v": 0.966
+            },
+            "leftAnkle": {
+              "x": 57.8,
+              "y": 101.1,
+              "v": 0.978
+            },
+            "rightAnkle": {
+              "x": 29.5,
+              "y": 93.3,
+              "v": 0.952
+            },
+            "leftHeel": {
+              "x": 54.6,
+              "y": 102.6,
+              "v": 0.946
+            },
+            "rightHeel": {
+              "x": 28.8,
+              "y": 95.8,
+              "v": 0.744
+            },
+            "leftFootIndex": {
+              "x": 60.6,
+              "y": 110.5,
+              "v": 0.973
+            },
+            "rightFootIndex": {
+              "x": 27.1,
+              "y": 99.2,
+              "v": 0.924
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.3,
+                "y": 17.8
+              },
+              "roll": 175.4,
+              "yaw": 0.094,
+              "pitch": 0.391
+            },
+            "torso": {
+              "center": {
+                "x": 51.9,
+                "y": 30.5
+              },
+              "angle": 90.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76.4,
+                "y": 41.7
+              },
+              "angle": -40.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 26.2,
+                "y": 51.6
+              },
+              "angle": -83.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 54.6,
+                "y": 102.6
+              },
+              "angle": -52.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 28.8,
+                "y": 95.8
+              },
+              "angle": -116.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.986,
+          "keypoints": {
+            "nose": {
+              "x": 61.6,
+              "y": 17.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63,
+              "y": 16.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.9,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.4,
+              "y": 17.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.1,
+              "y": 16.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68,
+              "y": 27.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49,
+              "y": 28.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.3,
+              "y": 43.3,
+              "v": 0.882
+            },
+            "rightElbow": {
+              "x": 36.9,
+              "y": 41.8,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 84.5,
+              "y": 55.3,
+              "v": 0.967
+            },
+            "rightWrist": {
+              "x": 33.4,
+              "y": 56.1,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 87.5,
+              "y": 58.7,
+              "v": 0.957
+            },
+            "rightIndex": {
+              "x": 33,
+              "y": 60.7,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 71,
+              "y": 57.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59,
+              "y": 59.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 85.7,
+              "y": 76.4,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 52.6,
+              "y": 83.1,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 78.5,
+              "y": 102.5,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 47.6,
+              "y": 106.2,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 75.5,
+              "y": 107.1,
+              "v": 0.982
+            },
+            "rightHeel": {
+              "x": 47.1,
+              "y": 108.4,
+              "v": 0.931
+            },
+            "leftFootIndex": {
+              "x": 85.8,
+              "y": 111.1,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 45.9,
+              "y": 117.1,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 61,
+                "y": 16
+              },
+              "roll": 174.4,
+              "yaw": 0.158,
+              "pitch": 0.461
+            },
+            "torso": {
+              "center": {
+                "x": 58.5,
+                "y": 28.2
+              },
+              "angle": 102.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.5,
+                "y": 55.3
+              },
+              "angle": -48.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.4,
+                "y": 56.1
+              },
+              "angle": -95
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 75.5,
+                "y": 107.1
+              },
+              "angle": -21.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.1,
+                "y": 108.4
+              },
+              "angle": -97.9
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.81,
+          "keypoints": {
+            "nose": {
+              "x": 62.7,
+              "y": 19.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.4,
+              "y": 18.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 60.8,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.5,
+              "y": 20,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 58.8,
+              "y": 19.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.3,
+              "y": 31.6,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 55,
+              "y": 30.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73,
+              "y": 39.9,
+              "v": 0.216
+            },
+            "rightElbow": {
+              "x": 54,
+              "y": 39.3,
+              "v": 0.759
+            },
+            "leftWrist": {
+              "x": 73.7,
+              "y": 38.7,
+              "v": 0.172
+            },
+            "rightWrist": {
+              "x": 52.1,
+              "y": 35.4,
+              "v": 0.921
+            },
+            "leftIndex": {
+              "x": 73.8,
+              "y": 37.1,
+              "v": 0.29
+            },
+            "rightIndex": {
+              "x": 51.5,
+              "y": 33,
+              "v": 0.938
+            },
+            "leftHip": {
+              "x": 64.9,
+              "y": 57.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.4,
+              "y": 55.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 64.2,
+              "y": 72.7,
+              "v": 0.666
+            },
+            "rightKnee": {
+              "x": 53.5,
+              "y": 70.4,
+              "v": 0.759
+            },
+            "leftAnkle": {
+              "x": 59.6,
+              "y": 87.1,
+              "v": 0.899
+            },
+            "rightAnkle": {
+              "x": 50.5,
+              "y": 84.5,
+              "v": 0.841
+            },
+            "leftHeel": {
+              "x": 57.9,
+              "y": 89.3,
+              "v": 0.842
+            },
+            "rightHeel": {
+              "x": 50.4,
+              "y": 86.5,
+              "v": 0.63
+            },
+            "leftFootIndex": {
+              "x": 60.8,
+              "y": 92.5,
+              "v": 0.9
+            },
+            "rightFootIndex": {
+              "x": 50.6,
+              "y": 90.7,
+              "v": 0.792
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.6,
+                "y": 18.4
+              },
+              "roll": 178.4,
+              "yaw": 0.028,
+              "pitch": 0.43
+            },
+            "torso": {
+              "center": {
+                "x": 62.7,
+                "y": 31.1
+              },
+              "angle": 85.5
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 52.1,
+                "y": 35.4
+              },
+              "angle": 104
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 57.9,
+                "y": 89.3
+              },
+              "angle": -47.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 50.4,
+                "y": 86.5
+              },
+              "angle": -87.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.872,
+          "keypoints": {
+            "nose": {
+              "x": 67.9,
+              "y": 19.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.2,
+              "y": 17.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.3,
+              "y": 17.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.7,
+              "y": 18.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.4,
+              "y": 17.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.4,
+              "y": 30.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.8,
+              "y": 30,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.2,
+              "y": 44.6,
+              "v": 0.947
+            },
+            "rightElbow": {
+              "x": 50.9,
+              "y": 44,
+              "v": 0.987
+            },
+            "leftWrist": {
+              "x": 84.6,
+              "y": 58,
+              "v": 0.946
+            },
+            "rightWrist": {
+              "x": 47.9,
+              "y": 56.1,
+              "v": 0.946
+            },
+            "leftIndex": {
+              "x": 86.2,
+              "y": 61.7,
+              "v": 0.92
+            },
+            "rightIndex": {
+              "x": 49.2,
+              "y": 59.6,
+              "v": 0.902
+            },
+            "leftHip": {
+              "x": 71.7,
+              "y": 57.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.7,
+              "y": 56.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.8,
+              "y": 80.1,
+              "v": 0.802
+            },
+            "rightKnee": {
+              "x": 59,
+              "y": 77,
+              "v": 0.787
+            },
+            "leftAnkle": {
+              "x": 73.3,
+              "y": 97.8,
+              "v": 0.852
+            },
+            "rightAnkle": {
+              "x": 52.9,
+              "y": 91,
+              "v": 0.622
+            },
+            "leftHeel": {
+              "x": 70.4,
+              "y": 101.2,
+              "v": 0.595
+            },
+            "rightHeel": {
+              "x": 52.4,
+              "y": 93,
+              "v": 0.279
+            },
+            "leftFootIndex": {
+              "x": 74.1,
+              "y": 105,
+              "v": 0.854
+            },
+            "rightFootIndex": {
+              "x": 51.9,
+              "y": 97.8,
+              "v": 0.625
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.8,
+                "y": 17.7
+              },
+              "roll": 174.2,
+              "yaw": 0.03,
+              "pitch": 0.437
+            },
+            "torso": {
+              "center": {
+                "x": 66.6,
+                "y": 30.1
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.6,
+                "y": 58
+              },
+              "angle": -66.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.9,
+                "y": 56.1
+              },
+              "angle": -69.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.4,
+                "y": 101.2
+              },
+              "angle": -45.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 52.9,
+                "y": 91
+              },
+              "angle": -98.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.962,
+          "keypoints": {
+            "nose": {
+              "x": 67.1,
+              "y": 19.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.4,
+              "y": 18,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.9,
+              "y": 17.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.1,
+              "y": 19,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.3,
+              "y": 18.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.1,
+              "y": 32.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56,
+              "y": 30.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.8,
+              "y": 47,
+              "v": 0.932
+            },
+            "rightElbow": {
+              "x": 48.2,
+              "y": 44.4,
+              "v": 0.989
+            },
+            "leftWrist": {
+              "x": 84.8,
+              "y": 59.5,
+              "v": 0.961
+            },
+            "rightWrist": {
+              "x": 46.8,
+              "y": 58.5,
+              "v": 0.963
+            },
+            "leftIndex": {
+              "x": 86.6,
+              "y": 63.4,
+              "v": 0.949
+            },
+            "rightIndex": {
+              "x": 47.2,
+              "y": 62.8,
+              "v": 0.934
+            },
+            "leftHip": {
+              "x": 69.4,
+              "y": 63.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.1,
+              "y": 63.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.8,
+              "y": 86.4,
+              "v": 0.903
+            },
+            "rightKnee": {
+              "x": 52.4,
+              "y": 85.3,
+              "v": 0.968
+            },
+            "leftAnkle": {
+              "x": 74.7,
+              "y": 107.6,
+              "v": 0.975
+            },
+            "rightAnkle": {
+              "x": 47,
+              "y": 106.4,
+              "v": 0.977
+            },
+            "leftHeel": {
+              "x": 72.8,
+              "y": 111.9,
+              "v": 0.888
+            },
+            "rightHeel": {
+              "x": 45.9,
+              "y": 108.9,
+              "v": 0.759
+            },
+            "leftFootIndex": {
+              "x": 83.3,
+              "y": 113.2,
+              "v": 0.975
+            },
+            "rightFootIndex": {
+              "x": 45.9,
+              "y": 116.7,
+              "v": 0.965
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.2,
+                "y": 17.8
+              },
+              "roll": 173.7,
+              "yaw": -0.011,
+              "pitch": 0.387
+            },
+            "torso": {
+              "center": {
+                "x": 65.1,
+                "y": 31.4
+              },
+              "angle": 87.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.8,
+                "y": 59.5
+              },
+              "angle": -65.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 46.8,
+                "y": 58.5
+              },
+              "angle": -84.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.8,
+                "y": 111.9
+              },
+              "angle": -7.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45.9,
+                "y": 108.9
+              },
+              "angle": -90
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/carito/poses.json
+++ b/public/assets/fighters/carito/poses.json
@@ -1,0 +1,8342 @@
+{
+  "version": 1,
+  "fighter": "carito",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:40:16.722Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.796,
+          "keypoints": {
+            "nose": {
+              "x": 69.3,
+              "y": 23,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.7,
+              "y": 21.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66,
+              "y": 20.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.7,
+              "y": 22.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.6,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.1,
+              "y": 38.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.9,
+              "y": 34.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.3,
+              "y": 57,
+              "v": 0.464
+            },
+            "rightElbow": {
+              "x": 51.5,
+              "y": 45.9,
+              "v": 0.789
+            },
+            "leftWrist": {
+              "x": 85.1,
+              "y": 67.1,
+              "v": 0.64
+            },
+            "rightWrist": {
+              "x": 47.3,
+              "y": 46.2,
+              "v": 0.922
+            },
+            "leftIndex": {
+              "x": 87.6,
+              "y": 68.1,
+              "v": 0.712
+            },
+            "rightIndex": {
+              "x": 45.8,
+              "y": 45.4,
+              "v": 0.934
+            },
+            "leftHip": {
+              "x": 70.7,
+              "y": 68.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.7,
+              "y": 67.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.4,
+              "y": 91.6,
+              "v": 0.611
+            },
+            "rightKnee": {
+              "x": 50.6,
+              "y": 92.1,
+              "v": 0.652
+            },
+            "leftAnkle": {
+              "x": 76,
+              "y": 113.1,
+              "v": 0.665
+            },
+            "rightAnkle": {
+              "x": 48.5,
+              "y": 115.7,
+              "v": 0.753
+            },
+            "leftHeel": {
+              "x": 73.7,
+              "y": 116.2,
+              "v": 0.435
+            },
+            "rightHeel": {
+              "x": 48,
+              "y": 118.9,
+              "v": 0.268
+            },
+            "leftFootIndex": {
+              "x": 80.3,
+              "y": 120.4,
+              "v": 0.74
+            },
+            "rightFootIndex": {
+              "x": 47.3,
+              "y": 125.5,
+              "v": 0.717
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.9,
+                "y": 21
+              },
+              "roll": 176.9,
+              "yaw": 0.391,
+              "pitch": 0.54
+            },
+            "torso": {
+              "center": {
+                "x": 65.5,
+                "y": 36.6
+              },
+              "angle": 87.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.1,
+                "y": 67.1
+              },
+              "angle": -21.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.3,
+                "y": 46.2
+              },
+              "angle": 151.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.7,
+                "y": 116.2
+              },
+              "angle": -32.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.5,
+                "y": 115.7
+              },
+              "angle": -97
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.752,
+          "keypoints": {
+            "nose": {
+              "x": 68.1,
+              "y": 24,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.8,
+              "y": 22.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66,
+              "y": 22.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.8,
+              "y": 23.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.9,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.3,
+              "y": 38.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.8,
+              "y": 33.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.7,
+              "y": 54.2,
+              "v": 0.272
+            },
+            "rightElbow": {
+              "x": 52.2,
+              "y": 46.5,
+              "v": 0.78
+            },
+            "leftWrist": {
+              "x": 80.8,
+              "y": 63.8,
+              "v": 0.208
+            },
+            "rightWrist": {
+              "x": 51.6,
+              "y": 51.7,
+              "v": 0.786
+            },
+            "leftIndex": {
+              "x": 81.2,
+              "y": 64.9,
+              "v": 0.259
+            },
+            "rightIndex": {
+              "x": 51.6,
+              "y": 53.1,
+              "v": 0.788
+            },
+            "leftHip": {
+              "x": 70.2,
+              "y": 67.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.4,
+              "y": 67.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.9,
+              "y": 90.8,
+              "v": 0.569
+            },
+            "rightKnee": {
+              "x": 51.6,
+              "y": 91.7,
+              "v": 0.667
+            },
+            "leftAnkle": {
+              "x": 75.1,
+              "y": 113.9,
+              "v": 0.76
+            },
+            "rightAnkle": {
+              "x": 48,
+              "y": 116.6,
+              "v": 0.823
+            },
+            "leftHeel": {
+              "x": 72.5,
+              "y": 117.4,
+              "v": 0.518
+            },
+            "rightHeel": {
+              "x": 47.7,
+              "y": 119.2,
+              "v": 0.295
+            },
+            "leftFootIndex": {
+              "x": 81,
+              "y": 120.5,
+              "v": 0.8
+            },
+            "rightFootIndex": {
+              "x": 47.1,
+              "y": 125.7,
+              "v": 0.763
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.9,
+                "y": 22.4
+              },
+              "roll": 178.5,
+              "yaw": 0.053,
+              "pitch": 0.434
+            },
+            "torso": {
+              "center": {
+                "x": 65.6,
+                "y": 36.1
+              },
+              "angle": 86.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 51.6,
+                "y": 51.7
+              },
+              "angle": -90
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.5,
+                "y": 117.4
+              },
+              "angle": -20
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48,
+                "y": 116.6
+              },
+              "angle": -95.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.754,
+          "keypoints": {
+            "nose": {
+              "x": 67.1,
+              "y": 25.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.8,
+              "y": 22.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.3,
+              "y": 22.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73,
+              "y": 23.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.9,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.5,
+              "y": 39.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.6,
+              "y": 35.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.6,
+              "y": 54.3,
+              "v": 0.56
+            },
+            "rightElbow": {
+              "x": 53.3,
+              "y": 48.4,
+              "v": 0.775
+            },
+            "leftWrist": {
+              "x": 86.1,
+              "y": 59.6,
+              "v": 0.614
+            },
+            "rightWrist": {
+              "x": 50.3,
+              "y": 52.3,
+              "v": 0.853
+            },
+            "leftIndex": {
+              "x": 88.2,
+              "y": 59.2,
+              "v": 0.653
+            },
+            "rightIndex": {
+              "x": 49.9,
+              "y": 53.7,
+              "v": 0.839
+            },
+            "leftHip": {
+              "x": 72.6,
+              "y": 66.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.3,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.2,
+              "y": 88.6,
+              "v": 0.376
+            },
+            "rightKnee": {
+              "x": 49.7,
+              "y": 89.6,
+              "v": 0.604
+            },
+            "leftAnkle": {
+              "x": 78.4,
+              "y": 112.5,
+              "v": 0.566
+            },
+            "rightAnkle": {
+              "x": 46.3,
+              "y": 115,
+              "v": 0.692
+            },
+            "leftHeel": {
+              "x": 75.3,
+              "y": 116.1,
+              "v": 0.336
+            },
+            "rightHeel": {
+              "x": 45.3,
+              "y": 117.1,
+              "v": 0.207
+            },
+            "leftFootIndex": {
+              "x": 82.9,
+              "y": 119.2,
+              "v": 0.642
+            },
+            "rightFootIndex": {
+              "x": 44.6,
+              "y": 126.3,
+              "v": 0.635
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.6,
+                "y": 22.5
+              },
+              "roll": -177.5,
+              "yaw": -0.1,
+              "pitch": 0.577
+            },
+            "torso": {
+              "center": {
+                "x": 68.6,
+                "y": 37.5
+              },
+              "angle": 84.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.1,
+                "y": 59.6
+              },
+              "angle": 10.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.3,
+                "y": 52.3
+              },
+              "angle": -105.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 75.3,
+                "y": 116.1
+              },
+              "angle": -22.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 46.3,
+                "y": 115
+              },
+              "angle": -98.6
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.69,
+          "keypoints": {
+            "nose": {
+              "x": 68.1,
+              "y": 22.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.6,
+              "y": 20.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.5,
+              "y": 20.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.2,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.2,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.2,
+              "y": 37.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.1,
+              "y": 35.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.6,
+              "y": 52.7,
+              "v": 0.27
+            },
+            "rightElbow": {
+              "x": 50.9,
+              "y": 46.9,
+              "v": 0.374
+            },
+            "leftWrist": {
+              "x": 75.5,
+              "y": 46.6,
+              "v": 0.423
+            },
+            "rightWrist": {
+              "x": 40.7,
+              "y": 34.4,
+              "v": 0.734
+            },
+            "leftIndex": {
+              "x": 74.5,
+              "y": 42.8,
+              "v": 0.524
+            },
+            "rightIndex": {
+              "x": 39.2,
+              "y": 31.4,
+              "v": 0.795
+            },
+            "leftHip": {
+              "x": 69,
+              "y": 69.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56,
+              "y": 68.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.9,
+              "y": 91.7,
+              "v": 0.292
+            },
+            "rightKnee": {
+              "x": 49.2,
+              "y": 91.9,
+              "v": 0.484
+            },
+            "leftAnkle": {
+              "x": 75.2,
+              "y": 112.5,
+              "v": 0.512
+            },
+            "rightAnkle": {
+              "x": 48,
+              "y": 115.3,
+              "v": 0.673
+            },
+            "leftHeel": {
+              "x": 73.1,
+              "y": 116.5,
+              "v": 0.349
+            },
+            "rightHeel": {
+              "x": 47.3,
+              "y": 118.1,
+              "v": 0.285
+            },
+            "leftFootIndex": {
+              "x": 79,
+              "y": 119,
+              "v": 0.58
+            },
+            "rightFootIndex": {
+              "x": 46.2,
+              "y": 126.7,
+              "v": 0.574
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.1,
+                "y": 20.8
+              },
+              "roll": -176.6,
+              "yaw": 0.206,
+              "pitch": 0.382
+            },
+            "torso": {
+              "center": {
+                "x": 65.2,
+                "y": 36.4
+              },
+              "angle": 85.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 75.5,
+                "y": 46.6
+              },
+              "angle": 104.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40.7,
+                "y": 34.4
+              },
+              "angle": 116.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.1,
+                "y": 116.5
+              },
+              "angle": -23
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48,
+                "y": 115.3
+              },
+              "angle": -99
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.71,
+          "keypoints": {
+            "nose": {
+              "x": 68.1,
+              "y": 18.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.3,
+              "y": 15.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.9,
+              "y": 16.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.6,
+              "y": 17.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78,
+              "y": 30.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.7,
+              "y": 29.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.5,
+              "y": 50.1,
+              "v": 0.427
+            },
+            "rightElbow": {
+              "x": 53.1,
+              "y": 48.6,
+              "v": 0.631
+            },
+            "leftWrist": {
+              "x": 76,
+              "y": 44.5,
+              "v": 0.384
+            },
+            "rightWrist": {
+              "x": 53.5,
+              "y": 47,
+              "v": 0.672
+            },
+            "leftIndex": {
+              "x": 75.7,
+              "y": 40,
+              "v": 0.434
+            },
+            "rightIndex": {
+              "x": 55.4,
+              "y": 45.7,
+              "v": 0.7
+            },
+            "leftHip": {
+              "x": 70,
+              "y": 64.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.4,
+              "y": 63.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.4,
+              "y": 86.9,
+              "v": 0.547
+            },
+            "rightKnee": {
+              "x": 51.2,
+              "y": 90.3,
+              "v": 0.657
+            },
+            "leftAnkle": {
+              "x": 75.5,
+              "y": 108.4,
+              "v": 0.473
+            },
+            "rightAnkle": {
+              "x": 48.3,
+              "y": 114.4,
+              "v": 0.675
+            },
+            "leftHeel": {
+              "x": 74.2,
+              "y": 110.7,
+              "v": 0.362
+            },
+            "rightHeel": {
+              "x": 47.9,
+              "y": 116.6,
+              "v": 0.329
+            },
+            "leftFootIndex": {
+              "x": 77.9,
+              "y": 116.8,
+              "v": 0.481
+            },
+            "rightFootIndex": {
+              "x": 45.2,
+              "y": 124.6,
+              "v": 0.548
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.2,
+                "y": 16
+              },
+              "roll": -170.8,
+              "yaw": 0.218,
+              "pitch": 0.677
+            },
+            "torso": {
+              "center": {
+                "x": 65.9,
+                "y": 29.9
+              },
+              "angle": 85.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76,
+                "y": 44.5
+              },
+              "angle": 93.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 53.5,
+                "y": 47
+              },
+              "angle": 34.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.2,
+                "y": 110.7
+              },
+              "angle": -58.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.9,
+                "y": 116.6
+              },
+              "angle": -108.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.819,
+          "keypoints": {
+            "nose": {
+              "x": 68.3,
+              "y": 24,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.7,
+              "y": 21.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.4,
+              "y": 21.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.2,
+              "y": 23.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.8,
+              "y": 22.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.6,
+              "y": 39.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.2,
+              "y": 36.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.8,
+              "y": 57.1,
+              "v": 0.29
+            },
+            "rightElbow": {
+              "x": 49.7,
+              "y": 51.8,
+              "v": 0.558
+            },
+            "leftWrist": {
+              "x": 79,
+              "y": 53.7,
+              "v": 0.567
+            },
+            "rightWrist": {
+              "x": 56.3,
+              "y": 40.5,
+              "v": 0.878
+            },
+            "leftIndex": {
+              "x": 78.5,
+              "y": 50.2,
+              "v": 0.725
+            },
+            "rightIndex": {
+              "x": 57.5,
+              "y": 35,
+              "v": 0.9
+            },
+            "leftHip": {
+              "x": 69,
+              "y": 71.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.3,
+              "y": 71.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.8,
+              "y": 92.9,
+              "v": 0.535
+            },
+            "rightKnee": {
+              "x": 48.3,
+              "y": 94,
+              "v": 0.619
+            },
+            "leftAnkle": {
+              "x": 75.6,
+              "y": 114,
+              "v": 0.868
+            },
+            "rightAnkle": {
+              "x": 48.6,
+              "y": 116.4,
+              "v": 0.883
+            },
+            "leftHeel": {
+              "x": 72.7,
+              "y": 117.2,
+              "v": 0.739
+            },
+            "rightHeel": {
+              "x": 48,
+              "y": 118.9,
+              "v": 0.568
+            },
+            "leftFootIndex": {
+              "x": 81.3,
+              "y": 120.4,
+              "v": 0.89
+            },
+            "rightFootIndex": {
+              "x": 46.9,
+              "y": 125.7,
+              "v": 0.828
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.6,
+                "y": 21.6
+              },
+              "roll": 173.4,
+              "yaw": 0.173,
+              "pitch": 0.566
+            },
+            "torso": {
+              "center": {
+                "x": 65.4,
+                "y": 38
+              },
+              "angle": 84.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 79,
+                "y": 53.7
+              },
+              "angle": 98.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 56.3,
+                "y": 40.5
+              },
+              "angle": 77.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.7,
+                "y": 117.2
+              },
+              "angle": -20.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48,
+                "y": 118.9
+              },
+              "angle": -99.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.849,
+          "keypoints": {
+            "nose": {
+              "x": 67,
+              "y": 24.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.3,
+              "y": 22.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.9,
+              "y": 22.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.5,
+              "y": 24.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.5,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.7,
+              "y": 39.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.5,
+              "y": 35.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.2,
+              "y": 54.8,
+              "v": 0.485
+            },
+            "rightElbow": {
+              "x": 50.4,
+              "y": 42.8,
+              "v": 0.782
+            },
+            "leftWrist": {
+              "x": 80.5,
+              "y": 57.9,
+              "v": 0.662
+            },
+            "rightWrist": {
+              "x": 38.2,
+              "y": 32.9,
+              "v": 0.936
+            },
+            "leftIndex": {
+              "x": 80.9,
+              "y": 56.4,
+              "v": 0.706
+            },
+            "rightIndex": {
+              "x": 34.2,
+              "y": 28.9,
+              "v": 0.941
+            },
+            "leftHip": {
+              "x": 70.5,
+              "y": 68,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.3,
+              "y": 67.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.9,
+              "y": 91.1,
+              "v": 0.687
+            },
+            "rightKnee": {
+              "x": 49.8,
+              "y": 91.4,
+              "v": 0.796
+            },
+            "leftAnkle": {
+              "x": 76,
+              "y": 113.7,
+              "v": 0.826
+            },
+            "rightAnkle": {
+              "x": 48.2,
+              "y": 116.7,
+              "v": 0.892
+            },
+            "leftHeel": {
+              "x": 73.7,
+              "y": 117,
+              "v": 0.636
+            },
+            "rightHeel": {
+              "x": 48.3,
+              "y": 118.9,
+              "v": 0.475
+            },
+            "leftFootIndex": {
+              "x": 80.7,
+              "y": 120.4,
+              "v": 0.86
+            },
+            "rightFootIndex": {
+              "x": 46.6,
+              "y": 125.8,
+              "v": 0.851
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.1,
+                "y": 22.8
+              },
+              "roll": 177.4,
+              "yaw": -0.023,
+              "pitch": 0.477
+            },
+            "torso": {
+              "center": {
+                "x": 65.6,
+                "y": 37.4
+              },
+              "angle": 86.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.5,
+                "y": 57.9
+              },
+              "angle": 75.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.2,
+                "y": 32.9
+              },
+              "angle": 135
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.7,
+                "y": 117
+              },
+              "angle": -25.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.3,
+                "y": 118.9
+              },
+              "angle": -103.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.715,
+          "keypoints": {
+            "nose": {
+              "x": 68.5,
+              "y": 21.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.5,
+              "y": 20.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.9,
+              "y": 20,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.3,
+              "y": 21.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.3,
+              "y": 35.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.3,
+              "y": 34.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.5,
+              "y": 50.4,
+              "v": 0.282
+            },
+            "rightElbow": {
+              "x": 51,
+              "y": 47.2,
+              "v": 0.697
+            },
+            "leftWrist": {
+              "x": 70.8,
+              "y": 45.2,
+              "v": 0.187
+            },
+            "rightWrist": {
+              "x": 50.6,
+              "y": 50.8,
+              "v": 0.563
+            },
+            "leftIndex": {
+              "x": 69.2,
+              "y": 42.2,
+              "v": 0.203
+            },
+            "rightIndex": {
+              "x": 51.5,
+              "y": 52.4,
+              "v": 0.548
+            },
+            "leftHip": {
+              "x": 68.4,
+              "y": 68.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.3,
+              "y": 66.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.3,
+              "y": 90.6,
+              "v": 0.591
+            },
+            "rightKnee": {
+              "x": 50.6,
+              "y": 91.3,
+              "v": 0.599
+            },
+            "leftAnkle": {
+              "x": 75.4,
+              "y": 113.4,
+              "v": 0.685
+            },
+            "rightAnkle": {
+              "x": 48.2,
+              "y": 114.7,
+              "v": 0.804
+            },
+            "leftHeel": {
+              "x": 73.3,
+              "y": 116.8,
+              "v": 0.453
+            },
+            "rightHeel": {
+              "x": 47.1,
+              "y": 119,
+              "v": 0.337
+            },
+            "leftFootIndex": {
+              "x": 81.3,
+              "y": 120.6,
+              "v": 0.74
+            },
+            "rightFootIndex": {
+              "x": 46.6,
+              "y": 124.3,
+              "v": 0.747
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.7,
+                "y": 20.2
+              },
+              "roll": 175.2,
+              "yaw": 0.221,
+              "pitch": 0.429
+            },
+            "torso": {
+              "center": {
+                "x": 65.3,
+                "y": 35
+              },
+              "angle": 84.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 50.6,
+                "y": 50.8
+              },
+              "angle": -60.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.3,
+                "y": 116.8
+              },
+              "angle": -25.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.1,
+                "y": 119
+              },
+              "angle": -95.4
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.84,
+          "keypoints": {
+            "nose": {
+              "x": 68.7,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.5,
+              "y": 21.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.3,
+              "y": 21.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.1,
+              "y": 22.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.9,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.1,
+              "y": 39.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.9,
+              "y": 35.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.7,
+              "y": 55.8,
+              "v": 0.548
+            },
+            "rightElbow": {
+              "x": 52.2,
+              "y": 48.4,
+              "v": 0.858
+            },
+            "leftWrist": {
+              "x": 77.6,
+              "y": 50.6,
+              "v": 0.671
+            },
+            "rightWrist": {
+              "x": 51,
+              "y": 51.1,
+              "v": 0.922
+            },
+            "leftIndex": {
+              "x": 76.7,
+              "y": 46.8,
+              "v": 0.726
+            },
+            "rightIndex": {
+              "x": 50.8,
+              "y": 50.5,
+              "v": 0.922
+            },
+            "leftHip": {
+              "x": 69.4,
+              "y": 70.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.6,
+              "y": 69.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76,
+              "y": 91.3,
+              "v": 0.787
+            },
+            "rightKnee": {
+              "x": 50.7,
+              "y": 93.7,
+              "v": 0.756
+            },
+            "leftAnkle": {
+              "x": 75.8,
+              "y": 113,
+              "v": 0.762
+            },
+            "rightAnkle": {
+              "x": 48.5,
+              "y": 115,
+              "v": 0.824
+            },
+            "leftHeel": {
+              "x": 74,
+              "y": 116,
+              "v": 0.596
+            },
+            "rightHeel": {
+              "x": 48,
+              "y": 117.8,
+              "v": 0.368
+            },
+            "leftFootIndex": {
+              "x": 80.5,
+              "y": 120.3,
+              "v": 0.819
+            },
+            "rightFootIndex": {
+              "x": 47.3,
+              "y": 124.7,
+              "v": 0.77
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.4,
+                "y": 21.5
+              },
+              "roll": -175.9,
+              "yaw": 0.309,
+              "pitch": 0.534
+            },
+            "torso": {
+              "center": {
+                "x": 65.5,
+                "y": 37.6
+              },
+              "angle": 85.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 77.6,
+                "y": 50.6
+              },
+              "angle": 103.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 51,
+                "y": 51.1
+              },
+              "angle": 108.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74,
+                "y": 116
+              },
+              "angle": -33.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48,
+                "y": 117.8
+              },
+              "angle": -95.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.799,
+          "keypoints": {
+            "nose": {
+              "x": 66.5,
+              "y": 23.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.5,
+              "y": 21.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.1,
+              "y": 20.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.8,
+              "y": 23.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.2,
+              "y": 21.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.1,
+              "y": 35.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.5,
+              "y": 33.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.7,
+              "y": 40.1,
+              "v": 0.717
+            },
+            "rightElbow": {
+              "x": 46.4,
+              "y": 43.8,
+              "v": 0.835
+            },
+            "leftWrist": {
+              "x": 87.9,
+              "y": 39.5,
+              "v": 0.814
+            },
+            "rightWrist": {
+              "x": 34.8,
+              "y": 31.7,
+              "v": 0.892
+            },
+            "leftIndex": {
+              "x": 91.2,
+              "y": 35.5,
+              "v": 0.837
+            },
+            "rightIndex": {
+              "x": 31,
+              "y": 27.9,
+              "v": 0.885
+            },
+            "leftHip": {
+              "x": 64.2,
+              "y": 68.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.1,
+              "y": 68,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.9,
+              "y": 92.6,
+              "v": 0.363
+            },
+            "rightKnee": {
+              "x": 45.2,
+              "y": 92.3,
+              "v": 0.53
+            },
+            "leftAnkle": {
+              "x": 72.2,
+              "y": 114.2,
+              "v": 0.595
+            },
+            "rightAnkle": {
+              "x": 44.4,
+              "y": 116.6,
+              "v": 0.72
+            },
+            "leftHeel": {
+              "x": 69.7,
+              "y": 117.1,
+              "v": 0.483
+            },
+            "rightHeel": {
+              "x": 43.9,
+              "y": 119.8,
+              "v": 0.417
+            },
+            "leftFootIndex": {
+              "x": 78.7,
+              "y": 119.9,
+              "v": 0.647
+            },
+            "rightFootIndex": {
+              "x": 42.3,
+              "y": 127,
+              "v": 0.646
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.3,
+                "y": 21
+              },
+              "roll": 168.4,
+              "yaw": 0.045,
+              "pitch": 0.523
+            },
+            "torso": {
+              "center": {
+                "x": 61.8,
+                "y": 34.5
+              },
+              "angle": 83
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.9,
+                "y": 39.5
+              },
+              "angle": 50.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.8,
+                "y": 31.7
+              },
+              "angle": 135
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.7,
+                "y": 117.1
+              },
+              "angle": -17.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.9,
+                "y": 119.8
+              },
+              "angle": -102.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.873,
+          "keypoints": {
+            "nose": {
+              "x": 70.5,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.5,
+              "y": 21.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.1,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.2,
+              "y": 22.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.1,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.4,
+              "y": 33.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.4,
+              "y": 32.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.7,
+              "y": 37.7,
+              "v": 0.893
+            },
+            "rightElbow": {
+              "x": 49.6,
+              "y": 40.6,
+              "v": 0.885
+            },
+            "leftWrist": {
+              "x": 97,
+              "y": 35.6,
+              "v": 0.958
+            },
+            "rightWrist": {
+              "x": 37.9,
+              "y": 30,
+              "v": 0.92
+            },
+            "leftIndex": {
+              "x": 101.8,
+              "y": 35.3,
+              "v": 0.947
+            },
+            "rightIndex": {
+              "x": 34.1,
+              "y": 26.2,
+              "v": 0.902
+            },
+            "leftHip": {
+              "x": 70.2,
+              "y": 64.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.7,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.7,
+              "y": 86.9,
+              "v": 0.639
+            },
+            "rightKnee": {
+              "x": 50.4,
+              "y": 86.7,
+              "v": 0.785
+            },
+            "leftAnkle": {
+              "x": 76,
+              "y": 111.5,
+              "v": 0.734
+            },
+            "rightAnkle": {
+              "x": 48.5,
+              "y": 114.3,
+              "v": 0.797
+            },
+            "leftHeel": {
+              "x": 74.3,
+              "y": 115.7,
+              "v": 0.579
+            },
+            "rightHeel": {
+              "x": 49.2,
+              "y": 116.2,
+              "v": 0.527
+            },
+            "leftFootIndex": {
+              "x": 80.4,
+              "y": 119.1,
+              "v": 0.77
+            },
+            "rightFootIndex": {
+              "x": 45.6,
+              "y": 124.4,
+              "v": 0.747
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.3,
+                "y": 20.9
+              },
+              "roll": 164.7,
+              "yaw": 0.044,
+              "pitch": 0.548
+            },
+            "torso": {
+              "center": {
+                "x": 66.4,
+                "y": 33.2
+              },
+              "angle": 85.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97,
+                "y": 35.6
+              },
+              "angle": 3.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.9,
+                "y": 30
+              },
+              "angle": 135
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.3,
+                "y": 115.7
+              },
+              "angle": -29.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 49.2,
+                "y": 116.2
+              },
+              "angle": -113.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.817,
+          "keypoints": {
+            "nose": {
+              "x": 70.1,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.9,
+              "y": 21.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.6,
+              "y": 21,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73,
+              "y": 23,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.8,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76,
+              "y": 33.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.5,
+              "y": 33.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.6,
+              "y": 36.4,
+              "v": 0.962
+            },
+            "rightElbow": {
+              "x": 51.9,
+              "y": 40.1,
+              "v": 0.857
+            },
+            "leftWrist": {
+              "x": 97.7,
+              "y": 35.8,
+              "v": 0.983
+            },
+            "rightWrist": {
+              "x": 48,
+              "y": 45.5,
+              "v": 0.844
+            },
+            "leftIndex": {
+              "x": 103.2,
+              "y": 35.6,
+              "v": 0.978
+            },
+            "rightIndex": {
+              "x": 41.7,
+              "y": 43.6,
+              "v": 0.831
+            },
+            "leftHip": {
+              "x": 71,
+              "y": 65.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.4,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.7,
+              "y": 88.2,
+              "v": 0.695
+            },
+            "rightKnee": {
+              "x": 52.6,
+              "y": 82.5,
+              "v": 0.539
+            },
+            "leftAnkle": {
+              "x": 76,
+              "y": 112,
+              "v": 0.662
+            },
+            "rightAnkle": {
+              "x": 44.7,
+              "y": 104,
+              "v": 0.496
+            },
+            "leftHeel": {
+              "x": 74.1,
+              "y": 115.7,
+              "v": 0.5
+            },
+            "rightHeel": {
+              "x": 44.3,
+              "y": 107.4,
+              "v": 0.255
+            },
+            "leftFootIndex": {
+              "x": 80.8,
+              "y": 119.3,
+              "v": 0.706
+            },
+            "rightFootIndex": {
+              "x": 42.5,
+              "y": 111.7,
+              "v": 0.481
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.8,
+                "y": 21.3
+              },
+              "roll": 173.4,
+              "yaw": 0.081,
+              "pitch": 0.589
+            },
+            "torso": {
+              "center": {
+                "x": 67.3,
+                "y": 33.4
+              },
+              "angle": 85.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.7,
+                "y": 35.8
+              },
+              "angle": 2.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48,
+                "y": 45.5
+              },
+              "angle": 163.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.1,
+                "y": 115.7
+              },
+              "angle": -28.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.7,
+                "y": 104
+              },
+              "angle": -105.9
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.807,
+          "keypoints": {
+            "nose": {
+              "x": 63.3,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64,
+              "y": 19.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 59.7,
+              "y": 19.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.8,
+              "y": 20.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 55.7,
+              "y": 20.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.2,
+              "y": 32.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.2,
+              "y": 32.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.9,
+              "y": 37.3,
+              "v": 0.921
+            },
+            "rightElbow": {
+              "x": 44,
+              "y": 42.7,
+              "v": 0.876
+            },
+            "leftWrist": {
+              "x": 92,
+              "y": 36.5,
+              "v": 0.982
+            },
+            "rightWrist": {
+              "x": 34.1,
+              "y": 34.2,
+              "v": 0.934
+            },
+            "leftIndex": {
+              "x": 98.3,
+              "y": 35.1,
+              "v": 0.984
+            },
+            "rightIndex": {
+              "x": 32,
+              "y": 33.3,
+              "v": 0.945
+            },
+            "leftHip": {
+              "x": 61.9,
+              "y": 64.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.9,
+              "y": 64.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 68.3,
+              "y": 88,
+              "v": 0.428
+            },
+            "rightKnee": {
+              "x": 44.2,
+              "y": 89.1,
+              "v": 0.525
+            },
+            "leftAnkle": {
+              "x": 68.2,
+              "y": 112.9,
+              "v": 0.514
+            },
+            "rightAnkle": {
+              "x": 39.6,
+              "y": 115,
+              "v": 0.594
+            },
+            "leftHeel": {
+              "x": 65.4,
+              "y": 116.8,
+              "v": 0.382
+            },
+            "rightHeel": {
+              "x": 38.7,
+              "y": 118.2,
+              "v": 0.29
+            },
+            "leftFootIndex": {
+              "x": 73.8,
+              "y": 119.7,
+              "v": 0.625
+            },
+            "rightFootIndex": {
+              "x": 38.4,
+              "y": 124.6,
+              "v": 0.568
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 61.9,
+                "y": 19.5
+              },
+              "roll": 178.7,
+              "yaw": 0.337,
+              "pitch": 0.477
+            },
+            "torso": {
+              "center": {
+                "x": 58.2,
+                "y": 32.6
+              },
+              "angle": 85
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92,
+                "y": 36.5
+              },
+              "angle": 12.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.1,
+                "y": 34.2
+              },
+              "angle": 156.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 65.4,
+                "y": 116.8
+              },
+              "angle": -19
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.6,
+                "y": 115
+              },
+              "angle": -97.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.795,
+          "keypoints": {
+            "nose": {
+              "x": 66.5,
+              "y": 21.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.5,
+              "y": 18.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.5,
+              "y": 19.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.8,
+              "y": 19.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.4,
+              "y": 21.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.5,
+              "y": 33.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.5,
+              "y": 33.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.7,
+              "y": 47.1,
+              "v": 0.409
+            },
+            "rightElbow": {
+              "x": 51.6,
+              "y": 46.2,
+              "v": 0.711
+            },
+            "leftWrist": {
+              "x": 80.9,
+              "y": 44.2,
+              "v": 0.58
+            },
+            "rightWrist": {
+              "x": 48.2,
+              "y": 46.5,
+              "v": 0.773
+            },
+            "leftIndex": {
+              "x": 81.3,
+              "y": 41.4,
+              "v": 0.645
+            },
+            "rightIndex": {
+              "x": 47.2,
+              "y": 45.7,
+              "v": 0.776
+            },
+            "leftHip": {
+              "x": 70,
+              "y": 65.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.5,
+              "y": 65.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.5,
+              "y": 88.8,
+              "v": 0.566
+            },
+            "rightKnee": {
+              "x": 49.6,
+              "y": 89.9,
+              "v": 0.805
+            },
+            "leftAnkle": {
+              "x": 74.1,
+              "y": 111.3,
+              "v": 0.731
+            },
+            "rightAnkle": {
+              "x": 46.6,
+              "y": 115,
+              "v": 0.852
+            },
+            "leftHeel": {
+              "x": 71.6,
+              "y": 115.6,
+              "v": 0.457
+            },
+            "rightHeel": {
+              "x": 46,
+              "y": 116.9,
+              "v": 0.426
+            },
+            "leftFootIndex": {
+              "x": 78.3,
+              "y": 119.5,
+              "v": 0.756
+            },
+            "rightFootIndex": {
+              "x": 44.3,
+              "y": 126.2,
+              "v": 0.807
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66,
+                "y": 19.4
+              },
+              "roll": -169.8,
+              "yaw": 0.098,
+              "pitch": 0.443
+            },
+            "torso": {
+              "center": {
+                "x": 66,
+                "y": 33.6
+              },
+              "angle": 85.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.9,
+                "y": 44.2
+              },
+              "angle": 81.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48.2,
+                "y": 46.5
+              },
+              "angle": 141.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.6,
+                "y": 115.6
+              },
+              "angle": -30.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 46,
+                "y": 116.9
+              },
+              "angle": -100.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.964,
+          "keypoints": {
+            "nose": {
+              "x": 56.2,
+              "y": 23.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.1,
+              "y": 21.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.4,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.5,
+              "y": 22.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.1,
+              "y": 22.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 61.2,
+              "y": 33.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.1,
+              "y": 35.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.5,
+              "y": 34.7,
+              "v": 0.998
+            },
+            "rightElbow": {
+              "x": 36.7,
+              "y": 47.3,
+              "v": 0.775
+            },
+            "leftWrist": {
+              "x": 88,
+              "y": 33,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 26.7,
+              "y": 43.9,
+              "v": 0.93
+            },
+            "leftIndex": {
+              "x": 91.6,
+              "y": 30.8,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 22.6,
+              "y": 42.7,
+              "v": 0.917
+            },
+            "leftHip": {
+              "x": 58.4,
+              "y": 65.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.9,
+              "y": 67.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.2,
+              "y": 85.6,
+              "v": 0.989
+            },
+            "rightKnee": {
+              "x": 35.5,
+              "y": 87.1,
+              "v": 0.933
+            },
+            "leftAnkle": {
+              "x": 88.1,
+              "y": 106.3,
+              "v": 0.951
+            },
+            "rightAnkle": {
+              "x": 31.5,
+              "y": 115.6,
+              "v": 0.967
+            },
+            "leftHeel": {
+              "x": 90.3,
+              "y": 109,
+              "v": 0.856
+            },
+            "rightHeel": {
+              "x": 33.9,
+              "y": 120.7,
+              "v": 0.951
+            },
+            "leftFootIndex": {
+              "x": 86.4,
+              "y": 115.4,
+              "v": 0.953
+            },
+            "rightFootIndex": {
+              "x": 21.9,
+              "y": 122.9,
+              "v": 0.967
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55.8,
+                "y": 21.7
+              },
+              "roll": 175.1,
+              "yaw": 0.095,
+              "pitch": 0.466
+            },
+            "torso": {
+              "center": {
+                "x": 52.2,
+                "y": 34.2
+              },
+              "angle": 90.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88,
+                "y": 33
+              },
+              "angle": 31.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 26.7,
+                "y": 43.9
+              },
+              "angle": 163.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 90.3,
+                "y": 109
+              },
+              "angle": -121.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33.9,
+                "y": 120.7
+              },
+              "angle": -169.6
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.95,
+          "keypoints": {
+            "nose": {
+              "x": 63.5,
+              "y": 24.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.4,
+              "y": 22.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 60.8,
+              "y": 21.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63,
+              "y": 23.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.7,
+              "y": 22.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66.5,
+              "y": 33.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.6,
+              "y": 37.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.4,
+              "y": 35.2,
+              "v": 0.993
+            },
+            "rightElbow": {
+              "x": 42.6,
+              "y": 47.2,
+              "v": 0.987
+            },
+            "leftWrist": {
+              "x": 94.4,
+              "y": 33.8,
+              "v": 0.993
+            },
+            "rightWrist": {
+              "x": 32.9,
+              "y": 47.1,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 99.1,
+              "y": 33.8,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 28,
+              "y": 45.3,
+              "v": 0.988
+            },
+            "leftHip": {
+              "x": 63.1,
+              "y": 66,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.4,
+              "y": 67.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.7,
+              "y": 88.7,
+              "v": 0.971
+            },
+            "rightKnee": {
+              "x": 31.2,
+              "y": 86.1,
+              "v": 0.963
+            },
+            "leftAnkle": {
+              "x": 91.2,
+              "y": 114.6,
+              "v": 0.895
+            },
+            "rightAnkle": {
+              "x": 23.9,
+              "y": 114.9,
+              "v": 0.931
+            },
+            "leftHeel": {
+              "x": 90.6,
+              "y": 118.5,
+              "v": 0.621
+            },
+            "rightHeel": {
+              "x": 25.9,
+              "y": 119.7,
+              "v": 0.747
+            },
+            "leftFootIndex": {
+              "x": 93.2,
+              "y": 123.4,
+              "v": 0.877
+            },
+            "rightFootIndex": {
+              "x": 16.4,
+              "y": 122.9,
+              "v": 0.898
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.6,
+                "y": 22.2
+              },
+              "roll": 166,
+              "yaw": 0.243,
+              "pitch": 0.606
+            },
+            "torso": {
+              "center": {
+                "x": 57.1,
+                "y": 35.5
+              },
+              "angle": 87.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.4,
+                "y": 33.8
+              },
+              "angle": 0
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.9,
+                "y": 47.1
+              },
+              "angle": 159.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 90.6,
+                "y": 118.5
+              },
+              "angle": -62
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25.9,
+                "y": 119.7
+              },
+              "angle": -161.4
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.842,
+          "keypoints": {
+            "nose": {
+              "x": 60.3,
+              "y": 23.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62,
+              "y": 21.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58,
+              "y": 21,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.9,
+              "y": 22.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 55.1,
+              "y": 21.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.9,
+              "y": 33.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.5,
+              "y": 31.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.6,
+              "y": 36.4,
+              "v": 0.988
+            },
+            "rightElbow": {
+              "x": 43.5,
+              "y": 44,
+              "v": 0.923
+            },
+            "leftWrist": {
+              "x": 90.8,
+              "y": 35.5,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 41.7,
+              "y": 51.1,
+              "v": 0.771
+            },
+            "leftIndex": {
+              "x": 97.3,
+              "y": 36.1,
+              "v": 0.99
+            },
+            "rightIndex": {
+              "x": 41.4,
+              "y": 53.7,
+              "v": 0.692
+            },
+            "leftHip": {
+              "x": 60.3,
+              "y": 63.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.4,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 67,
+              "y": 87.7,
+              "v": 0.738
+            },
+            "rightKnee": {
+              "x": 40.4,
+              "y": 88.9,
+              "v": 0.707
+            },
+            "leftAnkle": {
+              "x": 66.4,
+              "y": 111.8,
+              "v": 0.665
+            },
+            "rightAnkle": {
+              "x": 39.1,
+              "y": 115.5,
+              "v": 0.758
+            },
+            "leftHeel": {
+              "x": 63.7,
+              "y": 115.1,
+              "v": 0.424
+            },
+            "rightHeel": {
+              "x": 39.4,
+              "y": 117.9,
+              "v": 0.385
+            },
+            "leftFootIndex": {
+              "x": 72.2,
+              "y": 119.5,
+              "v": 0.667
+            },
+            "rightFootIndex": {
+              "x": 36.2,
+              "y": 126,
+              "v": 0.672
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60,
+                "y": 21.2
+              },
+              "roll": 174.3,
+              "yaw": 0.075,
+              "pitch": 0.473
+            },
+            "torso": {
+              "center": {
+                "x": 56.2,
+                "y": 32.5
+              },
+              "angle": 85.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.8,
+                "y": 35.5
+              },
+              "angle": -5.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.7,
+                "y": 51.1
+              },
+              "angle": -96.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 63.7,
+                "y": 115.1
+              },
+              "angle": -27.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.4,
+                "y": 117.9
+              },
+              "angle": -111.6
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.866,
+          "keypoints": {
+            "nose": {
+              "x": 63.5,
+              "y": 22.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.3,
+              "y": 20.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 60.4,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.2,
+              "y": 21.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.5,
+              "y": 22.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66.7,
+              "y": 37.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.7,
+              "y": 36.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 67.9,
+              "y": 52.9,
+              "v": 0.145
+            },
+            "rightElbow": {
+              "x": 44.6,
+              "y": 52.3,
+              "v": 0.872
+            },
+            "leftWrist": {
+              "x": 74.9,
+              "y": 58.5,
+              "v": 0.228
+            },
+            "rightWrist": {
+              "x": 44.4,
+              "y": 53,
+              "v": 0.776
+            },
+            "leftIndex": {
+              "x": 76.9,
+              "y": 57.9,
+              "v": 0.34
+            },
+            "rightIndex": {
+              "x": 45,
+              "y": 50.7,
+              "v": 0.791
+            },
+            "leftHip": {
+              "x": 63.2,
+              "y": 67.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.4,
+              "y": 68.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.8,
+              "y": 81.1,
+              "v": 0.98
+            },
+            "rightKnee": {
+              "x": 46.3,
+              "y": 88.6,
+              "v": 0.975
+            },
+            "leftAnkle": {
+              "x": 93.3,
+              "y": 85.7,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 42.1,
+              "y": 112.8,
+              "v": 0.987
+            },
+            "leftHeel": {
+              "x": 94.7,
+              "y": 88.9,
+              "v": 0.979
+            },
+            "rightHeel": {
+              "x": 41.9,
+              "y": 114.4,
+              "v": 0.874
+            },
+            "leftFootIndex": {
+              "x": 101.1,
+              "y": 82.7,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 40.8,
+              "y": 122.1,
+              "v": 0.976
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.4,
+                "y": 20.2
+              },
+              "roll": 178.5,
+              "yaw": 0.295,
+              "pitch": 0.551
+            },
+            "torso": {
+              "center": {
+                "x": 57.7,
+                "y": 36.8
+              },
+              "angle": 89.3
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 44.4,
+                "y": 53
+              },
+              "angle": 75.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 94.7,
+                "y": 88.9
+              },
+              "angle": 44.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.9,
+                "y": 114.4
+              },
+              "angle": -98.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.851,
+          "keypoints": {
+            "nose": {
+              "x": 63.5,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.1,
+              "y": 19.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 59.8,
+              "y": 20,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.8,
+              "y": 21,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.2,
+              "y": 22.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.4,
+              "y": 36.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.4,
+              "y": 35.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.8,
+              "y": 53.4,
+              "v": 0.089
+            },
+            "rightElbow": {
+              "x": 42.9,
+              "y": 47.5,
+              "v": 0.928
+            },
+            "leftWrist": {
+              "x": 73.9,
+              "y": 56.2,
+              "v": 0.167
+            },
+            "rightWrist": {
+              "x": 30.8,
+              "y": 32.9,
+              "v": 0.974
+            },
+            "leftIndex": {
+              "x": 75.3,
+              "y": 56.7,
+              "v": 0.247
+            },
+            "rightIndex": {
+              "x": 27.4,
+              "y": 27.9,
+              "v": 0.971
+            },
+            "leftHip": {
+              "x": 61.5,
+              "y": 65.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.8,
+              "y": 67.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.3,
+              "y": 77.1,
+              "v": 0.913
+            },
+            "rightKnee": {
+              "x": 43.8,
+              "y": 88.6,
+              "v": 0.94
+            },
+            "leftAnkle": {
+              "x": 96.5,
+              "y": 83.7,
+              "v": 0.947
+            },
+            "rightAnkle": {
+              "x": 41.5,
+              "y": 114.3,
+              "v": 0.941
+            },
+            "leftHeel": {
+              "x": 98.6,
+              "y": 86.9,
+              "v": 0.905
+            },
+            "rightHeel": {
+              "x": 40.8,
+              "y": 116.6,
+              "v": 0.682
+            },
+            "leftFootIndex": {
+              "x": 103.2,
+              "y": 81.3,
+              "v": 0.968
+            },
+            "rightFootIndex": {
+              "x": 40.2,
+              "y": 124.6,
+              "v": 0.897
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62,
+                "y": 20
+              },
+              "roll": -178.7,
+              "yaw": 0.36,
+              "pitch": 0.523
+            },
+            "torso": {
+              "center": {
+                "x": 58.9,
+                "y": 36
+              },
+              "angle": 84
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 30.8,
+                "y": 32.9
+              },
+              "angle": 124.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 98.6,
+                "y": 86.9
+              },
+              "angle": 50.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.8,
+                "y": 116.6
+              },
+              "angle": -94.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.75,
+          "keypoints": {
+            "nose": {
+              "x": 60.6,
+              "y": 23.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.5,
+              "y": 20.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.2,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61,
+              "y": 21.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.1,
+              "y": 22.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.6,
+              "y": 32.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.5,
+              "y": 33.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 66.7,
+              "y": 44.1,
+              "v": 0.077
+            },
+            "rightElbow": {
+              "x": 45.3,
+              "y": 51.1,
+              "v": 0.728
+            },
+            "leftWrist": {
+              "x": 63.5,
+              "y": 43.1,
+              "v": 0.074
+            },
+            "rightWrist": {
+              "x": 45.1,
+              "y": 55.4,
+              "v": 0.413
+            },
+            "leftIndex": {
+              "x": 62.6,
+              "y": 41,
+              "v": 0.112
+            },
+            "rightIndex": {
+              "x": 45.2,
+              "y": 55.3,
+              "v": 0.395
+            },
+            "leftHip": {
+              "x": 59.6,
+              "y": 64.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.9,
+              "y": 64.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.1,
+              "y": 87.4,
+              "v": 0.775
+            },
+            "rightKnee": {
+              "x": 46.4,
+              "y": 86.8,
+              "v": 0.758
+            },
+            "leftAnkle": {
+              "x": 59.7,
+              "y": 114.1,
+              "v": 0.938
+            },
+            "rightAnkle": {
+              "x": 34.4,
+              "y": 105.6,
+              "v": 0.88
+            },
+            "leftHeel": {
+              "x": 56.5,
+              "y": 118.5,
+              "v": 0.82
+            },
+            "rightHeel": {
+              "x": 32.1,
+              "y": 108.2,
+              "v": 0.503
+            },
+            "leftFootIndex": {
+              "x": 65.3,
+              "y": 123.3,
+              "v": 0.935
+            },
+            "rightFootIndex": {
+              "x": 36.1,
+              "y": 114.3,
+              "v": 0.841
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.4,
+                "y": 20.9
+              },
+              "roll": -170.8,
+              "yaw": 0.287,
+              "pitch": 0.539
+            },
+            "torso": {
+              "center": {
+                "x": 57.6,
+                "y": 33.3
+              },
+              "angle": 84.9
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 45.1,
+                "y": 55.4
+              },
+              "angle": 45
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 56.5,
+                "y": 118.5
+              },
+              "angle": -28.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.1,
+                "y": 108.2
+              },
+              "angle": -56.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.636,
+          "keypoints": {
+            "nose": {
+              "x": 67,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.8,
+              "y": 21.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.8,
+              "y": 22.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.4,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.1,
+              "y": 36.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.7,
+              "y": 33.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.4,
+              "y": 51.9,
+              "v": 0.161
+            },
+            "rightElbow": {
+              "x": 51.7,
+              "y": 42.6,
+              "v": 0.701
+            },
+            "leftWrist": {
+              "x": 67.5,
+              "y": 42.2,
+              "v": 0.26
+            },
+            "rightWrist": {
+              "x": 38.8,
+              "y": 31.1,
+              "v": 0.903
+            },
+            "leftIndex": {
+              "x": 67.1,
+              "y": 37.8,
+              "v": 0.263
+            },
+            "rightIndex": {
+              "x": 34.4,
+              "y": 26,
+              "v": 0.884
+            },
+            "leftHip": {
+              "x": 66,
+              "y": 67.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.2,
+              "y": 65.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.7,
+              "y": 91.2,
+              "v": 0.215
+            },
+            "rightKnee": {
+              "x": 49.8,
+              "y": 89.6,
+              "v": 0.283
+            },
+            "leftAnkle": {
+              "x": 74.6,
+              "y": 112.7,
+              "v": 0.368
+            },
+            "rightAnkle": {
+              "x": 47.6,
+              "y": 113.2,
+              "v": 0.411
+            },
+            "leftHeel": {
+              "x": 73,
+              "y": 116.2,
+              "v": 0.238
+            },
+            "rightHeel": {
+              "x": 48.4,
+              "y": 115.2,
+              "v": 0.149
+            },
+            "leftFootIndex": {
+              "x": 78.5,
+              "y": 119,
+              "v": 0.435
+            },
+            "rightFootIndex": {
+              "x": 45.8,
+              "y": 122.3,
+              "v": 0.364
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.9,
+                "y": 21.2
+              },
+              "roll": -180,
+              "yaw": 0.026,
+              "pitch": 0.447
+            },
+            "torso": {
+              "center": {
+                "x": 65.9,
+                "y": 35.1
+              },
+              "angle": 80.4
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 38.8,
+                "y": 31.1
+              },
+              "angle": 130.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.6,
+                "y": 112.7
+              },
+              "angle": -58.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.6,
+                "y": 113.2
+              },
+              "angle": -101.2
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.727,
+          "keypoints": {
+            "nose": {
+              "x": 58.8,
+              "y": 23.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.9,
+              "y": 21.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.7,
+              "y": 19.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.6,
+              "y": 23.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.2,
+              "y": 20.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.3,
+              "y": 39.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.5,
+              "y": 35.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 69,
+              "y": 57.1,
+              "v": 0.12
+            },
+            "rightElbow": {
+              "x": 45.7,
+              "y": 49.5,
+              "v": 0.325
+            },
+            "leftWrist": {
+              "x": 71.4,
+              "y": 50.4,
+              "v": 0.265
+            },
+            "rightWrist": {
+              "x": 39.9,
+              "y": 46.1,
+              "v": 0.228
+            },
+            "leftIndex": {
+              "x": 72.8,
+              "y": 45.5,
+              "v": 0.382
+            },
+            "rightIndex": {
+              "x": 37.9,
+              "y": 42.8,
+              "v": 0.24
+            },
+            "leftHip": {
+              "x": 59.4,
+              "y": 67.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.7,
+              "y": 70.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.3,
+              "y": 63.4,
+              "v": 0.623
+            },
+            "rightKnee": {
+              "x": 42.1,
+              "y": 89.3,
+              "v": 0.905
+            },
+            "leftAnkle": {
+              "x": 105.9,
+              "y": 53.6,
+              "v": 0.777
+            },
+            "rightAnkle": {
+              "x": 42.8,
+              "y": 114.3,
+              "v": 0.801
+            },
+            "leftHeel": {
+              "x": 111.9,
+              "y": 50.7,
+              "v": 0.805
+            },
+            "rightHeel": {
+              "x": 42.4,
+              "y": 115.9,
+              "v": 0.634
+            },
+            "leftFootIndex": {
+              "x": 114.5,
+              "y": 38.5,
+              "v": 0.92
+            },
+            "rightFootIndex": {
+              "x": 43.8,
+              "y": 123.4,
+              "v": 0.702
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.3,
+                "y": 20.5
+              },
+              "roll": 166,
+              "yaw": -0.093,
+              "pitch": 0.476
+            },
+            "torso": {
+              "center": {
+                "x": 56.9,
+                "y": 37.3
+              },
+              "angle": 83.9
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 111.9,
+                "y": 50.7
+              },
+              "angle": 78
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.4,
+                "y": 115.9
+              },
+              "angle": -79.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.861,
+          "keypoints": {
+            "nose": {
+              "x": 61.6,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63.6,
+              "y": 22.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 59.8,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.9,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.9,
+              "y": 20.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67,
+              "y": 36.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.1,
+              "y": 31.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 68.4,
+              "y": 49.6,
+              "v": 0.671
+            },
+            "rightElbow": {
+              "x": 44.1,
+              "y": 41.3,
+              "v": 0.815
+            },
+            "leftWrist": {
+              "x": 63.6,
+              "y": 42.1,
+              "v": 0.538
+            },
+            "rightWrist": {
+              "x": 41.7,
+              "y": 42,
+              "v": 0.804
+            },
+            "leftIndex": {
+              "x": 62.2,
+              "y": 35.9,
+              "v": 0.533
+            },
+            "rightIndex": {
+              "x": 41.4,
+              "y": 41.2,
+              "v": 0.793
+            },
+            "leftHip": {
+              "x": 58.1,
+              "y": 67,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.7,
+              "y": 65.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 68,
+              "y": 89.5,
+              "v": 0.817
+            },
+            "rightKnee": {
+              "x": 43.5,
+              "y": 90.2,
+              "v": 0.827
+            },
+            "leftAnkle": {
+              "x": 69.4,
+              "y": 113.8,
+              "v": 0.905
+            },
+            "rightAnkle": {
+              "x": 40.8,
+              "y": 114.6,
+              "v": 0.922
+            },
+            "leftHeel": {
+              "x": 66.8,
+              "y": 117.6,
+              "v": 0.779
+            },
+            "rightHeel": {
+              "x": 40,
+              "y": 117.8,
+              "v": 0.623
+            },
+            "leftFootIndex": {
+              "x": 76.6,
+              "y": 120.3,
+              "v": 0.912
+            },
+            "rightFootIndex": {
+              "x": 40.2,
+              "y": 121.8,
+              "v": 0.867
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 61.7,
+                "y": 21.4
+              },
+              "roll": 149.9,
+              "yaw": -0.023,
+              "pitch": 0.501
+            },
+            "torso": {
+              "center": {
+                "x": 57.6,
+                "y": 34.2
+              },
+              "angle": 80.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 63.6,
+                "y": 42.1
+              },
+              "angle": 102.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.7,
+                "y": 42
+              },
+              "angle": 110.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 66.8,
+                "y": 117.6
+              },
+              "angle": -15.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40,
+                "y": 117.8
+              },
+              "angle": -87.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.817,
+          "keypoints": {
+            "nose": {
+              "x": 60.9,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.8,
+              "y": 21.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.7,
+              "y": 20.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.5,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 55.8,
+              "y": 21.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66.1,
+              "y": 36,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.9,
+              "y": 31.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 67,
+              "y": 52.4,
+              "v": 0.253
+            },
+            "rightElbow": {
+              "x": 44.5,
+              "y": 41.9,
+              "v": 0.893
+            },
+            "leftWrist": {
+              "x": 67.8,
+              "y": 59.6,
+              "v": 0.248
+            },
+            "rightWrist": {
+              "x": 43.8,
+              "y": 52.7,
+              "v": 0.858
+            },
+            "leftIndex": {
+              "x": 68.2,
+              "y": 60.4,
+              "v": 0.329
+            },
+            "rightIndex": {
+              "x": 43.1,
+              "y": 56.2,
+              "v": 0.821
+            },
+            "leftHip": {
+              "x": 61.3,
+              "y": 66.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.1,
+              "y": 64.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 68.7,
+              "y": 86.3,
+              "v": 0.774
+            },
+            "rightKnee": {
+              "x": 45.6,
+              "y": 83.1,
+              "v": 0.832
+            },
+            "leftAnkle": {
+              "x": 77.5,
+              "y": 105.8,
+              "v": 0.914
+            },
+            "rightAnkle": {
+              "x": 36.3,
+              "y": 106.1,
+              "v": 0.868
+            },
+            "leftHeel": {
+              "x": 77.2,
+              "y": 109.5,
+              "v": 0.76
+            },
+            "rightHeel": {
+              "x": 35.4,
+              "y": 109.5,
+              "v": 0.486
+            },
+            "leftFootIndex": {
+              "x": 82.4,
+              "y": 111.4,
+              "v": 0.93
+            },
+            "rightFootIndex": {
+              "x": 35.2,
+              "y": 114.9,
+              "v": 0.832
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.8,
+                "y": 21
+              },
+              "roll": 169,
+              "yaw": 0.036,
+              "pitch": 0.431
+            },
+            "torso": {
+              "center": {
+                "x": 58,
+                "y": 33.8
+              },
+              "angle": 86.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 43.8,
+                "y": 52.7
+              },
+              "angle": -101.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 77.2,
+                "y": 109.5
+              },
+              "angle": -20.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.4,
+                "y": 109.5
+              },
+              "angle": -92.1
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.743,
+          "keypoints": {
+            "nose": {
+              "x": 61.4,
+              "y": 22.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62,
+              "y": 20.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 59,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 62.4,
+              "y": 21.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 55.9,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66,
+              "y": 34.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.6,
+              "y": 31.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 65.9,
+              "y": 49.5,
+              "v": 0.245
+            },
+            "rightElbow": {
+              "x": 46.2,
+              "y": 45.2,
+              "v": 0.716
+            },
+            "leftWrist": {
+              "x": 63.4,
+              "y": 45.5,
+              "v": 0.309
+            },
+            "rightWrist": {
+              "x": 43.4,
+              "y": 52.2,
+              "v": 0.457
+            },
+            "leftIndex": {
+              "x": 63,
+              "y": 42.4,
+              "v": 0.362
+            },
+            "rightIndex": {
+              "x": 43.1,
+              "y": 55.2,
+              "v": 0.423
+            },
+            "leftHip": {
+              "x": 60,
+              "y": 64.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.3,
+              "y": 63.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 67,
+              "y": 85.9,
+              "v": 0.715
+            },
+            "rightKnee": {
+              "x": 43.9,
+              "y": 85.3,
+              "v": 0.577
+            },
+            "leftAnkle": {
+              "x": 68.9,
+              "y": 112.7,
+              "v": 0.881
+            },
+            "rightAnkle": {
+              "x": 36.7,
+              "y": 107,
+              "v": 0.75
+            },
+            "leftHeel": {
+              "x": 67.2,
+              "y": 116.7,
+              "v": 0.682
+            },
+            "rightHeel": {
+              "x": 35.7,
+              "y": 110.3,
+              "v": 0.342
+            },
+            "leftFootIndex": {
+              "x": 74.5,
+              "y": 118.9,
+              "v": 0.903
+            },
+            "rightFootIndex": {
+              "x": 37.1,
+              "y": 114.2,
+              "v": 0.716
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.5,
+                "y": 20.3
+              },
+              "roll": 172.4,
+              "yaw": 0.297,
+              "pitch": 0.727
+            },
+            "torso": {
+              "center": {
+                "x": 58.8,
+                "y": 32.9
+              },
+              "angle": 83.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 63.4,
+                "y": 45.5
+              },
+              "angle": 97.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.4,
+                "y": 52.2
+              },
+              "angle": -95.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.2,
+                "y": 116.7
+              },
+              "angle": -16.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.7,
+                "y": 110.3
+              },
+              "angle": -70.3
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.75,
+          "keypoints": {
+            "nose": {
+              "x": 56.5,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.4,
+              "y": 21.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.7,
+              "y": 21.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.8,
+              "y": 22.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.3,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.9,
+              "y": 35.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44.5,
+              "y": 30.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.5,
+              "y": 51.3,
+              "v": 0.447
+            },
+            "rightElbow": {
+              "x": 39.3,
+              "y": 45.3,
+              "v": 0.802
+            },
+            "leftWrist": {
+              "x": 65,
+              "y": 58.2,
+              "v": 0.466
+            },
+            "rightWrist": {
+              "x": 38.7,
+              "y": 51.3,
+              "v": 0.836
+            },
+            "leftIndex": {
+              "x": 66.1,
+              "y": 59.2,
+              "v": 0.505
+            },
+            "rightIndex": {
+              "x": 39.2,
+              "y": 52.2,
+              "v": 0.805
+            },
+            "leftHip": {
+              "x": 55.6,
+              "y": 60.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.5,
+              "y": 58.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 57.3,
+              "y": 82.6,
+              "v": 0.419
+            },
+            "rightKnee": {
+              "x": 34.3,
+              "y": 79.2,
+              "v": 0.544
+            },
+            "leftAnkle": {
+              "x": 66.1,
+              "y": 95.7,
+              "v": 0.757
+            },
+            "rightAnkle": {
+              "x": 23.2,
+              "y": 100.3,
+              "v": 0.621
+            },
+            "leftHeel": {
+              "x": 66.6,
+              "y": 98.5,
+              "v": 0.456
+            },
+            "rightHeel": {
+              "x": 22.2,
+              "y": 103,
+              "v": 0.206
+            },
+            "leftFootIndex": {
+              "x": 68.1,
+              "y": 98.9,
+              "v": 0.811
+            },
+            "rightFootIndex": {
+              "x": 20,
+              "y": 107.3,
+              "v": 0.576
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.1,
+                "y": 21.5
+              },
+              "roll": 170.3,
+              "yaw": 0.094,
+              "pitch": 0.461
+            },
+            "torso": {
+              "center": {
+                "x": 54.7,
+                "y": 33.2
+              },
+              "angle": 78.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 65,
+                "y": 58.2
+              },
+              "angle": -42.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.7,
+                "y": 51.3
+              },
+              "angle": -60.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 66.6,
+                "y": 98.5
+              },
+              "angle": -14.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.2,
+                "y": 100.3
+              },
+              "angle": -114.6
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.866,
+          "keypoints": {
+            "nose": {
+              "x": 56.8,
+              "y": 22.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.4,
+              "y": 20.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55,
+              "y": 20.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.5,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.3,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.1,
+              "y": 32.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.2,
+              "y": 29.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.5,
+              "y": 42.5,
+              "v": 0.941
+            },
+            "rightElbow": {
+              "x": 42.1,
+              "y": 41.8,
+              "v": 0.784
+            },
+            "leftWrist": {
+              "x": 86,
+              "y": 36.4,
+              "v": 0.984
+            },
+            "rightWrist": {
+              "x": 35.4,
+              "y": 40.8,
+              "v": 0.786
+            },
+            "leftIndex": {
+              "x": 92.5,
+              "y": 33.4,
+              "v": 0.979
+            },
+            "rightIndex": {
+              "x": 32.7,
+              "y": 39,
+              "v": 0.769
+            },
+            "leftHip": {
+              "x": 57.4,
+              "y": 64.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.2,
+              "y": 63.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 62.6,
+              "y": 88.2,
+              "v": 0.719
+            },
+            "rightKnee": {
+              "x": 38.3,
+              "y": 88.3,
+              "v": 0.834
+            },
+            "leftAnkle": {
+              "x": 63.1,
+              "y": 113.4,
+              "v": 0.723
+            },
+            "rightAnkle": {
+              "x": 35.5,
+              "y": 115.7,
+              "v": 0.834
+            },
+            "leftHeel": {
+              "x": 61.3,
+              "y": 117,
+              "v": 0.488
+            },
+            "rightHeel": {
+              "x": 35.6,
+              "y": 119.1,
+              "v": 0.54
+            },
+            "leftFootIndex": {
+              "x": 67.3,
+              "y": 119.5,
+              "v": 0.751
+            },
+            "rightFootIndex": {
+              "x": 31.8,
+              "y": 124.6,
+              "v": 0.789
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.7,
+                "y": 20.7
+              },
+              "roll": 175,
+              "yaw": 0.029,
+              "pitch": 0.571
+            },
+            "torso": {
+              "center": {
+                "x": 55.7,
+                "y": 31.3
+              },
+              "angle": 82.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86,
+                "y": 36.4
+              },
+              "angle": 24.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.4,
+                "y": 40.8
+              },
+              "angle": 146.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.3,
+                "y": 117
+              },
+              "angle": -22.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.6,
+                "y": 119.1
+              },
+              "angle": -124.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.634,
+          "keypoints": {
+            "nose": {
+              "x": 58.7,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.9,
+              "y": 18.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60,
+              "y": 20,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52,
+              "y": 19.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.7,
+              "y": 32.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44.8,
+              "y": 31.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.3,
+              "y": 45.1,
+              "v": 0.478
+            },
+            "rightElbow": {
+              "x": 40.8,
+              "y": 44.1,
+              "v": 0.664
+            },
+            "leftWrist": {
+              "x": 86.7,
+              "y": 36.9,
+              "v": 0.694
+            },
+            "rightWrist": {
+              "x": 33.3,
+              "y": 38,
+              "v": 0.805
+            },
+            "leftIndex": {
+              "x": 90.5,
+              "y": 32.8,
+              "v": 0.677
+            },
+            "rightIndex": {
+              "x": 30.4,
+              "y": 34.3,
+              "v": 0.766
+            },
+            "leftHip": {
+              "x": 57.2,
+              "y": 64.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.5,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 67.1,
+              "y": 87.1,
+              "v": 0.139
+            },
+            "rightKnee": {
+              "x": 40.1,
+              "y": 91.4,
+              "v": 0.259
+            },
+            "leftAnkle": {
+              "x": 65.5,
+              "y": 107.2,
+              "v": 0.147
+            },
+            "rightAnkle": {
+              "x": 38.1,
+              "y": 116.2,
+              "v": 0.286
+            },
+            "leftHeel": {
+              "x": 65.4,
+              "y": 109.9,
+              "v": 0.12
+            },
+            "rightHeel": {
+              "x": 37.3,
+              "y": 118,
+              "v": 0.12
+            },
+            "leftFootIndex": {
+              "x": 70.1,
+              "y": 115.1,
+              "v": 0.184
+            },
+            "rightFootIndex": {
+              "x": 35.9,
+              "y": 126.8,
+              "v": 0.232
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58,
+                "y": 18.9
+              },
+              "roll": 178.5,
+              "yaw": 0.192,
+              "pitch": 0.602
+            },
+            "torso": {
+              "center": {
+                "x": 54.8,
+                "y": 32.1
+              },
+              "angle": 83.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.7,
+                "y": 36.9
+              },
+              "angle": 47.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.3,
+                "y": 38
+              },
+              "angle": 128.1
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.794,
+          "keypoints": {
+            "nose": {
+              "x": 77.7,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 78.7,
+              "y": 19.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 74.6,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 78.3,
+              "y": 20.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 70.7,
+              "y": 19.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 82.6,
+              "y": 37.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63.7,
+              "y": 33.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.3,
+              "y": 56,
+              "v": 0.337
+            },
+            "rightElbow": {
+              "x": 57.3,
+              "y": 46.7,
+              "v": 0.679
+            },
+            "leftWrist": {
+              "x": 90.9,
+              "y": 63.3,
+              "v": 0.33
+            },
+            "rightWrist": {
+              "x": 48.7,
+              "y": 44.6,
+              "v": 0.751
+            },
+            "leftIndex": {
+              "x": 92.1,
+              "y": 63.7,
+              "v": 0.415
+            },
+            "rightIndex": {
+              "x": 45.5,
+              "y": 42.4,
+              "v": 0.764
+            },
+            "leftHip": {
+              "x": 75.9,
+              "y": 68.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.7,
+              "y": 66.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.7,
+              "y": 92.6,
+              "v": 0.631
+            },
+            "rightKnee": {
+              "x": 55.4,
+              "y": 90,
+              "v": 0.784
+            },
+            "leftAnkle": {
+              "x": 83.4,
+              "y": 113.1,
+              "v": 0.847
+            },
+            "rightAnkle": {
+              "x": 54.3,
+              "y": 115,
+              "v": 0.889
+            },
+            "leftHeel": {
+              "x": 81,
+              "y": 116.1,
+              "v": 0.654
+            },
+            "rightHeel": {
+              "x": 54.9,
+              "y": 117.4,
+              "v": 0.494
+            },
+            "leftFootIndex": {
+              "x": 89.1,
+              "y": 119.2,
+              "v": 0.854
+            },
+            "rightFootIndex": {
+              "x": 52.5,
+              "y": 125.9,
+              "v": 0.831
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 76.7,
+                "y": 19.1
+              },
+              "roll": 173,
+              "yaw": 0.254,
+              "pitch": 0.521
+            },
+            "torso": {
+              "center": {
+                "x": 73.2,
+                "y": 35.6
+              },
+              "angle": 84
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.9,
+                "y": 63.3
+              },
+              "angle": -18.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48.7,
+                "y": 44.6
+              },
+              "angle": 145.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 81,
+                "y": 116.1
+              },
+              "angle": -20.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 54.9,
+                "y": 117.4
+              },
+              "angle": -105.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.877,
+          "keypoints": {
+            "nose": {
+              "x": 77.5,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.6,
+              "y": 16.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.6,
+              "y": 17,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 76.9,
+              "y": 17.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 70,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 83.4,
+              "y": 34,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63.9,
+              "y": 32.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86,
+              "y": 52.5,
+              "v": 0.463
+            },
+            "rightElbow": {
+              "x": 65.2,
+              "y": 47.4,
+              "v": 0.932
+            },
+            "leftWrist": {
+              "x": 90.1,
+              "y": 60.8,
+              "v": 0.731
+            },
+            "rightWrist": {
+              "x": 74.7,
+              "y": 35.9,
+              "v": 0.979
+            },
+            "leftIndex": {
+              "x": 90.6,
+              "y": 60.9,
+              "v": 0.835
+            },
+            "rightIndex": {
+              "x": 76.9,
+              "y": 30.7,
+              "v": 0.977
+            },
+            "leftHip": {
+              "x": 78.7,
+              "y": 66.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64.6,
+              "y": 65.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86.3,
+              "y": 88.5,
+              "v": 0.669
+            },
+            "rightKnee": {
+              "x": 57.6,
+              "y": 91.8,
+              "v": 0.807
+            },
+            "leftAnkle": {
+              "x": 84.5,
+              "y": 113.6,
+              "v": 0.863
+            },
+            "rightAnkle": {
+              "x": 56.7,
+              "y": 115.9,
+              "v": 0.907
+            },
+            "leftHeel": {
+              "x": 81.7,
+              "y": 116.7,
+              "v": 0.726
+            },
+            "rightHeel": {
+              "x": 56.3,
+              "y": 118.9,
+              "v": 0.55
+            },
+            "leftFootIndex": {
+              "x": 90.7,
+              "y": 119.9,
+              "v": 0.88
+            },
+            "rightFootIndex": {
+              "x": 54.5,
+              "y": 126.4,
+              "v": 0.859
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 75.6,
+                "y": 17
+              },
+              "roll": -178.6,
+              "yaw": 0.475,
+              "pitch": 0.562
+            },
+            "torso": {
+              "center": {
+                "x": 73.7,
+                "y": 33.2
+              },
+              "angle": 86.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.1,
+                "y": 60.8
+              },
+              "angle": -11.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 74.7,
+                "y": 35.9
+              },
+              "angle": 67.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 81.7,
+                "y": 116.7
+              },
+              "angle": -19.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 56.3,
+                "y": 118.9
+              },
+              "angle": -103.5
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.92,
+          "keypoints": {
+            "nose": {
+              "x": 76.8,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.6,
+              "y": 18,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.3,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 77.9,
+              "y": 19,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 69.9,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 86.8,
+              "y": 36,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63.9,
+              "y": 34.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 90.6,
+              "y": 60.5,
+              "v": 0.582
+            },
+            "rightElbow": {
+              "x": 63.4,
+              "y": 48.2,
+              "v": 0.938
+            },
+            "leftWrist": {
+              "x": 102.8,
+              "y": 73.9,
+              "v": 0.792
+            },
+            "rightWrist": {
+              "x": 67.8,
+              "y": 37.9,
+              "v": 0.959
+            },
+            "leftIndex": {
+              "x": 107.9,
+              "y": 75.2,
+              "v": 0.834
+            },
+            "rightIndex": {
+              "x": 68.4,
+              "y": 32.2,
+              "v": 0.949
+            },
+            "leftHip": {
+              "x": 78.8,
+              "y": 68.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65,
+              "y": 67,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86.3,
+              "y": 92.8,
+              "v": 0.749
+            },
+            "rightKnee": {
+              "x": 58.8,
+              "y": 92.8,
+              "v": 0.934
+            },
+            "leftAnkle": {
+              "x": 85,
+              "y": 113.9,
+              "v": 0.938
+            },
+            "rightAnkle": {
+              "x": 57.1,
+              "y": 115.5,
+              "v": 0.958
+            },
+            "leftHeel": {
+              "x": 82.1,
+              "y": 117.5,
+              "v": 0.872
+            },
+            "rightHeel": {
+              "x": 56.7,
+              "y": 118.6,
+              "v": 0.788
+            },
+            "leftFootIndex": {
+              "x": 92.1,
+              "y": 120.9,
+              "v": 0.942
+            },
+            "rightFootIndex": {
+              "x": 54.9,
+              "y": 125.9,
+              "v": 0.936
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 75.4,
+                "y": 18.4
+              },
+              "roll": -169.5,
+              "yaw": 0.309,
+              "pitch": 0.434
+            },
+            "torso": {
+              "center": {
+                "x": 75.4,
+                "y": 35.3
+              },
+              "angle": 83.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 102.8,
+                "y": 73.9
+              },
+              "angle": -14.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 67.8,
+                "y": 37.9
+              },
+              "angle": 84
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 82.1,
+                "y": 117.5
+              },
+              "angle": -18.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 56.7,
+                "y": 118.6
+              },
+              "angle": -103.9
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.724,
+          "keypoints": {
+            "nose": {
+              "x": 68.7,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70,
+              "y": 21,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.1,
+              "y": 20.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.6,
+              "y": 22.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.9,
+              "y": 22.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.8,
+              "y": 35.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.2,
+              "y": 35.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.7,
+              "y": 54.3,
+              "v": 0.197
+            },
+            "rightElbow": {
+              "x": 59.9,
+              "y": 52.2,
+              "v": 0.809
+            },
+            "leftWrist": {
+              "x": 76.8,
+              "y": 46.7,
+              "v": 0.409
+            },
+            "rightWrist": {
+              "x": 69.2,
+              "y": 42.4,
+              "v": 0.982
+            },
+            "leftIndex": {
+              "x": 76.6,
+              "y": 45.1,
+              "v": 0.571
+            },
+            "rightIndex": {
+              "x": 71.2,
+              "y": 37,
+              "v": 0.979
+            },
+            "leftHip": {
+              "x": 70.4,
+              "y": 67.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.5,
+              "y": 66.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.3,
+              "y": 90.3,
+              "v": 0.323
+            },
+            "rightKnee": {
+              "x": 52.6,
+              "y": 91.6,
+              "v": 0.444
+            },
+            "leftAnkle": {
+              "x": 75.5,
+              "y": 113,
+              "v": 0.452
+            },
+            "rightAnkle": {
+              "x": 48.4,
+              "y": 115.8,
+              "v": 0.709
+            },
+            "leftHeel": {
+              "x": 73.5,
+              "y": 116.9,
+              "v": 0.338
+            },
+            "rightHeel": {
+              "x": 48.1,
+              "y": 118.8,
+              "v": 0.276
+            },
+            "leftFootIndex": {
+              "x": 81.8,
+              "y": 120.4,
+              "v": 0.545
+            },
+            "rightFootIndex": {
+              "x": 46.2,
+              "y": 124.1,
+              "v": 0.624
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.1,
+                "y": 20.9
+              },
+              "roll": 175.6,
+              "yaw": 0.166,
+              "pitch": 0.499
+            },
+            "torso": {
+              "center": {
+                "x": 66.5,
+                "y": 35.5
+              },
+              "angle": 85.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76.8,
+                "y": 46.7
+              },
+              "angle": 97.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 69.2,
+                "y": 42.4
+              },
+              "angle": 69.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.5,
+                "y": 116.9
+              },
+              "angle": -22.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.4,
+                "y": 115.8
+              },
+              "angle": -104.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.656,
+          "keypoints": {
+            "nose": {
+              "x": 69.7,
+              "y": 22.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.3,
+              "y": 20.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.1,
+              "y": 19.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.2,
+              "y": 21.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.4,
+              "y": 20.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.8,
+              "y": 34.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.2,
+              "y": 33.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.5,
+              "y": 51.7,
+              "v": 0.117
+            },
+            "rightElbow": {
+              "x": 62.5,
+              "y": 50.3,
+              "v": 0.786
+            },
+            "leftWrist": {
+              "x": 78.8,
+              "y": 49.4,
+              "v": 0.163
+            },
+            "rightWrist": {
+              "x": 72.6,
+              "y": 40.2,
+              "v": 0.966
+            },
+            "leftIndex": {
+              "x": 78.5,
+              "y": 47,
+              "v": 0.238
+            },
+            "rightIndex": {
+              "x": 73.1,
+              "y": 36.5,
+              "v": 0.958
+            },
+            "leftHip": {
+              "x": 68.2,
+              "y": 66.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.6,
+              "y": 65.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.9,
+              "y": 90.5,
+              "v": 0.289
+            },
+            "rightKnee": {
+              "x": 51.8,
+              "y": 89.9,
+              "v": 0.389
+            },
+            "leftAnkle": {
+              "x": 75.9,
+              "y": 112,
+              "v": 0.363
+            },
+            "rightAnkle": {
+              "x": 46.1,
+              "y": 113.6,
+              "v": 0.51
+            },
+            "leftHeel": {
+              "x": 73.9,
+              "y": 115.8,
+              "v": 0.281
+            },
+            "rightHeel": {
+              "x": 45.9,
+              "y": 117.5,
+              "v": 0.193
+            },
+            "leftFootIndex": {
+              "x": 81.7,
+              "y": 119,
+              "v": 0.421
+            },
+            "rightFootIndex": {
+              "x": 46.1,
+              "y": 122.3,
+              "v": 0.425
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.2,
+                "y": 20.3
+              },
+              "roll": 167.9,
+              "yaw": 0.116,
+              "pitch": 0.477
+            },
+            "torso": {
+              "center": {
+                "x": 66.5,
+                "y": 33.8
+              },
+              "angle": 82.7
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 72.6,
+                "y": 40.2
+              },
+              "angle": 82.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 75.9,
+                "y": 112
+              },
+              "angle": -50.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 46.1,
+                "y": 113.6
+              },
+              "angle": -90
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.61,
+          "keypoints": {
+            "nose": {
+              "x": 78.9,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 82.5,
+              "y": 22.9,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 77.8,
+              "y": 20.1,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 83.2,
+              "y": 24.8,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 75.2,
+              "y": 19.7,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 81.2,
+              "y": 34.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 65.4,
+              "y": 31.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 93.6,
+              "y": 32.1,
+              "v": 0.55
+            },
+            "rightElbow": {
+              "x": 55.6,
+              "y": 45.6,
+              "v": 0.817
+            },
+            "leftWrist": {
+              "x": 87.9,
+              "y": 20,
+              "v": 0.471
+            },
+            "rightWrist": {
+              "x": 66.8,
+              "y": 54.3,
+              "v": 0.836
+            },
+            "leftIndex": {
+              "x": 86,
+              "y": 15.6,
+              "v": 0.337
+            },
+            "rightIndex": {
+              "x": 72.1,
+              "y": 55.1,
+              "v": 0.741
+            },
+            "leftHip": {
+              "x": 70.2,
+              "y": 66.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56,
+              "y": 64.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 85,
+              "y": 84.7,
+              "v": 0.272
+            },
+            "rightKnee": {
+              "x": 54.2,
+              "y": 89.4,
+              "v": 0.166
+            },
+            "leftAnkle": {
+              "x": 84.4,
+              "y": 111.5,
+              "v": 0.186
+            },
+            "rightAnkle": {
+              "x": 47.2,
+              "y": 112.3,
+              "v": 0.153
+            },
+            "leftHeel": {
+              "x": 81.3,
+              "y": 116,
+              "v": 0.151
+            },
+            "rightHeel": {
+              "x": 46,
+              "y": 114,
+              "v": 0.048
+            },
+            "leftFootIndex": {
+              "x": 90.3,
+              "y": 119.7,
+              "v": 0.206
+            },
+            "rightFootIndex": {
+              "x": 45.5,
+              "y": 123.4,
+              "v": 0.115
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 80.2,
+                "y": 21.5
+              },
+              "roll": 149.2,
+              "yaw": -0.228,
+              "pitch": 0.347
+            },
+            "torso": {
+              "center": {
+                "x": 73.3,
+                "y": 33
+              },
+              "angle": 72.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.9,
+                "y": 20
+              },
+              "angle": 113.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 66.8,
+                "y": 54.3
+              },
+              "angle": -8.6
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.843,
+          "keypoints": {
+            "nose": {
+              "x": 73.8,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.4,
+              "y": 20.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.4,
+              "y": 20.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 76.6,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.1,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.9,
+              "y": 37.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63.2,
+              "y": 35.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.8,
+              "y": 51.4,
+              "v": 0.174
+            },
+            "rightElbow": {
+              "x": 55.1,
+              "y": 48.2,
+              "v": 0.927
+            },
+            "leftWrist": {
+              "x": 85.3,
+              "y": 53.7,
+              "v": 0.34
+            },
+            "rightWrist": {
+              "x": 63.9,
+              "y": 55.1,
+              "v": 0.914
+            },
+            "leftIndex": {
+              "x": 86.4,
+              "y": 52.8,
+              "v": 0.475
+            },
+            "rightIndex": {
+              "x": 68.2,
+              "y": 54.8,
+              "v": 0.887
+            },
+            "leftHip": {
+              "x": 75.5,
+              "y": 68.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.7,
+              "y": 69.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.5,
+              "y": 91,
+              "v": 0.694
+            },
+            "rightKnee": {
+              "x": 55.1,
+              "y": 92.8,
+              "v": 0.946
+            },
+            "leftAnkle": {
+              "x": 80.2,
+              "y": 113.2,
+              "v": 0.855
+            },
+            "rightAnkle": {
+              "x": 53.2,
+              "y": 116.6,
+              "v": 0.963
+            },
+            "leftHeel": {
+              "x": 78,
+              "y": 116.6,
+              "v": 0.685
+            },
+            "rightHeel": {
+              "x": 52.6,
+              "y": 119.4,
+              "v": 0.738
+            },
+            "leftFootIndex": {
+              "x": 85.1,
+              "y": 119.9,
+              "v": 0.855
+            },
+            "rightFootIndex": {
+              "x": 51.3,
+              "y": 127.3,
+              "v": 0.931
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.9,
+                "y": 20.5
+              },
+              "roll": -176.6,
+              "yaw": 0.18,
+              "pitch": 0.489
+            },
+            "torso": {
+              "center": {
+                "x": 71.6,
+                "y": 36.4
+              },
+              "angle": 86.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.3,
+                "y": 53.7
+              },
+              "angle": 39.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 63.9,
+                "y": 55.1
+              },
+              "angle": 4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78,
+                "y": 116.6
+              },
+              "angle": -24.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 52.6,
+                "y": 119.4
+              },
+              "angle": -99.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.755,
+          "keypoints": {
+            "nose": {
+              "x": 74.1,
+              "y": 22,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.5,
+              "y": 19.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.1,
+              "y": 20.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.9,
+              "y": 19.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.9,
+              "y": 22.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 81.7,
+              "y": 34.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63.2,
+              "y": 35,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.5,
+              "y": 49.1,
+              "v": 0.17
+            },
+            "rightElbow": {
+              "x": 54.7,
+              "y": 47.9,
+              "v": 0.803
+            },
+            "leftWrist": {
+              "x": 82,
+              "y": 55.8,
+              "v": 0.093
+            },
+            "rightWrist": {
+              "x": 64.9,
+              "y": 53.9,
+              "v": 0.628
+            },
+            "leftIndex": {
+              "x": 81.6,
+              "y": 56,
+              "v": 0.14
+            },
+            "rightIndex": {
+              "x": 69.5,
+              "y": 53.6,
+              "v": 0.583
+            },
+            "leftHip": {
+              "x": 76.2,
+              "y": 67.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.8,
+              "y": 67.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.5,
+              "y": 90.4,
+              "v": 0.694
+            },
+            "rightKnee": {
+              "x": 56.5,
+              "y": 91.2,
+              "v": 0.852
+            },
+            "leftAnkle": {
+              "x": 80.4,
+              "y": 113.7,
+              "v": 0.785
+            },
+            "rightAnkle": {
+              "x": 52.8,
+              "y": 116.2,
+              "v": 0.919
+            },
+            "leftHeel": {
+              "x": 78.1,
+              "y": 117.1,
+              "v": 0.53
+            },
+            "rightHeel": {
+              "x": 53.2,
+              "y": 119.7,
+              "v": 0.541
+            },
+            "leftFootIndex": {
+              "x": 85.5,
+              "y": 120.1,
+              "v": 0.774
+            },
+            "rightFootIndex": {
+              "x": 51.1,
+              "y": 125.7,
+              "v": 0.861
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.3,
+                "y": 19.8
+              },
+              "roll": -163.5,
+              "yaw": 0.392,
+              "pitch": 0.49
+            },
+            "torso": {
+              "center": {
+                "x": 72.5,
+                "y": 34.6
+              },
+              "angle": 85.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 64.9,
+                "y": 53.9
+              },
+              "angle": 3.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.1,
+                "y": 117.1
+              },
+              "angle": -22.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 53.2,
+                "y": 119.7
+              },
+              "angle": -109.3
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.702,
+          "keypoints": {
+            "nose": {
+              "x": 68.7,
+              "y": 22.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.1,
+              "y": 20,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.9,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.2,
+              "y": 21.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.1,
+              "y": 22,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.9,
+              "y": 38.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.5,
+              "y": 35.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.3,
+              "y": 55.1,
+              "v": 0.2
+            },
+            "rightElbow": {
+              "x": 52.4,
+              "y": 48.8,
+              "v": 0.577
+            },
+            "leftWrist": {
+              "x": 81.5,
+              "y": 61.8,
+              "v": 0.285
+            },
+            "rightWrist": {
+              "x": 47.7,
+              "y": 44.8,
+              "v": 0.826
+            },
+            "leftIndex": {
+              "x": 81.6,
+              "y": 62.3,
+              "v": 0.444
+            },
+            "rightIndex": {
+              "x": 46.3,
+              "y": 42.1,
+              "v": 0.872
+            },
+            "leftHip": {
+              "x": 68.9,
+              "y": 68.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.3,
+              "y": 68.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74,
+              "y": 91,
+              "v": 0.388
+            },
+            "rightKnee": {
+              "x": 50.4,
+              "y": 90.2,
+              "v": 0.432
+            },
+            "leftAnkle": {
+              "x": 75,
+              "y": 112.9,
+              "v": 0.587
+            },
+            "rightAnkle": {
+              "x": 46.9,
+              "y": 111.4,
+              "v": 0.613
+            },
+            "leftHeel": {
+              "x": 72.6,
+              "y": 116.5,
+              "v": 0.461
+            },
+            "rightHeel": {
+              "x": 45.4,
+              "y": 115.1,
+              "v": 0.271
+            },
+            "leftFootIndex": {
+              "x": 80.8,
+              "y": 119,
+              "v": 0.663
+            },
+            "rightFootIndex": {
+              "x": 46.6,
+              "y": 119.6,
+              "v": 0.521
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.5,
+                "y": 20.1
+              },
+              "roll": -178.9,
+              "yaw": 0.231,
+              "pitch": 0.394
+            },
+            "torso": {
+              "center": {
+                "x": 66.2,
+                "y": 37
+              },
+              "angle": 83.5
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 47.7,
+                "y": 44.8
+              },
+              "angle": 117.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.6,
+                "y": 116.5
+              },
+              "angle": -17
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 46.9,
+                "y": 111.4
+              },
+              "angle": -92.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.897,
+          "keypoints": {
+            "nose": {
+              "x": 80.8,
+              "y": 23,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 83,
+              "y": 20.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 78.7,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 84.8,
+              "y": 22.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 76.7,
+              "y": 23.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 87.8,
+              "y": 38,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 70.5,
+              "y": 34.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.8,
+              "y": 53.4,
+              "v": 0.419
+            },
+            "rightElbow": {
+              "x": 62.4,
+              "y": 48.2,
+              "v": 0.964
+            },
+            "leftWrist": {
+              "x": 90.5,
+              "y": 56,
+              "v": 0.618
+            },
+            "rightWrist": {
+              "x": 53.2,
+              "y": 53.4,
+              "v": 0.986
+            },
+            "leftIndex": {
+              "x": 91.3,
+              "y": 58.3,
+              "v": 0.671
+            },
+            "rightIndex": {
+              "x": 47.2,
+              "y": 55.3,
+              "v": 0.982
+            },
+            "leftHip": {
+              "x": 77.5,
+              "y": 68.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.5,
+              "y": 66.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.1,
+              "y": 92.2,
+              "v": 0.916
+            },
+            "rightKnee": {
+              "x": 54.6,
+              "y": 90.1,
+              "v": 0.952
+            },
+            "leftAnkle": {
+              "x": 76.3,
+              "y": 117.1,
+              "v": 0.889
+            },
+            "rightAnkle": {
+              "x": 48,
+              "y": 115.3,
+              "v": 0.95
+            },
+            "leftHeel": {
+              "x": 72.5,
+              "y": 121,
+              "v": 0.76
+            },
+            "rightHeel": {
+              "x": 47.9,
+              "y": 118.9,
+              "v": 0.689
+            },
+            "leftFootIndex": {
+              "x": 81.2,
+              "y": 125,
+              "v": 0.902
+            },
+            "rightFootIndex": {
+              "x": 44.9,
+              "y": 124.1,
+              "v": 0.925
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 80.9,
+                "y": 21.2
+              },
+              "roll": -172.1,
+              "yaw": -0.012,
+              "pitch": 0.415
+            },
+            "torso": {
+              "center": {
+                "x": 79.2,
+                "y": 36.2
+              },
+              "angle": 77.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.5,
+                "y": 56
+              },
+              "angle": -70.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 53.2,
+                "y": 53.4
+              },
+              "angle": -162.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.5,
+                "y": 121
+              },
+              "angle": -24.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.9,
+                "y": 118.9
+              },
+              "angle": -120
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.825,
+          "keypoints": {
+            "nose": {
+              "x": 89.5,
+              "y": 27.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 92.8,
+              "y": 26.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 87.7,
+              "y": 25,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 94.5,
+              "y": 29,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 85.8,
+              "y": 26.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 93.7,
+              "y": 45.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 75.3,
+              "y": 37.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 100.3,
+              "y": 55.6,
+              "v": 0.606
+            },
+            "rightElbow": {
+              "x": 63.3,
+              "y": 46.5,
+              "v": 0.624
+            },
+            "leftWrist": {
+              "x": 98.6,
+              "y": 50.6,
+              "v": 0.725
+            },
+            "rightWrist": {
+              "x": 54.3,
+              "y": 48.6,
+              "v": 0.731
+            },
+            "leftIndex": {
+              "x": 98.7,
+              "y": 46.4,
+              "v": 0.751
+            },
+            "rightIndex": {
+              "x": 50,
+              "y": 48.6,
+              "v": 0.75
+            },
+            "leftHip": {
+              "x": 69.3,
+              "y": 74.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.1,
+              "y": 67.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.9,
+              "y": 92.3,
+              "v": 0.77
+            },
+            "rightKnee": {
+              "x": 35.9,
+              "y": 81.5,
+              "v": 0.886
+            },
+            "leftAnkle": {
+              "x": 54.2,
+              "y": 106.8,
+              "v": 0.599
+            },
+            "rightAnkle": {
+              "x": 18.5,
+              "y": 107,
+              "v": 0.896
+            },
+            "leftHeel": {
+              "x": 49.3,
+              "y": 106.3,
+              "v": 0.617
+            },
+            "rightHeel": {
+              "x": 17.7,
+              "y": 109.1,
+              "v": 0.578
+            },
+            "leftFootIndex": {
+              "x": 52.3,
+              "y": 120.3,
+              "v": 0.631
+            },
+            "rightFootIndex": {
+              "x": 10.2,
+              "y": 119.1,
+              "v": 0.808
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 90.3,
+                "y": 25.8
+              },
+              "roll": 163.6,
+              "yaw": -0.141,
+              "pitch": 0.31
+            },
+            "torso": {
+              "center": {
+                "x": 84.5,
+                "y": 41.1
+              },
+              "angle": 54.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.6,
+                "y": 50.6
+              },
+              "angle": 88.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 54.3,
+                "y": 48.6
+              },
+              "angle": -180
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 49.3,
+                "y": 106.3
+              },
+              "angle": -77.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 17.7,
+                "y": 109.1
+              },
+              "angle": -126.9
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.628,
+          "keypoints": {
+            "nose": {
+              "x": 88.5,
+              "y": 36.8,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 91.6,
+              "y": 37.5,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 90,
+              "y": 36.2,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 94.1,
+              "y": 41.9,
+              "v": 0.997
+            },
+            "rightEar": {
+              "x": 90.7,
+              "y": 38.6,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 89.3,
+              "y": 56.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 78.6,
+              "y": 41.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.8,
+              "y": 59.7,
+              "v": 0.272
+            },
+            "rightElbow": {
+              "x": 62.7,
+              "y": 42,
+              "v": 0.551
+            },
+            "leftWrist": {
+              "x": 83,
+              "y": 52.3,
+              "v": 0.354
+            },
+            "rightWrist": {
+              "x": 48.2,
+              "y": 37.9,
+              "v": 0.845
+            },
+            "leftIndex": {
+              "x": 85.1,
+              "y": 50.5,
+              "v": 0.345
+            },
+            "rightIndex": {
+              "x": 42.8,
+              "y": 36.1,
+              "v": 0.794
+            },
+            "leftHip": {
+              "x": 62.4,
+              "y": 64.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.2,
+              "y": 54.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 52.4,
+              "y": 82.2,
+              "v": 0.47
+            },
+            "rightKnee": {
+              "x": 38.1,
+              "y": 60.3,
+              "v": 0.369
+            },
+            "leftAnkle": {
+              "x": 39.4,
+              "y": 99.8,
+              "v": 0.429
+            },
+            "rightAnkle": {
+              "x": 25.2,
+              "y": 74.3,
+              "v": 0.104
+            },
+            "leftHeel": {
+              "x": 35.5,
+              "y": 100.4,
+              "v": 0.286
+            },
+            "rightHeel": {
+              "x": 24.5,
+              "y": 76.7,
+              "v": 0.085
+            },
+            "leftFootIndex": {
+              "x": 37.1,
+              "y": 107.6,
+              "v": 0.446
+            },
+            "rightFootIndex": {
+              "x": 18.6,
+              "y": 79.3,
+              "v": 0.106
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 90.8,
+                "y": 36.9
+              },
+              "roll": 140.9,
+              "yaw": -1.116,
+              "pitch": -0.024
+            },
+            "torso": {
+              "center": {
+                "x": 83.9,
+                "y": 48.9
+              },
+              "angle": 23.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 83,
+                "y": 52.3
+              },
+              "angle": 40.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48.2,
+                "y": 37.9
+              },
+              "angle": 161.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 39.4,
+                "y": 99.8
+              },
+              "angle": -106.4
+            },
+            "rightFoot": null
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.764,
+          "keypoints": {
+            "nose": {
+              "x": 68.8,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.2,
+              "y": 20.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.2,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.9,
+              "y": 22.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63,
+              "y": 22,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.8,
+              "y": 36.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.3,
+              "y": 35.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.1,
+              "y": 53.2,
+              "v": 0.343
+            },
+            "rightElbow": {
+              "x": 53.8,
+              "y": 53.7,
+              "v": 0.408
+            },
+            "leftWrist": {
+              "x": 87.1,
+              "y": 52.3,
+              "v": 0.475
+            },
+            "rightWrist": {
+              "x": 49.4,
+              "y": 43.9,
+              "v": 0.649
+            },
+            "leftIndex": {
+              "x": 89,
+              "y": 49.4,
+              "v": 0.551
+            },
+            "rightIndex": {
+              "x": 46.9,
+              "y": 38.9,
+              "v": 0.715
+            },
+            "leftHip": {
+              "x": 71.6,
+              "y": 67.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.7,
+              "y": 66.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.6,
+              "y": 90.6,
+              "v": 0.601
+            },
+            "rightKnee": {
+              "x": 51.4,
+              "y": 89.9,
+              "v": 0.646
+            },
+            "leftAnkle": {
+              "x": 76.1,
+              "y": 112.5,
+              "v": 0.772
+            },
+            "rightAnkle": {
+              "x": 49.1,
+              "y": 114.3,
+              "v": 0.842
+            },
+            "leftHeel": {
+              "x": 73.5,
+              "y": 116,
+              "v": 0.586
+            },
+            "rightHeel": {
+              "x": 48.6,
+              "y": 118,
+              "v": 0.436
+            },
+            "leftFootIndex": {
+              "x": 80.9,
+              "y": 119.3,
+              "v": 0.788
+            },
+            "rightFootIndex": {
+              "x": 46.6,
+              "y": 125.3,
+              "v": 0.769
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.2,
+                "y": 20.5
+              },
+              "roll": 175.7,
+              "yaw": 0.15,
+              "pitch": 0.611
+            },
+            "torso": {
+              "center": {
+                "x": 66.1,
+                "y": 36.1
+              },
+              "angle": 88.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.1,
+                "y": 52.3
+              },
+              "angle": 56.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 49.4,
+                "y": 43.9
+              },
+              "angle": 116.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.5,
+                "y": 116
+              },
+              "angle": -24
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.6,
+                "y": 118
+              },
+              "angle": -105.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.778,
+          "keypoints": {
+            "nose": {
+              "x": 67,
+              "y": 23.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.9,
+              "y": 21.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.6,
+              "y": 20.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.7,
+              "y": 22.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.5,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.8,
+              "y": 38.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.4,
+              "y": 36.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.2,
+              "y": 56,
+              "v": 0.263
+            },
+            "rightElbow": {
+              "x": 48,
+              "y": 44.7,
+              "v": 0.798
+            },
+            "leftWrist": {
+              "x": 85.4,
+              "y": 63.9,
+              "v": 0.358
+            },
+            "rightWrist": {
+              "x": 37.3,
+              "y": 30.7,
+              "v": 0.959
+            },
+            "leftIndex": {
+              "x": 87,
+              "y": 64.3,
+              "v": 0.49
+            },
+            "rightIndex": {
+              "x": 33.5,
+              "y": 26,
+              "v": 0.965
+            },
+            "leftHip": {
+              "x": 69.1,
+              "y": 69.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.6,
+              "y": 68.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.8,
+              "y": 93.7,
+              "v": 0.41
+            },
+            "rightKnee": {
+              "x": 49.3,
+              "y": 91.9,
+              "v": 0.496
+            },
+            "leftAnkle": {
+              "x": 76.1,
+              "y": 113.3,
+              "v": 0.763
+            },
+            "rightAnkle": {
+              "x": 47.9,
+              "y": 115.8,
+              "v": 0.78
+            },
+            "leftHeel": {
+              "x": 73.7,
+              "y": 116.8,
+              "v": 0.617
+            },
+            "rightHeel": {
+              "x": 48.7,
+              "y": 118.4,
+              "v": 0.442
+            },
+            "leftFootIndex": {
+              "x": 80,
+              "y": 120.6,
+              "v": 0.812
+            },
+            "rightFootIndex": {
+              "x": 45,
+              "y": 125.1,
+              "v": 0.736
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.8,
+                "y": 21.2
+              },
+              "roll": 173.4,
+              "yaw": 0.058,
+              "pitch": 0.474
+            },
+            "torso": {
+              "center": {
+                "x": 66.6,
+                "y": 37.4
+              },
+              "angle": 83.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.4,
+                "y": 63.9
+              },
+              "angle": -14
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.3,
+                "y": 30.7
+              },
+              "angle": 129
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.7,
+                "y": 116.8
+              },
+              "angle": -31.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.7,
+                "y": 118.4
+              },
+              "angle": -118.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.746,
+          "keypoints": {
+            "nose": {
+              "x": 69.3,
+              "y": 25.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.6,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.9,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.1,
+              "y": 24.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.2,
+              "y": 24.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73,
+              "y": 36,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.6,
+              "y": 38.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.4,
+              "y": 45.1,
+              "v": 0.754
+            },
+            "rightElbow": {
+              "x": 53.2,
+              "y": 56.5,
+              "v": 0.477
+            },
+            "leftWrist": {
+              "x": 89.5,
+              "y": 31.1,
+              "v": 0.961
+            },
+            "rightWrist": {
+              "x": 48.2,
+              "y": 50.4,
+              "v": 0.597
+            },
+            "leftIndex": {
+              "x": 91.6,
+              "y": 26,
+              "v": 0.96
+            },
+            "rightIndex": {
+              "x": 45.7,
+              "y": 48.1,
+              "v": 0.633
+            },
+            "leftHip": {
+              "x": 69.3,
+              "y": 69.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.3,
+              "y": 69.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.2,
+              "y": 91.8,
+              "v": 0.479
+            },
+            "rightKnee": {
+              "x": 50.8,
+              "y": 91.4,
+              "v": 0.339
+            },
+            "leftAnkle": {
+              "x": 76.4,
+              "y": 113.8,
+              "v": 0.563
+            },
+            "rightAnkle": {
+              "x": 48.8,
+              "y": 114.3,
+              "v": 0.55
+            },
+            "leftHeel": {
+              "x": 74.6,
+              "y": 117.3,
+              "v": 0.448
+            },
+            "rightHeel": {
+              "x": 48.8,
+              "y": 117.5,
+              "v": 0.287
+            },
+            "leftFootIndex": {
+              "x": 81,
+              "y": 120.6,
+              "v": 0.621
+            },
+            "rightFootIndex": {
+              "x": 46.6,
+              "y": 123.6,
+              "v": 0.486
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.8,
+                "y": 23
+              },
+              "roll": 176.9,
+              "yaw": 0.418,
+              "pitch": 0.675
+            },
+            "torso": {
+              "center": {
+                "x": 64.3,
+                "y": 37.1
+              },
+              "angle": 89.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.5,
+                "y": 31.1
+              },
+              "angle": 67.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48.2,
+                "y": 50.4
+              },
+              "angle": 137.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.6,
+                "y": 117.3
+              },
+              "angle": -27.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.8,
+                "y": 114.3
+              },
+              "angle": -103.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.772,
+          "keypoints": {
+            "nose": {
+              "x": 69.4,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.8,
+              "y": 21.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.1,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.1,
+              "y": 22.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.9,
+              "y": 22.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.9,
+              "y": 35.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.2,
+              "y": 35.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84,
+              "y": 43.7,
+              "v": 0.87
+            },
+            "rightElbow": {
+              "x": 53.7,
+              "y": 51.2,
+              "v": 0.535
+            },
+            "leftWrist": {
+              "x": 89.9,
+              "y": 29.3,
+              "v": 0.983
+            },
+            "rightWrist": {
+              "x": 47.7,
+              "y": 48.9,
+              "v": 0.62
+            },
+            "leftIndex": {
+              "x": 92.6,
+              "y": 24.4,
+              "v": 0.981
+            },
+            "rightIndex": {
+              "x": 43.9,
+              "y": 47.7,
+              "v": 0.664
+            },
+            "leftHip": {
+              "x": 68.1,
+              "y": 68.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.7,
+              "y": 68.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.4,
+              "y": 92.6,
+              "v": 0.566
+            },
+            "rightKnee": {
+              "x": 50.7,
+              "y": 92.7,
+              "v": 0.43
+            },
+            "leftAnkle": {
+              "x": 76.5,
+              "y": 113.9,
+              "v": 0.573
+            },
+            "rightAnkle": {
+              "x": 48.9,
+              "y": 115.7,
+              "v": 0.648
+            },
+            "leftHeel": {
+              "x": 74.7,
+              "y": 117.4,
+              "v": 0.406
+            },
+            "rightHeel": {
+              "x": 48.4,
+              "y": 119.8,
+              "v": 0.3
+            },
+            "leftFootIndex": {
+              "x": 81,
+              "y": 120.6,
+              "v": 0.621
+            },
+            "rightFootIndex": {
+              "x": 46.5,
+              "y": 124.3,
+              "v": 0.571
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.9,
+                "y": 21.5
+              },
+              "roll": -180,
+              "yaw": 0.392,
+              "pitch": 0.622
+            },
+            "torso": {
+              "center": {
+                "x": 64.6,
+                "y": 35.4
+              },
+              "angle": 86.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.9,
+                "y": 29.3
+              },
+              "angle": 61.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.7,
+                "y": 48.9
+              },
+              "angle": 162.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.7,
+                "y": 117.4
+              },
+              "angle": -26.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.4,
+                "y": 119.8
+              },
+              "angle": -112.9
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.646,
+          "keypoints": {
+            "nose": {
+              "x": 72.8,
+              "y": 21.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.2,
+              "y": 20,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.3,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.9,
+              "y": 21.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.7,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.4,
+              "y": 35.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61.9,
+              "y": 32.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.1,
+              "y": 51.7,
+              "v": 0.076
+            },
+            "rightElbow": {
+              "x": 57.8,
+              "y": 47.4,
+              "v": 0.785
+            },
+            "leftWrist": {
+              "x": 79.2,
+              "y": 55.9,
+              "v": 0.148
+            },
+            "rightWrist": {
+              "x": 56.3,
+              "y": 57.8,
+              "v": 0.391
+            },
+            "leftIndex": {
+              "x": 80.1,
+              "y": 55.2,
+              "v": 0.234
+            },
+            "rightIndex": {
+              "x": 55.9,
+              "y": 60.3,
+              "v": 0.325
+            },
+            "leftHip": {
+              "x": 64.4,
+              "y": 67.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.5,
+              "y": 66.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.6,
+              "y": 89.5,
+              "v": 0.201
+            },
+            "rightKnee": {
+              "x": 51.9,
+              "y": 91.8,
+              "v": 0.657
+            },
+            "leftAnkle": {
+              "x": 73.2,
+              "y": 114,
+              "v": 0.395
+            },
+            "rightAnkle": {
+              "x": 47,
+              "y": 115.9,
+              "v": 0.749
+            },
+            "leftHeel": {
+              "x": 70.9,
+              "y": 118,
+              "v": 0.304
+            },
+            "rightHeel": {
+              "x": 44.6,
+              "y": 120.8,
+              "v": 0.433
+            },
+            "leftFootIndex": {
+              "x": 78.6,
+              "y": 119.9,
+              "v": 0.481
+            },
+            "rightFootIndex": {
+              "x": 46.8,
+              "y": 124.4,
+              "v": 0.673
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.3,
+                "y": 19.6
+              },
+              "roll": 168.4,
+              "yaw": 0.138,
+              "pitch": 0.427
+            },
+            "torso": {
+              "center": {
+                "x": 68.2,
+                "y": 34
+              },
+              "angle": 76
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 56.3,
+                "y": 57.8
+              },
+              "angle": -99.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.9,
+                "y": 118
+              },
+              "angle": -13.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.6,
+                "y": 120.8
+              },
+              "angle": -58.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.795,
+          "keypoints": {
+            "nose": {
+              "x": 69.2,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.3,
+              "y": 18.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.2,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.4,
+              "y": 19.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.6,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.6,
+              "y": 35.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.5,
+              "y": 30.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.5,
+              "y": 51.8,
+              "v": 0.434
+            },
+            "rightElbow": {
+              "x": 52.5,
+              "y": 45.8,
+              "v": 0.959
+            },
+            "leftWrist": {
+              "x": 80,
+              "y": 55.5,
+              "v": 0.542
+            },
+            "rightWrist": {
+              "x": 47.6,
+              "y": 60.6,
+              "v": 0.984
+            },
+            "leftIndex": {
+              "x": 80,
+              "y": 54.6,
+              "v": 0.586
+            },
+            "rightIndex": {
+              "x": 46.6,
+              "y": 65.9,
+              "v": 0.973
+            },
+            "leftHip": {
+              "x": 69.4,
+              "y": 64.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.5,
+              "y": 62.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.6,
+              "y": 88.1,
+              "v": 0.502
+            },
+            "rightKnee": {
+              "x": 49.7,
+              "y": 89,
+              "v": 0.757
+            },
+            "leftAnkle": {
+              "x": 75.2,
+              "y": 111.5,
+              "v": 0.652
+            },
+            "rightAnkle": {
+              "x": 48.2,
+              "y": 115,
+              "v": 0.779
+            },
+            "leftHeel": {
+              "x": 73.6,
+              "y": 114.8,
+              "v": 0.383
+            },
+            "rightHeel": {
+              "x": 48.6,
+              "y": 117.4,
+              "v": 0.314
+            },
+            "leftFootIndex": {
+              "x": 79.6,
+              "y": 118.1,
+              "v": 0.691
+            },
+            "rightFootIndex": {
+              "x": 46.7,
+              "y": 126.5,
+              "v": 0.722
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.8,
+                "y": 18.2
+              },
+              "roll": -177.8,
+              "yaw": 0.088,
+              "pitch": 0.411
+            },
+            "torso": {
+              "center": {
+                "x": 67.6,
+                "y": 32.9
+              },
+              "angle": 81.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80,
+                "y": 55.5
+              },
+              "angle": 90
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.6,
+                "y": 60.6
+              },
+              "angle": -100.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.6,
+                "y": 114.8
+              },
+              "angle": -28.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.6,
+                "y": 117.4
+              },
+              "angle": -101.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.866,
+          "keypoints": {
+            "nose": {
+              "x": 71.2,
+              "y": 20.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.2,
+              "y": 18.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.4,
+              "y": 19.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.3,
+              "y": 19.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.1,
+              "y": 21.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.2,
+              "y": 35.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.2,
+              "y": 33.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.1,
+              "y": 50.8,
+              "v": 0.245
+            },
+            "rightElbow": {
+              "x": 55.9,
+              "y": 52.1,
+              "v": 0.962
+            },
+            "leftWrist": {
+              "x": 82.4,
+              "y": 52.3,
+              "v": 0.281
+            },
+            "rightWrist": {
+              "x": 56.4,
+              "y": 68.5,
+              "v": 0.942
+            },
+            "leftIndex": {
+              "x": 81.9,
+              "y": 50.7,
+              "v": 0.388
+            },
+            "rightIndex": {
+              "x": 57.6,
+              "y": 73.8,
+              "v": 0.908
+            },
+            "leftHip": {
+              "x": 72.3,
+              "y": 68,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.4,
+              "y": 67.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.3,
+              "y": 89.2,
+              "v": 0.888
+            },
+            "rightKnee": {
+              "x": 50.3,
+              "y": 92,
+              "v": 0.952
+            },
+            "leftAnkle": {
+              "x": 76.9,
+              "y": 112.8,
+              "v": 0.943
+            },
+            "rightAnkle": {
+              "x": 48.8,
+              "y": 115.7,
+              "v": 0.968
+            },
+            "leftHeel": {
+              "x": 74.2,
+              "y": 116,
+              "v": 0.811
+            },
+            "rightHeel": {
+              "x": 48.3,
+              "y": 118.5,
+              "v": 0.742
+            },
+            "leftFootIndex": {
+              "x": 82.3,
+              "y": 120.2,
+              "v": 0.94
+            },
+            "rightFootIndex": {
+              "x": 46.6,
+              "y": 126.3,
+              "v": 0.948
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.8,
+                "y": 19
+              },
+              "roll": -164.8,
+              "yaw": 0.282,
+              "pitch": 0.292
+            },
+            "torso": {
+              "center": {
+                "x": 69.2,
+                "y": 34.5
+              },
+              "angle": 82.5
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 56.4,
+                "y": 68.5
+              },
+              "angle": -77.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.2,
+                "y": 116
+              },
+              "angle": -27.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.3,
+                "y": 118.5
+              },
+              "angle": -102.3
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.871,
+          "keypoints": {
+            "nose": {
+              "x": 66.3,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.3,
+              "y": 18.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.6,
+              "y": 20,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70,
+              "y": 19.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.8,
+              "y": 21.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.9,
+              "y": 33.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56,
+              "y": 32.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.8,
+              "y": 54,
+              "v": 0.614
+            },
+            "rightElbow": {
+              "x": 52.1,
+              "y": 42.2,
+              "v": 0.926
+            },
+            "leftWrist": {
+              "x": 90.4,
+              "y": 70.4,
+              "v": 0.706
+            },
+            "rightWrist": {
+              "x": 38.5,
+              "y": 30.9,
+              "v": 0.989
+            },
+            "leftIndex": {
+              "x": 94.4,
+              "y": 74,
+              "v": 0.693
+            },
+            "rightIndex": {
+              "x": 34.6,
+              "y": 26.6,
+              "v": 0.986
+            },
+            "leftHip": {
+              "x": 71.8,
+              "y": 66.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.2,
+              "y": 65.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.4,
+              "y": 89.1,
+              "v": 0.631
+            },
+            "rightKnee": {
+              "x": 50.2,
+              "y": 89.4,
+              "v": 0.875
+            },
+            "leftAnkle": {
+              "x": 75.9,
+              "y": 112.2,
+              "v": 0.809
+            },
+            "rightAnkle": {
+              "x": 48.1,
+              "y": 115.2,
+              "v": 0.882
+            },
+            "leftHeel": {
+              "x": 73.8,
+              "y": 116,
+              "v": 0.67
+            },
+            "rightHeel": {
+              "x": 48.1,
+              "y": 118,
+              "v": 0.537
+            },
+            "leftFootIndex": {
+              "x": 80.5,
+              "y": 119,
+              "v": 0.855
+            },
+            "rightFootIndex": {
+              "x": 46.3,
+              "y": 126.7,
+              "v": 0.861
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66,
+                "y": 19.3
+              },
+              "roll": -163.4,
+              "yaw": 0.071,
+              "pitch": 0.387
+            },
+            "torso": {
+              "center": {
+                "x": 66.5,
+                "y": 33
+              },
+              "angle": 88.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.4,
+                "y": 70.4
+              },
+              "angle": -42
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.5,
+                "y": 30.9
+              },
+              "angle": 132.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.8,
+                "y": 116
+              },
+              "angle": -24.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.1,
+                "y": 118
+              },
+              "angle": -101.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.775,
+          "keypoints": {
+            "nose": {
+              "x": 70.2,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.2,
+              "y": 20.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.8,
+              "y": 19.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.4,
+              "y": 21.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.2,
+              "y": 21.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.3,
+              "y": 35.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58,
+              "y": 33.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.4,
+              "y": 52.1,
+              "v": 0.161
+            },
+            "rightElbow": {
+              "x": 53.4,
+              "y": 45.8,
+              "v": 0.857
+            },
+            "leftWrist": {
+              "x": 77.8,
+              "y": 62.2,
+              "v": 0.087
+            },
+            "rightWrist": {
+              "x": 52.4,
+              "y": 55.5,
+              "v": 0.623
+            },
+            "leftIndex": {
+              "x": 78.8,
+              "y": 64.1,
+              "v": 0.122
+            },
+            "rightIndex": {
+              "x": 51.3,
+              "y": 57.4,
+              "v": 0.587
+            },
+            "leftHip": {
+              "x": 71,
+              "y": 66.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59,
+              "y": 65.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.9,
+              "y": 87.7,
+              "v": 0.842
+            },
+            "rightKnee": {
+              "x": 54.5,
+              "y": 88.9,
+              "v": 0.889
+            },
+            "leftAnkle": {
+              "x": 75.7,
+              "y": 112.2,
+              "v": 0.824
+            },
+            "rightAnkle": {
+              "x": 46.4,
+              "y": 113.3,
+              "v": 0.927
+            },
+            "leftHeel": {
+              "x": 73.3,
+              "y": 116.3,
+              "v": 0.681
+            },
+            "rightHeel": {
+              "x": 45.5,
+              "y": 117.4,
+              "v": 0.494
+            },
+            "leftFootIndex": {
+              "x": 82,
+              "y": 119.1,
+              "v": 0.855
+            },
+            "rightFootIndex": {
+              "x": 46.3,
+              "y": 121.1,
+              "v": 0.887
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.5,
+                "y": 20.1
+              },
+              "roll": 171.6,
+              "yaw": 0.204,
+              "pitch": 0.422
+            },
+            "torso": {
+              "center": {
+                "x": 66.2,
+                "y": 34.7
+              },
+              "angle": 87.9
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 52.4,
+                "y": 55.5
+              },
+              "angle": -120.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.3,
+                "y": 116.3
+              },
+              "angle": -17.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45.5,
+                "y": 117.4
+              },
+              "angle": -77.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.62,
+          "keypoints": {
+            "nose": {
+              "x": 68.3,
+              "y": 24,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 69,
+              "y": 22.5,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 66.8,
+              "y": 22.4,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 69.2,
+              "y": 23.5,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 66.3,
+              "y": 23.4,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 59.8,
+              "y": 32.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 72.3,
+              "y": 32.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 59.5,
+              "y": 49.8,
+              "v": 0.086
+            },
+            "rightElbow": {
+              "x": 73,
+              "y": 49.6,
+              "v": 0.199
+            },
+            "leftWrist": {
+              "x": 57,
+              "y": 47,
+              "v": 0.116
+            },
+            "rightWrist": {
+              "x": 76.7,
+              "y": 54.1,
+              "v": 0.286
+            },
+            "leftIndex": {
+              "x": 56.3,
+              "y": 44.3,
+              "v": 0.185
+            },
+            "rightIndex": {
+              "x": 77.6,
+              "y": 54.4,
+              "v": 0.299
+            },
+            "leftHip": {
+              "x": 58.3,
+              "y": 66.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.3,
+              "y": 65.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 62.4,
+              "y": 91.9,
+              "v": 0.287
+            },
+            "rightKnee": {
+              "x": 63.7,
+              "y": 87.7,
+              "v": 0.569
+            },
+            "leftAnkle": {
+              "x": 61.3,
+              "y": 113.3,
+              "v": 0.545
+            },
+            "rightAnkle": {
+              "x": 54.5,
+              "y": 113.7,
+              "v": 0.745
+            },
+            "leftHeel": {
+              "x": 60.5,
+              "y": 116.7,
+              "v": 0.457
+            },
+            "rightHeel": {
+              "x": 52.4,
+              "y": 117.8,
+              "v": 0.464
+            },
+            "leftFootIndex": {
+              "x": 61.7,
+              "y": 119.1,
+              "v": 0.436
+            },
+            "rightFootIndex": {
+              "x": 54.2,
+              "y": 121.7,
+              "v": 0.594
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.9,
+                "y": 22.5
+              },
+              "roll": 177.4,
+              "yaw": 0.182,
+              "pitch": 0.704
+            },
+            "torso": {
+              "center": {
+                "x": 66.1,
+                "y": 32.4
+              },
+              "angle": 80.2
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 60.5,
+                "y": 116.7
+              },
+              "angle": -63.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 52.4,
+                "y": 117.8
+              },
+              "angle": -65.2
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/cata/poses.json
+++ b/public/assets/fighters/cata/poses.json
@@ -1,0 +1,8140 @@
+{
+  "version": 1,
+  "fighter": "cata",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:40:05.906Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.958,
+          "keypoints": {
+            "nose": {
+              "x": 77.2,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 76.8,
+              "y": 22.2,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 75.3,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.8,
+              "y": 22.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 71.3,
+              "y": 22.7,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 78.3,
+              "y": 32.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63,
+              "y": 34.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.2,
+              "y": 43.6,
+              "v": 0.973
+            },
+            "rightElbow": {
+              "x": 65.3,
+              "y": 48.2,
+              "v": 0.863
+            },
+            "leftWrist": {
+              "x": 66.7,
+              "y": 55.8,
+              "v": 0.958
+            },
+            "rightWrist": {
+              "x": 70,
+              "y": 55,
+              "v": 0.842
+            },
+            "leftIndex": {
+              "x": 63.8,
+              "y": 59.5,
+              "v": 0.946
+            },
+            "rightIndex": {
+              "x": 74.3,
+              "y": 57.7,
+              "v": 0.849
+            },
+            "leftHip": {
+              "x": 73.3,
+              "y": 68.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.5,
+              "y": 68,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 89,
+              "y": 91.7,
+              "v": 0.987
+            },
+            "rightKnee": {
+              "x": 51.6,
+              "y": 90.9,
+              "v": 0.987
+            },
+            "leftAnkle": {
+              "x": 102.4,
+              "y": 114.5,
+              "v": 0.974
+            },
+            "rightAnkle": {
+              "x": 34.9,
+              "y": 113.9,
+              "v": 0.986
+            },
+            "leftHeel": {
+              "x": 103.6,
+              "y": 120.9,
+              "v": 0.877
+            },
+            "rightHeel": {
+              "x": 33.1,
+              "y": 117,
+              "v": 0.859
+            },
+            "leftFootIndex": {
+              "x": 102.8,
+              "y": 123.3,
+              "v": 0.964
+            },
+            "rightFootIndex": {
+              "x": 32.7,
+              "y": 121.7,
+              "v": 0.973
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 76.1,
+                "y": 22.2
+              },
+              "roll": -180,
+              "yaw": 0.767,
+              "pitch": 1.667
+            },
+            "torso": {
+              "center": {
+                "x": 70.7,
+                "y": 33.5
+              },
+              "angle": 85.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 66.7,
+                "y": 55.8
+              },
+              "angle": -128.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 70,
+                "y": 55
+              },
+              "angle": -32.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 103.6,
+                "y": 120.9
+              },
+              "angle": -108.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33.1,
+                "y": 117
+              },
+              "angle": -94.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.847,
+          "keypoints": {
+            "nose": {
+              "x": 77,
+              "y": 25.6,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 76.9,
+              "y": 23.7,
+              "v": 0.997
+            },
+            "rightEye": {
+              "x": 75.1,
+              "y": 23,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 75.3,
+              "y": 24.2,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 71.5,
+              "y": 23.5,
+              "v": 0.997
+            },
+            "leftShoulder": {
+              "x": 78.8,
+              "y": 33.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 62.3,
+              "y": 34.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.8,
+              "y": 45.6,
+              "v": 0.614
+            },
+            "rightElbow": {
+              "x": 57.6,
+              "y": 47.2,
+              "v": 0.446
+            },
+            "leftWrist": {
+              "x": 67.6,
+              "y": 56.3,
+              "v": 0.785
+            },
+            "rightWrist": {
+              "x": 50.5,
+              "y": 46.3,
+              "v": 0.879
+            },
+            "leftIndex": {
+              "x": 64.1,
+              "y": 59.9,
+              "v": 0.807
+            },
+            "rightIndex": {
+              "x": 48.8,
+              "y": 43.5,
+              "v": 0.924
+            },
+            "leftHip": {
+              "x": 72,
+              "y": 65.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.4,
+              "y": 63.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.4,
+              "y": 85.4,
+              "v": 0.722
+            },
+            "rightKnee": {
+              "x": 59.6,
+              "y": 82,
+              "v": 0.741
+            },
+            "leftAnkle": {
+              "x": 58.2,
+              "y": 108.1,
+              "v": 0.815
+            },
+            "rightAnkle": {
+              "x": 46.8,
+              "y": 106.7,
+              "v": 0.89
+            },
+            "leftHeel": {
+              "x": 50.7,
+              "y": 110.2,
+              "v": 0.612
+            },
+            "rightHeel": {
+              "x": 45.3,
+              "y": 110.7,
+              "v": 0.573
+            },
+            "leftFootIndex": {
+              "x": 55.1,
+              "y": 115.8,
+              "v": 0.828
+            },
+            "rightFootIndex": {
+              "x": 44,
+              "y": 114.5,
+              "v": 0.867
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 76,
+                "y": 23.4
+              },
+              "roll": 158.7,
+              "yaw": 0.518,
+              "pitch": 1.165
+            },
+            "torso": {
+              "center": {
+                "x": 70.6,
+                "y": 34.1
+              },
+              "angle": 83.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 67.6,
+                "y": 56.3
+              },
+              "angle": -134.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.5,
+                "y": 46.3
+              },
+              "angle": 121.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 50.7,
+                "y": 110.2
+              },
+              "angle": -51.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45.3,
+                "y": 110.7
+              },
+              "angle": -108.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.929,
+          "keypoints": {
+            "nose": {
+              "x": 50.3,
+              "y": 25.1,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 51.8,
+              "y": 23.4,
+              "v": 0.997
+            },
+            "rightEye": {
+              "x": 50.8,
+              "y": 23.2,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 56,
+              "y": 23.4,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 52.9,
+              "y": 23.2,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 66.1,
+              "y": 33.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.6,
+              "y": 32.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.2,
+              "y": 45.4,
+              "v": 0.69
+            },
+            "rightElbow": {
+              "x": 53.7,
+              "y": 44.8,
+              "v": 0.979
+            },
+            "leftWrist": {
+              "x": 74.1,
+              "y": 49.3,
+              "v": 0.72
+            },
+            "rightWrist": {
+              "x": 60.4,
+              "y": 56,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 72.1,
+              "y": 46.7,
+              "v": 0.791
+            },
+            "rightIndex": {
+              "x": 63.6,
+              "y": 58.8,
+              "v": 0.99
+            },
+            "leftHip": {
+              "x": 64.8,
+              "y": 66.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.8,
+              "y": 66.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.2,
+              "y": 91.3,
+              "v": 0.899
+            },
+            "rightKnee": {
+              "x": 38.5,
+              "y": 89.2,
+              "v": 0.984
+            },
+            "leftAnkle": {
+              "x": 92,
+              "y": 113.9,
+              "v": 0.957
+            },
+            "rightAnkle": {
+              "x": 24.9,
+              "y": 114.5,
+              "v": 0.976
+            },
+            "leftHeel": {
+              "x": 94,
+              "y": 115.4,
+              "v": 0.716
+            },
+            "rightHeel": {
+              "x": 23.7,
+              "y": 117.1,
+              "v": 0.773
+            },
+            "leftFootIndex": {
+              "x": 94.3,
+              "y": 125.6,
+              "v": 0.948
+            },
+            "rightFootIndex": {
+              "x": 24.7,
+              "y": 125.6,
+              "v": 0.969
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.3,
+                "y": 23.3
+              },
+              "roll": 168.7,
+              "yaw": -0.981,
+              "pitch": 1.765
+            },
+            "torso": {
+              "center": {
+                "x": 57.4,
+                "y": 32.9
+              },
+              "angle": 91.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 74.1,
+                "y": 49.3
+              },
+              "angle": 127.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 60.4,
+                "y": 56
+              },
+              "angle": -41.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 94,
+                "y": 115.4
+              },
+              "angle": -88.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.7,
+                "y": 117.1
+              },
+              "angle": -83.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.885,
+          "keypoints": {
+            "nose": {
+              "x": 77.2,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 76,
+              "y": 17.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 74.9,
+              "y": 17.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.6,
+              "y": 18.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 71.7,
+              "y": 19.1,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 73.2,
+              "y": 31.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 62,
+              "y": 30.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.7,
+              "y": 50,
+              "v": 0.285
+            },
+            "rightElbow": {
+              "x": 60.9,
+              "y": 49.6,
+              "v": 0.85
+            },
+            "leftWrist": {
+              "x": 70.9,
+              "y": 56.1,
+              "v": 0.601
+            },
+            "rightWrist": {
+              "x": 63.4,
+              "y": 53,
+              "v": 0.601
+            },
+            "leftIndex": {
+              "x": 70.8,
+              "y": 56.1,
+              "v": 0.725
+            },
+            "rightIndex": {
+              "x": 64.4,
+              "y": 51.8,
+              "v": 0.612
+            },
+            "leftHip": {
+              "x": 69.8,
+              "y": 66.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63,
+              "y": 65.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.5,
+              "y": 90.7,
+              "v": 0.925
+            },
+            "rightKnee": {
+              "x": 57.5,
+              "y": 88.7,
+              "v": 0.99
+            },
+            "leftAnkle": {
+              "x": 80,
+              "y": 115.8,
+              "v": 0.982
+            },
+            "rightAnkle": {
+              "x": 39.4,
+              "y": 112.2,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 79.6,
+              "y": 119.7,
+              "v": 0.93
+            },
+            "rightHeel": {
+              "x": 36.9,
+              "y": 115.3,
+              "v": 0.9
+            },
+            "leftFootIndex": {
+              "x": 83.6,
+              "y": 123.7,
+              "v": 0.982
+            },
+            "rightFootIndex": {
+              "x": 41.6,
+              "y": 125,
+              "v": 0.987
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 75.5,
+                "y": 17.8
+              },
+              "roll": 169.7,
+              "yaw": 1.565,
+              "pitch": 2.057
+            },
+            "torso": {
+              "center": {
+                "x": 67.6,
+                "y": 31.4
+              },
+              "angle": 88
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 70.9,
+                "y": 56.1
+              },
+              "angle": -180
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 63.4,
+                "y": 53
+              },
+              "angle": 50.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 79.6,
+                "y": 119.7
+              },
+              "angle": -45
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.9,
+                "y": 115.3
+              },
+              "angle": -64.1
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.966,
+          "keypoints": {
+            "nose": {
+              "x": 76.4,
+              "y": 24.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 76.7,
+              "y": 22.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 74.1,
+              "y": 21.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.6,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 69.5,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77,
+              "y": 33.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.7,
+              "y": 34.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.7,
+              "y": 45.2,
+              "v": 0.884
+            },
+            "rightElbow": {
+              "x": 60.8,
+              "y": 49,
+              "v": 0.96
+            },
+            "leftWrist": {
+              "x": 67.4,
+              "y": 55.1,
+              "v": 0.939
+            },
+            "rightWrist": {
+              "x": 71.1,
+              "y": 55,
+              "v": 0.974
+            },
+            "leftIndex": {
+              "x": 64.6,
+              "y": 58.3,
+              "v": 0.948
+            },
+            "rightIndex": {
+              "x": 76,
+              "y": 56,
+              "v": 0.97
+            },
+            "leftHip": {
+              "x": 69.9,
+              "y": 68.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.7,
+              "y": 66.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.2,
+              "y": 93.6,
+              "v": 0.956
+            },
+            "rightKnee": {
+              "x": 50.6,
+              "y": 91.7,
+              "v": 0.99
+            },
+            "leftAnkle": {
+              "x": 64.4,
+              "y": 112.3,
+              "v": 0.953
+            },
+            "rightAnkle": {
+              "x": 34.1,
+              "y": 113,
+              "v": 0.99
+            },
+            "leftHeel": {
+              "x": 61.5,
+              "y": 114.2,
+              "v": 0.865
+            },
+            "rightHeel": {
+              "x": 31.5,
+              "y": 114.7,
+              "v": 0.848
+            },
+            "leftFootIndex": {
+              "x": 61.9,
+              "y": 121.9,
+              "v": 0.953
+            },
+            "rightFootIndex": {
+              "x": 31.3,
+              "y": 124.6,
+              "v": 0.982
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 75.4,
+                "y": 22
+              },
+              "roll": 164.9,
+              "yaw": 0.371,
+              "pitch": 0.836
+            },
+            "torso": {
+              "center": {
+                "x": 68.9,
+                "y": 33.8
+              },
+              "angle": 83.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 67.4,
+                "y": 55.1
+              },
+              "angle": -131.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 71.1,
+                "y": 55
+              },
+              "angle": -11.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.5,
+                "y": 114.2
+              },
+              "angle": -87
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.5,
+                "y": 114.7
+              },
+              "angle": -91.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.985,
+          "keypoints": {
+            "nose": {
+              "x": 73.6,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.7,
+              "y": 9.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.5,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.9,
+              "y": 11,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.9,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.1,
+              "y": 26.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.8,
+              "y": 44.4,
+              "v": 0.798
+            },
+            "rightElbow": {
+              "x": 52.5,
+              "y": 40.1,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 86.6,
+              "y": 46.2,
+              "v": 0.968
+            },
+            "rightWrist": {
+              "x": 45.5,
+              "y": 54.6,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 90.4,
+              "y": 45.5,
+              "v": 0.971
+            },
+            "rightIndex": {
+              "x": 44,
+              "y": 59.8,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 66.6,
+              "y": 60.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.9,
+              "y": 58.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 55.7,
+              "y": 86.7,
+              "v": 0.969
+            },
+            "rightKnee": {
+              "x": 73.3,
+              "y": 86.2,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 41.5,
+              "y": 112.5,
+              "v": 0.982
+            },
+            "rightAnkle": {
+              "x": 77.3,
+              "y": 118.1,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 36,
+              "y": 116.1,
+              "v": 0.982
+            },
+            "rightHeel": {
+              "x": 75.6,
+              "y": 123.7,
+              "v": 0.996
+            },
+            "leftFootIndex": {
+              "x": 47.5,
+              "y": 123.1,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 89.3,
+              "y": 125.1,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.1,
+                "y": 9.8
+              },
+              "roll": -170.5,
+              "yaw": 2.055,
+              "pitch": 1.644
+            },
+            "torso": {
+              "center": {
+                "x": 66.6,
+                "y": 25.2
+              },
+              "angle": 87
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.6,
+                "y": 46.2
+              },
+              "angle": 10.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 45.5,
+                "y": 54.6
+              },
+              "angle": -106.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 36,
+                "y": 116.1
+              },
+              "angle": -31.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 75.6,
+                "y": 123.7
+              },
+              "angle": -5.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.969,
+          "keypoints": {
+            "nose": {
+              "x": 76.1,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.2,
+              "y": 14.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.8,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 76.2,
+              "y": 14.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 69.6,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78.8,
+              "y": 24.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60,
+              "y": 25.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.6,
+              "y": 36.3,
+              "v": 0.964
+            },
+            "rightElbow": {
+              "x": 54.7,
+              "y": 39.8,
+              "v": 0.954
+            },
+            "leftWrist": {
+              "x": 66.7,
+              "y": 48.4,
+              "v": 0.977
+            },
+            "rightWrist": {
+              "x": 47.7,
+              "y": 37.6,
+              "v": 0.962
+            },
+            "leftIndex": {
+              "x": 63.8,
+              "y": 53.1,
+              "v": 0.966
+            },
+            "rightIndex": {
+              "x": 45,
+              "y": 36.3,
+              "v": 0.943
+            },
+            "leftHip": {
+              "x": 74.9,
+              "y": 58.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.3,
+              "y": 57.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 89.9,
+              "y": 87.2,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 49.8,
+              "y": 86.6,
+              "v": 0.989
+            },
+            "leftAnkle": {
+              "x": 106.5,
+              "y": 114.1,
+              "v": 0.968
+            },
+            "rightAnkle": {
+              "x": 31,
+              "y": 113,
+              "v": 0.984
+            },
+            "leftHeel": {
+              "x": 108.6,
+              "y": 117.1,
+              "v": 0.836
+            },
+            "rightHeel": {
+              "x": 29.1,
+              "y": 115.7,
+              "v": 0.841
+            },
+            "leftFootIndex": {
+              "x": 104.5,
+              "y": 124.9,
+              "v": 0.958
+            },
+            "rightFootIndex": {
+              "x": 27.8,
+              "y": 125,
+              "v": 0.967
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 75.5,
+                "y": 13.6
+              },
+              "roll": 163.6,
+              "yaw": 0.169,
+              "pitch": 0.593
+            },
+            "torso": {
+              "center": {
+                "x": 69.4,
+                "y": 24.7
+              },
+              "angle": 86.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 66.7,
+                "y": 48.4
+              },
+              "angle": -121.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.7,
+                "y": 37.6
+              },
+              "angle": 154.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 108.6,
+                "y": 117.1
+              },
+              "angle": -117.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29.1,
+                "y": 115.7
+              },
+              "angle": -98
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.924,
+          "keypoints": {
+            "nose": {
+              "x": 71.8,
+              "y": 20.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.8,
+              "y": 17.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.3,
+              "y": 17.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.7,
+              "y": 17,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.5,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.5,
+              "y": 26.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.6,
+              "y": 25.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.7,
+              "y": 38.4,
+              "v": 0.946
+            },
+            "rightElbow": {
+              "x": 50.8,
+              "y": 36.4,
+              "v": 0.949
+            },
+            "leftWrist": {
+              "x": 62.9,
+              "y": 51.2,
+              "v": 0.909
+            },
+            "rightWrist": {
+              "x": 55.8,
+              "y": 45.3,
+              "v": 0.763
+            },
+            "leftIndex": {
+              "x": 60.3,
+              "y": 54.5,
+              "v": 0.885
+            },
+            "rightIndex": {
+              "x": 58.7,
+              "y": 47.6,
+              "v": 0.689
+            },
+            "leftHip": {
+              "x": 73.1,
+              "y": 59.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.5,
+              "y": 59.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 88,
+              "y": 87.9,
+              "v": 0.957
+            },
+            "rightKnee": {
+              "x": 48.5,
+              "y": 87.7,
+              "v": 0.982
+            },
+            "leftAnkle": {
+              "x": 103.9,
+              "y": 113.7,
+              "v": 0.94
+            },
+            "rightAnkle": {
+              "x": 29.2,
+              "y": 114,
+              "v": 0.982
+            },
+            "leftHeel": {
+              "x": 105.3,
+              "y": 117.2,
+              "v": 0.601
+            },
+            "rightHeel": {
+              "x": 26.7,
+              "y": 117.9,
+              "v": 0.734
+            },
+            "leftFootIndex": {
+              "x": 102.2,
+              "y": 124.1,
+              "v": 0.937
+            },
+            "rightFootIndex": {
+              "x": 27,
+              "y": 124.2,
+              "v": 0.969
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.1,
+                "y": 17.8
+              },
+              "roll": 176.7,
+              "yaw": -0.071,
+              "pitch": 0.856
+            },
+            "torso": {
+              "center": {
+                "x": 67.6,
+                "y": 26
+              },
+              "angle": 87
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 62.9,
+                "y": 51.2
+              },
+              "angle": -128.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 55.8,
+                "y": 45.3
+              },
+              "angle": -38.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 105.3,
+                "y": 117.2
+              },
+              "angle": -114.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 26.7,
+                "y": 117.9
+              },
+              "angle": -87.3
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 74.6,
+              "y": 18.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73,
+              "y": 14.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.2,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.5,
+              "y": 14.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.4,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.8,
+              "y": 23.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.5,
+              "y": 26.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86,
+              "y": 22.5,
+              "v": 0.975
+            },
+            "rightElbow": {
+              "x": 46.3,
+              "y": 42.2,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 104,
+              "y": 20.5,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 61.4,
+              "y": 42.9,
+              "v": 0.947
+            },
+            "leftIndex": {
+              "x": 108.9,
+              "y": 20.7,
+              "v": 0.993
+            },
+            "rightIndex": {
+              "x": 67.5,
+              "y": 46.1,
+              "v": 0.932
+            },
+            "leftHip": {
+              "x": 59.3,
+              "y": 66.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.6,
+              "y": 62.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 91.4,
+              "y": 81,
+              "v": 0.926
+            },
+            "rightKnee": {
+              "x": 70.6,
+              "y": 66,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 81.7,
+              "y": 121.2,
+              "v": 0.984
+            },
+            "rightAnkle": {
+              "x": 31,
+              "y": 106.7,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 78.1,
+              "y": 126.7,
+              "v": 0.973
+            },
+            "rightHeel": {
+              "x": 23.1,
+              "y": 110.1,
+              "v": 0.928
+            },
+            "leftFootIndex": {
+              "x": 91.1,
+              "y": 130.9,
+              "v": 0.987
+            },
+            "rightFootIndex": {
+              "x": 21.3,
+              "y": 124.7,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.6,
+                "y": 14.7
+              },
+              "roll": -180,
+              "yaw": 2.5,
+              "pitch": 4.25
+            },
+            "torso": {
+              "center": {
+                "x": 58.2,
+                "y": 25.2
+              },
+              "angle": 86.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 104,
+                "y": 20.5
+              },
+              "angle": -2.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 61.4,
+                "y": 42.9
+              },
+              "angle": -27.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.1,
+                "y": 126.7
+              },
+              "angle": -17.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.1,
+                "y": 110.1
+              },
+              "angle": -97
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.923,
+          "keypoints": {
+            "nose": {
+              "x": 72.5,
+              "y": 13.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.3,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.8,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.9,
+              "y": 11.1,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 75.6,
+              "y": 23,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.3,
+              "y": 25.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 88.6,
+              "y": 23.2,
+              "v": 0.909
+            },
+            "rightElbow": {
+              "x": 49.7,
+              "y": 38.4,
+              "v": 0.982
+            },
+            "leftWrist": {
+              "x": 99.7,
+              "y": 19.6,
+              "v": 0.965
+            },
+            "rightWrist": {
+              "x": 66.4,
+              "y": 27.9,
+              "v": 0.963
+            },
+            "leftIndex": {
+              "x": 102.6,
+              "y": 18.8,
+              "v": 0.96
+            },
+            "rightIndex": {
+              "x": 71.5,
+              "y": 24.4,
+              "v": 0.93
+            },
+            "leftHip": {
+              "x": 75.1,
+              "y": 62,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.6,
+              "y": 62.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 85.1,
+              "y": 87.3,
+              "v": 0.931
+            },
+            "rightKnee": {
+              "x": 44,
+              "y": 87.5,
+              "v": 0.875
+            },
+            "leftAnkle": {
+              "x": 102.6,
+              "y": 114.7,
+              "v": 0.924
+            },
+            "rightAnkle": {
+              "x": 25.1,
+              "y": 111.4,
+              "v": 0.894
+            },
+            "leftHeel": {
+              "x": 105.2,
+              "y": 118.4,
+              "v": 0.644
+            },
+            "rightHeel": {
+              "x": 23.6,
+              "y": 113.5,
+              "v": 0.523
+            },
+            "leftFootIndex": {
+              "x": 103.5,
+              "y": 125.6,
+              "v": 0.899
+            },
+            "rightFootIndex": {
+              "x": 20.3,
+              "y": 124.2,
+              "v": 0.838
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.2,
+                "y": 10.9
+              },
+              "roll": 165.4,
+              "yaw": 0.568,
+              "pitch": 1.094
+            },
+            "torso": {
+              "center": {
+                "x": 64.9,
+                "y": 24.2
+              },
+              "angle": 93.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 99.7,
+                "y": 19.6
+              },
+              "angle": 15.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 66.4,
+                "y": 27.9
+              },
+              "angle": 34.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 105.2,
+                "y": 118.4
+              },
+              "angle": -103.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.6,
+                "y": 113.5
+              },
+              "angle": -107.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.728,
+          "keypoints": {
+            "nose": {
+              "x": 60.7,
+              "y": 15.1,
+              "v": 0.997
+            },
+            "leftEye": {
+              "x": 61.2,
+              "y": 12.8,
+              "v": 0.99
+            },
+            "rightEye": {
+              "x": 57.8,
+              "y": 12.3,
+              "v": 0.996
+            },
+            "leftEar": {
+              "x": 59.8,
+              "y": 13.7,
+              "v": 0.994
+            },
+            "rightEar": {
+              "x": 53,
+              "y": 12.8,
+              "v": 0.99
+            },
+            "leftShoulder": {
+              "x": 64.8,
+              "y": 25,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.8,
+              "y": 28.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.3,
+              "y": 24.8,
+              "v": 0.77
+            },
+            "rightElbow": {
+              "x": 37.1,
+              "y": 44.1,
+              "v": 0.911
+            },
+            "leftWrist": {
+              "x": 73.2,
+              "y": 29.3,
+              "v": 0.498
+            },
+            "rightWrist": {
+              "x": 53.8,
+              "y": 46.9,
+              "v": 0.878
+            },
+            "leftIndex": {
+              "x": 63.8,
+              "y": 27.3,
+              "v": 0.391
+            },
+            "rightIndex": {
+              "x": 59.7,
+              "y": 47.1,
+              "v": 0.791
+            },
+            "leftHip": {
+              "x": 64.7,
+              "y": 63.3,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 47.8,
+              "y": 63.1,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 74.2,
+              "y": 86.3,
+              "v": 0.663
+            },
+            "rightKnee": {
+              "x": 31.4,
+              "y": 89.6,
+              "v": 0.41
+            },
+            "leftAnkle": {
+              "x": 91.6,
+              "y": 115.5,
+              "v": 0.603
+            },
+            "rightAnkle": {
+              "x": 15.6,
+              "y": 113.8,
+              "v": 0.552
+            },
+            "leftHeel": {
+              "x": 94,
+              "y": 119.8,
+              "v": 0.194
+            },
+            "rightHeel": {
+              "x": 13.8,
+              "y": 117.2,
+              "v": 0.144
+            },
+            "leftFootIndex": {
+              "x": 91.7,
+              "y": 126.4,
+              "v": 0.54
+            },
+            "rightFootIndex": {
+              "x": 11.7,
+              "y": 124.3,
+              "v": 0.423
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.5,
+                "y": 12.6
+              },
+              "roll": 171.6,
+              "yaw": 0.349,
+              "pitch": 0.742
+            },
+            "torso": {
+              "center": {
+                "x": 52.8,
+                "y": 26.6
+              },
+              "angle": 95.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.2,
+                "y": 29.3
+              },
+              "angle": 168
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 53.8,
+                "y": 46.9
+              },
+              "angle": -1.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 91.6,
+                "y": 115.5
+              },
+              "angle": -89.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 15.6,
+                "y": 113.8
+              },
+              "angle": -110.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.931,
+          "keypoints": {
+            "nose": {
+              "x": 63,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.3,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.3,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 62.4,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.9,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66.2,
+              "y": 22.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.7,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.7,
+              "y": 23,
+              "v": 0.952
+            },
+            "rightElbow": {
+              "x": 44.4,
+              "y": 35.2,
+              "v": 0.861
+            },
+            "leftWrist": {
+              "x": 95.6,
+              "y": 21.6,
+              "v": 0.979
+            },
+            "rightWrist": {
+              "x": 50.5,
+              "y": 32.5,
+              "v": 0.897
+            },
+            "leftIndex": {
+              "x": 100.3,
+              "y": 24.4,
+              "v": 0.976
+            },
+            "rightIndex": {
+              "x": 53.4,
+              "y": 30.7,
+              "v": 0.9
+            },
+            "leftHip": {
+              "x": 71.6,
+              "y": 60.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.8,
+              "y": 62.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.6,
+              "y": 89.1,
+              "v": 0.945
+            },
+            "rightKnee": {
+              "x": 37.3,
+              "y": 86.2,
+              "v": 0.889
+            },
+            "leftAnkle": {
+              "x": 95.8,
+              "y": 114.8,
+              "v": 0.91
+            },
+            "rightAnkle": {
+              "x": 19.3,
+              "y": 109.5,
+              "v": 0.942
+            },
+            "leftHeel": {
+              "x": 98.2,
+              "y": 117.5,
+              "v": 0.58
+            },
+            "rightHeel": {
+              "x": 18.7,
+              "y": 112.9,
+              "v": 0.775
+            },
+            "leftFootIndex": {
+              "x": 93.8,
+              "y": 126.4,
+              "v": 0.892
+            },
+            "rightFootIndex": {
+              "x": 14.3,
+              "y": 122.2,
+              "v": 0.926
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.8,
+                "y": 12
+              },
+              "roll": 161.6,
+              "yaw": 0.063,
+              "pitch": 0.854
+            },
+            "torso": {
+              "center": {
+                "x": 56,
+                "y": 22.7
+              },
+              "angle": 102.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.6,
+                "y": 21.6
+              },
+              "angle": -30.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.5,
+                "y": 32.5
+              },
+              "angle": 31.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 98.2,
+                "y": 117.5
+              },
+              "angle": -116.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 18.7,
+                "y": 112.9
+              },
+              "angle": -115.3
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.893,
+          "keypoints": {
+            "nose": {
+              "x": 69.4,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.2,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.5,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.8,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.8,
+              "y": 22.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.4,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 88.9,
+              "y": 22.9,
+              "v": 0.801
+            },
+            "rightElbow": {
+              "x": 43.7,
+              "y": 38.8,
+              "v": 0.814
+            },
+            "leftWrist": {
+              "x": 103,
+              "y": 20.3,
+              "v": 0.957
+            },
+            "rightWrist": {
+              "x": 50.8,
+              "y": 33.1,
+              "v": 0.907
+            },
+            "leftIndex": {
+              "x": 104.6,
+              "y": 18.5,
+              "v": 0.964
+            },
+            "rightIndex": {
+              "x": 56.4,
+              "y": 29.4,
+              "v": 0.894
+            },
+            "leftHip": {
+              "x": 77.8,
+              "y": 59.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 70.2,
+              "y": 64.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 56.7,
+              "y": 73.3,
+              "v": 0.93
+            },
+            "rightKnee": {
+              "x": 86.5,
+              "y": 89,
+              "v": 0.38
+            },
+            "leftAnkle": {
+              "x": 35.4,
+              "y": 95.7,
+              "v": 0.913
+            },
+            "rightAnkle": {
+              "x": 100.5,
+              "y": 113.1,
+              "v": 0.707
+            },
+            "leftHeel": {
+              "x": 36.5,
+              "y": 105.1,
+              "v": 0.895
+            },
+            "rightHeel": {
+              "x": 104.1,
+              "y": 117.1,
+              "v": 0.716
+            },
+            "leftFootIndex": {
+              "x": 23,
+              "y": 113.3,
+              "v": 0.946
+            },
+            "rightFootIndex": {
+              "x": 100.7,
+              "y": 125.8,
+              "v": 0.727
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.6,
+                "y": 10.6
+              },
+              "roll": 167.7,
+              "yaw": 0.244,
+              "pitch": 0.778
+            },
+            "torso": {
+              "center": {
+                "x": 62.6,
+                "y": 23.7
+              },
+              "angle": 106.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103,
+                "y": 20.3
+              },
+              "angle": 48.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.8,
+                "y": 33.1
+              },
+              "angle": 33.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 36.5,
+                "y": 105.1
+              },
+              "angle": -148.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 104.1,
+                "y": 117.1
+              },
+              "angle": -111.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.937,
+          "keypoints": {
+            "nose": {
+              "x": 81.6,
+              "y": 14,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 80.9,
+              "y": 12,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 78.8,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 78.9,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 73.8,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 86,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63.2,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 89.7,
+              "y": 38.7,
+              "v": 0.891
+            },
+            "rightElbow": {
+              "x": 45,
+              "y": 22.5,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 90.8,
+              "y": 33.1,
+              "v": 0.943
+            },
+            "rightWrist": {
+              "x": 27,
+              "y": 19.4,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 90.1,
+              "y": 29.8,
+              "v": 0.951
+            },
+            "rightIndex": {
+              "x": 21,
+              "y": 18.9,
+              "v": 0.992
+            },
+            "leftHip": {
+              "x": 85.2,
+              "y": 62,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 68.8,
+              "y": 61.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95.8,
+              "y": 89.7,
+              "v": 0.912
+            },
+            "rightKnee": {
+              "x": 52.3,
+              "y": 87.9,
+              "v": 0.954
+            },
+            "leftAnkle": {
+              "x": 110.9,
+              "y": 115.1,
+              "v": 0.915
+            },
+            "rightAnkle": {
+              "x": 33.7,
+              "y": 111.9,
+              "v": 0.93
+            },
+            "leftHeel": {
+              "x": 112.8,
+              "y": 118.4,
+              "v": 0.636
+            },
+            "rightHeel": {
+              "x": 31.5,
+              "y": 114.5,
+              "v": 0.606
+            },
+            "leftFootIndex": {
+              "x": 110.3,
+              "y": 128.5,
+              "v": 0.926
+            },
+            "rightFootIndex": {
+              "x": 31.7,
+              "y": 125.2,
+              "v": 0.911
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 79.9,
+                "y": 11.9
+              },
+              "roll": 174.6,
+              "yaw": 0.83,
+              "pitch": 0.995
+            },
+            "torso": {
+              "center": {
+                "x": 74.6,
+                "y": 24.5
+              },
+              "angle": 93.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.8,
+                "y": 33.1
+              },
+              "angle": 102
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 27,
+                "y": 19.4
+              },
+              "angle": 175.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 112.8,
+                "y": 118.4
+              },
+              "angle": -103.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.5,
+                "y": 114.5
+              },
+              "angle": -88.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.913,
+          "keypoints": {
+            "nose": {
+              "x": 71,
+              "y": 17.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71,
+              "y": 15.2,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 68.2,
+              "y": 14.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69,
+              "y": 16.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.5,
+              "y": 15.1,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 74.6,
+              "y": 27.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.2,
+              "y": 29.3,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 86.7,
+              "y": 27.4,
+              "v": 0.963
+            },
+            "rightElbow": {
+              "x": 43,
+              "y": 43.4,
+              "v": 0.811
+            },
+            "leftWrist": {
+              "x": 99.2,
+              "y": 25,
+              "v": 0.977
+            },
+            "rightWrist": {
+              "x": 45.6,
+              "y": 45.5,
+              "v": 0.588
+            },
+            "leftIndex": {
+              "x": 102.3,
+              "y": 23.1,
+              "v": 0.968
+            },
+            "rightIndex": {
+              "x": 48.3,
+              "y": 44.2,
+              "v": 0.557
+            },
+            "leftHip": {
+              "x": 75.1,
+              "y": 67.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.8,
+              "y": 67.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.1,
+              "y": 91.7,
+              "v": 0.973
+            },
+            "rightKnee": {
+              "x": 43.4,
+              "y": 90.7,
+              "v": 0.922
+            },
+            "leftAnkle": {
+              "x": 99.7,
+              "y": 115.1,
+              "v": 0.969
+            },
+            "rightAnkle": {
+              "x": 28.4,
+              "y": 111.1,
+              "v": 0.953
+            },
+            "leftHeel": {
+              "x": 102.2,
+              "y": 117.6,
+              "v": 0.727
+            },
+            "rightHeel": {
+              "x": 28,
+              "y": 113.6,
+              "v": 0.73
+            },
+            "leftFootIndex": {
+              "x": 99.3,
+              "y": 126.4,
+              "v": 0.945
+            },
+            "rightFootIndex": {
+              "x": 22.6,
+              "y": 123,
+              "v": 0.915
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.6,
+                "y": 14.9
+              },
+              "roll": 166,
+              "yaw": 0.485,
+              "pitch": 1.022
+            },
+            "torso": {
+              "center": {
+                "x": 63.9,
+                "y": 28.5
+              },
+              "angle": 95.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 99.2,
+                "y": 25
+              },
+              "angle": 31.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 45.6,
+                "y": 45.5
+              },
+              "angle": 25.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 102.2,
+                "y": 117.6
+              },
+              "angle": -108.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 28,
+                "y": 113.6
+              },
+              "angle": -119.9
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.815,
+          "keypoints": {
+            "nose": {
+              "x": 64.5,
+              "y": 15.1,
+              "v": 0.998
+            },
+            "leftEye": {
+              "x": 65,
+              "y": 12.5,
+              "v": 0.997
+            },
+            "rightEye": {
+              "x": 62.4,
+              "y": 11.6,
+              "v": 0.998
+            },
+            "leftEar": {
+              "x": 64.6,
+              "y": 12.7,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 61.1,
+              "y": 11.5,
+              "v": 0.992
+            },
+            "leftShoulder": {
+              "x": 67.7,
+              "y": 23.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53,
+              "y": 24.1,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 82.3,
+              "y": 24.3,
+              "v": 0.725
+            },
+            "rightElbow": {
+              "x": 55.7,
+              "y": 40.8,
+              "v": 0.078
+            },
+            "leftWrist": {
+              "x": 91.1,
+              "y": 26.8,
+              "v": 0.803
+            },
+            "rightWrist": {
+              "x": 58.6,
+              "y": 40.9,
+              "v": 0.232
+            },
+            "leftIndex": {
+              "x": 94,
+              "y": 24.7,
+              "v": 0.821
+            },
+            "rightIndex": {
+              "x": 58.8,
+              "y": 39,
+              "v": 0.354
+            },
+            "leftHip": {
+              "x": 72.7,
+              "y": 61.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.8,
+              "y": 63,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 55.4,
+              "y": 82.9,
+              "v": 0.85
+            },
+            "rightKnee": {
+              "x": 65.5,
+              "y": 85.5,
+              "v": 0.631
+            },
+            "leftAnkle": {
+              "x": 47.1,
+              "y": 109.1,
+              "v": 0.917
+            },
+            "rightAnkle": {
+              "x": 60.7,
+              "y": 115.1,
+              "v": 0.919
+            },
+            "leftHeel": {
+              "x": 46.9,
+              "y": 112.4,
+              "v": 0.771
+            },
+            "rightHeel": {
+              "x": 62.1,
+              "y": 120.1,
+              "v": 0.861
+            },
+            "leftFootIndex": {
+              "x": 40.3,
+              "y": 119.2,
+              "v": 0.901
+            },
+            "rightFootIndex": {
+              "x": 51.9,
+              "y": 124.1,
+              "v": 0.899
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.7,
+                "y": 12.1
+              },
+              "roll": 160.9,
+              "yaw": 0.291,
+              "pitch": 1.109
+            },
+            "torso": {
+              "center": {
+                "x": 60.4,
+                "y": 23.8
+              },
+              "angle": 103.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.1,
+                "y": 26.8
+              },
+              "angle": 35.9
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 46.9,
+                "y": 112.4
+              },
+              "angle": -134.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 62.1,
+                "y": 120.1
+              },
+              "angle": -158.6
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.984,
+          "keypoints": {
+            "nose": {
+              "x": 71.6,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.3,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.1,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.2,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.6,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.9,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.3,
+              "y": 25,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.3,
+              "y": 22.4,
+              "v": 0.994
+            },
+            "rightElbow": {
+              "x": 52.2,
+              "y": 39.4,
+              "v": 0.991
+            },
+            "leftWrist": {
+              "x": 97.1,
+              "y": 19.8,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 44.8,
+              "y": 38.6,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 100.9,
+              "y": 18.6,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 41.9,
+              "y": 35.7,
+              "v": 0.993
+            },
+            "leftHip": {
+              "x": 74.5,
+              "y": 60.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.8,
+              "y": 60.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 85.5,
+              "y": 87.6,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 43.7,
+              "y": 85.9,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 101.7,
+              "y": 115.1,
+              "v": 0.977
+            },
+            "rightAnkle": {
+              "x": 23.8,
+              "y": 112.9,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 104.3,
+              "y": 117.7,
+              "v": 0.822
+            },
+            "rightHeel": {
+              "x": 21.5,
+              "y": 116.2,
+              "v": 0.919
+            },
+            "leftFootIndex": {
+              "x": 100.4,
+              "y": 126.3,
+              "v": 0.973
+            },
+            "rightFootIndex": {
+              "x": 21,
+              "y": 125.3,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.2,
+                "y": 11.5
+              },
+              "roll": 162.3,
+              "yaw": 0.606,
+              "pitch": 1.018
+            },
+            "torso": {
+              "center": {
+                "x": 63.6,
+                "y": 24.1
+              },
+              "angle": 95.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.1,
+                "y": 19.8
+              },
+              "angle": 17.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.8,
+                "y": 38.6
+              },
+              "angle": 135
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 104.3,
+                "y": 117.7
+              },
+              "angle": -114.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 21.5,
+                "y": 116.2
+              },
+              "angle": -93.1
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.949,
+          "keypoints": {
+            "nose": {
+              "x": 68.7,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.9,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.9,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.3,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.7,
+              "y": 27.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.5,
+              "y": 22.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.4,
+              "y": 40.8,
+              "v": 0.281
+            },
+            "rightElbow": {
+              "x": 43.9,
+              "y": 36.7,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 80.3,
+              "y": 33,
+              "v": 0.84
+            },
+            "rightWrist": {
+              "x": 36.5,
+              "y": 50,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 82.7,
+              "y": 29.1,
+              "v": 0.878
+            },
+            "rightIndex": {
+              "x": 35.2,
+              "y": 54.9,
+              "v": 0.995
+            },
+            "leftHip": {
+              "x": 63.1,
+              "y": 60.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.1,
+              "y": 56.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 62.3,
+              "y": 87,
+              "v": 0.98
+            },
+            "rightKnee": {
+              "x": 88.8,
+              "y": 45.5,
+              "v": 0.982
+            },
+            "leftAnkle": {
+              "x": 52.6,
+              "y": 114.7,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 80.2,
+              "y": 70.9,
+              "v": 0.967
+            },
+            "leftHeel": {
+              "x": 48.5,
+              "y": 118,
+              "v": 0.995
+            },
+            "rightHeel": {
+              "x": 74.5,
+              "y": 72.1,
+              "v": 0.946
+            },
+            "leftFootIndex": {
+              "x": 60.5,
+              "y": 125.2,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 78.9,
+              "y": 85.1,
+              "v": 0.976
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.4,
+                "y": 11.5
+              },
+              "roll": 153.4,
+              "yaw": 1.163,
+              "pitch": 2.46
+            },
+            "torso": {
+              "center": {
+                "x": 59.1,
+                "y": 24.8
+              },
+              "angle": 94.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.3,
+                "y": 33
+              },
+              "angle": 58.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.5,
+                "y": 50
+              },
+              "angle": -104.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 48.5,
+                "y": 118
+              },
+              "angle": -31
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 74.5,
+                "y": 72.1
+              },
+              "angle": -71.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.966,
+          "keypoints": {
+            "nose": {
+              "x": 72.1,
+              "y": 16,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.2,
+              "y": 13.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.2,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.7,
+              "y": 14.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.6,
+              "y": 13.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.2,
+              "y": 27,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.8,
+              "y": 27.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.1,
+              "y": 44.7,
+              "v": 0.868
+            },
+            "rightElbow": {
+              "x": 50.8,
+              "y": 44.2,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 71.2,
+              "y": 47.3,
+              "v": 0.864
+            },
+            "rightWrist": {
+              "x": 67.3,
+              "y": 47.5,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 72.7,
+              "y": 50,
+              "v": 0.882
+            },
+            "rightIndex": {
+              "x": 72.5,
+              "y": 47.9,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 72.6,
+              "y": 63.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.2,
+              "y": 63,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.9,
+              "y": 87.4,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 43.9,
+              "y": 88.3,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 101.6,
+              "y": 113,
+              "v": 0.978
+            },
+            "rightAnkle": {
+              "x": 26.2,
+              "y": 113.5,
+              "v": 0.991
+            },
+            "leftHeel": {
+              "x": 103.9,
+              "y": 116.9,
+              "v": 0.852
+            },
+            "rightHeel": {
+              "x": 24,
+              "y": 116.2,
+              "v": 0.865
+            },
+            "leftFootIndex": {
+              "x": 101,
+              "y": 125.4,
+              "v": 0.976
+            },
+            "rightFootIndex": {
+              "x": 23.5,
+              "y": 125.6,
+              "v": 0.984
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.2,
+                "y": 13.4
+              },
+              "roll": 166,
+              "yaw": 0.218,
+              "pitch": 0.631
+            },
+            "torso": {
+              "center": {
+                "x": 64.5,
+                "y": 27.1
+              },
+              "angle": 89.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 71.2,
+                "y": 47.3
+              },
+              "angle": -60.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 67.3,
+                "y": 47.5
+              },
+              "angle": -4.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 103.9,
+                "y": 116.9
+              },
+              "angle": -108.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 24,
+                "y": 116.2
+              },
+              "angle": -93
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.999,
+          "keypoints": {
+            "nose": {
+              "x": 66.7,
+              "y": 16.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.4,
+              "y": 13.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.7,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.6,
+              "y": 14.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.9,
+              "y": 14,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 60.5,
+              "y": 30.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.8,
+              "y": 23,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.3,
+              "y": 43.6,
+              "v": 0.982
+            },
+            "rightElbow": {
+              "x": 35.2,
+              "y": 29.5,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 73.5,
+              "y": 34.2,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 18.6,
+              "y": 35.2,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 75.8,
+              "y": 29.1,
+              "v": 0.993
+            },
+            "rightIndex": {
+              "x": 13.7,
+              "y": 38.1,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 48.5,
+              "y": 63.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.1,
+              "y": 59.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 47.1,
+              "y": 90.5,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 80.4,
+              "y": 64.6,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 27,
+              "y": 112.9,
+              "v": 1
+            },
+            "rightAnkle": {
+              "x": 106.5,
+              "y": 78.1,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 21.8,
+              "y": 115.4,
+              "v": 1
+            },
+            "rightHeel": {
+              "x": 107.6,
+              "y": 82.7,
+              "v": 1
+            },
+            "leftFootIndex": {
+              "x": 30.3,
+              "y": 123,
+              "v": 1
+            },
+            "rightFootIndex": {
+              "x": 115.7,
+              "y": 76.7,
+              "v": 1
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.1,
+                "y": 13.8
+              },
+              "roll": 156.8,
+              "yaw": 2.167,
+              "pitch": 3.217
+            },
+            "torso": {
+              "center": {
+                "x": 55.7,
+                "y": 27
+              },
+              "angle": 77.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.5,
+                "y": 34.2
+              },
+              "angle": 65.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 18.6,
+                "y": 35.2
+              },
+              "angle": -149.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 21.8,
+                "y": 115.4
+              },
+              "angle": -41.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 107.6,
+                "y": 82.7
+              },
+              "angle": 36.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 65.6,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.1,
+              "y": 13.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.1,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60.8,
+              "y": 13.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59,
+              "y": 13,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.4,
+              "y": 30.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.3,
+              "y": 22.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 62.8,
+              "y": 42.1,
+              "v": 0.961
+            },
+            "rightElbow": {
+              "x": 34,
+              "y": 28.9,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 73.4,
+              "y": 31.8,
+              "v": 0.977
+            },
+            "rightWrist": {
+              "x": 18.4,
+              "y": 34,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 74.5,
+              "y": 27,
+              "v": 0.973
+            },
+            "rightIndex": {
+              "x": 14.2,
+              "y": 37.3,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 48,
+              "y": 62.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.3,
+              "y": 58.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 47.8,
+              "y": 90.4,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 73.3,
+              "y": 60.8,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 29.2,
+              "y": 113.7,
+              "v": 1
+            },
+            "rightAnkle": {
+              "x": 97.5,
+              "y": 78.3,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 24.4,
+              "y": 115.3,
+              "v": 1
+            },
+            "rightHeel": {
+              "x": 98.5,
+              "y": 85,
+              "v": 1
+            },
+            "leftFootIndex": {
+              "x": 29,
+              "y": 126.8,
+              "v": 1
+            },
+            "rightFootIndex": {
+              "x": 110.7,
+              "y": 73.8,
+              "v": 1
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.6,
+                "y": 13.1
+              },
+              "roll": 153.4,
+              "yaw": 1.789,
+              "pitch": 2.37
+            },
+            "torso": {
+              "center": {
+                "x": 54.9,
+                "y": 26.7
+              },
+              "angle": 75.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.4,
+                "y": 31.8
+              },
+              "angle": 77.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 18.4,
+                "y": 34
+              },
+              "angle": -141.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 24.4,
+                "y": 115.3
+              },
+              "angle": -68.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 98.5,
+                "y": 85
+              },
+              "angle": 42.6
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.954,
+          "keypoints": {
+            "nose": {
+              "x": 77.2,
+              "y": 24.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.7,
+              "y": 22.2,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 75.2,
+              "y": 22.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 76.3,
+              "y": 22.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 70.8,
+              "y": 22.6,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 79.9,
+              "y": 33,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61.8,
+              "y": 34.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.9,
+              "y": 48.5,
+              "v": 0.765
+            },
+            "rightElbow": {
+              "x": 60.7,
+              "y": 51.6,
+              "v": 0.96
+            },
+            "leftWrist": {
+              "x": 77.4,
+              "y": 53.1,
+              "v": 0.806
+            },
+            "rightWrist": {
+              "x": 73.2,
+              "y": 47.6,
+              "v": 0.924
+            },
+            "leftIndex": {
+              "x": 74.7,
+              "y": 52.9,
+              "v": 0.832
+            },
+            "rightIndex": {
+              "x": 77.3,
+              "y": 43.5,
+              "v": 0.877
+            },
+            "leftHip": {
+              "x": 75.2,
+              "y": 68.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.9,
+              "y": 67.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90.4,
+              "y": 91.5,
+              "v": 0.989
+            },
+            "rightKnee": {
+              "x": 52.4,
+              "y": 91.2,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 104.8,
+              "y": 115.7,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 35.4,
+              "y": 113.3,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 105,
+              "y": 119.8,
+              "v": 0.939
+            },
+            "rightHeel": {
+              "x": 33.5,
+              "y": 115.3,
+              "v": 0.9
+            },
+            "leftFootIndex": {
+              "x": 102.9,
+              "y": 125,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 32.5,
+              "y": 124.4,
+              "v": 0.986
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 76.5,
+                "y": 22.2
+              },
+              "roll": 177.7,
+              "yaw": 0.3,
+              "pitch": 0.979
+            },
+            "torso": {
+              "center": {
+                "x": 70.9,
+                "y": 33.9
+              },
+              "angle": 87
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 77.4,
+                "y": 53.1
+              },
+              "angle": 175.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 73.2,
+                "y": 47.6
+              },
+              "angle": 45
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 105,
+                "y": 119.8
+              },
+              "angle": -112
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33.5,
+                "y": 115.3
+              },
+              "angle": -96.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.929,
+          "keypoints": {
+            "nose": {
+              "x": 70.1,
+              "y": 25.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.9,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68,
+              "y": 21.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.8,
+              "y": 25.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.1,
+              "y": 21.6,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 72.7,
+              "y": 34.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.5,
+              "y": 31.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 66.3,
+              "y": 53.7,
+              "v": 0.618
+            },
+            "rightElbow": {
+              "x": 44.8,
+              "y": 46.4,
+              "v": 0.896
+            },
+            "leftWrist": {
+              "x": 51.8,
+              "y": 48.3,
+              "v": 0.569
+            },
+            "rightWrist": {
+              "x": 46.5,
+              "y": 46.3,
+              "v": 0.888
+            },
+            "leftIndex": {
+              "x": 46.6,
+              "y": 43.4,
+              "v": 0.605
+            },
+            "rightIndex": {
+              "x": 47,
+              "y": 44,
+              "v": 0.884
+            },
+            "leftHip": {
+              "x": 68.9,
+              "y": 65.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.5,
+              "y": 66.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 85.5,
+              "y": 76.2,
+              "v": 0.984
+            },
+            "rightKnee": {
+              "x": 48.3,
+              "y": 90.2,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 105.6,
+              "y": 73.1,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 32.4,
+              "y": 112,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 108,
+              "y": 74.1,
+              "v": 0.967
+            },
+            "rightHeel": {
+              "x": 31.2,
+              "y": 113.7,
+              "v": 0.977
+            },
+            "leftFootIndex": {
+              "x": 109,
+              "y": 72.9,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 28.7,
+              "y": 125.4,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.5,
+                "y": 22.7
+              },
+              "roll": 157.8,
+              "yaw": -0.066,
+              "pitch": 0.529
+            },
+            "torso": {
+              "center": {
+                "x": 63.1,
+                "y": 33.2
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 51.8,
+                "y": 48.3
+              },
+              "angle": 136.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 46.5,
+                "y": 46.3
+              },
+              "angle": 77.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 108,
+                "y": 74.1
+              },
+              "angle": 50.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.2,
+                "y": 113.7
+              },
+              "angle": -102.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.989,
+          "keypoints": {
+            "nose": {
+              "x": 44.1,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 43.5,
+              "y": 14.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 41.3,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 41.2,
+              "y": 14.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 37.5,
+              "y": 14.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 48,
+              "y": 25,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 29.4,
+              "y": 28.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 67.1,
+              "y": 29.8,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 20.7,
+              "y": 40.1,
+              "v": 0.991
+            },
+            "leftWrist": {
+              "x": 62.8,
+              "y": 27,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 25.3,
+              "y": 38.8,
+              "v": 0.978
+            },
+            "leftIndex": {
+              "x": 59.3,
+              "y": 22.3,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 26.7,
+              "y": 37.6,
+              "v": 0.951
+            },
+            "leftHip": {
+              "x": 51.5,
+              "y": 57.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 41.2,
+              "y": 63.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 68,
+              "y": 47.6,
+              "v": 0.994
+            },
+            "rightKnee": {
+              "x": 36.1,
+              "y": 88,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 81.5,
+              "y": 38.7,
+              "v": 0.964
+            },
+            "rightAnkle": {
+              "x": 31.1,
+              "y": 115.2,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 83.3,
+              "y": 39.8,
+              "v": 0.925
+            },
+            "rightHeel": {
+              "x": 33.2,
+              "y": 117.1,
+              "v": 0.996
+            },
+            "leftFootIndex": {
+              "x": 84.5,
+              "y": 32.3,
+              "v": 0.966
+            },
+            "rightFootIndex": {
+              "x": 21.6,
+              "y": 119.4,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 42.4,
+                "y": 14
+              },
+              "roll": 172.2,
+              "yaw": 0.766,
+              "pitch": 1.058
+            },
+            "torso": {
+              "center": {
+                "x": 38.7,
+                "y": 26.9
+              },
+              "angle": 102.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 62.8,
+                "y": 27
+              },
+              "angle": 126.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 25.3,
+                "y": 38.8
+              },
+              "angle": 40.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.3,
+                "y": 39.8
+              },
+              "angle": 80.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33.2,
+                "y": 117.1
+              },
+              "angle": -168.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.998,
+          "keypoints": {
+            "nose": {
+              "x": 40.3,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 38.9,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 37.9,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 35.5,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 33.5,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 42.6,
+              "y": 21.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 23.4,
+              "y": 28,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 57.7,
+              "y": 20.4,
+              "v": 0.981
+            },
+            "rightElbow": {
+              "x": 13.3,
+              "y": 41.7,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 70.8,
+              "y": 17.9,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 18.7,
+              "y": 41.7,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 73.9,
+              "y": 16.5,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 23,
+              "y": 41,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 56,
+              "y": 51.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47,
+              "y": 60.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.4,
+              "y": 37.8,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 52.2,
+              "y": 84,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 95.2,
+              "y": 33.5,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 57.5,
+              "y": 117,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 96,
+              "y": 33.8,
+              "v": 0.995
+            },
+            "rightHeel": {
+              "x": 60.9,
+              "y": 121.1,
+              "v": 0.996
+            },
+            "leftFootIndex": {
+              "x": 100.7,
+              "y": 24.1,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 47.7,
+              "y": 126.1,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 38.4,
+                "y": 12.3
+              },
+              "roll": -158.2,
+              "yaw": 1.764,
+              "pitch": 1.95
+            },
+            "torso": {
+              "center": {
+                "x": 33,
+                "y": 24.6
+              },
+              "angle": 120.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 70.8,
+                "y": 17.9
+              },
+              "angle": 24.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 18.7,
+                "y": 41.7
+              },
+              "angle": 9.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 96,
+                "y": 33.8
+              },
+              "angle": 64.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 60.9,
+                "y": 121.1
+              },
+              "angle": -159.3
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.972,
+          "keypoints": {
+            "nose": {
+              "x": 77.3,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.6,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 75,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.7,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 70.9,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78.8,
+              "y": 34.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61.5,
+              "y": 33,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.7,
+              "y": 48.6,
+              "v": 0.954
+            },
+            "rightElbow": {
+              "x": 57.1,
+              "y": 47.1,
+              "v": 0.887
+            },
+            "leftWrist": {
+              "x": 73.9,
+              "y": 52.4,
+              "v": 0.978
+            },
+            "rightWrist": {
+              "x": 50.7,
+              "y": 44.8,
+              "v": 0.923
+            },
+            "leftIndex": {
+              "x": 72.3,
+              "y": 56,
+              "v": 0.976
+            },
+            "rightIndex": {
+              "x": 47.6,
+              "y": 42.5,
+              "v": 0.931
+            },
+            "leftHip": {
+              "x": 75.2,
+              "y": 67.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.9,
+              "y": 65.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90.1,
+              "y": 92.6,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 53.2,
+              "y": 89,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 102.6,
+              "y": 114.2,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 36.3,
+              "y": 111.8,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 98.5,
+              "y": 120,
+              "v": 0.884
+            },
+            "rightHeel": {
+              "x": 33.8,
+              "y": 115.2,
+              "v": 0.89
+            },
+            "leftFootIndex": {
+              "x": 101.8,
+              "y": 124.4,
+              "v": 0.985
+            },
+            "rightFootIndex": {
+              "x": 32.8,
+              "y": 123.4,
+              "v": 0.987
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 76.3,
+                "y": 23
+              },
+              "roll": 173.4,
+              "yaw": 0.382,
+              "pitch": 0.669
+            },
+            "torso": {
+              "center": {
+                "x": 70.2,
+                "y": 33.7
+              },
+              "angle": 88.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.9,
+                "y": 52.4
+              },
+              "angle": -114
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.7,
+                "y": 44.8
+              },
+              "angle": 143.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 98.5,
+                "y": 120
+              },
+              "angle": -53.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33.8,
+                "y": 115.2
+              },
+              "angle": -97
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.956,
+          "keypoints": {
+            "nose": {
+              "x": 69.4,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.9,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.2,
+              "y": 21.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.5,
+              "y": 22.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65,
+              "y": 22.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.3,
+              "y": 33.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.9,
+              "y": 33.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74,
+              "y": 46.2,
+              "v": 0.984
+            },
+            "rightElbow": {
+              "x": 49.2,
+              "y": 42.2,
+              "v": 0.92
+            },
+            "leftWrist": {
+              "x": 64.8,
+              "y": 54.7,
+              "v": 0.976
+            },
+            "rightWrist": {
+              "x": 54.1,
+              "y": 51,
+              "v": 0.815
+            },
+            "leftIndex": {
+              "x": 60.6,
+              "y": 57.1,
+              "v": 0.97
+            },
+            "rightIndex": {
+              "x": 57,
+              "y": 53.9,
+              "v": 0.791
+            },
+            "leftHip": {
+              "x": 68.9,
+              "y": 66.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.2,
+              "y": 64.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.7,
+              "y": 91.3,
+              "v": 0.981
+            },
+            "rightKnee": {
+              "x": 46.8,
+              "y": 89.4,
+              "v": 0.985
+            },
+            "leftAnkle": {
+              "x": 97.8,
+              "y": 115.6,
+              "v": 0.978
+            },
+            "rightAnkle": {
+              "x": 28.4,
+              "y": 113.8,
+              "v": 0.987
+            },
+            "leftHeel": {
+              "x": 99.2,
+              "y": 119.5,
+              "v": 0.822
+            },
+            "rightHeel": {
+              "x": 25.6,
+              "y": 116.5,
+              "v": 0.831
+            },
+            "leftFootIndex": {
+              "x": 98.1,
+              "y": 125.1,
+              "v": 0.972
+            },
+            "rightFootIndex": {
+              "x": 25.7,
+              "y": 125.5,
+              "v": 0.976
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.6,
+                "y": 21.5
+              },
+              "roll": 173.7,
+              "yaw": 0.313,
+              "pitch": 0.791
+            },
+            "torso": {
+              "center": {
+                "x": 64.6,
+                "y": 33.7
+              },
+              "angle": 86.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 64.8,
+                "y": 54.7
+              },
+              "angle": -150.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 54.1,
+                "y": 51
+              },
+              "angle": -45
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 99.2,
+                "y": 119.5
+              },
+              "angle": -101.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25.6,
+                "y": 116.5
+              },
+              "angle": -89.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.9,
+          "keypoints": {
+            "nose": {
+              "x": 67,
+              "y": 25.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.9,
+              "y": 24,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.9,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 66.9,
+              "y": 24.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.1,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 69.6,
+              "y": 33.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.8,
+              "y": 32.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.2,
+              "y": 43.8,
+              "v": 0.618
+            },
+            "rightElbow": {
+              "x": 40.7,
+              "y": 39.8,
+              "v": 0.875
+            },
+            "leftWrist": {
+              "x": 76.5,
+              "y": 48.8,
+              "v": 0.532
+            },
+            "rightWrist": {
+              "x": 44.2,
+              "y": 44.2,
+              "v": 0.927
+            },
+            "leftIndex": {
+              "x": 75.7,
+              "y": 49.5,
+              "v": 0.578
+            },
+            "rightIndex": {
+              "x": 45.7,
+              "y": 44.6,
+              "v": 0.922
+            },
+            "leftHip": {
+              "x": 70.3,
+              "y": 60.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.9,
+              "y": 61.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.2,
+              "y": 85.6,
+              "v": 0.968
+            },
+            "rightKnee": {
+              "x": 51.2,
+              "y": 78,
+              "v": 0.886
+            },
+            "leftAnkle": {
+              "x": 92.4,
+              "y": 109.4,
+              "v": 0.976
+            },
+            "rightAnkle": {
+              "x": 41,
+              "y": 93.5,
+              "v": 0.949
+            },
+            "leftHeel": {
+              "x": 93.4,
+              "y": 112,
+              "v": 0.798
+            },
+            "rightHeel": {
+              "x": 39,
+              "y": 97.2,
+              "v": 0.779
+            },
+            "leftFootIndex": {
+              "x": 95.2,
+              "y": 121.8,
+              "v": 0.961
+            },
+            "rightFootIndex": {
+              "x": 33.2,
+              "y": 105.6,
+              "v": 0.927
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.4,
+                "y": 23.5
+              },
+              "roll": 159.9,
+              "yaw": 0.188,
+              "pitch": 0.61
+            },
+            "torso": {
+              "center": {
+                "x": 60.7,
+                "y": 33.3
+              },
+              "angle": 96.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76.5,
+                "y": 48.8
+              },
+              "angle": -138.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.2,
+                "y": 44.2
+              },
+              "angle": -14.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.4,
+                "y": 112
+              },
+              "angle": -79.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39,
+                "y": 97.2
+              },
+              "angle": -124.6
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.851,
+          "keypoints": {
+            "nose": {
+              "x": 62.5,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63.3,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 60.2,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.3,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.3,
+              "y": 10.7,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 66.4,
+              "y": 22.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42.9,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.4,
+              "y": 25.4,
+              "v": 0.855
+            },
+            "rightElbow": {
+              "x": 33.1,
+              "y": 36.7,
+              "v": 0.936
+            },
+            "leftWrist": {
+              "x": 75,
+              "y": 25.4,
+              "v": 0.868
+            },
+            "rightWrist": {
+              "x": 46,
+              "y": 32.6,
+              "v": 0.812
+            },
+            "leftIndex": {
+              "x": 77.6,
+              "y": 26.3,
+              "v": 0.872
+            },
+            "rightIndex": {
+              "x": 50.7,
+              "y": 30.5,
+              "v": 0.74
+            },
+            "leftHip": {
+              "x": 70.2,
+              "y": 60.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.4,
+              "y": 62.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.3,
+              "y": 87.7,
+              "v": 0.749
+            },
+            "rightKnee": {
+              "x": 35.7,
+              "y": 87.5,
+              "v": 0.77
+            },
+            "leftAnkle": {
+              "x": 94.8,
+              "y": 114.6,
+              "v": 0.752
+            },
+            "rightAnkle": {
+              "x": 16.7,
+              "y": 112.3,
+              "v": 0.869
+            },
+            "leftHeel": {
+              "x": 98,
+              "y": 117.1,
+              "v": 0.288
+            },
+            "rightHeel": {
+              "x": 15.3,
+              "y": 115.8,
+              "v": 0.546
+            },
+            "leftFootIndex": {
+              "x": 93.2,
+              "y": 125.8,
+              "v": 0.705
+            },
+            "rightFootIndex": {
+              "x": 13.1,
+              "y": 124.4,
+              "v": 0.82
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 61.8,
+                "y": 11.6
+              },
+              "roll": 158.8,
+              "yaw": 0.226,
+              "pitch": 0.782
+            },
+            "torso": {
+              "center": {
+                "x": 54.7,
+                "y": 23.4
+              },
+              "angle": 102.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 75,
+                "y": 25.4
+              },
+              "angle": -19.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 46,
+                "y": 32.6
+              },
+              "angle": 24.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 94.8,
+                "y": 114.6
+              },
+              "angle": -98.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 15.3,
+                "y": 115.8
+              },
+              "angle": -104.3
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.742,
+          "keypoints": {
+            "nose": {
+              "x": 55,
+              "y": 16.9,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 54.2,
+              "y": 14.6,
+              "v": 0.997
+            },
+            "rightEye": {
+              "x": 51.9,
+              "y": 14.6,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 51.5,
+              "y": 15.3,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 46.5,
+              "y": 15.3,
+              "v": 0.997
+            },
+            "leftShoulder": {
+              "x": 56.5,
+              "y": 26.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 36.6,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.1,
+              "y": 33.1,
+              "v": 0.557
+            },
+            "rightElbow": {
+              "x": 26.5,
+              "y": 40.8,
+              "v": 0.888
+            },
+            "leftWrist": {
+              "x": 72.6,
+              "y": 32.1,
+              "v": 0.449
+            },
+            "rightWrist": {
+              "x": 40.1,
+              "y": 44.4,
+              "v": 0.848
+            },
+            "leftIndex": {
+              "x": 69.6,
+              "y": 30.5,
+              "v": 0.431
+            },
+            "rightIndex": {
+              "x": 47.2,
+              "y": 45,
+              "v": 0.773
+            },
+            "leftHip": {
+              "x": 57,
+              "y": 61,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.2,
+              "y": 62.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 66.2,
+              "y": 83.9,
+              "v": 0.436
+            },
+            "rightKnee": {
+              "x": 31.9,
+              "y": 82.6,
+              "v": 0.361
+            },
+            "leftAnkle": {
+              "x": 69.8,
+              "y": 115.7,
+              "v": 0.736
+            },
+            "rightAnkle": {
+              "x": 18.8,
+              "y": 109.2,
+              "v": 0.678
+            },
+            "leftHeel": {
+              "x": 69.7,
+              "y": 119.7,
+              "v": 0.385
+            },
+            "rightHeel": {
+              "x": 17.3,
+              "y": 113.4,
+              "v": 0.255
+            },
+            "leftFootIndex": {
+              "x": 72.6,
+              "y": 126.9,
+              "v": 0.687
+            },
+            "rightFootIndex": {
+              "x": 11.3,
+              "y": 122.1,
+              "v": 0.59
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.1,
+                "y": 14.6
+              },
+              "roll": -180,
+              "yaw": 0.848,
+              "pitch": 1
+            },
+            "torso": {
+              "center": {
+                "x": 46.6,
+                "y": 27.5
+              },
+              "angle": 95.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 72.6,
+                "y": 32.1
+              },
+              "angle": 151.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40.1,
+                "y": 44.4
+              },
+              "angle": -4.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.7,
+                "y": 119.7
+              },
+              "angle": -68.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 18.8,
+                "y": 109.2
+              },
+              "angle": -120.2
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.962,
+          "keypoints": {
+            "nose": {
+              "x": 75.4,
+              "y": 26.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 76.6,
+              "y": 23.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.8,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.1,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 69.6,
+              "y": 23.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78,
+              "y": 33.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61,
+              "y": 33.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.4,
+              "y": 47,
+              "v": 0.944
+            },
+            "rightElbow": {
+              "x": 57.7,
+              "y": 48.6,
+              "v": 0.813
+            },
+            "leftWrist": {
+              "x": 65.9,
+              "y": 57.8,
+              "v": 0.949
+            },
+            "rightWrist": {
+              "x": 50,
+              "y": 46.3,
+              "v": 0.946
+            },
+            "leftIndex": {
+              "x": 64,
+              "y": 59.6,
+              "v": 0.936
+            },
+            "rightIndex": {
+              "x": 45.8,
+              "y": 43.2,
+              "v": 0.961
+            },
+            "leftHip": {
+              "x": 72.7,
+              "y": 67.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.5,
+              "y": 65.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 88.8,
+              "y": 92.2,
+              "v": 0.993
+            },
+            "rightKnee": {
+              "x": 52.1,
+              "y": 90.2,
+              "v": 0.992
+            },
+            "leftAnkle": {
+              "x": 102.6,
+              "y": 115.5,
+              "v": 0.98
+            },
+            "rightAnkle": {
+              "x": 38.4,
+              "y": 106.6,
+              "v": 0.985
+            },
+            "leftHeel": {
+              "x": 102.5,
+              "y": 118.5,
+              "v": 0.842
+            },
+            "rightHeel": {
+              "x": 36,
+              "y": 109.7,
+              "v": 0.843
+            },
+            "leftFootIndex": {
+              "x": 102.3,
+              "y": 123.4,
+              "v": 0.971
+            },
+            "rightFootIndex": {
+              "x": 33.3,
+              "y": 116.5,
+              "v": 0.971
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 75.2,
+                "y": 23.7
+              },
+              "roll": 173.9,
+              "yaw": 0.071,
+              "pitch": 1.048
+            },
+            "torso": {
+              "center": {
+                "x": 69.5,
+                "y": 33.7
+              },
+              "angle": 85.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 65.9,
+                "y": 57.8
+              },
+              "angle": -136.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50,
+                "y": 46.3
+              },
+              "angle": 143.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 102.5,
+                "y": 118.5
+              },
+              "angle": -92.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36,
+                "y": 109.7
+              },
+              "angle": -111.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.914,
+          "keypoints": {
+            "nose": {
+              "x": 74.5,
+              "y": 15,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.3,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.1,
+              "y": 13,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.9,
+              "y": 13.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.6,
+              "y": 26.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.8,
+              "y": 26,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.4,
+              "y": 32.9,
+              "v": 0.315
+            },
+            "rightElbow": {
+              "x": 76.7,
+              "y": 30.4,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 94.5,
+              "y": 20.8,
+              "v": 0.485
+            },
+            "rightWrist": {
+              "x": 91.9,
+              "y": 19.5,
+              "v": 0.985
+            },
+            "leftIndex": {
+              "x": 95.4,
+              "y": 16.1,
+              "v": 0.528
+            },
+            "rightIndex": {
+              "x": 93.7,
+              "y": 13,
+              "v": 0.967
+            },
+            "leftHip": {
+              "x": 70.3,
+              "y": 65.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.9,
+              "y": 63.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 97.1,
+              "y": 83.4,
+              "v": 0.94
+            },
+            "rightKnee": {
+              "x": 47.9,
+              "y": 89.2,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 91.8,
+              "y": 113.1,
+              "v": 0.955
+            },
+            "rightAnkle": {
+              "x": 28.4,
+              "y": 114.8,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 87.9,
+              "y": 118.6,
+              "v": 0.936
+            },
+            "rightHeel": {
+              "x": 23.7,
+              "y": 116.8,
+              "v": 0.951
+            },
+            "leftFootIndex": {
+              "x": 103.3,
+              "y": 120.2,
+              "v": 0.966
+            },
+            "rightFootIndex": {
+              "x": 27.9,
+              "y": 126.3,
+              "v": 0.994
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.7,
+                "y": 12.6
+              },
+              "roll": -180,
+              "yaw": 1.423,
+              "pitch": 1.846
+            },
+            "torso": {
+              "center": {
+                "x": 66.2,
+                "y": 26.4
+              },
+              "angle": 86.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.5,
+                "y": 20.8
+              },
+              "angle": 79.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 91.9,
+                "y": 19.5
+              },
+              "angle": 74.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 87.9,
+                "y": 118.6
+              },
+              "angle": -5.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.7,
+                "y": 116.8
+              },
+              "angle": -66.1
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.863,
+          "keypoints": {
+            "nose": {
+              "x": 53.5,
+              "y": 26.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.2,
+              "y": 23.9,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 53.5,
+              "y": 24.1,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 59.9,
+              "y": 23.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.1,
+              "y": 23.3,
+              "v": 0.997
+            },
+            "leftShoulder": {
+              "x": 71.7,
+              "y": 31.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.4,
+              "y": 34.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.6,
+              "y": 43.2,
+              "v": 0.986
+            },
+            "rightElbow": {
+              "x": 60.2,
+              "y": 48.2,
+              "v": 0.337
+            },
+            "leftWrist": {
+              "x": 68.6,
+              "y": 54.3,
+              "v": 0.991
+            },
+            "rightWrist": {
+              "x": 52,
+              "y": 45.4,
+              "v": 0.93
+            },
+            "leftIndex": {
+              "x": 64.6,
+              "y": 57.4,
+              "v": 0.986
+            },
+            "rightIndex": {
+              "x": 48.5,
+              "y": 43.5,
+              "v": 0.962
+            },
+            "leftHip": {
+              "x": 85.2,
+              "y": 62.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 73.3,
+              "y": 64.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90,
+              "y": 88.4,
+              "v": 0.87
+            },
+            "rightKnee": {
+              "x": 59.5,
+              "y": 76.9,
+              "v": 0.749
+            },
+            "leftAnkle": {
+              "x": 102.2,
+              "y": 108,
+              "v": 0.711
+            },
+            "rightAnkle": {
+              "x": 49.4,
+              "y": 95.5,
+              "v": 0.78
+            },
+            "leftHeel": {
+              "x": 102.9,
+              "y": 111.4,
+              "v": 0.356
+            },
+            "rightHeel": {
+              "x": 51.2,
+              "y": 102.3,
+              "v": 0.68
+            },
+            "leftFootIndex": {
+              "x": 102.1,
+              "y": 116.1,
+              "v": 0.706
+            },
+            "rightFootIndex": {
+              "x": 41.6,
+              "y": 102.8,
+              "v": 0.816
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.4,
+                "y": 24
+              },
+              "roll": -173.3,
+              "yaw": -0.497,
+              "pitch": 1.402
+            },
+            "torso": {
+              "center": {
+                "x": 64.1,
+                "y": 32.9
+              },
+              "angle": 116.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 68.6,
+                "y": 54.3
+              },
+              "angle": -142.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52,
+                "y": 45.4
+              },
+              "angle": 151.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 102.9,
+                "y": 111.4
+              },
+              "angle": -99.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 51.2,
+                "y": 102.3
+              },
+              "angle": -177
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.931,
+          "keypoints": {
+            "nose": {
+              "x": 58.5,
+              "y": 18.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 57.7,
+              "y": 16.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.4,
+              "y": 18.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.6,
+              "y": 18.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 54.4,
+              "y": 20.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.5,
+              "y": 28.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54,
+              "y": 34.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.5,
+              "y": 19.2,
+              "v": 0.936
+            },
+            "rightElbow": {
+              "x": 35.4,
+              "y": 26.2,
+              "v": 0.989
+            },
+            "leftWrist": {
+              "x": 76.1,
+              "y": 5.8,
+              "v": 0.97
+            },
+            "rightWrist": {
+              "x": 43.1,
+              "y": 11.4,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 70.5,
+              "y": 3.7,
+              "v": 0.954
+            },
+            "rightIndex": {
+              "x": 46.8,
+              "y": 7.6,
+              "v": 0.962
+            },
+            "leftHip": {
+              "x": 78,
+              "y": 69.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63,
+              "y": 68.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 99.6,
+              "y": 87.3,
+              "v": 0.783
+            },
+            "rightKnee": {
+              "x": 48.2,
+              "y": 92.3,
+              "v": 0.944
+            },
+            "leftAnkle": {
+              "x": 89.3,
+              "y": 114,
+              "v": 0.861
+            },
+            "rightAnkle": {
+              "x": 31.8,
+              "y": 113.7,
+              "v": 0.902
+            },
+            "leftHeel": {
+              "x": 86.4,
+              "y": 117.9,
+              "v": 0.826
+            },
+            "rightHeel": {
+              "x": 29.1,
+              "y": 115.4,
+              "v": 0.56
+            },
+            "leftFootIndex": {
+              "x": 100.7,
+              "y": 121.1,
+              "v": 0.879
+            },
+            "rightFootIndex": {
+              "x": 29.5,
+              "y": 125.7,
+              "v": 0.867
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.6,
+                "y": 17.5
+              },
+              "roll": -150.5,
+              "yaw": 0.738,
+              "pitch": 0.208
+            },
+            "torso": {
+              "center": {
+                "x": 62.8,
+                "y": 31.5
+              },
+              "angle": 101.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76.1,
+                "y": 5.8
+              },
+              "angle": 159.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.1,
+                "y": 11.4
+              },
+              "angle": 45.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 86.4,
+                "y": 117.9
+              },
+              "angle": -12.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29.1,
+                "y": 115.4
+              },
+              "angle": -87.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.901,
+          "keypoints": {
+            "nose": {
+              "x": 72.7,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.7,
+              "y": 10.1,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 70.1,
+              "y": 9.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.9,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.9,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.4,
+              "y": 24.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.7,
+              "y": 25.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.1,
+              "y": 42.9,
+              "v": 0.795
+            },
+            "rightElbow": {
+              "x": 52.3,
+              "y": 40.5,
+              "v": 0.839
+            },
+            "leftWrist": {
+              "x": 64.4,
+              "y": 38.5,
+              "v": 0.62
+            },
+            "rightWrist": {
+              "x": 55.5,
+              "y": 36.8,
+              "v": 0.896
+            },
+            "leftIndex": {
+              "x": 59.7,
+              "y": 34.7,
+              "v": 0.57
+            },
+            "rightIndex": {
+              "x": 57,
+              "y": 33.9,
+              "v": 0.893
+            },
+            "leftHip": {
+              "x": 75.9,
+              "y": 64.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.8,
+              "y": 63.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86.7,
+              "y": 88.6,
+              "v": 0.958
+            },
+            "rightKnee": {
+              "x": 43.7,
+              "y": 87.4,
+              "v": 0.951
+            },
+            "leftAnkle": {
+              "x": 102.4,
+              "y": 114,
+              "v": 0.949
+            },
+            "rightAnkle": {
+              "x": 25.8,
+              "y": 111.7,
+              "v": 0.965
+            },
+            "leftHeel": {
+              "x": 105.1,
+              "y": 116.9,
+              "v": 0.635
+            },
+            "rightHeel": {
+              "x": 25,
+              "y": 113.7,
+              "v": 0.794
+            },
+            "leftFootIndex": {
+              "x": 102,
+              "y": 125.3,
+              "v": 0.927
+            },
+            "rightFootIndex": {
+              "x": 22.1,
+              "y": 123.2,
+              "v": 0.946
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.4,
+                "y": 9.9
+              },
+              "roll": 171.3,
+              "yaw": 0.494,
+              "pitch": 1.102
+            },
+            "torso": {
+              "center": {
+                "x": 66.1,
+                "y": 25.1
+              },
+              "angle": 93.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 64.4,
+                "y": 38.5
+              },
+              "angle": 141
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 55.5,
+                "y": 36.8
+              },
+              "angle": 62.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 105.1,
+                "y": 116.9
+              },
+              "angle": -110.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25,
+                "y": 113.7
+              },
+              "angle": -107
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.979,
+          "keypoints": {
+            "nose": {
+              "x": 76.8,
+              "y": 26.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.7,
+              "y": 24,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 74.9,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.9,
+              "y": 24.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 70.7,
+              "y": 23.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.1,
+              "y": 34,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61.4,
+              "y": 35.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.4,
+              "y": 50.9,
+              "v": 0.946
+            },
+            "rightElbow": {
+              "x": 58.7,
+              "y": 51.5,
+              "v": 0.967
+            },
+            "leftWrist": {
+              "x": 67.2,
+              "y": 56.2,
+              "v": 0.98
+            },
+            "rightWrist": {
+              "x": 51.1,
+              "y": 47,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 64.2,
+              "y": 58.8,
+              "v": 0.978
+            },
+            "rightIndex": {
+              "x": 47.9,
+              "y": 43.3,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 75,
+              "y": 67.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.7,
+              "y": 66.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90.1,
+              "y": 90.8,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 53.1,
+              "y": 89.7,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 103.7,
+              "y": 115,
+              "v": 0.978
+            },
+            "rightAnkle": {
+              "x": 35.3,
+              "y": 113.6,
+              "v": 0.991
+            },
+            "leftHeel": {
+              "x": 103.9,
+              "y": 118.7,
+              "v": 0.893
+            },
+            "rightHeel": {
+              "x": 33,
+              "y": 115.4,
+              "v": 0.864
+            },
+            "leftFootIndex": {
+              "x": 103.5,
+              "y": 123.9,
+              "v": 0.978
+            },
+            "rightFootIndex": {
+              "x": 32.3,
+              "y": 124.2,
+              "v": 0.984
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 76.3,
+                "y": 23.8
+              },
+              "roll": 171.9,
+              "yaw": 0.177,
+              "pitch": 0.919
+            },
+            "torso": {
+              "center": {
+                "x": 70.3,
+                "y": 34.9
+              },
+              "angle": 87.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 67.2,
+                "y": 56.2
+              },
+              "angle": -139.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 51.1,
+                "y": 47
+              },
+              "angle": 130.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 103.9,
+                "y": 118.7
+              },
+              "angle": -94.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33,
+                "y": 115.4
+              },
+              "angle": -94.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.964,
+          "keypoints": {
+            "nose": {
+              "x": 78.2,
+              "y": 24.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.3,
+              "y": 22.2,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 76.2,
+              "y": 22.2,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 74,
+              "y": 22.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 72,
+              "y": 22.4,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 78.6,
+              "y": 33.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61.5,
+              "y": 34.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.6,
+              "y": 44.5,
+              "v": 0.976
+            },
+            "rightElbow": {
+              "x": 60.6,
+              "y": 48.2,
+              "v": 0.879
+            },
+            "leftWrist": {
+              "x": 67.7,
+              "y": 55,
+              "v": 0.977
+            },
+            "rightWrist": {
+              "x": 64.6,
+              "y": 51.2,
+              "v": 0.792
+            },
+            "leftIndex": {
+              "x": 65,
+              "y": 58.2,
+              "v": 0.971
+            },
+            "rightIndex": {
+              "x": 65.8,
+              "y": 50.2,
+              "v": 0.784
+            },
+            "leftHip": {
+              "x": 74.1,
+              "y": 68.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.4,
+              "y": 65.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 88,
+              "y": 91.5,
+              "v": 0.994
+            },
+            "rightKnee": {
+              "x": 52.4,
+              "y": 90.6,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 85.7,
+              "y": 115.3,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 35.2,
+              "y": 113.2,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 85.1,
+              "y": 118,
+              "v": 0.928
+            },
+            "rightHeel": {
+              "x": 32.3,
+              "y": 115.1,
+              "v": 0.92
+            },
+            "leftFootIndex": {
+              "x": 84.8,
+              "y": 124.7,
+              "v": 0.985
+            },
+            "rightFootIndex": {
+              "x": 32.4,
+              "y": 124.3,
+              "v": 0.991
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 76.8,
+                "y": 22.2
+              },
+              "roll": -180,
+              "yaw": 1.318,
+              "pitch": 2.182
+            },
+            "torso": {
+              "center": {
+                "x": 70.1,
+                "y": 33.8
+              },
+              "angle": 86.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 67.7,
+                "y": 55
+              },
+              "angle": -130.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 64.6,
+                "y": 51.2
+              },
+              "angle": 39.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85.1,
+                "y": 118
+              },
+              "angle": -92.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.3,
+                "y": 115.1
+              },
+              "angle": -89.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.941,
+          "keypoints": {
+            "nose": {
+              "x": 71.3,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.7,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.9,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.3,
+              "y": 12.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.1,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.5,
+              "y": 22.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54,
+              "y": 24.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 65.7,
+              "y": 37.7,
+              "v": 0.982
+            },
+            "rightElbow": {
+              "x": 49.9,
+              "y": 43.4,
+              "v": 0.975
+            },
+            "leftWrist": {
+              "x": 59.3,
+              "y": 51.2,
+              "v": 0.974
+            },
+            "rightWrist": {
+              "x": 40,
+              "y": 59.9,
+              "v": 0.971
+            },
+            "leftIndex": {
+              "x": 54.4,
+              "y": 55.8,
+              "v": 0.959
+            },
+            "rightIndex": {
+              "x": 36.4,
+              "y": 64.9,
+              "v": 0.956
+            },
+            "leftHip": {
+              "x": 73.4,
+              "y": 59.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.6,
+              "y": 60.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86,
+              "y": 88.2,
+              "v": 0.978
+            },
+            "rightKnee": {
+              "x": 44.4,
+              "y": 85.6,
+              "v": 0.969
+            },
+            "leftAnkle": {
+              "x": 102.5,
+              "y": 114.3,
+              "v": 0.905
+            },
+            "rightAnkle": {
+              "x": 26,
+              "y": 110.2,
+              "v": 0.956
+            },
+            "leftHeel": {
+              "x": 104.8,
+              "y": 117.6,
+              "v": 0.485
+            },
+            "rightHeel": {
+              "x": 25.1,
+              "y": 112.9,
+              "v": 0.703
+            },
+            "leftFootIndex": {
+              "x": 100.2,
+              "y": 122.7,
+              "v": 0.9
+            },
+            "rightFootIndex": {
+              "x": 21.8,
+              "y": 114.8,
+              "v": 0.941
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.3,
+                "y": 11.8
+              },
+              "roll": 167.9,
+              "yaw": 0.349,
+              "pitch": 0.838
+            },
+            "torso": {
+              "center": {
+                "x": 63.8,
+                "y": 23.9
+              },
+              "angle": 94.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 59.3,
+                "y": 51.2
+              },
+              "angle": -136.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40,
+                "y": 59.9
+              },
+              "angle": -125.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 104.8,
+                "y": 117.6
+              },
+              "angle": -132
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25.1,
+                "y": 112.9
+              },
+              "angle": -150.1
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.959,
+          "keypoints": {
+            "nose": {
+              "x": 67.7,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.6,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.7,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.9,
+              "y": 13,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.3,
+              "y": 28.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.5,
+              "y": 26.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.7,
+              "y": 47.3,
+              "v": 0.441
+            },
+            "rightElbow": {
+              "x": 44.8,
+              "y": 46.5,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 92.1,
+              "y": 55.6,
+              "v": 0.816
+            },
+            "rightWrist": {
+              "x": 38.3,
+              "y": 64.7,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 97.7,
+              "y": 55.9,
+              "v": 0.852
+            },
+            "rightIndex": {
+              "x": 35.4,
+              "y": 70.1,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 66.6,
+              "y": 63.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.6,
+              "y": 63.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95.5,
+              "y": 74.6,
+              "v": 0.979
+            },
+            "rightKnee": {
+              "x": 95.4,
+              "y": 66.4,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 82.9,
+              "y": 109.5,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 79.1,
+              "y": 92.9,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 77.9,
+              "y": 112.6,
+              "v": 0.99
+            },
+            "rightHeel": {
+              "x": 74.3,
+              "y": 93.2,
+              "v": 0.99
+            },
+            "leftFootIndex": {
+              "x": 86.6,
+              "y": 123.6,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 80.1,
+              "y": 106.4,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.7,
+                "y": 12.1
+              },
+              "roll": 171,
+              "yaw": 1.066,
+              "pitch": 1.222
+            },
+            "torso": {
+              "center": {
+                "x": 59.4,
+                "y": 27.8
+              },
+              "angle": 95.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92.1,
+                "y": 55.6
+              },
+              "angle": -3.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.3,
+                "y": 64.7
+              },
+              "angle": -118.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 77.9,
+                "y": 112.6
+              },
+              "angle": -51.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 74.3,
+                "y": 93.2
+              },
+              "angle": -66.3
+            }
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.969,
+          "keypoints": {
+            "nose": {
+              "x": 77.2,
+              "y": 25.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 76.8,
+              "y": 23.5,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 75.2,
+              "y": 23.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.2,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 70.9,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78.6,
+              "y": 31.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.5,
+              "y": 34.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 89.2,
+              "y": 22.1,
+              "v": 0.983
+            },
+            "rightElbow": {
+              "x": 57.7,
+              "y": 49.1,
+              "v": 0.867
+            },
+            "leftWrist": {
+              "x": 96,
+              "y": 8.6,
+              "v": 0.992
+            },
+            "rightWrist": {
+              "x": 50.5,
+              "y": 46.3,
+              "v": 0.921
+            },
+            "leftIndex": {
+              "x": 96.2,
+              "y": 3.8,
+              "v": 0.99
+            },
+            "rightIndex": {
+              "x": 47.3,
+              "y": 42.6,
+              "v": 0.925
+            },
+            "leftHip": {
+              "x": 80.3,
+              "y": 67.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 67.3,
+              "y": 67.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90.4,
+              "y": 92.8,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 52,
+              "y": 90.9,
+              "v": 0.973
+            },
+            "leftAnkle": {
+              "x": 104.3,
+              "y": 116.4,
+              "v": 0.986
+            },
+            "rightAnkle": {
+              "x": 36.2,
+              "y": 112,
+              "v": 0.98
+            },
+            "leftHeel": {
+              "x": 106.2,
+              "y": 119.2,
+              "v": 0.862
+            },
+            "rightHeel": {
+              "x": 35.6,
+              "y": 114.8,
+              "v": 0.882
+            },
+            "leftFootIndex": {
+              "x": 103.5,
+              "y": 125.4,
+              "v": 0.973
+            },
+            "rightFootIndex": {
+              "x": 32,
+              "y": 123.9,
+              "v": 0.962
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 76,
+                "y": 23.4
+              },
+              "roll": 169.4,
+              "yaw": 0.737,
+              "pitch": 1.198
+            },
+            "torso": {
+              "center": {
+                "x": 69.6,
+                "y": 33.2
+              },
+              "angle": 97.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96,
+                "y": 8.6
+              },
+              "angle": 87.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.5,
+                "y": 46.3
+              },
+              "angle": 130.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 106.2,
+                "y": 119.2
+              },
+              "angle": -113.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.6,
+                "y": 114.8
+              },
+              "angle": -111.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.661,
+          "keypoints": {
+            "nose": {
+              "x": 59.5,
+              "y": 46,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 57.3,
+              "y": 44.2,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 56.7,
+              "y": 48.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.1,
+              "y": 43.8,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 54.2,
+              "y": 50.8,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 64.1,
+              "y": 35.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63.5,
+              "y": 69.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.9,
+              "y": 24.6,
+              "v": 0.132
+            },
+            "rightElbow": {
+              "x": 87.6,
+              "y": 91.8,
+              "v": 0.084
+            },
+            "leftWrist": {
+              "x": 95,
+              "y": 11.7,
+              "v": 0.404
+            },
+            "rightWrist": {
+              "x": 100.6,
+              "y": 104.5,
+              "v": 0.405
+            },
+            "leftIndex": {
+              "x": 96.8,
+              "y": 6.5,
+              "v": 0.497
+            },
+            "rightIndex": {
+              "x": 103.4,
+              "y": 109.8,
+              "v": 0.528
+            },
+            "leftHip": {
+              "x": 104.3,
+              "y": 49.8,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 103.5,
+              "y": 69.6,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 60.6,
+              "y": 48.9,
+              "v": 0.641
+            },
+            "rightKnee": {
+              "x": 61.7,
+              "y": 79,
+              "v": 0.38
+            },
+            "leftAnkle": {
+              "x": 55.1,
+              "y": 88.4,
+              "v": 0.495
+            },
+            "rightAnkle": {
+              "x": 76.8,
+              "y": 62.9,
+              "v": 0.204
+            },
+            "leftHeel": {
+              "x": 53.6,
+              "y": 99.6,
+              "v": 0.749
+            },
+            "rightHeel": {
+              "x": 83.6,
+              "y": 59.4,
+              "v": 0.546
+            },
+            "leftFootIndex": {
+              "x": 33.8,
+              "y": 114.4,
+              "v": 0.746
+            },
+            "rightFootIndex": {
+              "x": 65.9,
+              "y": 62.3,
+              "v": 0.397
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57,
+                "y": 46.3
+              },
+              "roll": -98.3,
+              "yaw": 0.603,
+              "pitch": -0.06
+            },
+            "torso": {
+              "center": {
+                "x": 63.8,
+                "y": 52.7
+              },
+              "angle": 170
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95,
+                "y": 11.7
+              },
+              "angle": 70.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 100.6,
+                "y": 104.5
+              },
+              "angle": -62.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 53.6,
+                "y": 99.6
+              },
+              "angle": -143.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 83.6,
+                "y": 59.4
+              },
+              "angle": -170.7
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.965,
+          "keypoints": {
+            "nose": {
+              "x": 76,
+              "y": 21.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.6,
+              "y": 20.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.5,
+              "y": 20.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.6,
+              "y": 21.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 69.6,
+              "y": 22.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75,
+              "y": 32.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 64,
+              "y": 35.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.4,
+              "y": 20.6,
+              "v": 0.925
+            },
+            "rightElbow": {
+              "x": 61.5,
+              "y": 43.2,
+              "v": 0.946
+            },
+            "leftWrist": {
+              "x": 88.9,
+              "y": 8.5,
+              "v": 0.973
+            },
+            "rightWrist": {
+              "x": 69.1,
+              "y": 46.8,
+              "v": 0.756
+            },
+            "leftIndex": {
+              "x": 89,
+              "y": 4.4,
+              "v": 0.976
+            },
+            "rightIndex": {
+              "x": 72.1,
+              "y": 46.5,
+              "v": 0.772
+            },
+            "leftHip": {
+              "x": 73.8,
+              "y": 68.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.5,
+              "y": 68.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 88.6,
+              "y": 89.6,
+              "v": 0.979
+            },
+            "rightKnee": {
+              "x": 49.5,
+              "y": 92.4,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 100.2,
+              "y": 112.8,
+              "v": 0.987
+            },
+            "rightAnkle": {
+              "x": 33.6,
+              "y": 115.5,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 95.4,
+              "y": 118.2,
+              "v": 0.954
+            },
+            "rightHeel": {
+              "x": 30.4,
+              "y": 118.3,
+              "v": 0.962
+            },
+            "leftFootIndex": {
+              "x": 103.1,
+              "y": 122.2,
+              "v": 0.981
+            },
+            "rightFootIndex": {
+              "x": 32.3,
+              "y": 125.8,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.1,
+                "y": 20.6
+              },
+              "roll": -174.8,
+              "yaw": 1.765,
+              "pitch": 1.132
+            },
+            "torso": {
+              "center": {
+                "x": 69.5,
+                "y": 33.8
+              },
+              "angle": 87.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.9,
+                "y": 8.5
+              },
+              "angle": 88.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 69.1,
+                "y": 46.8
+              },
+              "angle": 5.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 95.4,
+                "y": 118.2
+              },
+              "angle": -27.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.4,
+                "y": 118.3
+              },
+              "angle": -75.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.988,
+          "keypoints": {
+            "nose": {
+              "x": 78.3,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 78.3,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 75.9,
+              "y": 21.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.9,
+              "y": 22.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 71.3,
+              "y": 22,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.8,
+              "y": 32.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.7,
+              "y": 33.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 90.6,
+              "y": 41.2,
+              "v": 0.949
+            },
+            "rightElbow": {
+              "x": 58,
+              "y": 47.8,
+              "v": 0.989
+            },
+            "leftWrist": {
+              "x": 99.7,
+              "y": 31.7,
+              "v": 0.992
+            },
+            "rightWrist": {
+              "x": 71,
+              "y": 43.2,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 101.2,
+              "y": 26.4,
+              "v": 0.99
+            },
+            "rightIndex": {
+              "x": 75.2,
+              "y": 39.4,
+              "v": 0.974
+            },
+            "leftHip": {
+              "x": 78.9,
+              "y": 67,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.2,
+              "y": 65.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90.6,
+              "y": 92.5,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 52.9,
+              "y": 90.1,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 103,
+              "y": 113.6,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 36.5,
+              "y": 113.2,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 100.2,
+              "y": 119.1,
+              "v": 0.947
+            },
+            "rightHeel": {
+              "x": 34.8,
+              "y": 116,
+              "v": 0.941
+            },
+            "leftFootIndex": {
+              "x": 104.1,
+              "y": 125.1,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 33.1,
+              "y": 124.9,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 77.1,
+                "y": 21.8
+              },
+              "roll": -175.2,
+              "yaw": 0.498,
+              "pitch": 0.747
+            },
+            "torso": {
+              "center": {
+                "x": 70.3,
+                "y": 33.1
+              },
+              "angle": 94
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 99.7,
+                "y": 31.7
+              },
+              "angle": 74.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 71,
+                "y": 43.2
+              },
+              "angle": 42.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 100.2,
+                "y": 119.1
+              },
+              "angle": -57
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 34.8,
+                "y": 116
+              },
+              "angle": -100.8
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.74,
+          "keypoints": {
+            "nose": {
+              "x": 75,
+              "y": 24,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.6,
+              "y": 22.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.8,
+              "y": 21.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.3,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 71.4,
+              "y": 22.5,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 77.5,
+              "y": 32.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63.1,
+              "y": 30.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.4,
+              "y": 44.6,
+              "v": 0.978
+            },
+            "rightElbow": {
+              "x": 57.1,
+              "y": 42,
+              "v": 0.208
+            },
+            "leftWrist": {
+              "x": 66.7,
+              "y": 56.4,
+              "v": 0.987
+            },
+            "rightWrist": {
+              "x": 49.8,
+              "y": 44,
+              "v": 0.633
+            },
+            "leftIndex": {
+              "x": 63.5,
+              "y": 59.9,
+              "v": 0.978
+            },
+            "rightIndex": {
+              "x": 45.9,
+              "y": 43.1,
+              "v": 0.719
+            },
+            "leftHip": {
+              "x": 65.6,
+              "y": 57.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.4,
+              "y": 53.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63.7,
+              "y": 71.8,
+              "v": 0.647
+            },
+            "rightKnee": {
+              "x": 43.2,
+              "y": 63.1,
+              "v": 0.365
+            },
+            "leftAnkle": {
+              "x": 48.1,
+              "y": 91.9,
+              "v": 0.511
+            },
+            "rightAnkle": {
+              "x": 33.5,
+              "y": 87.4,
+              "v": 0.417
+            },
+            "leftHeel": {
+              "x": 45.8,
+              "y": 94.4,
+              "v": 0.319
+            },
+            "rightHeel": {
+              "x": 34,
+              "y": 91.8,
+              "v": 0.346
+            },
+            "leftFootIndex": {
+              "x": 41.5,
+              "y": 98.7,
+              "v": 0.5
+            },
+            "rightFootIndex": {
+              "x": 25.5,
+              "y": 93.5,
+              "v": 0.413
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.2,
+                "y": 21.9
+              },
+              "roll": 167.9,
+              "yaw": 0.279,
+              "pitch": 0.733
+            },
+            "torso": {
+              "center": {
+                "x": 70.3,
+                "y": 31.5
+              },
+              "angle": 68.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 66.7,
+                "y": 56.4
+              },
+              "angle": -132.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 49.8,
+                "y": 44
+              },
+              "angle": 167
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 45.8,
+                "y": 94.4
+              },
+              "angle": -135
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 34,
+                "y": 91.8
+              },
+              "angle": -168.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.949,
+          "keypoints": {
+            "nose": {
+              "x": 76.7,
+              "y": 26.8,
+              "v": 0.998
+            },
+            "leftEye": {
+              "x": 76.1,
+              "y": 24.9,
+              "v": 0.997
+            },
+            "rightEye": {
+              "x": 74.8,
+              "y": 24.9,
+              "v": 0.997
+            },
+            "leftEar": {
+              "x": 73.8,
+              "y": 25.2,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 71.2,
+              "y": 24.7,
+              "v": 0.994
+            },
+            "leftShoulder": {
+              "x": 77,
+              "y": 34.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61.8,
+              "y": 33.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 69.7,
+              "y": 47.9,
+              "v": 0.99
+            },
+            "rightElbow": {
+              "x": 56.6,
+              "y": 46.4,
+              "v": 0.49
+            },
+            "leftWrist": {
+              "x": 66.2,
+              "y": 57.8,
+              "v": 0.99
+            },
+            "rightWrist": {
+              "x": 52.2,
+              "y": 47.3,
+              "v": 0.883
+            },
+            "leftIndex": {
+              "x": 63.4,
+              "y": 60.3,
+              "v": 0.985
+            },
+            "rightIndex": {
+              "x": 52.2,
+              "y": 47.3,
+              "v": 0.923
+            },
+            "leftHip": {
+              "x": 64.3,
+              "y": 62.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.4,
+              "y": 58.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60,
+              "y": 83.7,
+              "v": 0.987
+            },
+            "rightKnee": {
+              "x": 45.2,
+              "y": 73,
+              "v": 0.946
+            },
+            "leftAnkle": {
+              "x": 51,
+              "y": 103.3,
+              "v": 0.979
+            },
+            "rightAnkle": {
+              "x": 33.1,
+              "y": 96,
+              "v": 0.985
+            },
+            "leftHeel": {
+              "x": 49.5,
+              "y": 105.2,
+              "v": 0.84
+            },
+            "rightHeel": {
+              "x": 33.1,
+              "y": 100.4,
+              "v": 0.91
+            },
+            "leftFootIndex": {
+              "x": 46.5,
+              "y": 112.4,
+              "v": 0.967
+            },
+            "rightFootIndex": {
+              "x": 24.2,
+              "y": 102.3,
+              "v": 0.975
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 75.4,
+                "y": 24.9
+              },
+              "roll": -180,
+              "yaw": 0.962,
+              "pitch": 1.462
+            },
+            "torso": {
+              "center": {
+                "x": 69.4,
+                "y": 34.1
+              },
+              "angle": 70
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 66.2,
+                "y": 57.8
+              },
+              "angle": -138.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52.2,
+                "y": 47.3
+              },
+              "angle": 0
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 49.5,
+                "y": 105.2
+              },
+              "angle": -112.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33.1,
+                "y": 100.4
+              },
+              "angle": -167.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.811,
+          "keypoints": {
+            "nose": {
+              "x": 86,
+              "y": 71.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 86,
+              "y": 68.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 85.6,
+              "y": 68.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 82.7,
+              "y": 67.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 81.8,
+              "y": 67.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.7,
+              "y": 76.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 71.6,
+              "y": 74.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.5,
+              "y": 92.8,
+              "v": 0.13
+            },
+            "rightElbow": {
+              "x": 74.3,
+              "y": 91.8,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 79.3,
+              "y": 108.1,
+              "v": 0.297
+            },
+            "rightWrist": {
+              "x": 77.2,
+              "y": 109,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 79.9,
+              "y": 112.9,
+              "v": 0.413
+            },
+            "rightIndex": {
+              "x": 79.4,
+              "y": 113.6,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 54.3,
+              "y": 99.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.1,
+              "y": 98.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.5,
+              "y": 110.7,
+              "v": 0.271
+            },
+            "rightKnee": {
+              "x": 68,
+              "y": 118.5,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 58,
+              "y": 114.4,
+              "v": 0.46
+            },
+            "rightAnkle": {
+              "x": 39.2,
+              "y": 118.3,
+              "v": 0.991
+            },
+            "leftHeel": {
+              "x": 55.4,
+              "y": 113.6,
+              "v": 0.559
+            },
+            "rightHeel": {
+              "x": 34.6,
+              "y": 115.4,
+              "v": 0.954
+            },
+            "leftFootIndex": {
+              "x": 53.8,
+              "y": 118.5,
+              "v": 0.601
+            },
+            "rightFootIndex": {
+              "x": 27.5,
+              "y": 123,
+              "v": 0.985
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 85.8,
+                "y": 68.5
+              },
+              "roll": 153.4,
+              "yaw": 0.447,
+              "pitch": 6.932
+            },
+            "torso": {
+              "center": {
+                "x": 73.2,
+                "y": 75.5
+              },
+              "angle": 47
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 77.2,
+                "y": 109
+              },
+              "angle": -64.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 55.4,
+                "y": 113.6
+              },
+              "angle": -108.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 34.6,
+                "y": 115.4
+              },
+              "angle": -133.1
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.907,
+          "keypoints": {
+            "nose": {
+              "x": 75.4,
+              "y": 24.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.1,
+              "y": 21.9,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 72.8,
+              "y": 21.4,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 76.7,
+              "y": 23.1,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 70.1,
+              "y": 21.7,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 80.4,
+              "y": 33.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.5,
+              "y": 32.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.1,
+              "y": 48.9,
+              "v": 0.788
+            },
+            "rightElbow": {
+              "x": 53.9,
+              "y": 47.2,
+              "v": 0.833
+            },
+            "leftWrist": {
+              "x": 67.2,
+              "y": 56.6,
+              "v": 0.798
+            },
+            "rightWrist": {
+              "x": 59.6,
+              "y": 53.6,
+              "v": 0.772
+            },
+            "leftIndex": {
+              "x": 65.4,
+              "y": 57.2,
+              "v": 0.815
+            },
+            "rightIndex": {
+              "x": 61.9,
+              "y": 55.8,
+              "v": 0.763
+            },
+            "leftHip": {
+              "x": 80.2,
+              "y": 68.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.6,
+              "y": 67.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90,
+              "y": 92.8,
+              "v": 0.94
+            },
+            "rightKnee": {
+              "x": 53.7,
+              "y": 87.7,
+              "v": 0.946
+            },
+            "leftAnkle": {
+              "x": 98.3,
+              "y": 110.2,
+              "v": 0.954
+            },
+            "rightAnkle": {
+              "x": 36.6,
+              "y": 110.5,
+              "v": 0.967
+            },
+            "leftHeel": {
+              "x": 93.4,
+              "y": 117.6,
+              "v": 0.686
+            },
+            "rightHeel": {
+              "x": 37.3,
+              "y": 113.5,
+              "v": 0.738
+            },
+            "leftFootIndex": {
+              "x": 90.9,
+              "y": 128,
+              "v": 0.932
+            },
+            "rightFootIndex": {
+              "x": 32.3,
+              "y": 121.6,
+              "v": 0.943
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.9,
+                "y": 21.7
+              },
+              "roll": 173.4,
+              "yaw": 0.104,
+              "pitch": 0.612
+            },
+            "torso": {
+              "center": {
+                "x": 70.5,
+                "y": 33.1
+              },
+              "angle": 94.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 67.2,
+                "y": 56.6
+              },
+              "angle": -161.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 59.6,
+                "y": 53.6
+              },
+              "angle": -43.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.4,
+                "y": 117.6
+              },
+              "angle": -103.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.3,
+                "y": 113.5
+              },
+              "angle": -121.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.914,
+          "keypoints": {
+            "nose": {
+              "x": 78,
+              "y": 25.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.2,
+              "y": 23.1,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 75.9,
+              "y": 23,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.7,
+              "y": 23.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 72.1,
+              "y": 23.1,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 78.4,
+              "y": 33.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61.5,
+              "y": 32.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.6,
+              "y": 44.7,
+              "v": 0.977
+            },
+            "rightElbow": {
+              "x": 57.7,
+              "y": 46,
+              "v": 0.783
+            },
+            "leftWrist": {
+              "x": 67.3,
+              "y": 56.3,
+              "v": 0.959
+            },
+            "rightWrist": {
+              "x": 50.9,
+              "y": 46,
+              "v": 0.829
+            },
+            "leftIndex": {
+              "x": 64.2,
+              "y": 59.3,
+              "v": 0.923
+            },
+            "rightIndex": {
+              "x": 48.4,
+              "y": 44,
+              "v": 0.837
+            },
+            "leftHip": {
+              "x": 73.6,
+              "y": 67.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.1,
+              "y": 65.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 89.1,
+              "y": 91.4,
+              "v": 0.963
+            },
+            "rightKnee": {
+              "x": 52.8,
+              "y": 89.9,
+              "v": 0.961
+            },
+            "leftAnkle": {
+              "x": 102.6,
+              "y": 116,
+              "v": 0.865
+            },
+            "rightAnkle": {
+              "x": 35.3,
+              "y": 113.6,
+              "v": 0.965
+            },
+            "leftHeel": {
+              "x": 104.1,
+              "y": 119.4,
+              "v": 0.505
+            },
+            "rightHeel": {
+              "x": 33.1,
+              "y": 116.9,
+              "v": 0.699
+            },
+            "leftFootIndex": {
+              "x": 102.1,
+              "y": 125.2,
+              "v": 0.832
+            },
+            "rightFootIndex": {
+              "x": 33.1,
+              "y": 118.6,
+              "v": 0.932
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 76.6,
+                "y": 23.1
+              },
+              "roll": 175.6,
+              "yaw": 1.112,
+              "pitch": 1.726
+            },
+            "torso": {
+              "center": {
+                "x": 70,
+                "y": 33
+              },
+              "angle": 87.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 67.3,
+                "y": 56.3
+              },
+              "angle": -135.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.9,
+                "y": 46
+              },
+              "angle": 141.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 104.1,
+                "y": 119.4
+              },
+              "angle": -109
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33.1,
+                "y": 116.9
+              },
+              "angle": -90
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/chicha/poses.json
+++ b/public/assets/fighters/chicha/poses.json
@@ -1,0 +1,8271 @@
+{
+  "version": 1,
+  "fighter": "chicha",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:39:53.711Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 70.1,
+              "y": 13.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.9,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.7,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.7,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.1,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.7,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.8,
+              "y": 40.5,
+              "v": 0.984
+            },
+            "rightElbow": {
+              "x": 41.3,
+              "y": 35.1,
+              "v": 0.991
+            },
+            "leftWrist": {
+              "x": 90.9,
+              "y": 34.8,
+              "v": 0.993
+            },
+            "rightWrist": {
+              "x": 38.6,
+              "y": 40.2,
+              "v": 0.985
+            },
+            "leftIndex": {
+              "x": 93.7,
+              "y": 29.6,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 37.5,
+              "y": 41.2,
+              "v": 0.98
+            },
+            "leftHip": {
+              "x": 67.8,
+              "y": 60,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.5,
+              "y": 60,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.7,
+              "y": 87.4,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 40.6,
+              "y": 85.1,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 89.3,
+              "y": 111.2,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 37.1,
+              "y": 113.8,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 88.7,
+              "y": 117.7,
+              "v": 0.964
+            },
+            "rightHeel": {
+              "x": 39.2,
+              "y": 119.3,
+              "v": 0.976
+            },
+            "leftFootIndex": {
+              "x": 94.5,
+              "y": 119.7,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 24.8,
+              "y": 119.9,
+              "v": 0.994
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.5,
+                "y": 11.4
+              },
+              "roll": -180,
+              "yaw": 1.833,
+              "pitch": 2.778
+            },
+            "torso": {
+              "center": {
+                "x": 61.4,
+                "y": 24.5
+              },
+              "angle": 88.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.9,
+                "y": 34.8
+              },
+              "angle": 61.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.6,
+                "y": 40.2
+              },
+              "angle": -137.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 88.7,
+                "y": 117.7
+              },
+              "angle": -19
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.2,
+                "y": 119.3
+              },
+              "angle": -177.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.987,
+          "keypoints": {
+            "nose": {
+              "x": 70.6,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.2,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.8,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.8,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.6,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.7,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.2,
+              "y": 24,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.2,
+              "y": 39.3,
+              "v": 0.984
+            },
+            "rightElbow": {
+              "x": 40.7,
+              "y": 37.4,
+              "v": 0.974
+            },
+            "leftWrist": {
+              "x": 89.4,
+              "y": 35.6,
+              "v": 0.992
+            },
+            "rightWrist": {
+              "x": 39.5,
+              "y": 37,
+              "v": 0.935
+            },
+            "leftIndex": {
+              "x": 93.1,
+              "y": 30.3,
+              "v": 0.989
+            },
+            "rightIndex": {
+              "x": 40.9,
+              "y": 37.2,
+              "v": 0.931
+            },
+            "leftHip": {
+              "x": 67.1,
+              "y": 62.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.2,
+              "y": 62.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.2,
+              "y": 89.7,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 40.6,
+              "y": 87,
+              "v": 0.991
+            },
+            "leftAnkle": {
+              "x": 90,
+              "y": 116.1,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 35.9,
+              "y": 114.5,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 88.4,
+              "y": 121.4,
+              "v": 0.976
+            },
+            "rightHeel": {
+              "x": 38,
+              "y": 119.4,
+              "v": 0.955
+            },
+            "leftFootIndex": {
+              "x": 95.2,
+              "y": 124.5,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 24.3,
+              "y": 120.1,
+              "v": 0.986
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69,
+                "y": 11.1
+              },
+              "roll": -180,
+              "yaw": 4,
+              "pitch": 6.5
+            },
+            "torso": {
+              "center": {
+                "x": 61.5,
+                "y": 24.8
+              },
+              "angle": 88
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.4,
+                "y": 35.6
+              },
+              "angle": 55.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.5,
+                "y": 37
+              },
+              "angle": -8.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 88.4,
+                "y": 121.4
+              },
+              "angle": -24.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38,
+                "y": 119.4
+              },
+              "angle": -177.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.931,
+          "keypoints": {
+            "nose": {
+              "x": 71.4,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.5,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.6,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.4,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.7,
+              "y": 25.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.9,
+              "y": 26.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.4,
+              "y": 39.6,
+              "v": 0.855
+            },
+            "rightElbow": {
+              "x": 46.1,
+              "y": 41.8,
+              "v": 0.92
+            },
+            "leftWrist": {
+              "x": 84.7,
+              "y": 41.3,
+              "v": 0.913
+            },
+            "rightWrist": {
+              "x": 44.9,
+              "y": 38.9,
+              "v": 0.826
+            },
+            "leftIndex": {
+              "x": 85.7,
+              "y": 40.9,
+              "v": 0.913
+            },
+            "rightIndex": {
+              "x": 43.6,
+              "y": 34.9,
+              "v": 0.846
+            },
+            "leftHip": {
+              "x": 72.9,
+              "y": 62.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.6,
+              "y": 61.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86.1,
+              "y": 85,
+              "v": 0.955
+            },
+            "rightKnee": {
+              "x": 46.3,
+              "y": 86.5,
+              "v": 0.949
+            },
+            "leftAnkle": {
+              "x": 86.5,
+              "y": 114.3,
+              "v": 0.924
+            },
+            "rightAnkle": {
+              "x": 33.3,
+              "y": 114.9,
+              "v": 0.969
+            },
+            "leftHeel": {
+              "x": 83.4,
+              "y": 118.5,
+              "v": 0.801
+            },
+            "rightHeel": {
+              "x": 34.3,
+              "y": 117.6,
+              "v": 0.682
+            },
+            "leftFootIndex": {
+              "x": 96.2,
+              "y": 119.4,
+              "v": 0.92
+            },
+            "rightFootIndex": {
+              "x": 28.8,
+              "y": 118.5,
+              "v": 0.937
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.8,
+                "y": 11.7
+              },
+              "roll": 172.4,
+              "yaw": 1.09,
+              "pitch": 1.784
+            },
+            "torso": {
+              "center": {
+                "x": 64.3,
+                "y": 25.9
+              },
+              "angle": 92.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.7,
+                "y": 41.3
+              },
+              "angle": 21.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.9,
+                "y": 38.9
+              },
+              "angle": 108
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.4,
+                "y": 118.5
+              },
+              "angle": -4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 34.3,
+                "y": 117.6
+              },
+              "angle": -170.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.987,
+          "keypoints": {
+            "nose": {
+              "x": 70,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.7,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.7,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.9,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.3,
+              "y": 12,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.4,
+              "y": 25.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.7,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.5,
+              "y": 39.4,
+              "v": 0.939
+            },
+            "rightElbow": {
+              "x": 40,
+              "y": 37.1,
+              "v": 0.988
+            },
+            "leftWrist": {
+              "x": 89,
+              "y": 38.4,
+              "v": 0.964
+            },
+            "rightWrist": {
+              "x": 39,
+              "y": 38.5,
+              "v": 0.981
+            },
+            "leftIndex": {
+              "x": 93,
+              "y": 32.8,
+              "v": 0.967
+            },
+            "rightIndex": {
+              "x": 38.7,
+              "y": 36.5,
+              "v": 0.979
+            },
+            "leftHip": {
+              "x": 67.8,
+              "y": 61.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.6,
+              "y": 61.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.1,
+              "y": 89.5,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 39.6,
+              "y": 86.2,
+              "v": 0.99
+            },
+            "leftAnkle": {
+              "x": 90.5,
+              "y": 116.2,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 35.4,
+              "y": 114.2,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 89.5,
+              "y": 121.1,
+              "v": 0.966
+            },
+            "rightHeel": {
+              "x": 37.8,
+              "y": 119.3,
+              "v": 0.956
+            },
+            "leftFootIndex": {
+              "x": 95.7,
+              "y": 124.7,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 23.1,
+              "y": 120.3,
+              "v": 0.988
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.2,
+                "y": 11.3
+              },
+              "roll": -180,
+              "yaw": 1.8,
+              "pitch": 2.5
+            },
+            "torso": {
+              "center": {
+                "x": 61.6,
+                "y": 24.6
+              },
+              "angle": 88.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89,
+                "y": 38.4
+              },
+              "angle": 54.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39,
+                "y": 38.5
+              },
+              "angle": 98.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 89.5,
+                "y": 121.1
+              },
+              "angle": -30.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.8,
+                "y": 119.3
+              },
+              "angle": -176.1
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.89,
+          "keypoints": {
+            "nose": {
+              "x": 72.5,
+              "y": 14.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72,
+              "y": 12,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.7,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.1,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.7,
+              "y": 11.6,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 71.4,
+              "y": 25.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.6,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.4,
+              "y": 44.8,
+              "v": 0.454
+            },
+            "rightElbow": {
+              "x": 53,
+              "y": 41.2,
+              "v": 0.98
+            },
+            "leftWrist": {
+              "x": 80.5,
+              "y": 58.8,
+              "v": 0.68
+            },
+            "rightWrist": {
+              "x": 59.3,
+              "y": 55.1,
+              "v": 0.742
+            },
+            "leftIndex": {
+              "x": 81.6,
+              "y": 61.4,
+              "v": 0.704
+            },
+            "rightIndex": {
+              "x": 62.3,
+              "y": 58,
+              "v": 0.682
+            },
+            "leftHip": {
+              "x": 69.3,
+              "y": 60.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.9,
+              "y": 59.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.9,
+              "y": 83.3,
+              "v": 0.739
+            },
+            "rightKnee": {
+              "x": 56.6,
+              "y": 87.4,
+              "v": 0.984
+            },
+            "leftAnkle": {
+              "x": 82.1,
+              "y": 115.4,
+              "v": 0.902
+            },
+            "rightAnkle": {
+              "x": 39.7,
+              "y": 116,
+              "v": 0.985
+            },
+            "leftHeel": {
+              "x": 78.4,
+              "y": 122.2,
+              "v": 0.874
+            },
+            "rightHeel": {
+              "x": 36,
+              "y": 120.5,
+              "v": 0.832
+            },
+            "leftFootIndex": {
+              "x": 94.9,
+              "y": 122.3,
+              "v": 0.938
+            },
+            "rightFootIndex": {
+              "x": 43.6,
+              "y": 125.3,
+              "v": 0.976
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.4,
+                "y": 12
+              },
+              "roll": 175.6,
+              "yaw": 0.882,
+              "pitch": 1.956
+            },
+            "torso": {
+              "center": {
+                "x": 63.5,
+                "y": 24.3
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.5,
+                "y": 58.8
+              },
+              "angle": -67.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 59.3,
+                "y": 55.1
+              },
+              "angle": -44
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.4,
+                "y": 122.2
+              },
+              "angle": -0.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36,
+                "y": 120.5
+              },
+              "angle": -32.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.977,
+          "keypoints": {
+            "nose": {
+              "x": 70.1,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.5,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.1,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 66.8,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.8,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.1,
+              "y": 25.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.4,
+              "y": 23.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.9,
+              "y": 40.6,
+              "v": 0.909
+            },
+            "rightElbow": {
+              "x": 40,
+              "y": 36.3,
+              "v": 0.988
+            },
+            "leftWrist": {
+              "x": 91.4,
+              "y": 35.6,
+              "v": 0.97
+            },
+            "rightWrist": {
+              "x": 38.6,
+              "y": 37.1,
+              "v": 0.946
+            },
+            "leftIndex": {
+              "x": 95.7,
+              "y": 30.5,
+              "v": 0.967
+            },
+            "rightIndex": {
+              "x": 39.5,
+              "y": 34.9,
+              "v": 0.94
+            },
+            "leftHip": {
+              "x": 67.3,
+              "y": 61.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.3,
+              "y": 60.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.9,
+              "y": 86,
+              "v": 0.967
+            },
+            "rightKnee": {
+              "x": 41.6,
+              "y": 85.7,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 75.6,
+              "y": 115.3,
+              "v": 0.98
+            },
+            "rightAnkle": {
+              "x": 31.8,
+              "y": 115.8,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 72.3,
+              "y": 120.5,
+              "v": 0.95
+            },
+            "rightHeel": {
+              "x": 29.5,
+              "y": 119.2,
+              "v": 0.896
+            },
+            "leftFootIndex": {
+              "x": 85.4,
+              "y": 122.5,
+              "v": 0.984
+            },
+            "rightFootIndex": {
+              "x": 32,
+              "y": 122.1,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.8,
+                "y": 11.4
+              },
+              "roll": 171.9,
+              "yaw": 0.919,
+              "pitch": 2.051
+            },
+            "torso": {
+              "center": {
+                "x": 61.3,
+                "y": 24.6
+              },
+              "angle": 88.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.4,
+                "y": 35.6
+              },
+              "angle": 49.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.6,
+                "y": 37.1
+              },
+              "angle": 67.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.3,
+                "y": 120.5
+              },
+              "angle": -8.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29.5,
+                "y": 119.2
+              },
+              "angle": -49.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 68.5,
+              "y": 15.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.2,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.9,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.5,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.7,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.4,
+              "y": 23.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.7,
+              "y": 39.8,
+              "v": 0.993
+            },
+            "rightElbow": {
+              "x": 41.7,
+              "y": 33.9,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 88.8,
+              "y": 38.7,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 38.7,
+              "y": 39.7,
+              "v": 0.989
+            },
+            "leftIndex": {
+              "x": 93.9,
+              "y": 32.7,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 37.1,
+              "y": 40.5,
+              "v": 0.987
+            },
+            "leftHip": {
+              "x": 67.3,
+              "y": 60.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.9,
+              "y": 60.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79,
+              "y": 88.3,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 39.2,
+              "y": 84.4,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 90.8,
+              "y": 115.7,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 35.2,
+              "y": 114.2,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 89.1,
+              "y": 122.4,
+              "v": 0.979
+            },
+            "rightHeel": {
+              "x": 37.3,
+              "y": 120,
+              "v": 0.99
+            },
+            "leftFootIndex": {
+              "x": 94.7,
+              "y": 124.7,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 23,
+              "y": 120.4,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.6,
+                "y": 11.9
+              },
+              "roll": 178.3,
+              "yaw": 0.288,
+              "pitch": 0.984
+            },
+            "torso": {
+              "center": {
+                "x": 62.2,
+                "y": 24.3
+              },
+              "angle": 86.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.8,
+                "y": 38.7
+              },
+              "angle": 49.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.7,
+                "y": 39.7
+              },
+              "angle": -153.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 89.1,
+                "y": 122.4
+              },
+              "angle": -22.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.3,
+                "y": 120
+              },
+              "angle": -178.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.947,
+          "keypoints": {
+            "nose": {
+              "x": 72.4,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.5,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.1,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.9,
+              "y": 12,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.1,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.8,
+              "y": 26.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.5,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.8,
+              "y": 43.9,
+              "v": 0.662
+            },
+            "rightElbow": {
+              "x": 41.5,
+              "y": 37.6,
+              "v": 0.984
+            },
+            "leftWrist": {
+              "x": 89.6,
+              "y": 40,
+              "v": 0.912
+            },
+            "rightWrist": {
+              "x": 39.7,
+              "y": 38.4,
+              "v": 0.961
+            },
+            "leftIndex": {
+              "x": 92.9,
+              "y": 37.2,
+              "v": 0.926
+            },
+            "rightIndex": {
+              "x": 40.5,
+              "y": 35.8,
+              "v": 0.954
+            },
+            "leftHip": {
+              "x": 69.7,
+              "y": 63,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.6,
+              "y": 62.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.2,
+              "y": 88.1,
+              "v": 0.836
+            },
+            "rightKnee": {
+              "x": 47.9,
+              "y": 87.3,
+              "v": 0.974
+            },
+            "leftAnkle": {
+              "x": 80.5,
+              "y": 116.4,
+              "v": 0.956
+            },
+            "rightAnkle": {
+              "x": 33.9,
+              "y": 115.5,
+              "v": 0.982
+            },
+            "leftHeel": {
+              "x": 76.4,
+              "y": 122.4,
+              "v": 0.905
+            },
+            "rightHeel": {
+              "x": 30.7,
+              "y": 118.5,
+              "v": 0.782
+            },
+            "leftFootIndex": {
+              "x": 92.2,
+              "y": 123.3,
+              "v": 0.972
+            },
+            "rightFootIndex": {
+              "x": 38.5,
+              "y": 124.8,
+              "v": 0.975
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.8,
+                "y": 11.8
+              },
+              "roll": 175.9,
+              "yaw": 1.14,
+              "pitch": 1.817
+            },
+            "torso": {
+              "center": {
+                "x": 62.7,
+                "y": 24.9
+              },
+              "angle": 90.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.6,
+                "y": 40
+              },
+              "angle": 40.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.7,
+                "y": 38.4
+              },
+              "angle": 72.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.4,
+                "y": 122.4
+              },
+              "angle": -3.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.7,
+                "y": 118.5
+              },
+              "angle": -38.9
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.977,
+          "keypoints": {
+            "nose": {
+              "x": 63.7,
+              "y": 14.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 62.4,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.8,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.6,
+              "y": 26.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44.4,
+              "y": 26.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84,
+              "y": 33.1,
+              "v": 0.998
+            },
+            "rightElbow": {
+              "x": 36,
+              "y": 43.3,
+              "v": 0.97
+            },
+            "leftWrist": {
+              "x": 102.3,
+              "y": 32,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 28.5,
+              "y": 46.6,
+              "v": 0.816
+            },
+            "leftIndex": {
+              "x": 108,
+              "y": 28,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 25.4,
+              "y": 45.9,
+              "v": 0.797
+            },
+            "leftHip": {
+              "x": 62.8,
+              "y": 62.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.1,
+              "y": 62.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.4,
+              "y": 88.6,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 33.9,
+              "y": 85.9,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 87.4,
+              "y": 116.7,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 30.7,
+              "y": 113.8,
+              "v": 0.992
+            },
+            "leftHeel": {
+              "x": 85,
+              "y": 125.4,
+              "v": 0.968
+            },
+            "rightHeel": {
+              "x": 32.8,
+              "y": 119.4,
+              "v": 0.964
+            },
+            "leftFootIndex": {
+              "x": 91.4,
+              "y": 126.4,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 18.2,
+              "y": 120.8,
+              "v": 0.986
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.5,
+                "y": 12.1
+              },
+              "roll": 170.5,
+              "yaw": 0.395,
+              "pitch": 0.937
+            },
+            "torso": {
+              "center": {
+                "x": 56.5,
+                "y": 26.4
+              },
+              "angle": 88.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 102.3,
+                "y": 32
+              },
+              "angle": 35.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.5,
+                "y": 46.6
+              },
+              "angle": 167.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85,
+                "y": 125.4
+              },
+              "angle": -8.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.8,
+                "y": 119.4
+              },
+              "angle": -174.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 63.8,
+              "y": 15.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.7,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.7,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.4,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.8,
+              "y": 24.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42.1,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.4,
+              "y": 31,
+              "v": 0.999
+            },
+            "rightElbow": {
+              "x": 34.3,
+              "y": 36.5,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 96.8,
+              "y": 29.5,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 29,
+              "y": 45.3,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 102.1,
+              "y": 27.5,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 25.1,
+              "y": 46.9,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 58.4,
+              "y": 57.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.9,
+              "y": 57.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.3,
+              "y": 81.7,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 35.7,
+              "y": 79.9,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 77.7,
+              "y": 111.1,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 25,
+              "y": 105.5,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 75.2,
+              "y": 116.4,
+              "v": 0.992
+            },
+            "rightHeel": {
+              "x": 25.3,
+              "y": 110.4,
+              "v": 0.976
+            },
+            "leftFootIndex": {
+              "x": 87,
+              "y": 117.8,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 16.2,
+              "y": 112.1,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.4,
+                "y": 12.9
+              },
+              "roll": -180,
+              "yaw": 2.071,
+              "pitch": 3.143
+            },
+            "torso": {
+              "center": {
+                "x": 54,
+                "y": 24.6
+              },
+              "angle": 86.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.8,
+                "y": 29.5
+              },
+              "angle": 20.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29,
+                "y": 45.3
+              },
+              "angle": -157.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 75.2,
+                "y": 116.4
+              },
+              "angle": -6.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25.3,
+                "y": 110.4
+              },
+              "angle": -169.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.964,
+          "keypoints": {
+            "nose": {
+              "x": 60.9,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 60.1,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.5,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.8,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 54.5,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.4,
+              "y": 25.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.8,
+              "y": 24.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.8,
+              "y": 32,
+              "v": 0.982
+            },
+            "rightElbow": {
+              "x": 31.9,
+              "y": 37.9,
+              "v": 0.916
+            },
+            "leftWrist": {
+              "x": 93.1,
+              "y": 31.8,
+              "v": 0.985
+            },
+            "rightWrist": {
+              "x": 30.1,
+              "y": 32.4,
+              "v": 0.87
+            },
+            "leftIndex": {
+              "x": 99.3,
+              "y": 28,
+              "v": 0.984
+            },
+            "rightIndex": {
+              "x": 30.2,
+              "y": 28.5,
+              "v": 0.896
+            },
+            "leftHip": {
+              "x": 60.1,
+              "y": 63,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46,
+              "y": 62.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73,
+              "y": 89.1,
+              "v": 0.987
+            },
+            "rightKnee": {
+              "x": 31.2,
+              "y": 87.2,
+              "v": 0.936
+            },
+            "leftAnkle": {
+              "x": 82.9,
+              "y": 115.8,
+              "v": 0.984
+            },
+            "rightAnkle": {
+              "x": 29.1,
+              "y": 114.7,
+              "v": 0.966
+            },
+            "leftHeel": {
+              "x": 81.4,
+              "y": 121.7,
+              "v": 0.894
+            },
+            "rightHeel": {
+              "x": 31.3,
+              "y": 120.3,
+              "v": 0.846
+            },
+            "leftFootIndex": {
+              "x": 88.1,
+              "y": 124.8,
+              "v": 0.979
+            },
+            "rightFootIndex": {
+              "x": 17.6,
+              "y": 120.6,
+              "v": 0.947
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.3,
+                "y": 11.5
+              },
+              "roll": 169.4,
+              "yaw": 0.983,
+              "pitch": 1.628
+            },
+            "torso": {
+              "center": {
+                "x": 53.1,
+                "y": 24.8
+              },
+              "angle": 89.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.1,
+                "y": 31.8
+              },
+              "angle": 31.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 30.1,
+                "y": 32.4
+              },
+              "angle": 88.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 81.4,
+                "y": 121.7
+              },
+              "angle": -24.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.3,
+                "y": 120.3
+              },
+              "angle": -178.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.973,
+          "keypoints": {
+            "nose": {
+              "x": 63.7,
+              "y": 14.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.5,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.9,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.7,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.1,
+              "y": 26,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42.6,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.1,
+              "y": 32.7,
+              "v": 0.995
+            },
+            "rightElbow": {
+              "x": 33.8,
+              "y": 34.4,
+              "v": 0.988
+            },
+            "leftWrist": {
+              "x": 94.8,
+              "y": 31.6,
+              "v": 0.992
+            },
+            "rightWrist": {
+              "x": 31.2,
+              "y": 40.4,
+              "v": 0.929
+            },
+            "leftIndex": {
+              "x": 98.8,
+              "y": 28.9,
+              "v": 0.99
+            },
+            "rightIndex": {
+              "x": 29.1,
+              "y": 41.6,
+              "v": 0.914
+            },
+            "leftHip": {
+              "x": 62.4,
+              "y": 60.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.5,
+              "y": 61,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.1,
+              "y": 87.2,
+              "v": 0.993
+            },
+            "rightKnee": {
+              "x": 33,
+              "y": 85.4,
+              "v": 0.969
+            },
+            "leftAnkle": {
+              "x": 86.3,
+              "y": 117.7,
+              "v": 0.972
+            },
+            "rightAnkle": {
+              "x": 29.8,
+              "y": 114.8,
+              "v": 0.975
+            },
+            "leftHeel": {
+              "x": 85.5,
+              "y": 122.2,
+              "v": 0.836
+            },
+            "rightHeel": {
+              "x": 31.9,
+              "y": 120.1,
+              "v": 0.899
+            },
+            "leftFootIndex": {
+              "x": 90.3,
+              "y": 124.5,
+              "v": 0.962
+            },
+            "rightFootIndex": {
+              "x": 16.9,
+              "y": 120.4,
+              "v": 0.96
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.3,
+                "y": 11.7
+              },
+              "roll": -180,
+              "yaw": 0.967,
+              "pitch": 1.933
+            },
+            "torso": {
+              "center": {
+                "x": 54.9,
+                "y": 24.9
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.8,
+                "y": 31.6
+              },
+              "angle": 34
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31.2,
+                "y": 40.4
+              },
+              "angle": -150.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85.5,
+                "y": 122.2
+              },
+              "angle": -25.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.9,
+                "y": 120.1
+              },
+              "angle": -178.9
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.975,
+          "keypoints": {
+            "nose": {
+              "x": 58.4,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.2,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.5,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.9,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.2,
+              "y": 11,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.9,
+              "y": 24.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.1,
+              "y": 23.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.8,
+              "y": 29.6,
+              "v": 0.992
+            },
+            "rightElbow": {
+              "x": 28.6,
+              "y": 36.8,
+              "v": 0.974
+            },
+            "leftWrist": {
+              "x": 97.1,
+              "y": 29.8,
+              "v": 0.99
+            },
+            "rightWrist": {
+              "x": 27.6,
+              "y": 35.9,
+              "v": 0.939
+            },
+            "leftIndex": {
+              "x": 102.2,
+              "y": 27.5,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 29.9,
+              "y": 37.2,
+              "v": 0.938
+            },
+            "leftHip": {
+              "x": 57.9,
+              "y": 62,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 41.8,
+              "y": 61.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.7,
+              "y": 88.8,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 26.9,
+              "y": 84.9,
+              "v": 0.954
+            },
+            "leftAnkle": {
+              "x": 83.2,
+              "y": 119.7,
+              "v": 0.987
+            },
+            "rightAnkle": {
+              "x": 25.6,
+              "y": 114,
+              "v": 0.968
+            },
+            "leftHeel": {
+              "x": 83,
+              "y": 124.5,
+              "v": 0.896
+            },
+            "rightHeel": {
+              "x": 28.1,
+              "y": 119.7,
+              "v": 0.865
+            },
+            "leftFootIndex": {
+              "x": 86.7,
+              "y": 126.6,
+              "v": 0.982
+            },
+            "rightFootIndex": {
+              "x": 12.6,
+              "y": 119.9,
+              "v": 0.954
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.4,
+                "y": 11.6
+              },
+              "roll": 166.8,
+              "yaw": 0.601,
+              "pitch": 1.546
+            },
+            "torso": {
+              "center": {
+                "x": 50.5,
+                "y": 24
+              },
+              "angle": 89
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.1,
+                "y": 29.8
+              },
+              "angle": 24.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 27.6,
+                "y": 35.9
+              },
+              "angle": -29.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83,
+                "y": 124.5
+              },
+              "angle": -29.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 28.1,
+                "y": 119.7
+              },
+              "angle": -179.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.972,
+          "keypoints": {
+            "nose": {
+              "x": 59,
+              "y": 13,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.3,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.5,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.1,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.4,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.1,
+              "y": 25.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.3,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.6,
+              "y": 29.5,
+              "v": 0.983
+            },
+            "rightElbow": {
+              "x": 29.4,
+              "y": 34.1,
+              "v": 0.968
+            },
+            "leftWrist": {
+              "x": 95.5,
+              "y": 30.5,
+              "v": 0.973
+            },
+            "rightWrist": {
+              "x": 28.2,
+              "y": 34.2,
+              "v": 0.913
+            },
+            "leftIndex": {
+              "x": 99.1,
+              "y": 28.4,
+              "v": 0.97
+            },
+            "rightIndex": {
+              "x": 30.6,
+              "y": 35,
+              "v": 0.913
+            },
+            "leftHip": {
+              "x": 58.3,
+              "y": 62.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.5,
+              "y": 62.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.9,
+              "y": 88.4,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 28.2,
+              "y": 86.2,
+              "v": 0.944
+            },
+            "leftAnkle": {
+              "x": 81.6,
+              "y": 116.5,
+              "v": 0.988
+            },
+            "rightAnkle": {
+              "x": 26.6,
+              "y": 114.3,
+              "v": 0.972
+            },
+            "leftHeel": {
+              "x": 80.6,
+              "y": 122.6,
+              "v": 0.921
+            },
+            "rightHeel": {
+              "x": 29.4,
+              "y": 119.8,
+              "v": 0.878
+            },
+            "leftFootIndex": {
+              "x": 86.7,
+              "y": 124.8,
+              "v": 0.983
+            },
+            "rightFootIndex": {
+              "x": 14.8,
+              "y": 120.6,
+              "v": 0.951
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.4,
+                "y": 10.9
+              },
+              "roll": 164.5,
+              "yaw": 0.856,
+              "pitch": 1.151
+            },
+            "torso": {
+              "center": {
+                "x": 51.2,
+                "y": 24.6
+              },
+              "angle": 89.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.5,
+                "y": 30.5
+              },
+              "angle": 30.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.2,
+                "y": 34.2
+              },
+              "angle": -18.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80.6,
+                "y": 122.6
+              },
+              "angle": -19.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29.4,
+                "y": 119.8
+              },
+              "angle": -176.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.951,
+          "keypoints": {
+            "nose": {
+              "x": 59.7,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.8,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.2,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.1,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.7,
+              "y": 26,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.6,
+              "y": 24.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.8,
+              "y": 30.1,
+              "v": 0.976
+            },
+            "rightElbow": {
+              "x": 29,
+              "y": 37.9,
+              "v": 0.92
+            },
+            "leftWrist": {
+              "x": 92.7,
+              "y": 29.5,
+              "v": 0.968
+            },
+            "rightWrist": {
+              "x": 26.9,
+              "y": 28.2,
+              "v": 0.818
+            },
+            "leftIndex": {
+              "x": 96.8,
+              "y": 28,
+              "v": 0.962
+            },
+            "rightIndex": {
+              "x": 26.9,
+              "y": 23.6,
+              "v": 0.828
+            },
+            "leftHip": {
+              "x": 57.5,
+              "y": 62.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.7,
+              "y": 63.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.5,
+              "y": 90.6,
+              "v": 0.981
+            },
+            "rightKnee": {
+              "x": 27.7,
+              "y": 86,
+              "v": 0.898
+            },
+            "leftAnkle": {
+              "x": 81.2,
+              "y": 116.6,
+              "v": 0.976
+            },
+            "rightAnkle": {
+              "x": 25.7,
+              "y": 113.5,
+              "v": 0.959
+            },
+            "leftHeel": {
+              "x": 80.5,
+              "y": 120.8,
+              "v": 0.844
+            },
+            "rightHeel": {
+              "x": 27.3,
+              "y": 119.9,
+              "v": 0.849
+            },
+            "leftFootIndex": {
+              "x": 84.5,
+              "y": 124.9,
+              "v": 0.966
+            },
+            "rightFootIndex": {
+              "x": 12.5,
+              "y": 120.7,
+              "v": 0.937
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58,
+                "y": 11.3
+              },
+              "roll": 176.4,
+              "yaw": 1.06,
+              "pitch": 1.466
+            },
+            "torso": {
+              "center": {
+                "x": 50.7,
+                "y": 25.4
+              },
+              "angle": 89.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92.7,
+                "y": 29.5
+              },
+              "angle": 20.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 26.9,
+                "y": 28.2
+              },
+              "angle": 90
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80.5,
+                "y": 120.8
+              },
+              "angle": -45.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27.3,
+                "y": 119.9
+              },
+              "angle": -176.9
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.775,
+          "keypoints": {
+            "nose": {
+              "x": 108.6,
+              "y": 29.1,
+              "v": 0.844
+            },
+            "leftEye": {
+              "x": 109.5,
+              "y": 28.6,
+              "v": 0.778
+            },
+            "rightEye": {
+              "x": 109.7,
+              "y": 29.9,
+              "v": 0.888
+            },
+            "leftEar": {
+              "x": 109.2,
+              "y": 27.8,
+              "v": 0.864
+            },
+            "rightEar": {
+              "x": 109.5,
+              "y": 31.2,
+              "v": 0.852
+            },
+            "leftShoulder": {
+              "x": 106.7,
+              "y": 24.2,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 107.4,
+              "y": 33.8,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 112.7,
+              "y": 20.5,
+              "v": 0.494
+            },
+            "rightElbow": {
+              "x": 112,
+              "y": 32.7,
+              "v": 0.582
+            },
+            "leftWrist": {
+              "x": 118.1,
+              "y": 23,
+              "v": 0.656
+            },
+            "rightWrist": {
+              "x": 117.6,
+              "y": 32,
+              "v": 0.839
+            },
+            "leftIndex": {
+              "x": 121.3,
+              "y": 23.1,
+              "v": 0.652
+            },
+            "rightIndex": {
+              "x": 119.2,
+              "y": 31.7,
+              "v": 0.802
+            },
+            "leftHip": {
+              "x": 91.5,
+              "y": 25.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 91.6,
+              "y": 31.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.9,
+              "y": 26.4,
+              "v": 0.282
+            },
+            "rightKnee": {
+              "x": 76.2,
+              "y": 32.5,
+              "v": 0.737
+            },
+            "leftAnkle": {
+              "x": 64.1,
+              "y": 25.3,
+              "v": 0.793
+            },
+            "rightAnkle": {
+              "x": 64.3,
+              "y": 29.7,
+              "v": 0.832
+            },
+            "leftHeel": {
+              "x": 63.2,
+              "y": 24.8,
+              "v": 0.856
+            },
+            "rightHeel": {
+              "x": 63.7,
+              "y": 28.9,
+              "v": 0.771
+            },
+            "leftFootIndex": {
+              "x": 59.3,
+              "y": 25.2,
+              "v": 0.661
+            },
+            "rightFootIndex": {
+              "x": 58.7,
+              "y": 30.3,
+              "v": 0.653
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 109.6,
+                "y": 29.3
+              },
+              "roll": -81.3,
+              "yaw": -0.76,
+              "pitch": -0.114
+            },
+            "torso": {
+              "center": {
+                "x": 107.1,
+                "y": 29
+              },
+              "angle": -1.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 118.1,
+                "y": 23
+              },
+              "angle": -1.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 117.6,
+                "y": 32
+              },
+              "angle": 10.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 63.2,
+                "y": 24.8
+              },
+              "angle": -174.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 63.7,
+                "y": 28.9
+              },
+              "angle": -164.4
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.987,
+          "keypoints": {
+            "nose": {
+              "x": 57.8,
+              "y": 13.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.5,
+              "y": 11,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.6,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52.1,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 61.6,
+              "y": 26.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 35.7,
+              "y": 25,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.9,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightElbow": {
+              "x": 26,
+              "y": 39.5,
+              "v": 0.974
+            },
+            "leftWrist": {
+              "x": 101.5,
+              "y": 29.3,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 22.3,
+              "y": 30.7,
+              "v": 0.95
+            },
+            "leftIndex": {
+              "x": 107.9,
+              "y": 27.9,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 20.5,
+              "y": 24.9,
+              "v": 0.95
+            },
+            "leftHip": {
+              "x": 55.9,
+              "y": 64,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 40.5,
+              "y": 63.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.7,
+              "y": 90.9,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 26.6,
+              "y": 86.4,
+              "v": 0.979
+            },
+            "leftAnkle": {
+              "x": 81,
+              "y": 121.2,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 23.1,
+              "y": 114.2,
+              "v": 0.987
+            },
+            "leftHeel": {
+              "x": 80.4,
+              "y": 124.4,
+              "v": 0.959
+            },
+            "rightHeel": {
+              "x": 25.4,
+              "y": 119.4,
+              "v": 0.942
+            },
+            "leftFootIndex": {
+              "x": 83.3,
+              "y": 126.3,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 11.3,
+              "y": 120.2,
+              "v": 0.981
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.1,
+                "y": 11.1
+              },
+              "roll": -173.7,
+              "yaw": 1.933,
+              "pitch": 2.595
+            },
+            "torso": {
+              "center": {
+                "x": 48.7,
+                "y": 25.8
+              },
+              "angle": 89.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 101.5,
+                "y": 29.3
+              },
+              "angle": 12.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 22.3,
+                "y": 30.7
+              },
+              "angle": 107.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80.4,
+                "y": 124.4
+              },
+              "angle": -33.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25.4,
+                "y": 119.4
+              },
+              "angle": -176.8
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.711,
+          "keypoints": {
+            "nose": {
+              "x": 71,
+              "y": 16.1,
+              "v": 0.998
+            },
+            "leftEye": {
+              "x": 70,
+              "y": 13.1,
+              "v": 0.995
+            },
+            "rightEye": {
+              "x": 69,
+              "y": 13.2,
+              "v": 0.996
+            },
+            "leftEar": {
+              "x": 67.9,
+              "y": 13.3,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 66.3,
+              "y": 13.7,
+              "v": 0.993
+            },
+            "leftShoulder": {
+              "x": 77.6,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57,
+              "y": 25.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 67.5,
+              "y": 42.4,
+              "v": 0.929
+            },
+            "rightElbow": {
+              "x": 50.6,
+              "y": 41,
+              "v": 0.244
+            },
+            "leftWrist": {
+              "x": 52.2,
+              "y": 36.7,
+              "v": 0.777
+            },
+            "rightWrist": {
+              "x": 52.3,
+              "y": 40.9,
+              "v": 0.083
+            },
+            "leftIndex": {
+              "x": 49.7,
+              "y": 34.7,
+              "v": 0.743
+            },
+            "rightIndex": {
+              "x": 53.5,
+              "y": 39.1,
+              "v": 0.154
+            },
+            "leftHip": {
+              "x": 71,
+              "y": 63,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.3,
+              "y": 62.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.4,
+              "y": 88.2,
+              "v": 0.832
+            },
+            "rightKnee": {
+              "x": 41.4,
+              "y": 86.4,
+              "v": 0.37
+            },
+            "leftAnkle": {
+              "x": 96.1,
+              "y": 117.2,
+              "v": 0.713
+            },
+            "rightAnkle": {
+              "x": 38.8,
+              "y": 114.1,
+              "v": 0.618
+            },
+            "leftHeel": {
+              "x": 96.1,
+              "y": 122.2,
+              "v": 0.307
+            },
+            "rightHeel": {
+              "x": 41.5,
+              "y": 119.8,
+              "v": 0.455
+            },
+            "leftFootIndex": {
+              "x": 100,
+              "y": 123.2,
+              "v": 0.618
+            },
+            "rightFootIndex": {
+              "x": 26.4,
+              "y": 119.8,
+              "v": 0.528
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.5,
+                "y": 13.2
+              },
+              "roll": -174.3,
+              "yaw": 1.493,
+              "pitch": 2.935
+            },
+            "torso": {
+              "center": {
+                "x": 67.3,
+                "y": 26.7
+              },
+              "angle": 85
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 52.2,
+                "y": 36.7
+              },
+              "angle": 141.3
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 96.1,
+                "y": 122.2
+              },
+              "angle": -14.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.5,
+                "y": 119.8
+              },
+              "angle": -180
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.99,
+          "keypoints": {
+            "nose": {
+              "x": 70.2,
+              "y": 14.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.3,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.3,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.6,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.3,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.1,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.9,
+              "y": 38.7,
+              "v": 0.97
+            },
+            "rightElbow": {
+              "x": 41.2,
+              "y": 36.8,
+              "v": 0.993
+            },
+            "leftWrist": {
+              "x": 91.9,
+              "y": 37.7,
+              "v": 0.97
+            },
+            "rightWrist": {
+              "x": 36.9,
+              "y": 40.8,
+              "v": 0.979
+            },
+            "leftIndex": {
+              "x": 94.4,
+              "y": 32.3,
+              "v": 0.967
+            },
+            "rightIndex": {
+              "x": 34.3,
+              "y": 41,
+              "v": 0.974
+            },
+            "leftHip": {
+              "x": 67.5,
+              "y": 60.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.5,
+              "y": 60.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.2,
+              "y": 85,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 41.3,
+              "y": 85.1,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 90.9,
+              "y": 114.3,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 35.9,
+              "y": 113.3,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 88.8,
+              "y": 119.7,
+              "v": 0.971
+            },
+            "rightHeel": {
+              "x": 38.4,
+              "y": 117.9,
+              "v": 0.973
+            },
+            "leftFootIndex": {
+              "x": 95.9,
+              "y": 123.4,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 24.2,
+              "y": 117.8,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.8,
+                "y": 11.8
+              },
+              "roll": 168.7,
+              "yaw": 1.373,
+              "pitch": 2.746
+            },
+            "torso": {
+              "center": {
+                "x": 61.6,
+                "y": 24.7
+              },
+              "angle": 88.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.9,
+                "y": 37.7
+              },
+              "angle": 65.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.9,
+                "y": 40.8
+              },
+              "angle": -175.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 88.8,
+                "y": 119.7
+              },
+              "angle": -27.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.4,
+                "y": 117.9
+              },
+              "angle": 179.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.754,
+          "keypoints": {
+            "nose": {
+              "x": 52.4,
+              "y": 16.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 52.3,
+              "y": 14.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 50.6,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 49.7,
+              "y": 14.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46.2,
+              "y": 13,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 55.1,
+              "y": 26.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 33.4,
+              "y": 23.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 64.3,
+              "y": 39.9,
+              "v": 0.624
+            },
+            "rightElbow": {
+              "x": 19.8,
+              "y": 31,
+              "v": 0.866
+            },
+            "leftWrist": {
+              "x": 66.1,
+              "y": 42.6,
+              "v": 0.305
+            },
+            "rightWrist": {
+              "x": 12.3,
+              "y": 40,
+              "v": 0.784
+            },
+            "leftIndex": {
+              "x": 65.8,
+              "y": 41.5,
+              "v": 0.325
+            },
+            "rightIndex": {
+              "x": 11.5,
+              "y": 42,
+              "v": 0.758
+            },
+            "leftHip": {
+              "x": 47.2,
+              "y": 57.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 36,
+              "y": 57.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 51.8,
+              "y": 79.3,
+              "v": 0.777
+            },
+            "rightKnee": {
+              "x": 30.8,
+              "y": 83.5,
+              "v": 0.628
+            },
+            "leftAnkle": {
+              "x": 57.9,
+              "y": 98.1,
+              "v": 0.549
+            },
+            "rightAnkle": {
+              "x": 38.1,
+              "y": 110.3,
+              "v": 0.68
+            },
+            "leftHeel": {
+              "x": 58.2,
+              "y": 100.9,
+              "v": 0.432
+            },
+            "rightHeel": {
+              "x": 40.8,
+              "y": 113.7,
+              "v": 0.504
+            },
+            "leftFootIndex": {
+              "x": 59.2,
+              "y": 105.4,
+              "v": 0.571
+            },
+            "rightFootIndex": {
+              "x": 33.8,
+              "y": 116.7,
+              "v": 0.548
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.5,
+                "y": 14
+              },
+              "roll": 157.6,
+              "yaw": 0.517,
+              "pitch": 1.605
+            },
+            "torso": {
+              "center": {
+                "x": 44.3,
+                "y": 24.8
+              },
+              "angle": 85.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 66.1,
+                "y": 42.6
+              },
+              "angle": 105.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 12.3,
+                "y": 40
+              },
+              "angle": -111.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 58.2,
+                "y": 100.9
+              },
+              "angle": -77.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.8,
+                "y": 113.7
+              },
+              "angle": -156.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.832,
+          "keypoints": {
+            "nose": {
+              "x": 54.9,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.8,
+              "y": 12.1,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 53.2,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.2,
+              "y": 11.9,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 57.5,
+              "y": 25,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 36.5,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.1,
+              "y": 38,
+              "v": 0.731
+            },
+            "rightElbow": {
+              "x": 29.2,
+              "y": 35.7,
+              "v": 0.91
+            },
+            "leftWrist": {
+              "x": 72.4,
+              "y": 35.1,
+              "v": 0.852
+            },
+            "rightWrist": {
+              "x": 25.9,
+              "y": 33.6,
+              "v": 0.915
+            },
+            "leftIndex": {
+              "x": 74.5,
+              "y": 31.2,
+              "v": 0.846
+            },
+            "rightIndex": {
+              "x": 26.2,
+              "y": 31,
+              "v": 0.901
+            },
+            "leftHip": {
+              "x": 50.8,
+              "y": 54.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 39.2,
+              "y": 54.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 57.6,
+              "y": 74.9,
+              "v": 0.619
+            },
+            "rightKnee": {
+              "x": 33.9,
+              "y": 75.3,
+              "v": 0.821
+            },
+            "leftAnkle": {
+              "x": 58,
+              "y": 91.7,
+              "v": 0.579
+            },
+            "rightAnkle": {
+              "x": 24.3,
+              "y": 94.9,
+              "v": 0.847
+            },
+            "leftHeel": {
+              "x": 56.9,
+              "y": 94.3,
+              "v": 0.395
+            },
+            "rightHeel": {
+              "x": 24.1,
+              "y": 98.3,
+              "v": 0.432
+            },
+            "leftFootIndex": {
+              "x": 60.6,
+              "y": 98.4,
+              "v": 0.558
+            },
+            "rightFootIndex": {
+              "x": 21,
+              "y": 101.2,
+              "v": 0.722
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54,
+                "y": 12
+              },
+              "roll": 169.4,
+              "yaw": 0.553,
+              "pitch": 1.444
+            },
+            "torso": {
+              "center": {
+                "x": 47,
+                "y": 24.4
+              },
+              "angle": 86.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 72.4,
+                "y": 35.1
+              },
+              "angle": 61.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 25.9,
+                "y": 33.6
+              },
+              "angle": 83.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 56.9,
+                "y": 94.3
+              },
+              "angle": -47.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 24.1,
+                "y": 98.3
+              },
+              "angle": -136.9
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.961,
+          "keypoints": {
+            "nose": {
+              "x": 44.6,
+              "y": 18.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 43.9,
+              "y": 16.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 42.2,
+              "y": 16.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 42.2,
+              "y": 17,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 38.5,
+              "y": 17.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 47.9,
+              "y": 25.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 30.2,
+              "y": 27.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 55.1,
+              "y": 38,
+              "v": 0.969
+            },
+            "rightElbow": {
+              "x": 28.9,
+              "y": 41.8,
+              "v": 0.919
+            },
+            "leftWrist": {
+              "x": 58.7,
+              "y": 42.4,
+              "v": 0.94
+            },
+            "rightWrist": {
+              "x": 25.1,
+              "y": 43.8,
+              "v": 0.957
+            },
+            "leftIndex": {
+              "x": 59.6,
+              "y": 42.8,
+              "v": 0.922
+            },
+            "rightIndex": {
+              "x": 23.9,
+              "y": 43,
+              "v": 0.951
+            },
+            "leftHip": {
+              "x": 43.4,
+              "y": 49.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 35.4,
+              "y": 50.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 45.8,
+              "y": 69.9,
+              "v": 0.949
+            },
+            "rightKnee": {
+              "x": 44.1,
+              "y": 68.6,
+              "v": 0.919
+            },
+            "leftAnkle": {
+              "x": 37.2,
+              "y": 88.5,
+              "v": 0.958
+            },
+            "rightAnkle": {
+              "x": 52.6,
+              "y": 86.9,
+              "v": 0.961
+            },
+            "leftHeel": {
+              "x": 37.5,
+              "y": 91.9,
+              "v": 0.86
+            },
+            "rightHeel": {
+              "x": 53.8,
+              "y": 89.8,
+              "v": 0.898
+            },
+            "leftFootIndex": {
+              "x": 39.1,
+              "y": 95,
+              "v": 0.946
+            },
+            "rightFootIndex": {
+              "x": 55.3,
+              "y": 91.9,
+              "v": 0.947
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 43.1,
+                "y": 16.7
+              },
+              "roll": -173.3,
+              "yaw": 0.906,
+              "pitch": 1.11
+            },
+            "torso": {
+              "center": {
+                "x": 39.1,
+                "y": 26.5
+              },
+              "angle": 90.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 58.7,
+                "y": 42.4
+              },
+              "angle": -24
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 25.1,
+                "y": 43.8
+              },
+              "angle": 146.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 37.5,
+                "y": 91.9
+              },
+              "angle": -62.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 53.8,
+                "y": 89.8
+              },
+              "angle": -54.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.674,
+          "keypoints": {
+            "nose": {
+              "x": 44.5,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 43.2,
+              "y": 16,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 42.1,
+              "y": 16.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 40.9,
+              "y": 16.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 38,
+              "y": 17,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 46.9,
+              "y": 24.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 28.4,
+              "y": 26.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 55.2,
+              "y": 35.5,
+              "v": 0.839
+            },
+            "rightElbow": {
+              "x": 27.1,
+              "y": 39.7,
+              "v": 0.912
+            },
+            "leftWrist": {
+              "x": 55.7,
+              "y": 37.7,
+              "v": 0.796
+            },
+            "rightWrist": {
+              "x": 28.9,
+              "y": 41.9,
+              "v": 0.815
+            },
+            "leftIndex": {
+              "x": 55,
+              "y": 38,
+              "v": 0.745
+            },
+            "rightIndex": {
+              "x": 30.1,
+              "y": 41,
+              "v": 0.754
+            },
+            "leftHip": {
+              "x": 42.4,
+              "y": 47.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 33,
+              "y": 49.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 52.6,
+              "y": 59.8,
+              "v": 0.215
+            },
+            "rightKnee": {
+              "x": 42,
+              "y": 64,
+              "v": 0.274
+            },
+            "leftAnkle": {
+              "x": 57.9,
+              "y": 80.5,
+              "v": 0.181
+            },
+            "rightAnkle": {
+              "x": 42.8,
+              "y": 86,
+              "v": 0.285
+            },
+            "leftHeel": {
+              "x": 57.3,
+              "y": 84,
+              "v": 0.134
+            },
+            "rightHeel": {
+              "x": 42.6,
+              "y": 89.2,
+              "v": 0.128
+            },
+            "leftFootIndex": {
+              "x": 61.9,
+              "y": 86.2,
+              "v": 0.207
+            },
+            "rightFootIndex": {
+              "x": 44.9,
+              "y": 92.4,
+              "v": 0.215
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 42.7,
+                "y": 16.1
+              },
+              "roll": -174.8,
+              "yaw": 1.675,
+              "pitch": 2.037
+            },
+            "torso": {
+              "center": {
+                "x": 37.7,
+                "y": 25.5
+              },
+              "angle": 90.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 55.7,
+                "y": 37.7
+              },
+              "angle": -156.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.9,
+                "y": 41.9
+              },
+              "angle": 36.9
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.829,
+          "keypoints": {
+            "nose": {
+              "x": 55.4,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.9,
+              "y": 14.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.3,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52.3,
+              "y": 14.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.9,
+              "y": 14.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 58.5,
+              "y": 23.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.4,
+              "y": 27,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.1,
+              "y": 27.4,
+              "v": 0.829
+            },
+            "rightElbow": {
+              "x": 34.2,
+              "y": 39.9,
+              "v": 0.733
+            },
+            "leftWrist": {
+              "x": 73.6,
+              "y": 29,
+              "v": 0.844
+            },
+            "rightWrist": {
+              "x": 33.8,
+              "y": 43.9,
+              "v": 0.633
+            },
+            "leftIndex": {
+              "x": 72.2,
+              "y": 27.4,
+              "v": 0.844
+            },
+            "rightIndex": {
+              "x": 32.9,
+              "y": 43.4,
+              "v": 0.649
+            },
+            "leftHip": {
+              "x": 57.8,
+              "y": 53.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.7,
+              "y": 56.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60.5,
+              "y": 65.2,
+              "v": 0.899
+            },
+            "rightKnee": {
+              "x": 49.2,
+              "y": 76.2,
+              "v": 0.652
+            },
+            "leftAnkle": {
+              "x": 62.5,
+              "y": 88.9,
+              "v": 0.797
+            },
+            "rightAnkle": {
+              "x": 51.3,
+              "y": 98.3,
+              "v": 0.693
+            },
+            "leftHeel": {
+              "x": 62.2,
+              "y": 92.2,
+              "v": 0.641
+            },
+            "rightHeel": {
+              "x": 53.1,
+              "y": 101.7,
+              "v": 0.491
+            },
+            "leftFootIndex": {
+              "x": 63.2,
+              "y": 96.8,
+              "v": 0.796
+            },
+            "rightFootIndex": {
+              "x": 48.4,
+              "y": 105.4,
+              "v": 0.576
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.1,
+                "y": 14.3
+              },
+              "roll": 176.4,
+              "yaw": 0.811,
+              "pitch": 1.279
+            },
+            "torso": {
+              "center": {
+                "x": 49,
+                "y": 25.2
+              },
+              "angle": 98.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.6,
+                "y": 29
+              },
+              "angle": 131.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.8,
+                "y": 43.9
+              },
+              "angle": 150.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 62.2,
+                "y": 92.2
+              },
+              "angle": -77.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 53.1,
+                "y": 101.7
+              },
+              "angle": -141.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.867,
+          "keypoints": {
+            "nose": {
+              "x": 54.6,
+              "y": 19.9,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 53.4,
+              "y": 18,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 51.8,
+              "y": 18.3,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 50.3,
+              "y": 19,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 47.6,
+              "y": 19.7,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 58.4,
+              "y": 27.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.4,
+              "y": 34.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72,
+              "y": 32.1,
+              "v": 0.734
+            },
+            "rightElbow": {
+              "x": 46.3,
+              "y": 45.4,
+              "v": 0.988
+            },
+            "leftWrist": {
+              "x": 74.2,
+              "y": 31.3,
+              "v": 0.61
+            },
+            "rightWrist": {
+              "x": 57.9,
+              "y": 34.9,
+              "v": 0.949
+            },
+            "leftIndex": {
+              "x": 73,
+              "y": 28.8,
+              "v": 0.605
+            },
+            "rightIndex": {
+              "x": 61.1,
+              "y": 30.2,
+              "v": 0.879
+            },
+            "leftHip": {
+              "x": 63.4,
+              "y": 56.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.6,
+              "y": 62.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.7,
+              "y": 68.5,
+              "v": 0.905
+            },
+            "rightKnee": {
+              "x": 49.4,
+              "y": 89.3,
+              "v": 0.969
+            },
+            "leftAnkle": {
+              "x": 88.6,
+              "y": 79.5,
+              "v": 0.596
+            },
+            "rightAnkle": {
+              "x": 57.8,
+              "y": 112.3,
+              "v": 0.962
+            },
+            "leftHeel": {
+              "x": 88.9,
+              "y": 81.7,
+              "v": 0.548
+            },
+            "rightHeel": {
+              "x": 61.3,
+              "y": 113.5,
+              "v": 0.824
+            },
+            "leftFootIndex": {
+              "x": 94.2,
+              "y": 83.5,
+              "v": 0.514
+            },
+            "rightFootIndex": {
+              "x": 52.3,
+              "y": 118,
+              "v": 0.872
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 52.6,
+                "y": 18.2
+              },
+              "roll": -169.4,
+              "yaw": 1.229,
+              "pitch": 1.075
+            },
+            "torso": {
+              "center": {
+                "x": 49.4,
+                "y": 31.1
+              },
+              "angle": 107.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 74.2,
+                "y": 31.3
+              },
+              "angle": 115.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 57.9,
+                "y": 34.9
+              },
+              "angle": 55.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 88.9,
+                "y": 81.7
+              },
+              "angle": -18.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 61.3,
+                "y": 113.5
+              },
+              "angle": -153.4
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.888,
+          "keypoints": {
+            "nose": {
+              "x": 52.9,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 53.9,
+              "y": 18.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 50.3,
+              "y": 17.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 53.5,
+              "y": 18.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46.7,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 56.9,
+              "y": 26.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.1,
+              "y": 29.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 66,
+              "y": 31.1,
+              "v": 0.957
+            },
+            "rightElbow": {
+              "x": 37,
+              "y": 41.1,
+              "v": 0.981
+            },
+            "leftWrist": {
+              "x": 72.9,
+              "y": 33.3,
+              "v": 0.832
+            },
+            "rightWrist": {
+              "x": 31.7,
+              "y": 47.4,
+              "v": 0.918
+            },
+            "leftIndex": {
+              "x": 74.6,
+              "y": 33.2,
+              "v": 0.778
+            },
+            "rightIndex": {
+              "x": 30.5,
+              "y": 49.7,
+              "v": 0.86
+            },
+            "leftHip": {
+              "x": 56,
+              "y": 48.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.6,
+              "y": 50.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 62.2,
+              "y": 67.9,
+              "v": 0.908
+            },
+            "rightKnee": {
+              "x": 51.8,
+              "y": 68.4,
+              "v": 0.703
+            },
+            "leftAnkle": {
+              "x": 71,
+              "y": 84.1,
+              "v": 0.888
+            },
+            "rightAnkle": {
+              "x": 55.9,
+              "y": 84.8,
+              "v": 0.71
+            },
+            "leftHeel": {
+              "x": 71.8,
+              "y": 87.2,
+              "v": 0.735
+            },
+            "rightHeel": {
+              "x": 56.9,
+              "y": 87.4,
+              "v": 0.512
+            },
+            "leftFootIndex": {
+              "x": 74,
+              "y": 88,
+              "v": 0.916
+            },
+            "rightFootIndex": {
+              "x": 55.8,
+              "y": 89.5,
+              "v": 0.717
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 52.1,
+                "y": 17.9
+              },
+              "roll": 170.5,
+              "yaw": 0.219,
+              "pitch": 0.658
+            },
+            "torso": {
+              "center": {
+                "x": 49,
+                "y": 28
+              },
+              "angle": 97.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 72.9,
+                "y": 33.3
+              },
+              "angle": 3.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31.7,
+                "y": 47.4
+              },
+              "angle": -117.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.8,
+                "y": 87.2
+              },
+              "angle": -20
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 56.9,
+                "y": 87.4
+              },
+              "angle": -117.6
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.74,
+          "keypoints": {
+            "nose": {
+              "x": 70.2,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.4,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.8,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.9,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.4,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 51.6,
+              "y": 23.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 73.5,
+              "y": 25.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 49.6,
+              "y": 38.7,
+              "v": 0.86
+            },
+            "rightElbow": {
+              "x": 77.3,
+              "y": 37.7,
+              "v": 0.295
+            },
+            "leftWrist": {
+              "x": 43.5,
+              "y": 33,
+              "v": 0.824
+            },
+            "rightWrist": {
+              "x": 81.2,
+              "y": 33.4,
+              "v": 0.208
+            },
+            "leftIndex": {
+              "x": 42.8,
+              "y": 28.6,
+              "v": 0.764
+            },
+            "rightIndex": {
+              "x": 83,
+              "y": 29.3,
+              "v": 0.168
+            },
+            "leftHip": {
+              "x": 60.6,
+              "y": 62,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63,
+              "y": 62.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.4,
+              "y": 91.9,
+              "v": 0.864
+            },
+            "rightKnee": {
+              "x": 46.3,
+              "y": 86.9,
+              "v": 0.575
+            },
+            "leftAnkle": {
+              "x": 89.1,
+              "y": 116.9,
+              "v": 0.763
+            },
+            "rightAnkle": {
+              "x": 35.8,
+              "y": 115,
+              "v": 0.611
+            },
+            "leftHeel": {
+              "x": 89,
+              "y": 122.3,
+              "v": 0.681
+            },
+            "rightHeel": {
+              "x": 37.8,
+              "y": 119.7,
+              "v": 0.424
+            },
+            "leftFootIndex": {
+              "x": 88.1,
+              "y": 125.5,
+              "v": 0.593
+            },
+            "rightFootIndex": {
+              "x": 24.7,
+              "y": 120.4,
+              "v": 0.385
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.1,
+                "y": 11.6
+              },
+              "roll": 170.5,
+              "yaw": 1.808,
+              "pitch": 4.521
+            },
+            "torso": {
+              "center": {
+                "x": 62.6,
+                "y": 24.6
+              },
+              "angle": 88.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 43.5,
+                "y": 33
+              },
+              "angle": 99
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 89,
+                "y": 122.3
+              },
+              "angle": -105.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.8,
+                "y": 119.7
+              },
+              "angle": -176.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.92,
+          "keypoints": {
+            "nose": {
+              "x": 49.7,
+              "y": 15.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 48.5,
+              "y": 13.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 47.8,
+              "y": 13,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 45,
+              "y": 13.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 43.2,
+              "y": 13.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 52.6,
+              "y": 27,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 30.6,
+              "y": 25.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.7,
+              "y": 31.6,
+              "v": 0.965
+            },
+            "rightElbow": {
+              "x": 22.7,
+              "y": 36.4,
+              "v": 0.922
+            },
+            "leftWrist": {
+              "x": 69.1,
+              "y": 32.6,
+              "v": 0.877
+            },
+            "rightWrist": {
+              "x": 19.9,
+              "y": 44.4,
+              "v": 0.611
+            },
+            "leftIndex": {
+              "x": 69.7,
+              "y": 32.2,
+              "v": 0.828
+            },
+            "rightIndex": {
+              "x": 20,
+              "y": 47.3,
+              "v": 0.533
+            },
+            "leftHip": {
+              "x": 46.6,
+              "y": 61.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 32.2,
+              "y": 62.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60.4,
+              "y": 86,
+              "v": 0.984
+            },
+            "rightKnee": {
+              "x": 20.6,
+              "y": 84.4,
+              "v": 0.927
+            },
+            "leftAnkle": {
+              "x": 71.2,
+              "y": 113.9,
+              "v": 0.975
+            },
+            "rightAnkle": {
+              "x": 16.1,
+              "y": 112.9,
+              "v": 0.967
+            },
+            "leftHeel": {
+              "x": 69.9,
+              "y": 118.5,
+              "v": 0.849
+            },
+            "rightHeel": {
+              "x": 17.4,
+              "y": 118.7,
+              "v": 0.819
+            },
+            "leftFootIndex": {
+              "x": 74.7,
+              "y": 121.5,
+              "v": 0.966
+            },
+            "rightFootIndex": {
+              "x": 4.3,
+              "y": 119.2,
+              "v": 0.932
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 48.2,
+                "y": 13.1
+              },
+              "roll": 164.1,
+              "yaw": 2.129,
+              "pitch": 3.434
+            },
+            "torso": {
+              "center": {
+                "x": 41.6,
+                "y": 26.3
+              },
+              "angle": 86.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 69.1,
+                "y": 32.6
+              },
+              "angle": 33.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 19.9,
+                "y": 44.4
+              },
+              "angle": -88
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.9,
+                "y": 118.5
+              },
+              "angle": -32
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 17.4,
+                "y": 118.7
+              },
+              "angle": -177.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.855,
+          "keypoints": {
+            "nose": {
+              "x": 50.5,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 49.4,
+              "y": 11,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 48.2,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 46.5,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 43.5,
+              "y": 11.7,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 54.4,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 31.9,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 62.5,
+              "y": 28.7,
+              "v": 0.924
+            },
+            "rightElbow": {
+              "x": 27.3,
+              "y": 40.2,
+              "v": 0.502
+            },
+            "leftWrist": {
+              "x": 71.8,
+              "y": 28.3,
+              "v": 0.907
+            },
+            "rightWrist": {
+              "x": 25,
+              "y": 38.9,
+              "v": 0.229
+            },
+            "leftIndex": {
+              "x": 73.7,
+              "y": 29.9,
+              "v": 0.891
+            },
+            "rightIndex": {
+              "x": 24.2,
+              "y": 37.4,
+              "v": 0.279
+            },
+            "leftHip": {
+              "x": 52.2,
+              "y": 60.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 38.4,
+              "y": 62,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 64.7,
+              "y": 86.4,
+              "v": 0.96
+            },
+            "rightKnee": {
+              "x": 25.1,
+              "y": 85.4,
+              "v": 0.844
+            },
+            "leftAnkle": {
+              "x": 76.6,
+              "y": 115.4,
+              "v": 0.96
+            },
+            "rightAnkle": {
+              "x": 21.1,
+              "y": 113.7,
+              "v": 0.922
+            },
+            "leftHeel": {
+              "x": 74.5,
+              "y": 119.8,
+              "v": 0.753
+            },
+            "rightHeel": {
+              "x": 23.1,
+              "y": 119,
+              "v": 0.703
+            },
+            "leftFootIndex": {
+              "x": 81.4,
+              "y": 124,
+              "v": 0.936
+            },
+            "rightFootIndex": {
+              "x": 10.2,
+              "y": 120.8,
+              "v": 0.861
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 48.8,
+                "y": 10.9
+              },
+              "roll": 170.5,
+              "yaw": 1.397,
+              "pitch": 1.891
+            },
+            "torso": {
+              "center": {
+                "x": 43.2,
+                "y": 24.2
+              },
+              "angle": 93.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 71.8,
+                "y": 28.3
+              },
+              "angle": -40.1
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 74.5,
+                "y": 119.8
+              },
+              "angle": -31.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.1,
+                "y": 119
+              },
+              "angle": -172.1
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.94,
+          "keypoints": {
+            "nose": {
+              "x": 51.6,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 51.6,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 48.9,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 50,
+              "y": 13.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 44.8,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 55.8,
+              "y": 24.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 33.3,
+              "y": 25.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 67,
+              "y": 27.2,
+              "v": 0.975
+            },
+            "rightElbow": {
+              "x": 26.2,
+              "y": 38.2,
+              "v": 0.913
+            },
+            "leftWrist": {
+              "x": 80.4,
+              "y": 29.1,
+              "v": 0.928
+            },
+            "rightWrist": {
+              "x": 25,
+              "y": 41.6,
+              "v": 0.721
+            },
+            "leftIndex": {
+              "x": 83.2,
+              "y": 29,
+              "v": 0.919
+            },
+            "rightIndex": {
+              "x": 25.3,
+              "y": 41.8,
+              "v": 0.722
+            },
+            "leftHip": {
+              "x": 53.8,
+              "y": 62.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 39,
+              "y": 63,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 67.2,
+              "y": 88.8,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 24.7,
+              "y": 86.4,
+              "v": 0.912
+            },
+            "leftAnkle": {
+              "x": 79.1,
+              "y": 120.5,
+              "v": 0.985
+            },
+            "rightAnkle": {
+              "x": 21.4,
+              "y": 114.7,
+              "v": 0.961
+            },
+            "leftHeel": {
+              "x": 79.1,
+              "y": 123.8,
+              "v": 0.844
+            },
+            "rightHeel": {
+              "x": 23.6,
+              "y": 120.2,
+              "v": 0.846
+            },
+            "leftFootIndex": {
+              "x": 81.7,
+              "y": 124.8,
+              "v": 0.971
+            },
+            "rightFootIndex": {
+              "x": 9.1,
+              "y": 120.9,
+              "v": 0.932
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 50.3,
+                "y": 12.2
+              },
+              "roll": 175.8,
+              "yaw": 0.499,
+              "pitch": 0.923
+            },
+            "torso": {
+              "center": {
+                "x": 44.6,
+                "y": 24.8
+              },
+              "angle": 92.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.4,
+                "y": 29.1
+              },
+              "angle": 2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 25,
+                "y": 41.6
+              },
+              "angle": -33.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 79.1,
+                "y": 123.8
+              },
+              "angle": -21
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.6,
+                "y": 120.2
+              },
+              "angle": -177.2
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.936,
+          "keypoints": {
+            "nose": {
+              "x": 59.8,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.9,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.5,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.2,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.3,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.2,
+              "y": 24.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.1,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.4,
+              "y": 30.7,
+              "v": 0.941
+            },
+            "rightElbow": {
+              "x": 31.7,
+              "y": 35,
+              "v": 0.908
+            },
+            "leftWrist": {
+              "x": 73.3,
+              "y": 31.5,
+              "v": 0.876
+            },
+            "rightWrist": {
+              "x": 29.1,
+              "y": 37.7,
+              "v": 0.895
+            },
+            "leftIndex": {
+              "x": 70,
+              "y": 28.8,
+              "v": 0.846
+            },
+            "rightIndex": {
+              "x": 27.4,
+              "y": 39.4,
+              "v": 0.893
+            },
+            "leftHip": {
+              "x": 58.2,
+              "y": 62.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.8,
+              "y": 62.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.5,
+              "y": 88.8,
+              "v": 0.959
+            },
+            "rightKnee": {
+              "x": 29.8,
+              "y": 85.2,
+              "v": 0.9
+            },
+            "leftAnkle": {
+              "x": 82.4,
+              "y": 116.3,
+              "v": 0.966
+            },
+            "rightAnkle": {
+              "x": 26,
+              "y": 113.9,
+              "v": 0.957
+            },
+            "leftHeel": {
+              "x": 81.4,
+              "y": 121.3,
+              "v": 0.759
+            },
+            "rightHeel": {
+              "x": 28.9,
+              "y": 119.4,
+              "v": 0.782
+            },
+            "leftFootIndex": {
+              "x": 86.2,
+              "y": 126,
+              "v": 0.944
+            },
+            "rightFootIndex": {
+              "x": 13.9,
+              "y": 121,
+              "v": 0.91
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58.2,
+                "y": 11.5
+              },
+              "roll": 171.9,
+              "yaw": 1.131,
+              "pitch": 2.051
+            },
+            "torso": {
+              "center": {
+                "x": 50.7,
+                "y": 23.6
+              },
+              "angle": 90.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.3,
+                "y": 31.5
+              },
+              "angle": 140.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.1,
+                "y": 37.7
+              },
+              "angle": -135
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 81.4,
+                "y": 121.3
+              },
+              "angle": -44.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 28.9,
+                "y": 119.4
+              },
+              "angle": -173.9
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.987,
+          "keypoints": {
+            "nose": {
+              "x": 70.5,
+              "y": 13.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69,
+              "y": 10.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.4,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.1,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.6,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.1,
+              "y": 25.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.8,
+              "y": 24.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.6,
+              "y": 40.1,
+              "v": 0.983
+            },
+            "rightElbow": {
+              "x": 40.9,
+              "y": 37.6,
+              "v": 0.974
+            },
+            "leftWrist": {
+              "x": 89.4,
+              "y": 37.6,
+              "v": 0.988
+            },
+            "rightWrist": {
+              "x": 38,
+              "y": 40.1,
+              "v": 0.931
+            },
+            "leftIndex": {
+              "x": 93.8,
+              "y": 32.1,
+              "v": 0.984
+            },
+            "rightIndex": {
+              "x": 36.6,
+              "y": 40.1,
+              "v": 0.927
+            },
+            "leftHip": {
+              "x": 68.1,
+              "y": 61.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.5,
+              "y": 61.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.1,
+              "y": 88.1,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 41.5,
+              "y": 85.6,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 91.6,
+              "y": 115.2,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 36.1,
+              "y": 114.7,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 90.4,
+              "y": 120.7,
+              "v": 0.97
+            },
+            "rightHeel": {
+              "x": 38.7,
+              "y": 120,
+              "v": 0.973
+            },
+            "leftFootIndex": {
+              "x": 97.1,
+              "y": 123.8,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 24,
+              "y": 120.4,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.7,
+                "y": 10.8
+              },
+              "roll": -180,
+              "yaw": 3,
+              "pitch": 4.333
+            },
+            "torso": {
+              "center": {
+                "x": 61.5,
+                "y": 25
+              },
+              "angle": 89
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.4,
+                "y": 37.6
+              },
+              "angle": 51.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38,
+                "y": 40.1
+              },
+              "angle": -180
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 90.4,
+                "y": 120.7
+              },
+              "angle": -24.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.7,
+                "y": 120
+              },
+              "angle": -178.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.972,
+          "keypoints": {
+            "nose": {
+              "x": 69,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.4,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.6,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 66.4,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.7,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.2,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.6,
+              "y": 36.6,
+              "v": 0.967
+            },
+            "rightElbow": {
+              "x": 41.5,
+              "y": 36.6,
+              "v": 0.985
+            },
+            "leftWrist": {
+              "x": 90.1,
+              "y": 37.9,
+              "v": 0.97
+            },
+            "rightWrist": {
+              "x": 38.5,
+              "y": 39.4,
+              "v": 0.965
+            },
+            "leftIndex": {
+              "x": 92.2,
+              "y": 34.9,
+              "v": 0.966
+            },
+            "rightIndex": {
+              "x": 38.6,
+              "y": 39.8,
+              "v": 0.959
+            },
+            "leftHip": {
+              "x": 67.4,
+              "y": 61.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54.2,
+              "y": 61.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.8,
+              "y": 88.3,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 41.3,
+              "y": 85.6,
+              "v": 0.974
+            },
+            "leftAnkle": {
+              "x": 90.3,
+              "y": 116,
+              "v": 0.977
+            },
+            "rightAnkle": {
+              "x": 37,
+              "y": 112.4,
+              "v": 0.974
+            },
+            "leftHeel": {
+              "x": 89.1,
+              "y": 120.2,
+              "v": 0.866
+            },
+            "rightHeel": {
+              "x": 39.2,
+              "y": 115.8,
+              "v": 0.853
+            },
+            "leftFootIndex": {
+              "x": 94.2,
+              "y": 122.6,
+              "v": 0.965
+            },
+            "rightFootIndex": {
+              "x": 28.5,
+              "y": 114.8,
+              "v": 0.943
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.5,
+                "y": 11.1
+              },
+              "roll": 176.8,
+              "yaw": 0.832,
+              "pitch": 1.525
+            },
+            "torso": {
+              "center": {
+                "x": 61.5,
+                "y": 24.8
+              },
+              "angle": 89
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.1,
+                "y": 37.9
+              },
+              "angle": 55
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.5,
+                "y": 39.4
+              },
+              "angle": -76
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 89.1,
+                "y": 120.2
+              },
+              "angle": -25.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.2,
+                "y": 115.8
+              },
+              "angle": 174.7
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.947,
+          "keypoints": {
+            "nose": {
+              "x": 80.6,
+              "y": 13.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 79.9,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 78.2,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 77.2,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 73.5,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.8,
+              "y": 29.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59,
+              "y": 22.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.7,
+              "y": 47,
+              "v": 0.544
+            },
+            "rightElbow": {
+              "x": 45,
+              "y": 36.8,
+              "v": 0.976
+            },
+            "leftWrist": {
+              "x": 91.1,
+              "y": 51.4,
+              "v": 0.804
+            },
+            "rightWrist": {
+              "x": 47.9,
+              "y": 37.6,
+              "v": 0.895
+            },
+            "leftIndex": {
+              "x": 97,
+              "y": 49.9,
+              "v": 0.847
+            },
+            "rightIndex": {
+              "x": 50,
+              "y": 35.6,
+              "v": 0.899
+            },
+            "leftHip": {
+              "x": 70.8,
+              "y": 62.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.3,
+              "y": 61.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 87.8,
+              "y": 84.6,
+              "v": 0.977
+            },
+            "rightKnee": {
+              "x": 45.4,
+              "y": 89.3,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 87.1,
+              "y": 113.8,
+              "v": 0.977
+            },
+            "rightAnkle": {
+              "x": 30.6,
+              "y": 119.7,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 83.1,
+              "y": 118.9,
+              "v": 0.949
+            },
+            "rightHeel": {
+              "x": 29.9,
+              "y": 124.5,
+              "v": 0.946
+            },
+            "leftFootIndex": {
+              "x": 97.4,
+              "y": 121.1,
+              "v": 0.977
+            },
+            "rightFootIndex": {
+              "x": 24.5,
+              "y": 124.2,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 79.1,
+                "y": 11
+              },
+              "roll": 166.8,
+              "yaw": 0.888,
+              "pitch": 1.661
+            },
+            "torso": {
+              "center": {
+                "x": 69.4,
+                "y": 26.1
+              },
+              "angle": 81.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.1,
+                "y": 51.4
+              },
+              "angle": 14.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.9,
+                "y": 37.6
+              },
+              "angle": 43.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.1,
+                "y": 118.9
+              },
+              "angle": -8.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29.9,
+                "y": 124.5
+              },
+              "angle": 176.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 69.1,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.3,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.5,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.4,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74,
+              "y": 25.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.6,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.1,
+              "y": 37.5,
+              "v": 0.988
+            },
+            "rightElbow": {
+              "x": 42.3,
+              "y": 35.3,
+              "v": 0.985
+            },
+            "leftWrist": {
+              "x": 90.1,
+              "y": 37.1,
+              "v": 0.986
+            },
+            "rightWrist": {
+              "x": 37.5,
+              "y": 41.7,
+              "v": 0.961
+            },
+            "leftIndex": {
+              "x": 92.5,
+              "y": 33.9,
+              "v": 0.983
+            },
+            "rightIndex": {
+              "x": 34.6,
+              "y": 42.9,
+              "v": 0.954
+            },
+            "leftHip": {
+              "x": 66.8,
+              "y": 59.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.4,
+              "y": 60.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77,
+              "y": 86,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 40.3,
+              "y": 83.9,
+              "v": 0.99
+            },
+            "leftAnkle": {
+              "x": 87.2,
+              "y": 112.4,
+              "v": 0.981
+            },
+            "rightAnkle": {
+              "x": 35.6,
+              "y": 113.6,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 87.4,
+              "y": 116,
+              "v": 0.869
+            },
+            "rightHeel": {
+              "x": 37.9,
+              "y": 119.1,
+              "v": 0.964
+            },
+            "leftFootIndex": {
+              "x": 89.8,
+              "y": 122.6,
+              "v": 0.976
+            },
+            "rightFootIndex": {
+              "x": 23.2,
+              "y": 119.4,
+              "v": 0.986
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.2,
+                "y": 11.6
+              },
+              "roll": 170.1,
+              "yaw": 0.407,
+              "pitch": 1.157
+            },
+            "torso": {
+              "center": {
+                "x": 61.8,
+                "y": 24.4
+              },
+              "angle": 87.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.1,
+                "y": 37.1
+              },
+              "angle": 53.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.5,
+                "y": 41.7
+              },
+              "angle": -157.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 87.4,
+                "y": 116
+              },
+              "angle": -70
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.9,
+                "y": 119.1
+              },
+              "angle": -178.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.944,
+          "keypoints": {
+            "nose": {
+              "x": 78.8,
+              "y": 17.8,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 79.2,
+              "y": 15.4,
+              "v": 0.997
+            },
+            "rightEye": {
+              "x": 77.9,
+              "y": 14.2,
+              "v": 0.998
+            },
+            "leftEar": {
+              "x": 76.5,
+              "y": 14.5,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 73.1,
+              "y": 12.6,
+              "v": 0.997
+            },
+            "leftShoulder": {
+              "x": 79.3,
+              "y": 31.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.2,
+              "y": 22.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.2,
+              "y": 49.2,
+              "v": 0.932
+            },
+            "rightElbow": {
+              "x": 48.6,
+              "y": 36.8,
+              "v": 0.798
+            },
+            "leftWrist": {
+              "x": 57.8,
+              "y": 41.8,
+              "v": 0.895
+            },
+            "rightWrist": {
+              "x": 48.9,
+              "y": 38.7,
+              "v": 0.793
+            },
+            "leftIndex": {
+              "x": 53.7,
+              "y": 39.3,
+              "v": 0.879
+            },
+            "rightIndex": {
+              "x": 50.6,
+              "y": 38,
+              "v": 0.841
+            },
+            "leftHip": {
+              "x": 65.6,
+              "y": 62.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.7,
+              "y": 60.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.4,
+              "y": 88.2,
+              "v": 0.979
+            },
+            "rightKnee": {
+              "x": 38.4,
+              "y": 81.8,
+              "v": 0.937
+            },
+            "leftAnkle": {
+              "x": 86.1,
+              "y": 115.3,
+              "v": 0.982
+            },
+            "rightAnkle": {
+              "x": 31.9,
+              "y": 112.1,
+              "v": 0.975
+            },
+            "leftHeel": {
+              "x": 84.2,
+              "y": 119.7,
+              "v": 0.895
+            },
+            "rightHeel": {
+              "x": 34.1,
+              "y": 118,
+              "v": 0.889
+            },
+            "leftFootIndex": {
+              "x": 89.9,
+              "y": 125.4,
+              "v": 0.973
+            },
+            "rightFootIndex": {
+              "x": 19.9,
+              "y": 118.9,
+              "v": 0.948
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 78.6,
+                "y": 14.8
+              },
+              "roll": 137.3,
+              "yaw": 0.141,
+              "pitch": 1.696
+            },
+            "torso": {
+              "center": {
+                "x": 68.3,
+                "y": 27.1
+              },
+              "angle": 74.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 57.8,
+                "y": 41.8
+              },
+              "angle": 148.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48.9,
+                "y": 38.7
+              },
+              "angle": 22.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 84.2,
+                "y": 119.7
+              },
+              "angle": -45
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 34.1,
+                "y": 118
+              },
+              "angle": -176.4
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.981,
+          "keypoints": {
+            "nose": {
+              "x": 70.2,
+              "y": 14.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.4,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.6,
+              "y": 12,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.3,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.8,
+              "y": 11,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.2,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.9,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.2,
+              "y": 38.6,
+              "v": 0.932
+            },
+            "rightElbow": {
+              "x": 41.7,
+              "y": 35.2,
+              "v": 0.976
+            },
+            "leftWrist": {
+              "x": 88.9,
+              "y": 36.9,
+              "v": 0.958
+            },
+            "rightWrist": {
+              "x": 39.5,
+              "y": 38.6,
+              "v": 0.952
+            },
+            "leftIndex": {
+              "x": 91.1,
+              "y": 32.9,
+              "v": 0.961
+            },
+            "rightIndex": {
+              "x": 38.5,
+              "y": 39,
+              "v": 0.949
+            },
+            "leftHip": {
+              "x": 68.6,
+              "y": 61.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.4,
+              "y": 61.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.1,
+              "y": 89.2,
+              "v": 0.994
+            },
+            "rightKnee": {
+              "x": 40.5,
+              "y": 85,
+              "v": 0.989
+            },
+            "leftAnkle": {
+              "x": 91.7,
+              "y": 114.8,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 36.3,
+              "y": 113.7,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 90.5,
+              "y": 120.3,
+              "v": 0.939
+            },
+            "rightHeel": {
+              "x": 38.7,
+              "y": 119.1,
+              "v": 0.954
+            },
+            "leftFootIndex": {
+              "x": 97.6,
+              "y": 123.9,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 24,
+              "y": 120.2,
+              "v": 0.988
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69,
+                "y": 12.1
+              },
+              "roll": 166,
+              "yaw": 1.455,
+              "pitch": 3.395
+            },
+            "torso": {
+              "center": {
+                "x": 61.1,
+                "y": 24.2
+              },
+              "angle": 89.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.9,
+                "y": 36.9
+              },
+              "angle": 61.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.5,
+                "y": 38.6
+              },
+              "angle": -158.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 90.5,
+                "y": 120.3
+              },
+              "angle": -26.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.7,
+                "y": 119.1
+              },
+              "angle": -175.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.94,
+          "keypoints": {
+            "nose": {
+              "x": 70.5,
+              "y": 13.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.5,
+              "y": 11.5,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 67.4,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.2,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.9,
+              "y": 13.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.4,
+              "y": 26.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.3,
+              "y": 28.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.7,
+              "y": 42.4,
+              "v": 0.683
+            },
+            "rightElbow": {
+              "x": 40.4,
+              "y": 44.4,
+              "v": 0.868
+            },
+            "leftWrist": {
+              "x": 95.8,
+              "y": 45.2,
+              "v": 0.858
+            },
+            "rightWrist": {
+              "x": 43.7,
+              "y": 40.3,
+              "v": 0.828
+            },
+            "leftIndex": {
+              "x": 98.8,
+              "y": 42.5,
+              "v": 0.875
+            },
+            "rightIndex": {
+              "x": 44.1,
+              "y": 35.1,
+              "v": 0.844
+            },
+            "leftHip": {
+              "x": 71.8,
+              "y": 65.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.9,
+              "y": 65.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 93.7,
+              "y": 81.8,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 41.6,
+              "y": 89.1,
+              "v": 0.991
+            },
+            "leftAnkle": {
+              "x": 77.4,
+              "y": 103.4,
+              "v": 0.947
+            },
+            "rightAnkle": {
+              "x": 26.8,
+              "y": 113.6,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 72.2,
+              "y": 105.3,
+              "v": 0.926
+            },
+            "rightHeel": {
+              "x": 25.6,
+              "y": 116.5,
+              "v": 0.911
+            },
+            "leftFootIndex": {
+              "x": 81,
+              "y": 116.4,
+              "v": 0.929
+            },
+            "rightFootIndex": {
+              "x": 23.7,
+              "y": 123.1,
+              "v": 0.976
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68,
+                "y": 11.5
+              },
+              "roll": -180,
+              "yaw": 2.318,
+              "pitch": 2.182
+            },
+            "torso": {
+              "center": {
+                "x": 63.4,
+                "y": 27.7
+              },
+              "angle": 91.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.8,
+                "y": 45.2
+              },
+              "angle": 42
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.7,
+                "y": 40.3
+              },
+              "angle": 85.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.2,
+                "y": 105.3
+              },
+              "angle": -51.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25.6,
+                "y": 116.5
+              },
+              "angle": -106.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.991,
+          "keypoints": {
+            "nose": {
+              "x": 98.1,
+              "y": 21.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 98.5,
+              "y": 19,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 97.6,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 95.1,
+              "y": 17.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 93.4,
+              "y": 16,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 90.9,
+              "y": 32.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 74,
+              "y": 19.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 88.4,
+              "y": 50.9,
+              "v": 0.954
+            },
+            "rightElbow": {
+              "x": 51.9,
+              "y": 25.3,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 105.7,
+              "y": 53.7,
+              "v": 0.992
+            },
+            "rightWrist": {
+              "x": 33.5,
+              "y": 34.4,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 112.2,
+              "y": 53.3,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 28.3,
+              "y": 38.5,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 74.6,
+              "y": 63.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.4,
+              "y": 57.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90,
+              "y": 88,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 45.7,
+              "y": 79.8,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 73.5,
+              "y": 112.7,
+              "v": 0.984
+            },
+            "rightAnkle": {
+              "x": 22.3,
+              "y": 100.6,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 67.2,
+              "y": 116,
+              "v": 0.978
+            },
+            "rightHeel": {
+              "x": 18.9,
+              "y": 101.5,
+              "v": 0.942
+            },
+            "leftFootIndex": {
+              "x": 80.7,
+              "y": 125.2,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 15.6,
+              "y": 113.5,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 98.1,
+                "y": 18.7
+              },
+              "roll": 142.1,
+              "yaw": 0.044,
+              "pitch": 2.675
+            },
+            "torso": {
+              "center": {
+                "x": 82.5,
+                "y": 26.4
+              },
+              "angle": 67.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 105.7,
+                "y": 53.7
+              },
+              "angle": 3.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.5,
+                "y": 34.4
+              },
+              "angle": -141.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.2,
+                "y": 116
+              },
+              "angle": -34.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 18.9,
+                "y": 101.5
+              },
+              "angle": -105.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.969,
+          "keypoints": {
+            "nose": {
+              "x": 95.9,
+              "y": 10,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 99,
+              "y": 9.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 98.6,
+              "y": 8.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 101.3,
+              "y": 13.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 100.6,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 101.4,
+              "y": 33,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 83.9,
+              "y": 17.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 100.4,
+              "y": 56.6,
+              "v": 1
+            },
+            "rightElbow": {
+              "x": 64.1,
+              "y": 34.4,
+              "v": 0.785
+            },
+            "leftWrist": {
+              "x": 94.6,
+              "y": 79.7,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 41.4,
+              "y": 42,
+              "v": 0.849
+            },
+            "leftIndex": {
+              "x": 91.9,
+              "y": 86.3,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 33.9,
+              "y": 42.4,
+              "v": 0.821
+            },
+            "leftHip": {
+              "x": 68.4,
+              "y": 57.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58,
+              "y": 48.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 54.1,
+              "y": 85.7,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 26.8,
+              "y": 57.7,
+              "v": 0.986
+            },
+            "leftAnkle": {
+              "x": 52.5,
+              "y": 114.3,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 27.3,
+              "y": 86.9,
+              "v": 0.974
+            },
+            "leftHeel": {
+              "x": 53.7,
+              "y": 119.7,
+              "v": 0.96
+            },
+            "rightHeel": {
+              "x": 29.9,
+              "y": 93,
+              "v": 0.95
+            },
+            "leftFootIndex": {
+              "x": 41.1,
+              "y": 122.6,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 13.7,
+              "y": 95.4,
+              "v": 0.98
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 98.8,
+                "y": 8.9
+              },
+              "roll": 135,
+              "yaw": -5.127,
+              "pitch": 1.945
+            },
+            "torso": {
+              "center": {
+                "x": 92.7,
+                "y": 25.4
+              },
+              "angle": 43.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.6,
+                "y": 79.7
+              },
+              "angle": -112.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.4,
+                "y": 42
+              },
+              "angle": -176.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 53.7,
+                "y": 119.7
+              },
+              "angle": -167
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29.9,
+                "y": 93
+              },
+              "angle": -171.6
+            }
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.99,
+          "keypoints": {
+            "nose": {
+              "x": 69.9,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.4,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.4,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.2,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.7,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.1,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.4,
+              "y": 38.5,
+              "v": 0.971
+            },
+            "rightElbow": {
+              "x": 41.4,
+              "y": 36.2,
+              "v": 0.991
+            },
+            "leftWrist": {
+              "x": 87.3,
+              "y": 38.3,
+              "v": 0.977
+            },
+            "rightWrist": {
+              "x": 37.4,
+              "y": 39.5,
+              "v": 0.962
+            },
+            "leftIndex": {
+              "x": 88.6,
+              "y": 34.9,
+              "v": 0.976
+            },
+            "rightIndex": {
+              "x": 35.3,
+              "y": 40.3,
+              "v": 0.954
+            },
+            "leftHip": {
+              "x": 67.5,
+              "y": 59.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54.1,
+              "y": 59.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.9,
+              "y": 86.6,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 42.9,
+              "y": 85.3,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 87.3,
+              "y": 113.4,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 36.6,
+              "y": 114,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 88.5,
+              "y": 117.8,
+              "v": 0.977
+            },
+            "rightHeel": {
+              "x": 39.3,
+              "y": 118.7,
+              "v": 0.984
+            },
+            "leftFootIndex": {
+              "x": 93.6,
+              "y": 123.4,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 25.3,
+              "y": 118.1,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.4,
+                "y": 11.9
+              },
+              "roll": 166,
+              "yaw": 0.728,
+              "pitch": 1.14
+            },
+            "torso": {
+              "center": {
+                "x": 62.1,
+                "y": 24.6
+              },
+              "angle": 88
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.3,
+                "y": 38.3
+              },
+              "angle": 69.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.4,
+                "y": 39.5
+              },
+              "angle": -159.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 88.5,
+                "y": 117.8
+              },
+              "angle": -47.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.3,
+                "y": 118.7
+              },
+              "angle": 177.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.991,
+          "keypoints": {
+            "nose": {
+              "x": 70.2,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.1,
+              "y": 10.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.4,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.9,
+              "y": 11,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.3,
+              "y": 25.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.1,
+              "y": 23,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81,
+              "y": 39.6,
+              "v": 0.986
+            },
+            "rightElbow": {
+              "x": 39.5,
+              "y": 36,
+              "v": 0.977
+            },
+            "leftWrist": {
+              "x": 91.2,
+              "y": 36.4,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 36.8,
+              "y": 39.6,
+              "v": 0.953
+            },
+            "leftIndex": {
+              "x": 94.9,
+              "y": 31.1,
+              "v": 0.993
+            },
+            "rightIndex": {
+              "x": 36.1,
+              "y": 38.6,
+              "v": 0.952
+            },
+            "leftHip": {
+              "x": 68,
+              "y": 61.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.7,
+              "y": 62,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.8,
+              "y": 89.2,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 39.1,
+              "y": 86,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 93,
+              "y": 118.2,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 36.5,
+              "y": 114.2,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 91.7,
+              "y": 123,
+              "v": 0.98
+            },
+            "rightHeel": {
+              "x": 38.6,
+              "y": 119.6,
+              "v": 0.975
+            },
+            "leftFootIndex": {
+              "x": 97,
+              "y": 125.4,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 23.7,
+              "y": 120.5,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.6,
+                "y": 10.8
+              },
+              "roll": -180,
+              "yaw": 1.5,
+              "pitch": 2.636
+            },
+            "torso": {
+              "center": {
+                "x": 61.7,
+                "y": 24.1
+              },
+              "angle": 88.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.2,
+                "y": 36.4
+              },
+              "angle": 55.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.8,
+                "y": 39.6
+              },
+              "angle": 125
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 91.7,
+                "y": 123
+              },
+              "angle": -24.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.6,
+                "y": 119.6
+              },
+              "angle": -176.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 71.1,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.1,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.5,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.5,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.9,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.5,
+              "y": 24.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.3,
+              "y": 24.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.8,
+              "y": 36.4,
+              "v": 0.952
+            },
+            "rightElbow": {
+              "x": 44.9,
+              "y": 36.5,
+              "v": 0.993
+            },
+            "leftWrist": {
+              "x": 85,
+              "y": 37.8,
+              "v": 0.989
+            },
+            "rightWrist": {
+              "x": 43.1,
+              "y": 37.1,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 84.8,
+              "y": 37.7,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 45,
+              "y": 36.2,
+              "v": 0.993
+            },
+            "leftHip": {
+              "x": 71.8,
+              "y": 59.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.3,
+              "y": 58.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.5,
+              "y": 80.8,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 48.8,
+              "y": 83.7,
+              "v": 0.989
+            },
+            "leftAnkle": {
+              "x": 86.4,
+              "y": 109.1,
+              "v": 0.979
+            },
+            "rightAnkle": {
+              "x": 36.5,
+              "y": 109.8,
+              "v": 0.989
+            },
+            "leftHeel": {
+              "x": 84.1,
+              "y": 112,
+              "v": 0.935
+            },
+            "rightHeel": {
+              "x": 36.1,
+              "y": 114.5,
+              "v": 0.862
+            },
+            "leftFootIndex": {
+              "x": 91.3,
+              "y": 117.8,
+              "v": 0.979
+            },
+            "rightFootIndex": {
+              "x": 31.5,
+              "y": 117.1,
+              "v": 0.98
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.3,
+                "y": 12.1
+              },
+              "roll": 166,
+              "yaw": 0.485,
+              "pitch": 1.576
+            },
+            "torso": {
+              "center": {
+                "x": 63.9,
+                "y": 24.7
+              },
+              "angle": 91.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85,
+                "y": 37.8
+              },
+              "angle": 153.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.1,
+                "y": 37.1
+              },
+              "angle": 25.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 84.1,
+                "y": 112
+              },
+              "angle": -38.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.1,
+                "y": 114.5
+              },
+              "angle": -150.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.951,
+          "keypoints": {
+            "nose": {
+              "x": 70.2,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.1,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.5,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.7,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.9,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.5,
+              "y": 25.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.5,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.6,
+              "y": 39.7,
+              "v": 0.852
+            },
+            "rightElbow": {
+              "x": 55.3,
+              "y": 37.6,
+              "v": 0.908
+            },
+            "leftWrist": {
+              "x": 73.4,
+              "y": 38.8,
+              "v": 0.903
+            },
+            "rightWrist": {
+              "x": 59.4,
+              "y": 38.8,
+              "v": 0.859
+            },
+            "leftIndex": {
+              "x": 73.2,
+              "y": 34.1,
+              "v": 0.897
+            },
+            "rightIndex": {
+              "x": 60.7,
+              "y": 37.1,
+              "v": 0.819
+            },
+            "leftHip": {
+              "x": 65.9,
+              "y": 60.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.7,
+              "y": 60,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.8,
+              "y": 87.8,
+              "v": 0.982
+            },
+            "rightKnee": {
+              "x": 40.8,
+              "y": 84.3,
+              "v": 0.966
+            },
+            "leftAnkle": {
+              "x": 88,
+              "y": 116.7,
+              "v": 0.982
+            },
+            "rightAnkle": {
+              "x": 36,
+              "y": 114.4,
+              "v": 0.983
+            },
+            "leftHeel": {
+              "x": 90.2,
+              "y": 121.2,
+              "v": 0.896
+            },
+            "rightHeel": {
+              "x": 37.4,
+              "y": 120.2,
+              "v": 0.894
+            },
+            "leftFootIndex": {
+              "x": 95.9,
+              "y": 124.3,
+              "v": 0.974
+            },
+            "rightFootIndex": {
+              "x": 24.3,
+              "y": 120.2,
+              "v": 0.966
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.8,
+                "y": 11.4
+              },
+              "roll": -170.5,
+              "yaw": 2.302,
+              "pitch": 4.521
+            },
+            "torso": {
+              "center": {
+                "x": 61,
+                "y": 24.4
+              },
+              "angle": 89.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.4,
+                "y": 38.8
+              },
+              "angle": 92.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 59.4,
+                "y": 38.8
+              },
+              "angle": 52.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 90.2,
+                "y": 121.2
+              },
+              "angle": -28.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.4,
+                "y": 120.2
+              },
+              "angle": -180
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.774,
+          "keypoints": {
+            "nose": {
+              "x": 73,
+              "y": 16.1,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 72.4,
+              "y": 13.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73,
+              "y": 14,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.4,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 70.8,
+              "y": 13.9,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 51,
+              "y": 21.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 77.5,
+              "y": 27.6,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 38.6,
+              "y": 35.9,
+              "v": 0.907
+            },
+            "rightElbow": {
+              "x": 82.5,
+              "y": 43,
+              "v": 0.128
+            },
+            "leftWrist": {
+              "x": 40.5,
+              "y": 33.7,
+              "v": 0.496
+            },
+            "rightWrist": {
+              "x": 89.5,
+              "y": 38.9,
+              "v": 0.076
+            },
+            "leftIndex": {
+              "x": 41.2,
+              "y": 30,
+              "v": 0.481
+            },
+            "rightIndex": {
+              "x": 89.5,
+              "y": 36,
+              "v": 0.088
+            },
+            "leftHip": {
+              "x": 52.6,
+              "y": 61.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.1,
+              "y": 62.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 46.3,
+              "y": 89.2,
+              "v": 0.952
+            },
+            "rightKnee": {
+              "x": 70.3,
+              "y": 87.7,
+              "v": 0.955
+            },
+            "leftAnkle": {
+              "x": 32.4,
+              "y": 114.5,
+              "v": 0.917
+            },
+            "rightAnkle": {
+              "x": 87.5,
+              "y": 114.8,
+              "v": 0.857
+            },
+            "leftHeel": {
+              "x": 34.1,
+              "y": 120.5,
+              "v": 0.935
+            },
+            "rightHeel": {
+              "x": 87.8,
+              "y": 120.9,
+              "v": 0.933
+            },
+            "leftFootIndex": {
+              "x": 21.3,
+              "y": 120.2,
+              "v": 0.588
+            },
+            "rightFootIndex": {
+              "x": 92.6,
+              "y": 122.6,
+              "v": 0.484
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.7,
+                "y": 13.9
+              },
+              "roll": -26.6,
+              "yaw": 0.447,
+              "pitch": 3.354
+            },
+            "torso": {
+              "center": {
+                "x": 64.3,
+                "y": 24.7
+              },
+              "angle": 81.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 40.5,
+                "y": 33.7
+              },
+              "angle": 79.3
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 34.1,
+                "y": 120.5
+              },
+              "angle": 178.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 87.8,
+                "y": 120.9
+              },
+              "angle": -19.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.772,
+          "keypoints": {
+            "nose": {
+              "x": 84.9,
+              "y": 30.3,
+              "v": 0.993
+            },
+            "leftEye": {
+              "x": 94.3,
+              "y": 27,
+              "v": 0.987
+            },
+            "rightEye": {
+              "x": 83.9,
+              "y": 22.5,
+              "v": 0.994
+            },
+            "leftEar": {
+              "x": 93.9,
+              "y": 25.7,
+              "v": 0.992
+            },
+            "rightEar": {
+              "x": 77.4,
+              "y": 19.1,
+              "v": 0.99
+            },
+            "leftShoulder": {
+              "x": 85.9,
+              "y": 44.4,
+              "v": 0.998
+            },
+            "rightShoulder": {
+              "x": 55.6,
+              "y": 31.4,
+              "v": 0.998
+            },
+            "leftElbow": {
+              "x": 82.3,
+              "y": 76.9,
+              "v": 0.505
+            },
+            "rightElbow": {
+              "x": 52,
+              "y": 60.4,
+              "v": 0.423
+            },
+            "leftWrist": {
+              "x": 76.5,
+              "y": 62.7,
+              "v": 0.439
+            },
+            "rightWrist": {
+              "x": 70.1,
+              "y": 60.4,
+              "v": 0.293
+            },
+            "leftIndex": {
+              "x": 76.3,
+              "y": 54.2,
+              "v": 0.51
+            },
+            "rightIndex": {
+              "x": 75.6,
+              "y": 56.7,
+              "v": 0.328
+            },
+            "leftHip": {
+              "x": 69,
+              "y": 86,
+              "v": 0.997
+            },
+            "rightHip": {
+              "x": 47.3,
+              "y": 81.6,
+              "v": 0.996
+            },
+            "leftKnee": {
+              "x": 95.6,
+              "y": 85.8,
+              "v": 0.895
+            },
+            "rightKnee": {
+              "x": 39.8,
+              "y": 69.7,
+              "v": 0.88
+            },
+            "leftAnkle": {
+              "x": 96.8,
+              "y": 124.2,
+              "v": 0.858
+            },
+            "rightAnkle": {
+              "x": 29.7,
+              "y": 107.9,
+              "v": 0.806
+            },
+            "leftHeel": {
+              "x": 91.7,
+              "y": 136.9,
+              "v": 0.727
+            },
+            "rightHeel": {
+              "x": 31.7,
+              "y": 115.4,
+              "v": 0.666
+            },
+            "leftFootIndex": {
+              "x": 98.1,
+              "y": 145.7,
+              "v": 0.794
+            },
+            "rightFootIndex": {
+              "x": 16.3,
+              "y": 119.4,
+              "v": 0.688
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 89.1,
+                "y": 24.8
+              },
+              "roll": 156.6,
+              "yaw": -0.371,
+              "pitch": 0.49
+            },
+            "torso": {
+              "center": {
+                "x": 70.8,
+                "y": 37.9
+              },
+              "angle": 74.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76.5,
+                "y": 62.7
+              },
+              "angle": 91.3
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 91.7,
+                "y": 136.9
+              },
+              "angle": -54
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.7,
+                "y": 115.4
+              },
+              "angle": -165.4
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.959,
+          "keypoints": {
+            "nose": {
+              "x": 74.8,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.3,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.8,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.6,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 69,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.7,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83,
+              "y": 39.6,
+              "v": 0.98
+            },
+            "rightElbow": {
+              "x": 45.7,
+              "y": 34.9,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 95.5,
+              "y": 35.8,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 38.4,
+              "y": 33.4,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 98,
+              "y": 30.9,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 38.3,
+              "y": 33.6,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 68.8,
+              "y": 56.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.4,
+              "y": 55.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.8,
+              "y": 81.1,
+              "v": 0.926
+            },
+            "rightKnee": {
+              "x": 52.3,
+              "y": 77,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 65.6,
+              "y": 93.2,
+              "v": 0.69
+            },
+            "rightAnkle": {
+              "x": 41.2,
+              "y": 102.4,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 63.8,
+              "y": 94.9,
+              "v": 0.713
+            },
+            "rightHeel": {
+              "x": 39.5,
+              "y": 106.2,
+              "v": 0.956
+            },
+            "leftFootIndex": {
+              "x": 68.1,
+              "y": 99.4,
+              "v": 0.798
+            },
+            "rightFootIndex": {
+              "x": 41.4,
+              "y": 110.6,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.6,
+                "y": 12.1
+              },
+              "roll": 176.2,
+              "yaw": 0.831,
+              "pitch": 1.763
+            },
+            "torso": {
+              "center": {
+                "x": 65.9,
+                "y": 24.1
+              },
+              "angle": 84.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.5,
+                "y": 35.8
+              },
+              "angle": 63
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.4,
+                "y": 33.4
+              },
+              "angle": -116.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 63.8,
+                "y": 94.9
+              },
+              "angle": -46.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.5,
+                "y": 106.2
+              },
+              "angle": -66.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.862,
+          "keypoints": {
+            "nose": {
+              "x": 70,
+              "y": 15.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.6,
+              "y": 12.7,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 68.5,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 66.8,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.3,
+              "y": 12,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.8,
+              "y": 24.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.5,
+              "y": 24.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.1,
+              "y": 37.8,
+              "v": 0.803
+            },
+            "rightElbow": {
+              "x": 42.8,
+              "y": 37.4,
+              "v": 0.866
+            },
+            "leftWrist": {
+              "x": 90.8,
+              "y": 36.2,
+              "v": 0.905
+            },
+            "rightWrist": {
+              "x": 41.7,
+              "y": 35.6,
+              "v": 0.872
+            },
+            "leftIndex": {
+              "x": 93,
+              "y": 32.4,
+              "v": 0.902
+            },
+            "rightIndex": {
+              "x": 41.2,
+              "y": 32.3,
+              "v": 0.877
+            },
+            "leftHip": {
+              "x": 67.2,
+              "y": 57.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.1,
+              "y": 57.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.9,
+              "y": 77.4,
+              "v": 0.679
+            },
+            "rightKnee": {
+              "x": 51,
+              "y": 77.4,
+              "v": 0.917
+            },
+            "leftAnkle": {
+              "x": 76,
+              "y": 95.8,
+              "v": 0.645
+            },
+            "rightAnkle": {
+              "x": 33.6,
+              "y": 94.3,
+              "v": 0.865
+            },
+            "leftHeel": {
+              "x": 73.5,
+              "y": 98.6,
+              "v": 0.558
+            },
+            "rightHeel": {
+              "x": 31.6,
+              "y": 96.8,
+              "v": 0.543
+            },
+            "leftFootIndex": {
+              "x": 80.1,
+              "y": 103.5,
+              "v": 0.627
+            },
+            "rightFootIndex": {
+              "x": 29.8,
+              "y": 102,
+              "v": 0.774
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.1,
+                "y": 12.6
+              },
+              "roll": 164.7,
+              "yaw": 0.833,
+              "pitch": 2.412
+            },
+            "torso": {
+              "center": {
+                "x": 62.2,
+                "y": 24.5
+              },
+              "angle": 89.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.8,
+                "y": 36.2
+              },
+              "angle": 59.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.7,
+                "y": 35.6
+              },
+              "angle": 98.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.5,
+                "y": 98.6
+              },
+              "angle": -36.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.6,
+                "y": 96.8
+              },
+              "angle": -109.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.933,
+          "keypoints": {
+            "nose": {
+              "x": 69.9,
+              "y": 15.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.5,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.4,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 66.4,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.6,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.5,
+              "y": 25.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.5,
+              "y": 23.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.2,
+              "y": 36.7,
+              "v": 0.785
+            },
+            "rightElbow": {
+              "x": 42.1,
+              "y": 37.4,
+              "v": 0.923
+            },
+            "leftWrist": {
+              "x": 88.6,
+              "y": 35.8,
+              "v": 0.909
+            },
+            "rightWrist": {
+              "x": 38.9,
+              "y": 35.2,
+              "v": 0.949
+            },
+            "leftIndex": {
+              "x": 90.5,
+              "y": 32.3,
+              "v": 0.921
+            },
+            "rightIndex": {
+              "x": 38,
+              "y": 32.8,
+              "v": 0.952
+            },
+            "leftHip": {
+              "x": 67.9,
+              "y": 57.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.2,
+              "y": 57.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.6,
+              "y": 75.1,
+              "v": 0.98
+            },
+            "rightKnee": {
+              "x": 45.8,
+              "y": 76.6,
+              "v": 0.961
+            },
+            "leftAnkle": {
+              "x": 68.2,
+              "y": 92.7,
+              "v": 0.827
+            },
+            "rightAnkle": {
+              "x": 35.6,
+              "y": 96.8,
+              "v": 0.969
+            },
+            "leftHeel": {
+              "x": 64.7,
+              "y": 92.9,
+              "v": 0.729
+            },
+            "rightHeel": {
+              "x": 35.7,
+              "y": 100,
+              "v": 0.827
+            },
+            "leftFootIndex": {
+              "x": 66.4,
+              "y": 104.7,
+              "v": 0.803
+            },
+            "rightFootIndex": {
+              "x": 30.4,
+              "y": 105.4,
+              "v": 0.929
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69,
+                "y": 12.3
+              },
+              "roll": 169.7,
+              "yaw": 0.85,
+              "pitch": 2.594
+            },
+            "torso": {
+              "center": {
+                "x": 61.5,
+                "y": 24.5
+              },
+              "angle": 90.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.6,
+                "y": 35.8
+              },
+              "angle": 61.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.9,
+                "y": 35.2
+              },
+              "angle": 110.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 64.7,
+                "y": 92.9
+              },
+              "angle": -81.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.7,
+                "y": 100
+              },
+              "angle": -134.5
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/gartner/poses.json
+++ b/public/assets/fighters/gartner/poses.json
@@ -1,0 +1,8402 @@
+{
+  "version": 1,
+  "fighter": "gartner",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:41:21.421Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 70.9,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.1,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.8,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.1,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.8,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.7,
+              "y": 23,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86,
+              "y": 40.9,
+              "v": 0.974
+            },
+            "rightElbow": {
+              "x": 40.8,
+              "y": 41.2,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 93.9,
+              "y": 25.7,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 39.8,
+              "y": 60.8,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 94.3,
+              "y": 18.7,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 40.4,
+              "y": 65.6,
+              "v": 0.976
+            },
+            "leftHip": {
+              "x": 71.1,
+              "y": 61.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.9,
+              "y": 61.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.6,
+              "y": 88.2,
+              "v": 0.986
+            },
+            "rightKnee": {
+              "x": 51.1,
+              "y": 89,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 76.8,
+              "y": 115.1,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 44.6,
+              "y": 114.4,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 73.9,
+              "y": 119.6,
+              "v": 0.985
+            },
+            "rightHeel": {
+              "x": 43.4,
+              "y": 118,
+              "v": 0.955
+            },
+            "leftFootIndex": {
+              "x": 87.5,
+              "y": 120.3,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 44.5,
+              "y": 124.9,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.9,
+                "y": 10.7
+              },
+              "roll": -180,
+              "yaw": 0.413,
+              "pitch": 1.304
+            },
+            "torso": {
+              "center": {
+                "x": 63.9,
+                "y": 24.2
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.9,
+                "y": 25.7
+              },
+              "angle": 86.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.8,
+                "y": 60.8
+              },
+              "angle": -82.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.9,
+                "y": 119.6
+              },
+              "angle": -2.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.4,
+                "y": 118
+              },
+              "angle": -80.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 73.7,
+              "y": 13.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.5,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.9,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.3,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.5,
+              "y": 24.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.3,
+              "y": 23.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.1,
+              "y": 43.6,
+              "v": 0.968
+            },
+            "rightElbow": {
+              "x": 45,
+              "y": 41.2,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 87.7,
+              "y": 60.9,
+              "v": 0.991
+            },
+            "rightWrist": {
+              "x": 43.4,
+              "y": 60.5,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 89.5,
+              "y": 65.8,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 44.6,
+              "y": 65.8,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 75.3,
+              "y": 60.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.6,
+              "y": 62,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.4,
+              "y": 87.5,
+              "v": 0.987
+            },
+            "rightKnee": {
+              "x": 54.2,
+              "y": 88.3,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 80.1,
+              "y": 114.1,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 47.8,
+              "y": 114.2,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 77.7,
+              "y": 118.7,
+              "v": 0.977
+            },
+            "rightHeel": {
+              "x": 47.7,
+              "y": 118,
+              "v": 0.939
+            },
+            "leftFootIndex": {
+              "x": 90.3,
+              "y": 120.3,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 46.5,
+              "y": 126.2,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.7,
+                "y": 10.4
+              },
+              "roll": 173.7,
+              "yaw": 0.276,
+              "pitch": 0.828
+            },
+            "torso": {
+              "center": {
+                "x": 66.9,
+                "y": 23.9
+              },
+              "angle": 91.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.7,
+                "y": 60.9
+              },
+              "angle": -69.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.4,
+                "y": 60.5
+              },
+              "angle": -77.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 77.7,
+                "y": 118.7
+              },
+              "angle": -7.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.7,
+                "y": 118
+              },
+              "angle": -98.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.986,
+          "keypoints": {
+            "nose": {
+              "x": 70.8,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.2,
+              "y": 8.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.9,
+              "y": 8.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.4,
+              "y": 9.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.2,
+              "y": 9.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.3,
+              "y": 24.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.1,
+              "y": 22.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.8,
+              "y": 40.4,
+              "v": 0.96
+            },
+            "rightElbow": {
+              "x": 41.6,
+              "y": 41.3,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 93.3,
+              "y": 27.5,
+              "v": 0.992
+            },
+            "rightWrist": {
+              "x": 40,
+              "y": 60.3,
+              "v": 0.981
+            },
+            "leftIndex": {
+              "x": 94.5,
+              "y": 20.5,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 40.3,
+              "y": 65.6,
+              "v": 0.965
+            },
+            "leftHip": {
+              "x": 71.8,
+              "y": 60.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.3,
+              "y": 61.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79,
+              "y": 87.9,
+              "v": 0.948
+            },
+            "rightKnee": {
+              "x": 51.6,
+              "y": 88.7,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 77.1,
+              "y": 113.7,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 44.2,
+              "y": 114.7,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 74.3,
+              "y": 119,
+              "v": 0.963
+            },
+            "rightHeel": {
+              "x": 43.7,
+              "y": 118.1,
+              "v": 0.924
+            },
+            "leftFootIndex": {
+              "x": 88.4,
+              "y": 120.8,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 44.6,
+              "y": 124.5,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.6,
+                "y": 8.6
+              },
+              "roll": 178.3,
+              "yaw": 0.379,
+              "pitch": 0.803
+            },
+            "torso": {
+              "center": {
+                "x": 63.7,
+                "y": 23.7
+              },
+              "angle": 91.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.3,
+                "y": 27.5
+              },
+              "angle": 80.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40,
+                "y": 60.3
+              },
+              "angle": -86.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.3,
+                "y": 119
+              },
+              "angle": -7.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.7,
+                "y": 118.1
+              },
+              "angle": -82
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.886,
+          "keypoints": {
+            "nose": {
+              "x": 74.4,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.6,
+              "y": 9.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 71.8,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.9,
+              "y": 10.2,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 67.2,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78.7,
+              "y": 23.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.2,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.1,
+              "y": 42.9,
+              "v": 0.192
+            },
+            "rightElbow": {
+              "x": 44.3,
+              "y": 42.7,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 74.1,
+              "y": 56.7,
+              "v": 0.176
+            },
+            "rightWrist": {
+              "x": 43.8,
+              "y": 63.5,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 76.4,
+              "y": 62.2,
+              "v": 0.213
+            },
+            "rightIndex": {
+              "x": 46.3,
+              "y": 68.3,
+              "v": 0.994
+            },
+            "leftHip": {
+              "x": 74,
+              "y": 62.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59,
+              "y": 63,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.7,
+              "y": 86.7,
+              "v": 0.987
+            },
+            "rightKnee": {
+              "x": 54,
+              "y": 89.9,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 79.7,
+              "y": 114.3,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 47.4,
+              "y": 116.4,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 76.8,
+              "y": 119.6,
+              "v": 0.961
+            },
+            "rightHeel": {
+              "x": 47.3,
+              "y": 120.1,
+              "v": 0.899
+            },
+            "leftFootIndex": {
+              "x": 91,
+              "y": 120.8,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 47,
+              "y": 125.2,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.2,
+                "y": 9.6
+              },
+              "roll": -180,
+              "yaw": 0.429,
+              "pitch": 0.893
+            },
+            "torso": {
+              "center": {
+                "x": 66.5,
+                "y": 23.7
+              },
+              "angle": 90.1
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 43.8,
+                "y": 63.5
+              },
+              "angle": -62.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.8,
+                "y": 119.6
+              },
+              "angle": -4.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.3,
+                "y": 120.1
+              },
+              "angle": -93.4
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.887,
+          "keypoints": {
+            "nose": {
+              "x": 72.3,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.9,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.8,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.6,
+              "y": 11,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.1,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.9,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.5,
+              "y": 22.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.3,
+              "y": 41.6,
+              "v": 0.194
+            },
+            "rightElbow": {
+              "x": 46.7,
+              "y": 40.5,
+              "v": 0.99
+            },
+            "leftWrist": {
+              "x": 77,
+              "y": 59,
+              "v": 0.254
+            },
+            "rightWrist": {
+              "x": 44.1,
+              "y": 59.4,
+              "v": 0.984
+            },
+            "leftIndex": {
+              "x": 76.9,
+              "y": 62.4,
+              "v": 0.312
+            },
+            "rightIndex": {
+              "x": 45.3,
+              "y": 65.4,
+              "v": 0.969
+            },
+            "leftHip": {
+              "x": 74,
+              "y": 60.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.2,
+              "y": 61.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80,
+              "y": 87.7,
+              "v": 0.939
+            },
+            "rightKnee": {
+              "x": 53.5,
+              "y": 87.2,
+              "v": 0.984
+            },
+            "leftAnkle": {
+              "x": 77.7,
+              "y": 114.7,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 45.4,
+              "y": 116.6,
+              "v": 0.992
+            },
+            "leftHeel": {
+              "x": 75.1,
+              "y": 120.2,
+              "v": 0.944
+            },
+            "rightHeel": {
+              "x": 45,
+              "y": 120.1,
+              "v": 0.878
+            },
+            "leftFootIndex": {
+              "x": 89.5,
+              "y": 121.1,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 44.1,
+              "y": 124.6,
+              "v": 0.988
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.9,
+                "y": 10.6
+              },
+              "roll": 177.2,
+              "yaw": 0.11,
+              "pitch": 0.78
+            },
+            "torso": {
+              "center": {
+                "x": 67.7,
+                "y": 23.1
+              },
+              "angle": 89.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 44.1,
+                "y": 59.4
+              },
+              "angle": -78.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 75.1,
+                "y": 120.2
+              },
+              "angle": -3.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45,
+                "y": 120.1
+              },
+              "angle": -101.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.992,
+          "keypoints": {
+            "nose": {
+              "x": 69.3,
+              "y": 12,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.6,
+              "y": 9.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.4,
+              "y": 9.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.4,
+              "y": 10.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.6,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.9,
+              "y": 24.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.2,
+              "y": 23,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.1,
+              "y": 40.8,
+              "v": 0.975
+            },
+            "rightElbow": {
+              "x": 41.5,
+              "y": 41.9,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 93,
+              "y": 27.3,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 39.7,
+              "y": 60.6,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 94,
+              "y": 20.2,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 40.7,
+              "y": 66,
+              "v": 0.994
+            },
+            "leftHip": {
+              "x": 72.2,
+              "y": 62,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.1,
+              "y": 63.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.1,
+              "y": 87.5,
+              "v": 0.989
+            },
+            "rightKnee": {
+              "x": 47.8,
+              "y": 90.3,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 78.5,
+              "y": 114.8,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 42.1,
+              "y": 114.4,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 76,
+              "y": 120.2,
+              "v": 0.976
+            },
+            "rightHeel": {
+              "x": 42.8,
+              "y": 119.2,
+              "v": 0.933
+            },
+            "leftFootIndex": {
+              "x": 90.2,
+              "y": 120.8,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 39.4,
+              "y": 123.7,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.5,
+                "y": 9.2
+              },
+              "roll": -180,
+              "yaw": 0.19,
+              "pitch": 0.667
+            },
+            "torso": {
+              "center": {
+                "x": 63.6,
+                "y": 23.8
+              },
+              "angle": 91.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93,
+                "y": 27.3
+              },
+              "angle": 82
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.7,
+                "y": 60.6
+              },
+              "angle": -79.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76,
+                "y": 120.2
+              },
+              "angle": -2.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.8,
+                "y": 119.2
+              },
+              "angle": -127.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.99,
+          "keypoints": {
+            "nose": {
+              "x": 72.7,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.9,
+              "y": 9.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.8,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.3,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.6,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78.8,
+              "y": 24.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.4,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.4,
+              "y": 44.8,
+              "v": 0.913
+            },
+            "rightElbow": {
+              "x": 45.2,
+              "y": 43.1,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 86.2,
+              "y": 58.6,
+              "v": 0.985
+            },
+            "rightWrist": {
+              "x": 44.7,
+              "y": 62.1,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 89.8,
+              "y": 63.4,
+              "v": 0.983
+            },
+            "rightIndex": {
+              "x": 45.4,
+              "y": 66.5,
+              "v": 0.994
+            },
+            "leftHip": {
+              "x": 73.7,
+              "y": 61.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60,
+              "y": 62.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.1,
+              "y": 88.9,
+              "v": 0.985
+            },
+            "rightKnee": {
+              "x": 52.8,
+              "y": 90.6,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 73.2,
+              "y": 114.3,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 41.1,
+              "y": 112.9,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 69.5,
+              "y": 119.4,
+              "v": 0.987
+            },
+            "rightHeel": {
+              "x": 39.8,
+              "y": 115.7,
+              "v": 0.95
+            },
+            "leftFootIndex": {
+              "x": 84.5,
+              "y": 120.5,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 40.9,
+              "y": 124.3,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.9,
+                "y": 9.6
+              },
+              "roll": -180,
+              "yaw": 0.207,
+              "pitch": 0.634
+            },
+            "torso": {
+              "center": {
+                "x": 67.1,
+                "y": 23.7
+              },
+              "angle": 89.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.2,
+                "y": 58.6
+              },
+              "angle": -53.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.7,
+                "y": 62.1
+              },
+              "angle": -81
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.5,
+                "y": 119.4
+              },
+              "angle": -4.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.8,
+                "y": 115.7
+              },
+              "angle": -82.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.988,
+          "keypoints": {
+            "nose": {
+              "x": 69.6,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.7,
+              "y": 9.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.8,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.3,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.1,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.5,
+              "y": 24.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.5,
+              "y": 23.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.9,
+              "y": 44,
+              "v": 0.947
+            },
+            "rightElbow": {
+              "x": 39.9,
+              "y": 41.1,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 84.1,
+              "y": 60.9,
+              "v": 0.986
+            },
+            "rightWrist": {
+              "x": 38.3,
+              "y": 61.3,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 87,
+              "y": 64.4,
+              "v": 0.983
+            },
+            "rightIndex": {
+              "x": 39,
+              "y": 66.2,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 71.5,
+              "y": 60.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.6,
+              "y": 61.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.8,
+              "y": 87.8,
+              "v": 0.983
+            },
+            "rightKnee": {
+              "x": 49.6,
+              "y": 89.2,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 75.4,
+              "y": 114.7,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 43.4,
+              "y": 113.4,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 72.6,
+              "y": 119.6,
+              "v": 0.977
+            },
+            "rightHeel": {
+              "x": 41.7,
+              "y": 118.6,
+              "v": 0.896
+            },
+            "leftFootIndex": {
+              "x": 86.1,
+              "y": 120.6,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 42.1,
+              "y": 125,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.3,
+                "y": 9.9
+              },
+              "roll": -178,
+              "yaw": 0.465,
+              "pitch": 0.81
+            },
+            "torso": {
+              "center": {
+                "x": 63.5,
+                "y": 23.7
+              },
+              "angle": 90.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.1,
+                "y": 60.9
+              },
+              "angle": -50.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.3,
+                "y": 61.3
+              },
+              "angle": -81.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.6,
+                "y": 119.6
+              },
+              "angle": -4.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.7,
+                "y": 118.6
+              },
+              "angle": -86.4
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.565,
+          "keypoints": {
+            "nose": {
+              "x": 54.9,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.4,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.7,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 53.1,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.5,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 49.1,
+              "y": 18.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.2,
+              "y": 22,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 45.2,
+              "y": 33.6,
+              "v": 0.17
+            },
+            "rightElbow": {
+              "x": 31.2,
+              "y": 34.6,
+              "v": 0.934
+            },
+            "leftWrist": {
+              "x": 37.1,
+              "y": 36.9,
+              "v": 0.224
+            },
+            "rightWrist": {
+              "x": 34.3,
+              "y": 33.7,
+              "v": 0.536
+            },
+            "leftIndex": {
+              "x": 35.4,
+              "y": 36.9,
+              "v": 0.165
+            },
+            "rightIndex": {
+              "x": 36.2,
+              "y": 31.9,
+              "v": 0.409
+            },
+            "leftHip": {
+              "x": 56.3,
+              "y": 33.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.5,
+              "y": 39.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76,
+              "y": 26.5,
+              "v": 0.344
+            },
+            "rightKnee": {
+              "x": 58.4,
+              "y": 40.2,
+              "v": 0.042
+            },
+            "leftAnkle": {
+              "x": 97.1,
+              "y": 26.7,
+              "v": 0.38
+            },
+            "rightAnkle": {
+              "x": 57.2,
+              "y": 45.4,
+              "v": 0.019
+            },
+            "leftHeel": {
+              "x": 99.1,
+              "y": 29.4,
+              "v": 0.314
+            },
+            "rightHeel": {
+              "x": 57.4,
+              "y": 47.3,
+              "v": 0.018
+            },
+            "leftFootIndex": {
+              "x": 102.5,
+              "y": 24.2,
+              "v": 0.426
+            },
+            "rightFootIndex": {
+              "x": 57.5,
+              "y": 43.8,
+              "v": 0.024
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.6,
+                "y": 10.7
+              },
+              "roll": -173.3,
+              "yaw": 0.204,
+              "pitch": 1.461
+            },
+            "torso": {
+              "center": {
+                "x": 44.2,
+                "y": 20.3
+              },
+              "angle": 122.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 34.3,
+                "y": 33.7
+              },
+              "angle": 43.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 99.1,
+                "y": 29.4
+              },
+              "angle": 56.8
+            },
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.966,
+          "keypoints": {
+            "nose": {
+              "x": 56,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.4,
+              "y": 9.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.6,
+              "y": 9.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 51.2,
+              "y": 10.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.5,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.3,
+              "y": 23.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.4,
+              "y": 25.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.8,
+              "y": 26.4,
+              "v": 0.992
+            },
+            "rightElbow": {
+              "x": 27.6,
+              "y": 42.6,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 96.4,
+              "y": 27.2,
+              "v": 0.988
+            },
+            "rightWrist": {
+              "x": 39.7,
+              "y": 36.7,
+              "v": 0.986
+            },
+            "leftIndex": {
+              "x": 101,
+              "y": 26.5,
+              "v": 0.982
+            },
+            "rightIndex": {
+              "x": 43.4,
+              "y": 32.1,
+              "v": 0.966
+            },
+            "leftHip": {
+              "x": 55.6,
+              "y": 56.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.7,
+              "y": 58.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 59.3,
+              "y": 82.3,
+              "v": 0.907
+            },
+            "rightKnee": {
+              "x": 37.1,
+              "y": 83.2,
+              "v": 0.976
+            },
+            "leftAnkle": {
+              "x": 60.2,
+              "y": 100.9,
+              "v": 0.941
+            },
+            "rightAnkle": {
+              "x": 30.7,
+              "y": 105.8,
+              "v": 0.984
+            },
+            "leftHeel": {
+              "x": 58.6,
+              "y": 102.1,
+              "v": 0.793
+            },
+            "rightHeel": {
+              "x": 31.9,
+              "y": 110.4,
+              "v": 0.858
+            },
+            "leftFootIndex": {
+              "x": 63.3,
+              "y": 110.5,
+              "v": 0.905
+            },
+            "rightFootIndex": {
+              "x": 28,
+              "y": 111.3,
+              "v": 0.957
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54,
+                "y": 9.5
+              },
+              "roll": 172.9,
+              "yaw": 2.481,
+              "pitch": 2.295
+            },
+            "torso": {
+              "center": {
+                "x": 48.3,
+                "y": 24.8
+              },
+              "angle": 92.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.4,
+                "y": 27.2
+              },
+              "angle": 8.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.7,
+                "y": 36.7
+              },
+              "angle": 51.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 58.6,
+                "y": 102.1
+              },
+              "angle": -60.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.9,
+                "y": 110.4
+              },
+              "angle": -167
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 54.8,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.5,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 52.1,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.8,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 47.5,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 60.5,
+              "y": 24.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.3,
+              "y": 26.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.1,
+              "y": 26.5,
+              "v": 0.998
+            },
+            "rightElbow": {
+              "x": 25.9,
+              "y": 44.9,
+              "v": 0.993
+            },
+            "leftWrist": {
+              "x": 96.5,
+              "y": 27.1,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 33.3,
+              "y": 35.8,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 101.5,
+              "y": 26.8,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 35.7,
+              "y": 30.5,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 55.7,
+              "y": 57.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.7,
+              "y": 57.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 61.2,
+              "y": 84.1,
+              "v": 0.968
+            },
+            "rightKnee": {
+              "x": 36.9,
+              "y": 84.9,
+              "v": 0.98
+            },
+            "leftAnkle": {
+              "x": 60.5,
+              "y": 103.5,
+              "v": 0.975
+            },
+            "rightAnkle": {
+              "x": 31.7,
+              "y": 106.2,
+              "v": 0.983
+            },
+            "leftHeel": {
+              "x": 59.5,
+              "y": 104.4,
+              "v": 0.904
+            },
+            "rightHeel": {
+              "x": 31.4,
+              "y": 106.8,
+              "v": 0.887
+            },
+            "leftFootIndex": {
+              "x": 63.8,
+              "y": 115,
+              "v": 0.969
+            },
+            "rightFootIndex": {
+              "x": 30.2,
+              "y": 114,
+              "v": 0.964
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.8,
+                "y": 11.1
+              },
+              "roll": -180,
+              "yaw": 0.294,
+              "pitch": 0.735
+            },
+            "torso": {
+              "center": {
+                "x": 49.4,
+                "y": 25.4
+              },
+              "angle": 89.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.5,
+                "y": 27.1
+              },
+              "angle": 3.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.3,
+                "y": 35.8
+              },
+              "angle": 65.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 59.5,
+                "y": 104.4
+              },
+              "angle": -67.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.4,
+                "y": 106.8
+              },
+              "angle": -99.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.985,
+          "keypoints": {
+            "nose": {
+              "x": 57.5,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.4,
+              "y": 10.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.3,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 53.6,
+              "y": 10.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.5,
+              "y": 11,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 61.4,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.5,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.4,
+              "y": 26.6,
+              "v": 0.998
+            },
+            "rightElbow": {
+              "x": 27.3,
+              "y": 42.7,
+              "v": 0.994
+            },
+            "leftWrist": {
+              "x": 96.9,
+              "y": 26.9,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 28,
+              "y": 36.3,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 101.9,
+              "y": 26.7,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 29.9,
+              "y": 33.6,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 55.5,
+              "y": 57,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.5,
+              "y": 57,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 59.7,
+              "y": 83.9,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 36,
+              "y": 84.6,
+              "v": 0.977
+            },
+            "leftAnkle": {
+              "x": 60,
+              "y": 104.5,
+              "v": 0.985
+            },
+            "rightAnkle": {
+              "x": 30.7,
+              "y": 106.6,
+              "v": 0.981
+            },
+            "leftHeel": {
+              "x": 59.4,
+              "y": 111.5,
+              "v": 0.925
+            },
+            "rightHeel": {
+              "x": 30.6,
+              "y": 109.5,
+              "v": 0.869
+            },
+            "leftFootIndex": {
+              "x": 61.5,
+              "y": 117,
+              "v": 0.984
+            },
+            "rightFootIndex": {
+              "x": 29.1,
+              "y": 113.8,
+              "v": 0.969
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55.9,
+                "y": 10.1
+              },
+              "roll": -174.8,
+              "yaw": 1.494,
+              "pitch": 2.037
+            },
+            "torso": {
+              "center": {
+                "x": 50,
+                "y": 24.2
+              },
+              "angle": 88.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.9,
+                "y": 26.9
+              },
+              "angle": 2.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28,
+                "y": 36.3
+              },
+              "angle": 54.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 59.4,
+                "y": 111.5
+              },
+              "angle": -69.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.6,
+                "y": 109.5
+              },
+              "angle": -109.2
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 56,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.2,
+              "y": 10.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.5,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.1,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.3,
+              "y": 22.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.7,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.9,
+              "y": 23.5,
+              "v": 0.998
+            },
+            "rightElbow": {
+              "x": 27.2,
+              "y": 43.4,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 105.4,
+              "y": 23.7,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 40.3,
+              "y": 33,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 112,
+              "y": 23.5,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 45.4,
+              "y": 28.7,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 57.9,
+              "y": 60.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.7,
+              "y": 60.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.6,
+              "y": 84.9,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 30.8,
+              "y": 85.9,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 70.2,
+              "y": 114.4,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 18.7,
+              "y": 115.9,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 67.1,
+              "y": 116.9,
+              "v": 0.984
+            },
+            "rightHeel": {
+              "x": 18.3,
+              "y": 120.3,
+              "v": 0.978
+            },
+            "leftFootIndex": {
+              "x": 77.6,
+              "y": 122,
+              "v": 0.986
+            },
+            "rightFootIndex": {
+              "x": 15.9,
+              "y": 123.5,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55.9,
+                "y": 10.2
+              },
+              "roll": 172.7,
+              "yaw": 0.032,
+              "pitch": 0.612
+            },
+            "torso": {
+              "center": {
+                "x": 50.5,
+                "y": 23
+              },
+              "angle": 90.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 105.4,
+                "y": 23.7
+              },
+              "angle": 1.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40.3,
+                "y": 33
+              },
+              "angle": 40.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.1,
+                "y": 116.9
+              },
+              "angle": -25.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 18.3,
+                "y": 120.3
+              },
+              "angle": -126.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.96,
+          "keypoints": {
+            "nose": {
+              "x": 35.1,
+              "y": 29.5,
+              "v": 0.997
+            },
+            "leftEye": {
+              "x": 35.6,
+              "y": 26,
+              "v": 0.991
+            },
+            "rightEye": {
+              "x": 33.8,
+              "y": 27.8,
+              "v": 0.994
+            },
+            "leftEar": {
+              "x": 38.9,
+              "y": 24.1,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 34.9,
+              "y": 27.6,
+              "v": 0.993
+            },
+            "leftShoulder": {
+              "x": 55.5,
+              "y": 29.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 33,
+              "y": 34.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.6,
+              "y": 23.8,
+              "v": 0.986
+            },
+            "rightElbow": {
+              "x": 27.8,
+              "y": 42.3,
+              "v": 0.87
+            },
+            "leftWrist": {
+              "x": 105.1,
+              "y": 23.2,
+              "v": 0.958
+            },
+            "rightWrist": {
+              "x": 33,
+              "y": 31.9,
+              "v": 0.855
+            },
+            "leftIndex": {
+              "x": 110.6,
+              "y": 24.9,
+              "v": 0.941
+            },
+            "rightIndex": {
+              "x": 35.2,
+              "y": 27.2,
+              "v": 0.798
+            },
+            "leftHip": {
+              "x": 58.3,
+              "y": 61.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.7,
+              "y": 62.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.3,
+              "y": 85.9,
+              "v": 0.91
+            },
+            "rightKnee": {
+              "x": 32,
+              "y": 84.9,
+              "v": 0.983
+            },
+            "leftAnkle": {
+              "x": 70.9,
+              "y": 113.4,
+              "v": 0.985
+            },
+            "rightAnkle": {
+              "x": 19.7,
+              "y": 114.7,
+              "v": 0.986
+            },
+            "leftHeel": {
+              "x": 68.1,
+              "y": 119,
+              "v": 0.954
+            },
+            "rightHeel": {
+              "x": 19.4,
+              "y": 117.5,
+              "v": 0.918
+            },
+            "leftFootIndex": {
+              "x": 81.1,
+              "y": 119.4,
+              "v": 0.976
+            },
+            "rightFootIndex": {
+              "x": 18.5,
+              "y": 124.1,
+              "v": 0.985
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 34.7,
+                "y": 26.9
+              },
+              "roll": -135,
+              "yaw": 0.157,
+              "pitch": 1.021
+            },
+            "torso": {
+              "center": {
+                "x": 44.3,
+                "y": 31.9
+              },
+              "angle": 103.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 105.1,
+                "y": 23.2
+              },
+              "angle": -17.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33,
+                "y": 31.9
+              },
+              "angle": 64.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.1,
+                "y": 119
+              },
+              "angle": -1.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 19.4,
+                "y": 117.5
+              },
+              "angle": -97.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.97,
+          "keypoints": {
+            "nose": {
+              "x": 59.1,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.5,
+              "y": 8.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.3,
+              "y": 6.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.1,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.9,
+              "y": 10,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 61.4,
+              "y": 24.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.4,
+              "y": 25.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.8,
+              "y": 22.4,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 30.3,
+              "y": 37.7,
+              "v": 0.946
+            },
+            "leftWrist": {
+              "x": 103.6,
+              "y": 22.4,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 35.2,
+              "y": 35,
+              "v": 0.801
+            },
+            "leftIndex": {
+              "x": 109.2,
+              "y": 24.7,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 37.3,
+              "y": 32,
+              "v": 0.775
+            },
+            "leftHip": {
+              "x": 59.7,
+              "y": 58.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.4,
+              "y": 57.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.4,
+              "y": 83.2,
+              "v": 0.981
+            },
+            "rightKnee": {
+              "x": 40.2,
+              "y": 75.3,
+              "v": 0.987
+            },
+            "leftAnkle": {
+              "x": 70.9,
+              "y": 113.4,
+              "v": 0.986
+            },
+            "rightAnkle": {
+              "x": 20.8,
+              "y": 112.7,
+              "v": 0.989
+            },
+            "leftHeel": {
+              "x": 68.3,
+              "y": 119.1,
+              "v": 0.969
+            },
+            "rightHeel": {
+              "x": 21,
+              "y": 118.1,
+              "v": 0.931
+            },
+            "leftFootIndex": {
+              "x": 81.8,
+              "y": 119.2,
+              "v": 0.981
+            },
+            "rightFootIndex": {
+              "x": 17.6,
+              "y": 123.5,
+              "v": 0.987
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.9,
+                "y": 7.6
+              },
+              "roll": 157.9,
+              "yaw": 0.347,
+              "pitch": 0.738
+            },
+            "torso": {
+              "center": {
+                "x": 49.4,
+                "y": 25.1
+              },
+              "angle": 97.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.6,
+                "y": 22.4
+              },
+              "angle": -22.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.2,
+                "y": 35
+              },
+              "angle": 55
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.3,
+                "y": 119.1
+              },
+              "angle": -0.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 21,
+                "y": 118.1
+              },
+              "angle": -122.2
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 57.2,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.4,
+              "y": 10,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.7,
+              "y": 9.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.3,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.1,
+              "y": 10,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.1,
+              "y": 21.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.6,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.8,
+              "y": 22.1,
+              "v": 0.999
+            },
+            "rightElbow": {
+              "x": 25.6,
+              "y": 38.7,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 104.9,
+              "y": 21.2,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 31.1,
+              "y": 28.2,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 110.4,
+              "y": 20.7,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 33.1,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 58.2,
+              "y": 58.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45,
+              "y": 59.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.9,
+              "y": 83.9,
+              "v": 0.991
+            },
+            "rightKnee": {
+              "x": 32.7,
+              "y": 83.1,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 71,
+              "y": 110.4,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 18.5,
+              "y": 114.2,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 68,
+              "y": 112.4,
+              "v": 0.976
+            },
+            "rightHeel": {
+              "x": 18.9,
+              "y": 118.2,
+              "v": 0.969
+            },
+            "leftFootIndex": {
+              "x": 76.2,
+              "y": 119.7,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 17.7,
+              "y": 121.6,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.1,
+                "y": 9.7
+              },
+              "roll": 171.5,
+              "yaw": 0.032,
+              "pitch": 0.621
+            },
+            "torso": {
+              "center": {
+                "x": 51.4,
+                "y": 23.1
+              },
+              "angle": 90.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 104.9,
+                "y": 21.2
+              },
+              "angle": 5.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31.1,
+                "y": 28.2
+              },
+              "angle": 66.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68,
+                "y": 112.4
+              },
+              "angle": -41.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 18.9,
+                "y": 118.2
+              },
+              "angle": -109.4
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.978,
+          "keypoints": {
+            "nose": {
+              "x": 58,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.1,
+              "y": 10.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 55.6,
+              "y": 9.2,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 57.9,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.5,
+              "y": 11.2,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 62.2,
+              "y": 24.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.9,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.4,
+              "y": 22.3,
+              "v": 0.993
+            },
+            "rightElbow": {
+              "x": 25.6,
+              "y": 35.1,
+              "v": 0.972
+            },
+            "leftWrist": {
+              "x": 105.6,
+              "y": 22.4,
+              "v": 0.989
+            },
+            "rightWrist": {
+              "x": 27,
+              "y": 36,
+              "v": 0.926
+            },
+            "leftIndex": {
+              "x": 108.1,
+              "y": 23.7,
+              "v": 0.976
+            },
+            "rightIndex": {
+              "x": 28.5,
+              "y": 34.6,
+              "v": 0.902
+            },
+            "leftHip": {
+              "x": 61.6,
+              "y": 59,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.1,
+              "y": 58.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.3,
+              "y": 84.6,
+              "v": 0.953
+            },
+            "rightKnee": {
+              "x": 34.6,
+              "y": 76.9,
+              "v": 0.974
+            },
+            "leftAnkle": {
+              "x": 72,
+              "y": 113.7,
+              "v": 0.983
+            },
+            "rightAnkle": {
+              "x": 19.4,
+              "y": 111.9,
+              "v": 0.991
+            },
+            "leftHeel": {
+              "x": 69.5,
+              "y": 119,
+              "v": 0.949
+            },
+            "rightHeel": {
+              "x": 21.7,
+              "y": 117.3,
+              "v": 0.934
+            },
+            "leftFootIndex": {
+              "x": 81.4,
+              "y": 118.1,
+              "v": 0.977
+            },
+            "rightFootIndex": {
+              "x": 16.4,
+              "y": 120.8,
+              "v": 0.987
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.4,
+                "y": 9.9
+              },
+              "roll": 158.2,
+              "yaw": 0.172,
+              "pitch": 0.663
+            },
+            "torso": {
+              "center": {
+                "x": 50.1,
+                "y": 24.7
+              },
+              "angle": 97.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 105.6,
+                "y": 22.4
+              },
+              "angle": -27.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 27,
+                "y": 36
+              },
+              "angle": 43
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.5,
+                "y": 119
+              },
+              "angle": 4.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 21.7,
+                "y": 117.3
+              },
+              "angle": -146.6
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.971,
+          "keypoints": {
+            "nose": {
+              "x": 56.7,
+              "y": 13.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.6,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 51.2,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.8,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 52,
+              "y": 24.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 34.7,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 60.5,
+              "y": 40.1,
+              "v": 0.815
+            },
+            "rightElbow": {
+              "x": 22.9,
+              "y": 43.2,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 80.1,
+              "y": 37.4,
+              "v": 0.949
+            },
+            "rightWrist": {
+              "x": 23.7,
+              "y": 63.8,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 85.4,
+              "y": 34.5,
+              "v": 0.95
+            },
+            "rightIndex": {
+              "x": 24.4,
+              "y": 69.6,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 50.9,
+              "y": 61.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.4,
+              "y": 62,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60.9,
+              "y": 88.9,
+              "v": 0.985
+            },
+            "rightKnee": {
+              "x": 75.3,
+              "y": 66.4,
+              "v": 0.935
+            },
+            "leftAnkle": {
+              "x": 52.4,
+              "y": 118,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 90.6,
+              "y": 87.4,
+              "v": 0.898
+            },
+            "leftHeel": {
+              "x": 49.5,
+              "y": 124.2,
+              "v": 0.993
+            },
+            "rightHeel": {
+              "x": 90.3,
+              "y": 93.1,
+              "v": 0.923
+            },
+            "leftFootIndex": {
+              "x": 63.3,
+              "y": 123.2,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 104,
+              "y": 85.6,
+              "v": 0.914
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55.3,
+                "y": 10.6
+              },
+              "roll": 170.5,
+              "yaw": 2.302,
+              "pitch": 4.685
+            },
+            "torso": {
+              "center": {
+                "x": 43.4,
+                "y": 23.9
+              },
+              "angle": 97.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.1,
+                "y": 37.4
+              },
+              "angle": 28.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 23.7,
+                "y": 63.8
+              },
+              "angle": -83.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 49.5,
+                "y": 124.2
+              },
+              "angle": 4.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 90.3,
+                "y": 93.1
+              },
+              "angle": 28.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 52.2,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 52,
+              "y": 9.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49.9,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 48.6,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 45,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 50.1,
+              "y": 25.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 28.4,
+              "y": 24.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 61.2,
+              "y": 38.8,
+              "v": 0.926
+            },
+            "rightElbow": {
+              "x": 19.9,
+              "y": 45.2,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 73.5,
+              "y": 29.1,
+              "v": 0.969
+            },
+            "rightWrist": {
+              "x": 21.5,
+              "y": 63.6,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 75.4,
+              "y": 22.9,
+              "v": 0.978
+            },
+            "rightIndex": {
+              "x": 23.2,
+              "y": 67.9,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 55.9,
+              "y": 57.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48,
+              "y": 60.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 59.8,
+              "y": 88.7,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 75.8,
+              "y": 59.6,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 54.2,
+              "y": 117.1,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 98.9,
+              "y": 75.9,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 51,
+              "y": 122.9,
+              "v": 0.999
+            },
+            "rightHeel": {
+              "x": 103.1,
+              "y": 82.5,
+              "v": 0.998
+            },
+            "leftFootIndex": {
+              "x": 65.1,
+              "y": 123.3,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 110.4,
+              "y": 71.3,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51,
+                "y": 9.6
+              },
+              "roll": -177.3,
+              "yaw": 0.595,
+              "pitch": 1.451
+            },
+            "torso": {
+              "center": {
+                "x": 39.3,
+                "y": 25
+              },
+              "angle": 110.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.5,
+                "y": 29.1
+              },
+              "angle": 73
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 21.5,
+                "y": 63.6
+              },
+              "angle": -68.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 51,
+                "y": 122.9
+              },
+              "angle": -1.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 103.1,
+                "y": 82.5
+              },
+              "angle": 56.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.984,
+          "keypoints": {
+            "nose": {
+              "x": 47.1,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 47.9,
+              "y": 9.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 44.8,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 46.4,
+              "y": 10.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 39.7,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 46.7,
+              "y": 23.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 26.3,
+              "y": 26.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 58.5,
+              "y": 36.8,
+              "v": 0.741
+            },
+            "rightElbow": {
+              "x": 18.5,
+              "y": 43.1,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 69.9,
+              "y": 28.1,
+              "v": 0.99
+            },
+            "rightWrist": {
+              "x": 18.6,
+              "y": 61.7,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 72.3,
+              "y": 22,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 20.9,
+              "y": 66.1,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 56.5,
+              "y": 52.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.6,
+              "y": 60.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.3,
+              "y": 58.7,
+              "v": 0.965
+            },
+            "rightKnee": {
+              "x": 64.6,
+              "y": 75.3,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 102.2,
+              "y": 63,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 61.2,
+              "y": 110.9,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 103.3,
+              "y": 76.5,
+              "v": 0.99
+            },
+            "rightHeel": {
+              "x": 58.7,
+              "y": 117.2,
+              "v": 0.979
+            },
+            "leftFootIndex": {
+              "x": 112.2,
+              "y": 64.5,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 63.6,
+              "y": 122.1,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 46.3,
+                "y": 9.6
+              },
+              "roll": 176.3,
+              "yaw": 0.241,
+              "pitch": 0.934
+            },
+            "torso": {
+              "center": {
+                "x": 36.5,
+                "y": 25.2
+              },
+              "angle": 117
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 69.9,
+                "y": 28.1
+              },
+              "angle": 68.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 18.6,
+                "y": 61.7
+              },
+              "angle": -62.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 103.3,
+                "y": 76.5
+              },
+              "angle": 53.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 58.7,
+                "y": 117.2
+              },
+              "angle": -45
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.999,
+          "keypoints": {
+            "nose": {
+              "x": 47,
+              "y": 11,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 48.3,
+              "y": 8.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 44.2,
+              "y": 8.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 48,
+              "y": 10.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 39.7,
+              "y": 9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 50.8,
+              "y": 23.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 29.4,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 59.1,
+              "y": 38.7,
+              "v": 0.993
+            },
+            "rightElbow": {
+              "x": 18.4,
+              "y": 40.7,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 69.6,
+              "y": 29.3,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 18.7,
+              "y": 60.5,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 72,
+              "y": 22.4,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 20.7,
+              "y": 65.3,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 52,
+              "y": 57.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45,
+              "y": 59.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 57.7,
+              "y": 89.6,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 76.3,
+              "y": 51.2,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 51.9,
+              "y": 118.4,
+              "v": 1
+            },
+            "rightAnkle": {
+              "x": 105.2,
+              "y": 61,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 48.8,
+              "y": 123.8,
+              "v": 1
+            },
+            "rightHeel": {
+              "x": 108.7,
+              "y": 66.9,
+              "v": 1
+            },
+            "leftFootIndex": {
+              "x": 62.9,
+              "y": 124.4,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 114.8,
+              "y": 51.9,
+              "v": 1
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 46.3,
+                "y": 8.6
+              },
+              "roll": 170.3,
+              "yaw": 0.18,
+              "pitch": 0.589
+            },
+            "torso": {
+              "center": {
+                "x": 40.1,
+                "y": 23.2
+              },
+              "angle": 103.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 69.6,
+                "y": 29.3
+              },
+              "angle": 70.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 18.7,
+                "y": 60.5
+              },
+              "angle": -67.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 48.8,
+                "y": 123.8
+              },
+              "angle": -2.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 108.7,
+                "y": 66.9
+              },
+              "angle": 67.9
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.96,
+          "keypoints": {
+            "nose": {
+              "x": 45,
+              "y": 14.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 45.3,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 42.9,
+              "y": 12,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 40.7,
+              "y": 13.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 37.3,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 43.7,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 25.1,
+              "y": 30.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 60.5,
+              "y": 33.9,
+              "v": 0.686
+            },
+            "rightElbow": {
+              "x": 18,
+              "y": 48,
+              "v": 0.984
+            },
+            "leftWrist": {
+              "x": 65.1,
+              "y": 21.5,
+              "v": 0.956
+            },
+            "rightWrist": {
+              "x": 21.9,
+              "y": 56.5,
+              "v": 0.835
+            },
+            "leftIndex": {
+              "x": 65.5,
+              "y": 15.5,
+              "v": 0.954
+            },
+            "rightIndex": {
+              "x": 22.9,
+              "y": 57.7,
+              "v": 0.77
+            },
+            "leftHip": {
+              "x": 59.5,
+              "y": 49.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.5,
+              "y": 58.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.6,
+              "y": 42.7,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 49.2,
+              "y": 85.9,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 109.5,
+              "y": 39.7,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 45.3,
+              "y": 118.6,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 114.2,
+              "y": 42.8,
+              "v": 0.981
+            },
+            "rightHeel": {
+              "x": 43.5,
+              "y": 123.3,
+              "v": 0.957
+            },
+            "leftFootIndex": {
+              "x": 116.6,
+              "y": 28.5,
+              "v": 0.992
+            },
+            "rightFootIndex": {
+              "x": 46.7,
+              "y": 126.1,
+              "v": 0.994
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 44.1,
+                "y": 11.8
+              },
+              "roll": -168.2,
+              "yaw": 0.367,
+              "pitch": 1.122
+            },
+            "torso": {
+              "center": {
+                "x": 34.4,
+                "y": 26.9
+              },
+              "angle": 126.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 65.1,
+                "y": 21.5
+              },
+              "angle": 86.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 21.9,
+                "y": 56.5
+              },
+              "angle": -50.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 114.2,
+                "y": 42.8
+              },
+              "angle": 80.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.5,
+                "y": 123.3
+              },
+              "angle": -41.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.985,
+          "keypoints": {
+            "nose": {
+              "x": 43.7,
+              "y": 15.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 44.8,
+              "y": 12,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 41.6,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 43.7,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 37,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 49,
+              "y": 22.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 24,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.2,
+              "y": 32.9,
+              "v": 0.958
+            },
+            "rightElbow": {
+              "x": 11.6,
+              "y": 40.9,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 66.1,
+              "y": 19.2,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 18.8,
+              "y": 58.6,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 65.4,
+              "y": 13.3,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 22.6,
+              "y": 62,
+              "v": 0.987
+            },
+            "leftHip": {
+              "x": 51.1,
+              "y": 51.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 39.8,
+              "y": 58.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77,
+              "y": 42.9,
+              "v": 0.974
+            },
+            "rightKnee": {
+              "x": 48,
+              "y": 86,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 94.9,
+              "y": 48.3,
+              "v": 0.975
+            },
+            "rightAnkle": {
+              "x": 44.5,
+              "y": 115.6,
+              "v": 0.991
+            },
+            "leftHeel": {
+              "x": 96.9,
+              "y": 51.2,
+              "v": 0.949
+            },
+            "rightHeel": {
+              "x": 43.1,
+              "y": 118.2,
+              "v": 0.903
+            },
+            "leftFootIndex": {
+              "x": 101.6,
+              "y": 45.6,
+              "v": 0.983
+            },
+            "rightFootIndex": {
+              "x": 50.3,
+              "y": 121.7,
+              "v": 0.975
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 43.2,
+                "y": 11.9
+              },
+              "roll": 174.6,
+              "yaw": 0.156,
+              "pitch": 1.042
+            },
+            "torso": {
+              "center": {
+                "x": 36.5,
+                "y": 22.3
+              },
+              "angle": 105.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 66.1,
+                "y": 19.2
+              },
+              "angle": 96.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 18.8,
+                "y": 58.6
+              },
+              "angle": -41.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 96.9,
+                "y": 51.2
+              },
+              "angle": 50
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.1,
+                "y": 118.2
+              },
+              "angle": -25.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.975,
+          "keypoints": {
+            "nose": {
+              "x": 19.8,
+              "y": 29.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 20,
+              "y": 27,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 17.5,
+              "y": 30.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 21.2,
+              "y": 25.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 16.3,
+              "y": 31.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 32.2,
+              "y": 23.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 24.3,
+              "y": 39.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 44.8,
+              "y": 20.4,
+              "v": 0.99
+            },
+            "rightElbow": {
+              "x": 23.8,
+              "y": 48.4,
+              "v": 0.889
+            },
+            "leftWrist": {
+              "x": 57.4,
+              "y": 16.4,
+              "v": 0.983
+            },
+            "rightWrist": {
+              "x": 20.7,
+              "y": 54.9,
+              "v": 0.946
+            },
+            "leftIndex": {
+              "x": 60.7,
+              "y": 15.3,
+              "v": 0.968
+            },
+            "rightIndex": {
+              "x": 18.7,
+              "y": 59.3,
+              "v": 0.942
+            },
+            "leftHip": {
+              "x": 60.4,
+              "y": 38.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.9,
+              "y": 47.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.8,
+              "y": 34.9,
+              "v": 0.967
+            },
+            "rightKnee": {
+              "x": 78.9,
+              "y": 41,
+              "v": 0.982
+            },
+            "leftAnkle": {
+              "x": 110.4,
+              "y": 35.5,
+              "v": 0.982
+            },
+            "rightAnkle": {
+              "x": 109.6,
+              "y": 36.6,
+              "v": 0.976
+            },
+            "leftHeel": {
+              "x": 116.2,
+              "y": 38.6,
+              "v": 0.943
+            },
+            "rightHeel": {
+              "x": 115.4,
+              "y": 38.5,
+              "v": 0.886
+            },
+            "leftFootIndex": {
+              "x": 117.5,
+              "y": 25,
+              "v": 0.986
+            },
+            "rightFootIndex": {
+              "x": 114.9,
+              "y": 33.2,
+              "v": 0.976
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 18.8,
+                "y": 28.7
+              },
+              "roll": -126.3,
+              "yaw": 0.249,
+              "pitch": 0.166
+            },
+            "torso": {
+              "center": {
+                "x": 28.3,
+                "y": 31.6
+              },
+              "angle": 159.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 57.4,
+                "y": 16.4
+              },
+              "angle": 18.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 20.7,
+                "y": 54.9
+              },
+              "angle": -114.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 116.2,
+                "y": 38.6
+              },
+              "angle": 84.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 115.4,
+                "y": 38.5
+              },
+              "angle": 95.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.978,
+          "keypoints": {
+            "nose": {
+              "x": 30.5,
+              "y": 20.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 29.4,
+              "y": 18.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 27.1,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 28.9,
+              "y": 19.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 24.3,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 39.4,
+              "y": 25,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 25.6,
+              "y": 38,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 55.1,
+              "y": 29.2,
+              "v": 0.872
+            },
+            "rightElbow": {
+              "x": 26.6,
+              "y": 53.6,
+              "v": 0.957
+            },
+            "leftWrist": {
+              "x": 62.1,
+              "y": 17.2,
+              "v": 0.956
+            },
+            "rightWrist": {
+              "x": 22.6,
+              "y": 56.7,
+              "v": 0.925
+            },
+            "leftIndex": {
+              "x": 62.1,
+              "y": 12.1,
+              "v": 0.955
+            },
+            "rightIndex": {
+              "x": 19.7,
+              "y": 56,
+              "v": 0.93
+            },
+            "leftHip": {
+              "x": 59.5,
+              "y": 45.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.7,
+              "y": 55.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.3,
+              "y": 40.4,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 46.9,
+              "y": 70.7,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 109,
+              "y": 35.9,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 50.6,
+              "y": 106.8,
+              "v": 0.992
+            },
+            "leftHeel": {
+              "x": 114.4,
+              "y": 38.8,
+              "v": 0.986
+            },
+            "rightHeel": {
+              "x": 54.1,
+              "y": 111.8,
+              "v": 0.949
+            },
+            "leftFootIndex": {
+              "x": 116.5,
+              "y": 26,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 46.5,
+              "y": 116.4,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 28.3,
+                "y": 19.3
+              },
+              "roll": -145.2,
+              "yaw": 0.803,
+              "pitch": 0.464
+            },
+            "torso": {
+              "center": {
+                "x": 32.5,
+                "y": 31.5
+              },
+              "angle": 140.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 62.1,
+                "y": 17.2
+              },
+              "angle": 90
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 22.6,
+                "y": 56.7
+              },
+              "angle": 166.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 114.4,
+                "y": 38.8
+              },
+              "angle": 80.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 54.1,
+                "y": 111.8
+              },
+              "angle": -148.8
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.712,
+          "keypoints": {
+            "nose": {
+              "x": 39.4,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 39.9,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 36.2,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 39.5,
+              "y": 11,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 32.7,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 44.7,
+              "y": 20.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 24.2,
+              "y": 25.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 59,
+              "y": 27.7,
+              "v": 0.825
+            },
+            "rightElbow": {
+              "x": 14.8,
+              "y": 42.5,
+              "v": 0.882
+            },
+            "leftWrist": {
+              "x": 60.2,
+              "y": 14.7,
+              "v": 0.973
+            },
+            "rightWrist": {
+              "x": 17.6,
+              "y": 34.3,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 58.5,
+              "y": 10.6,
+              "v": 0.967
+            },
+            "rightIndex": {
+              "x": 18.7,
+              "y": 29.3,
+              "v": 0.985
+            },
+            "leftHip": {
+              "x": 47.2,
+              "y": 47,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 37.2,
+              "y": 50.5,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 50.1,
+              "y": 65,
+              "v": 0.192
+            },
+            "rightKnee": {
+              "x": 40.9,
+              "y": 66.2,
+              "v": 0.086
+            },
+            "leftAnkle": {
+              "x": 50.6,
+              "y": 87.1,
+              "v": 0.253
+            },
+            "rightAnkle": {
+              "x": 45.2,
+              "y": 88.4,
+              "v": 0.254
+            },
+            "leftHeel": {
+              "x": 50,
+              "y": 90.2,
+              "v": 0.256
+            },
+            "rightHeel": {
+              "x": 46.5,
+              "y": 91.8,
+              "v": 0.177
+            },
+            "leftFootIndex": {
+              "x": 52.2,
+              "y": 95.4,
+              "v": 0.334
+            },
+            "rightFootIndex": {
+              "x": 45.3,
+              "y": 95.3,
+              "v": 0.213
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 38.1,
+                "y": 10.6
+              },
+              "roll": 176.9,
+              "yaw": 0.364,
+              "pitch": 0.621
+            },
+            "torso": {
+              "center": {
+                "x": 34.5,
+                "y": 23.1
+              },
+              "angle": 106.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 60.2,
+                "y": 14.7
+              },
+              "angle": 112.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 17.6,
+                "y": 34.3
+              },
+              "angle": 77.6
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.886,
+          "keypoints": {
+            "nose": {
+              "x": 41.5,
+              "y": 31.1,
+              "v": 0.988
+            },
+            "leftEye": {
+              "x": 41.3,
+              "y": 28.6,
+              "v": 0.951
+            },
+            "rightEye": {
+              "x": 39.7,
+              "y": 29.8,
+              "v": 0.984
+            },
+            "leftEar": {
+              "x": 41.6,
+              "y": 27.3,
+              "v": 0.984
+            },
+            "rightEar": {
+              "x": 38.2,
+              "y": 29.6,
+              "v": 0.979
+            },
+            "leftShoulder": {
+              "x": 55.9,
+              "y": 30.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 35.1,
+              "y": 36,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.8,
+              "y": 33.5,
+              "v": 0.663
+            },
+            "rightElbow": {
+              "x": 30.1,
+              "y": 43.5,
+              "v": 0.947
+            },
+            "leftWrist": {
+              "x": 84.2,
+              "y": 34,
+              "v": 0.592
+            },
+            "rightWrist": {
+              "x": 49.5,
+              "y": 41.1,
+              "v": 0.957
+            },
+            "leftIndex": {
+              "x": 86.7,
+              "y": 32.1,
+              "v": 0.644
+            },
+            "rightIndex": {
+              "x": 54.9,
+              "y": 38.4,
+              "v": 0.931
+            },
+            "leftHip": {
+              "x": 65.7,
+              "y": 62.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.2,
+              "y": 63.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.7,
+              "y": 87.2,
+              "v": 0.653
+            },
+            "rightKnee": {
+              "x": 42.8,
+              "y": 83,
+              "v": 0.972
+            },
+            "leftAnkle": {
+              "x": 73.3,
+              "y": 113.4,
+              "v": 0.819
+            },
+            "rightAnkle": {
+              "x": 25.8,
+              "y": 116.1,
+              "v": 0.953
+            },
+            "leftHeel": {
+              "x": 70.5,
+              "y": 119.3,
+              "v": 0.815
+            },
+            "rightHeel": {
+              "x": 26.5,
+              "y": 122.1,
+              "v": 0.824
+            },
+            "leftFootIndex": {
+              "x": 84,
+              "y": 120.4,
+              "v": 0.779
+            },
+            "rightFootIndex": {
+              "x": 28.9,
+              "y": 126.6,
+              "v": 0.949
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 40.5,
+                "y": 29.2
+              },
+              "roll": -143.1,
+              "yaw": 0.5,
+              "pitch": 0.95
+            },
+            "torso": {
+              "center": {
+                "x": 45.5,
+                "y": 33.2
+              },
+              "angle": 116.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.2,
+                "y": 34
+              },
+              "angle": 37.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 49.5,
+                "y": 41.1
+              },
+              "angle": 26.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.5,
+                "y": 119.3
+              },
+              "angle": -4.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 26.5,
+                "y": 122.1
+              },
+              "angle": -61.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.917,
+          "keypoints": {
+            "nose": {
+              "x": 50.6,
+              "y": 11.9,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 53,
+              "y": 9.9,
+              "v": 0.997
+            },
+            "rightEye": {
+              "x": 48.1,
+              "y": 9.3,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 53.6,
+              "y": 11.1,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 45.4,
+              "y": 10.1,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 56.9,
+              "y": 24.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 34,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 64.4,
+              "y": 34.7,
+              "v": 0.39
+            },
+            "rightElbow": {
+              "x": 32.1,
+              "y": 29.8,
+              "v": 0.951
+            },
+            "leftWrist": {
+              "x": 55.2,
+              "y": 33,
+              "v": 0.544
+            },
+            "rightWrist": {
+              "x": 41.8,
+              "y": 30.5,
+              "v": 0.97
+            },
+            "leftIndex": {
+              "x": 51.9,
+              "y": 32.7,
+              "v": 0.644
+            },
+            "rightIndex": {
+              "x": 47,
+              "y": 30.8,
+              "v": 0.964
+            },
+            "leftHip": {
+              "x": 55.6,
+              "y": 60.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44,
+              "y": 60.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 64.4,
+              "y": 89,
+              "v": 0.912
+            },
+            "rightKnee": {
+              "x": 31.1,
+              "y": 88.1,
+              "v": 0.976
+            },
+            "leftAnkle": {
+              "x": 59.7,
+              "y": 114.1,
+              "v": 0.978
+            },
+            "rightAnkle": {
+              "x": 23.7,
+              "y": 112.2,
+              "v": 0.986
+            },
+            "leftHeel": {
+              "x": 57.1,
+              "y": 119.7,
+              "v": 0.961
+            },
+            "rightHeel": {
+              "x": 23.9,
+              "y": 115.5,
+              "v": 0.874
+            },
+            "leftFootIndex": {
+              "x": 70.9,
+              "y": 119.9,
+              "v": 0.973
+            },
+            "rightFootIndex": {
+              "x": 21.7,
+              "y": 124,
+              "v": 0.976
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 50.6,
+                "y": 9.6
+              },
+              "roll": 173,
+              "yaw": 0.01,
+              "pitch": 0.466
+            },
+            "torso": {
+              "center": {
+                "x": 45.5,
+                "y": 24.3
+              },
+              "angle": 96.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 55.2,
+                "y": 33
+              },
+              "angle": 174.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.8,
+                "y": 30.5
+              },
+              "angle": -3.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 57.1,
+                "y": 119.7
+              },
+              "angle": -0.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.9,
+                "y": 115.5
+              },
+              "angle": -104.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.971,
+          "keypoints": {
+            "nose": {
+              "x": 55.2,
+              "y": 12,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.9,
+              "y": 9.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 52.8,
+              "y": 9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.6,
+              "y": 10.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.5,
+              "y": 9.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 58.9,
+              "y": 24.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.8,
+              "y": 21.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 69.7,
+              "y": 32.3,
+              "v": 0.735
+            },
+            "rightElbow": {
+              "x": 32.7,
+              "y": 27,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 73.8,
+              "y": 33.6,
+              "v": 0.924
+            },
+            "rightWrist": {
+              "x": 41.9,
+              "y": 29.3,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 73.2,
+              "y": 31.7,
+              "v": 0.942
+            },
+            "rightIndex": {
+              "x": 46.9,
+              "y": 30.3,
+              "v": 0.995
+            },
+            "leftHip": {
+              "x": 55.4,
+              "y": 60.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 41.9,
+              "y": 60.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 67.9,
+              "y": 87,
+              "v": 0.957
+            },
+            "rightKnee": {
+              "x": 32.5,
+              "y": 88.8,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 62.5,
+              "y": 114.9,
+              "v": 0.98
+            },
+            "rightAnkle": {
+              "x": 23.4,
+              "y": 115.9,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 59.3,
+              "y": 119.7,
+              "v": 0.965
+            },
+            "rightHeel": {
+              "x": 21.9,
+              "y": 119.2,
+              "v": 0.888
+            },
+            "leftFootIndex": {
+              "x": 73.5,
+              "y": 120.3,
+              "v": 0.983
+            },
+            "rightFootIndex": {
+              "x": 23.6,
+              "y": 126.7,
+              "v": 0.988
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.4,
+                "y": 9.3
+              },
+              "roll": 169,
+              "yaw": 0.269,
+              "pitch": 0.855
+            },
+            "torso": {
+              "center": {
+                "x": 48.3,
+                "y": 23.1
+              },
+              "angle": 90.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.8,
+                "y": 33.6
+              },
+              "angle": 107.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.9,
+                "y": 29.3
+              },
+              "angle": -11.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 59.3,
+                "y": 119.7
+              },
+              "angle": -2.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 21.9,
+                "y": 119.2
+              },
+              "angle": -77.2
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.923,
+          "keypoints": {
+            "nose": {
+              "x": 56.7,
+              "y": 12.2,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 56.7,
+              "y": 9.9,
+              "v": 0.996
+            },
+            "rightEye": {
+              "x": 54.2,
+              "y": 9.5,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 54.6,
+              "y": 10.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 50.3,
+              "y": 9.6,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 55.6,
+              "y": 23.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 36.6,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 64.7,
+              "y": 31.9,
+              "v": 0.439
+            },
+            "rightElbow": {
+              "x": 35.8,
+              "y": 28.5,
+              "v": 0.967
+            },
+            "leftWrist": {
+              "x": 76.6,
+              "y": 31.2,
+              "v": 0.734
+            },
+            "rightWrist": {
+              "x": 45.5,
+              "y": 30,
+              "v": 0.962
+            },
+            "leftIndex": {
+              "x": 79.7,
+              "y": 29.3,
+              "v": 0.801
+            },
+            "rightIndex": {
+              "x": 50.2,
+              "y": 30.8,
+              "v": 0.953
+            },
+            "leftHip": {
+              "x": 58.8,
+              "y": 61.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.4,
+              "y": 61.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.4,
+              "y": 87.2,
+              "v": 0.895
+            },
+            "rightKnee": {
+              "x": 31.9,
+              "y": 87,
+              "v": 0.952
+            },
+            "leftAnkle": {
+              "x": 63.7,
+              "y": 114,
+              "v": 0.956
+            },
+            "rightAnkle": {
+              "x": 22.3,
+              "y": 114.1,
+              "v": 0.967
+            },
+            "leftHeel": {
+              "x": 60.7,
+              "y": 119.3,
+              "v": 0.926
+            },
+            "rightHeel": {
+              "x": 22.5,
+              "y": 118.3,
+              "v": 0.773
+            },
+            "leftFootIndex": {
+              "x": 75,
+              "y": 119.7,
+              "v": 0.956
+            },
+            "rightFootIndex": {
+              "x": 21.3,
+              "y": 124,
+              "v": 0.958
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55.5,
+                "y": 9.7
+              },
+              "roll": 170.9,
+              "yaw": 0.494,
+              "pitch": 0.987
+            },
+            "torso": {
+              "center": {
+                "x": 46.1,
+                "y": 23.8
+              },
+              "angle": 99.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76.6,
+                "y": 31.2
+              },
+              "angle": 31.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 45.5,
+                "y": 30
+              },
+              "angle": -9.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.7,
+                "y": 119.3
+              },
+              "angle": -1.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 22.5,
+                "y": 118.3
+              },
+              "angle": -101.9
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.975,
+          "keypoints": {
+            "nose": {
+              "x": 57.6,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 57.3,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.9,
+              "y": 10,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.6,
+              "y": 10.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.5,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 60.1,
+              "y": 24.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.7,
+              "y": 20.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.5,
+              "y": 34.3,
+              "v": 0.807
+            },
+            "rightElbow": {
+              "x": 34.4,
+              "y": 28.3,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 80.7,
+              "y": 33,
+              "v": 0.958
+            },
+            "rightWrist": {
+              "x": 42.3,
+              "y": 29.3,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 81.8,
+              "y": 30.3,
+              "v": 0.967
+            },
+            "rightIndex": {
+              "x": 46.7,
+              "y": 30.5,
+              "v": 0.992
+            },
+            "leftHip": {
+              "x": 56.6,
+              "y": 60.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.1,
+              "y": 60.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.9,
+              "y": 87.3,
+              "v": 0.96
+            },
+            "rightKnee": {
+              "x": 32,
+              "y": 88.3,
+              "v": 0.993
+            },
+            "leftAnkle": {
+              "x": 63.7,
+              "y": 114.5,
+              "v": 0.984
+            },
+            "rightAnkle": {
+              "x": 22.6,
+              "y": 113.3,
+              "v": 0.991
+            },
+            "leftHeel": {
+              "x": 60.4,
+              "y": 119.5,
+              "v": 0.967
+            },
+            "rightHeel": {
+              "x": 21.3,
+              "y": 116.9,
+              "v": 0.86
+            },
+            "leftFootIndex": {
+              "x": 75.5,
+              "y": 120.4,
+              "v": 0.985
+            },
+            "rightFootIndex": {
+              "x": 21.8,
+              "y": 124.5,
+              "v": 0.983
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.6,
+                "y": 10.2
+              },
+              "roll": 167.9,
+              "yaw": 0.698,
+              "pitch": 1.921
+            },
+            "torso": {
+              "center": {
+                "x": 49.9,
+                "y": 22.6
+              },
+              "angle": 89.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.7,
+                "y": 33
+              },
+              "angle": 67.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 42.3,
+                "y": 29.3
+              },
+              "angle": -15.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.4,
+                "y": 119.5
+              },
+              "angle": -3.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 21.3,
+                "y": 116.9
+              },
+              "angle": -86.2
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.934,
+          "keypoints": {
+            "nose": {
+              "x": 68.6,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.6,
+              "y": 11.8,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 66,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.8,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.3,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.3,
+              "y": 24.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.2,
+              "y": 23.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79,
+              "y": 34.8,
+              "v": 0.915
+            },
+            "rightElbow": {
+              "x": 48.9,
+              "y": 29.8,
+              "v": 0.969
+            },
+            "leftWrist": {
+              "x": 64.1,
+              "y": 35.4,
+              "v": 0.938
+            },
+            "rightWrist": {
+              "x": 62.6,
+              "y": 34.6,
+              "v": 0.922
+            },
+            "leftIndex": {
+              "x": 58.7,
+              "y": 35.6,
+              "v": 0.915
+            },
+            "rightIndex": {
+              "x": 67.4,
+              "y": 34.4,
+              "v": 0.893
+            },
+            "leftHip": {
+              "x": 72.3,
+              "y": 59.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.9,
+              "y": 60.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.7,
+              "y": 89.2,
+              "v": 0.751
+            },
+            "rightKnee": {
+              "x": 50.7,
+              "y": 88.7,
+              "v": 0.942
+            },
+            "leftAnkle": {
+              "x": 77.6,
+              "y": 114.8,
+              "v": 0.899
+            },
+            "rightAnkle": {
+              "x": 42.2,
+              "y": 112.8,
+              "v": 0.953
+            },
+            "leftHeel": {
+              "x": 75.5,
+              "y": 119.3,
+              "v": 0.873
+            },
+            "rightHeel": {
+              "x": 41.3,
+              "y": 116.9,
+              "v": 0.656
+            },
+            "leftFootIndex": {
+              "x": 87.3,
+              "y": 120,
+              "v": 0.917
+            },
+            "rightFootIndex": {
+              "x": 42.8,
+              "y": 121.8,
+              "v": 0.935
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.3,
+                "y": 11.4
+              },
+              "roll": 168.9,
+              "yaw": 0.064,
+              "pitch": 0.629
+            },
+            "torso": {
+              "center": {
+                "x": 62.3,
+                "y": 23.9
+              },
+              "angle": 96.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 64.1,
+                "y": 35.4
+              },
+              "angle": -177.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 62.6,
+                "y": 34.6
+              },
+              "angle": 2.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 75.5,
+                "y": 119.3
+              },
+              "angle": -3.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.3,
+                "y": 116.9
+              },
+              "angle": -73
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.796,
+          "keypoints": {
+            "nose": {
+              "x": 69,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.9,
+              "y": 10,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67,
+              "y": 10,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.2,
+              "y": 11,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.8,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.5,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.5,
+              "y": 22.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.1,
+              "y": 33.3,
+              "v": 0.784
+            },
+            "rightElbow": {
+              "x": 51.8,
+              "y": 31,
+              "v": 0.719
+            },
+            "leftWrist": {
+              "x": 75.9,
+              "y": 34.5,
+              "v": 0.801
+            },
+            "rightWrist": {
+              "x": 59.5,
+              "y": 34.8,
+              "v": 0.51
+            },
+            "leftIndex": {
+              "x": 73.9,
+              "y": 33.7,
+              "v": 0.807
+            },
+            "rightIndex": {
+              "x": 63.2,
+              "y": 35.3,
+              "v": 0.524
+            },
+            "leftHip": {
+              "x": 75.2,
+              "y": 47.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.2,
+              "y": 48.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.1,
+              "y": 69.9,
+              "v": 0.711
+            },
+            "rightKnee": {
+              "x": 59.1,
+              "y": 68.2,
+              "v": 0.548
+            },
+            "leftAnkle": {
+              "x": 77,
+              "y": 92.3,
+              "v": 0.571
+            },
+            "rightAnkle": {
+              "x": 55.7,
+              "y": 97.3,
+              "v": 0.858
+            },
+            "leftHeel": {
+              "x": 76.8,
+              "y": 95.4,
+              "v": 0.405
+            },
+            "rightHeel": {
+              "x": 58.1,
+              "y": 102.3,
+              "v": 0.71
+            },
+            "leftFootIndex": {
+              "x": 77.6,
+              "y": 100.5,
+              "v": 0.553
+            },
+            "rightFootIndex": {
+              "x": 47.7,
+              "y": 106.1,
+              "v": 0.813
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.5,
+                "y": 10
+              },
+              "roll": -180,
+              "yaw": 0.19,
+              "pitch": 0.897
+            },
+            "torso": {
+              "center": {
+                "x": 64,
+                "y": 22
+              },
+              "angle": 103.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 75.9,
+                "y": 34.5
+              },
+              "angle": 158.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 59.5,
+                "y": 34.8
+              },
+              "angle": -7.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.8,
+                "y": 95.4
+              },
+              "angle": -81.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 58.1,
+                "y": 102.3
+              },
+              "angle": -159.9
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 68.9,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.6,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.3,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.8,
+              "y": 24.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.6,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.7,
+              "y": 43.6,
+              "v": 0.928
+            },
+            "rightElbow": {
+              "x": 38.6,
+              "y": 41,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 89.8,
+              "y": 51.5,
+              "v": 0.991
+            },
+            "rightWrist": {
+              "x": 37.1,
+              "y": 58.9,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 96.1,
+              "y": 50.3,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 38,
+              "y": 63.8,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 69.7,
+              "y": 60.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.6,
+              "y": 61.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.2,
+              "y": 86,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 49.2,
+              "y": 90.2,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 77.2,
+              "y": 114.5,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 40.5,
+              "y": 115.9,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 73.9,
+              "y": 119.5,
+              "v": 0.994
+            },
+            "rightHeel": {
+              "x": 38.8,
+              "y": 119.2,
+              "v": 0.957
+            },
+            "leftFootIndex": {
+              "x": 88.7,
+              "y": 120.7,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 40.5,
+              "y": 127,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.3,
+                "y": 11.3
+              },
+              "roll": 173.4,
+              "yaw": 0.229,
+              "pitch": 1.165
+            },
+            "torso": {
+              "center": {
+                "x": 61.2,
+                "y": 23.6
+              },
+              "angle": 92.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.8,
+                "y": 51.5
+              },
+              "angle": 10.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.1,
+                "y": 58.9
+              },
+              "angle": -79.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.9,
+                "y": 119.5
+              },
+              "angle": -4.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.8,
+                "y": 119.2
+              },
+              "angle": -77.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.992,
+          "keypoints": {
+            "nose": {
+              "x": 69.1,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.3,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.5,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.7,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.6,
+              "y": 23.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.9,
+              "y": 23.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.3,
+              "y": 39,
+              "v": 0.955
+            },
+            "rightElbow": {
+              "x": 37.7,
+              "y": 40.6,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 98.6,
+              "y": 28.8,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 29.5,
+              "y": 56.4,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 101.6,
+              "y": 21.5,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 28.3,
+              "y": 60.9,
+              "v": 0.99
+            },
+            "leftHip": {
+              "x": 75.3,
+              "y": 60.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61,
+              "y": 61.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 85.7,
+              "y": 88.9,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 53.9,
+              "y": 90.2,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 79.6,
+              "y": 114.4,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 45.8,
+              "y": 114.8,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 76.5,
+              "y": 119.8,
+              "v": 0.987
+            },
+            "rightHeel": {
+              "x": 44.6,
+              "y": 117.9,
+              "v": 0.944
+            },
+            "leftFootIndex": {
+              "x": 90.6,
+              "y": 121,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 44.8,
+              "y": 126.9,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.9,
+                "y": 11.8
+              },
+              "roll": 167.1,
+              "yaw": 0.041,
+              "pitch": 0.619
+            },
+            "torso": {
+              "center": {
+                "x": 63.3,
+                "y": 23.7
+              },
+              "angle": 97.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.6,
+                "y": 28.8
+              },
+              "angle": 67.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.5,
+                "y": 56.4
+              },
+              "angle": -104.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.5,
+                "y": 119.8
+              },
+              "angle": -4.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.6,
+                "y": 117.9
+              },
+              "angle": -88.7
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.447,
+          "keypoints": {
+            "nose": {
+              "x": 54.1,
+              "y": 6.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 51.9,
+              "y": 5.5,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 51.2,
+              "y": 6.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 49.6,
+              "y": 8.3,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 48.4,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 53.4,
+              "y": 16.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.9,
+              "y": 26.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 58.4,
+              "y": 25,
+              "v": 0.003
+            },
+            "rightElbow": {
+              "x": 46,
+              "y": 33.7,
+              "v": 0.564
+            },
+            "leftWrist": {
+              "x": 61,
+              "y": 28.8,
+              "v": 0.003
+            },
+            "rightWrist": {
+              "x": 45.3,
+              "y": 33.4,
+              "v": 0.277
+            },
+            "leftIndex": {
+              "x": 61,
+              "y": 29.2,
+              "v": 0.005
+            },
+            "rightIndex": {
+              "x": 44.4,
+              "y": 32.5,
+              "v": 0.193
+            },
+            "leftHip": {
+              "x": 70.1,
+              "y": 29.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 69.1,
+              "y": 37.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.7,
+              "y": 34,
+              "v": 0.004
+            },
+            "rightKnee": {
+              "x": 81.8,
+              "y": 38.6,
+              "v": 0.027
+            },
+            "leftAnkle": {
+              "x": 98.2,
+              "y": 38.8,
+              "v": 0.019
+            },
+            "rightAnkle": {
+              "x": 99.5,
+              "y": 42.4,
+              "v": 0.057
+            },
+            "leftHeel": {
+              "x": 100.4,
+              "y": 40.3,
+              "v": 0.019
+            },
+            "rightHeel": {
+              "x": 102.5,
+              "y": 42.8,
+              "v": 0.026
+            },
+            "leftFootIndex": {
+              "x": 102.1,
+              "y": 39.5,
+              "v": 0.034
+            },
+            "rightFootIndex": {
+              "x": 104.1,
+              "y": 42.9,
+              "v": 0.058
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.6,
+                "y": 6
+              },
+              "roll": -125,
+              "yaw": 2.089,
+              "pitch": 0.246
+            },
+            "torso": {
+              "center": {
+                "x": 50.7,
+                "y": 21.2
+              },
+              "angle": 146.7
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.954,
+          "keypoints": {
+            "nose": {
+              "x": 66.1,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.5,
+              "y": 9.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.2,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.9,
+              "y": 10,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 58.9,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.2,
+              "y": 22.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.3,
+              "y": 23.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.6,
+              "y": 41.2,
+              "v": 0.976
+            },
+            "rightElbow": {
+              "x": 38.9,
+              "y": 40.3,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 90.9,
+              "y": 54.2,
+              "v": 0.981
+            },
+            "rightWrist": {
+              "x": 34.4,
+              "y": 58.9,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 95.6,
+              "y": 56.6,
+              "v": 0.974
+            },
+            "rightIndex": {
+              "x": 34.5,
+              "y": 64.3,
+              "v": 0.986
+            },
+            "leftHip": {
+              "x": 72.9,
+              "y": 54.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.4,
+              "y": 56.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.8,
+              "y": 80.2,
+              "v": 0.967
+            },
+            "rightKnee": {
+              "x": 61.5,
+              "y": 82.4,
+              "v": 0.949
+            },
+            "leftAnkle": {
+              "x": 77.5,
+              "y": 102.4,
+              "v": 0.978
+            },
+            "rightAnkle": {
+              "x": 56.1,
+              "y": 101.7,
+              "v": 0.875
+            },
+            "leftHeel": {
+              "x": 77.9,
+              "y": 109.2,
+              "v": 0.885
+            },
+            "rightHeel": {
+              "x": 56.1,
+              "y": 105,
+              "v": 0.525
+            },
+            "leftFootIndex": {
+              "x": 80.9,
+              "y": 114.1,
+              "v": 0.98
+            },
+            "rightFootIndex": {
+              "x": 55.8,
+              "y": 112.1,
+              "v": 0.868
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.4,
+                "y": 9.4
+              },
+              "roll": -175,
+              "yaw": 0.758,
+              "pitch": 0.866
+            },
+            "torso": {
+              "center": {
+                "x": 61.3,
+                "y": 23.2
+              },
+              "angle": 99.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.9,
+                "y": 54.2
+              },
+              "angle": -27.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.4,
+                "y": 58.9
+              },
+              "angle": -88.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 77.9,
+                "y": 109.2
+              },
+              "angle": -58.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 56.1,
+                "y": 105
+              },
+              "angle": -92.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.998,
+          "keypoints": {
+            "nose": {
+              "x": 54.1,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.7,
+              "y": 8.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51,
+              "y": 9.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58,
+              "y": 9.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.3,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67,
+              "y": 22.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43,
+              "y": 26.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.8,
+              "y": 36.5,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 34.4,
+              "y": 45,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 94.9,
+              "y": 47.3,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 31.2,
+              "y": 61.2,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 100.5,
+              "y": 50,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 30.9,
+              "y": 65.7,
+              "v": 0.993
+            },
+            "leftHip": {
+              "x": 70.3,
+              "y": 57.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.6,
+              "y": 60.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 87.2,
+              "y": 78.4,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 50.9,
+              "y": 89.5,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 82.7,
+              "y": 105.5,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 39.8,
+              "y": 113,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 78.8,
+              "y": 109.3,
+              "v": 0.996
+            },
+            "rightHeel": {
+              "x": 37.1,
+              "y": 115.4,
+              "v": 0.981
+            },
+            "leftFootIndex": {
+              "x": 90.6,
+              "y": 115.2,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 40.6,
+              "y": 123.4,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.4,
+                "y": 8.9
+              },
+              "roll": -171.5,
+              "yaw": 0.158,
+              "pitch": 0.516
+            },
+            "torso": {
+              "center": {
+                "x": 55,
+                "y": 24.4
+              },
+              "angle": 103.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.9,
+                "y": 47.3
+              },
+              "angle": -25.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31.2,
+                "y": 61.2
+              },
+              "angle": -93.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.8,
+                "y": 109.3
+              },
+              "angle": -26.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.1,
+                "y": 115.4
+              },
+              "angle": -66.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 108.6,
+              "y": 40.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 113.1,
+              "y": 40.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 110.5,
+              "y": 36.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 114.5,
+              "y": 40.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 109.7,
+              "y": 33.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 112.4,
+              "y": 54.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 95.1,
+              "y": 30.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 112.6,
+              "y": 75.1,
+              "v": 0.999
+            },
+            "rightElbow": {
+              "x": 75.1,
+              "y": 27.4,
+              "v": 0.983
+            },
+            "leftWrist": {
+              "x": 110.6,
+              "y": 95,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 78.7,
+              "y": 12.2,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 109.8,
+              "y": 100.5,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 83.9,
+              "y": 6.7,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 74.6,
+              "y": 68.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 67.1,
+              "y": 53.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 56.5,
+              "y": 93.2,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 39.6,
+              "y": 45.9,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 39.7,
+              "y": 114.8,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 19.4,
+              "y": 65.7,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 37,
+              "y": 115.9,
+              "v": 0.964
+            },
+            "rightHeel": {
+              "x": 16.6,
+              "y": 71.7,
+              "v": 0.976
+            },
+            "leftFootIndex": {
+              "x": 31.9,
+              "y": 123.5,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 5,
+              "y": 60.2,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 111.8,
+                "y": 38.5
+              },
+              "roll": 124.4,
+              "yaw": -0.695,
+              "pitch": 0.456
+            },
+            "torso": {
+              "center": {
+                "x": 103.8,
+                "y": 42.6
+              },
+              "angle": 29.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 110.6,
+                "y": 95
+              },
+              "angle": -98.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 78.7,
+                "y": 12.2
+              },
+              "angle": 46.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 37,
+                "y": 115.9
+              },
+              "angle": -123.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 16.6,
+                "y": 71.7
+              },
+              "angle": 135.2
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 108.4,
+              "y": 40,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 113.1,
+              "y": 39.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 110.4,
+              "y": 35.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 114.2,
+              "y": 40.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 109.4,
+              "y": 32.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 111.7,
+              "y": 53.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 94.9,
+              "y": 30.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 112.5,
+              "y": 74.4,
+              "v": 0.999
+            },
+            "rightElbow": {
+              "x": 76.5,
+              "y": 27.9,
+              "v": 0.984
+            },
+            "leftWrist": {
+              "x": 110.7,
+              "y": 95.4,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 78.3,
+              "y": 12.4,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 110,
+              "y": 101.6,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 83.3,
+              "y": 6.4,
+              "v": 0.994
+            },
+            "leftHip": {
+              "x": 74.7,
+              "y": 68.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 67,
+              "y": 53.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 56.8,
+              "y": 93.7,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 41.2,
+              "y": 44.2,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 39.6,
+              "y": 115.9,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 19.1,
+              "y": 64.1,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 35,
+              "y": 117.8,
+              "v": 0.969
+            },
+            "rightHeel": {
+              "x": 16.3,
+              "y": 70.1,
+              "v": 0.971
+            },
+            "leftFootIndex": {
+              "x": 33.6,
+              "y": 125.4,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 4.9,
+              "y": 59.1,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 111.8,
+                "y": 37.7
+              },
+              "roll": 124.7,
+              "yaw": -0.706,
+              "pitch": 0.495
+            },
+            "torso": {
+              "center": {
+                "x": 103.3,
+                "y": 41.8
+              },
+              "angle": 30.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 110.7,
+                "y": 95.4
+              },
+              "angle": -96.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 78.3,
+                "y": 12.4
+              },
+              "angle": 50.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 35,
+                "y": 117.8
+              },
+              "angle": -100.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 16.3,
+                "y": 70.1
+              },
+              "angle": 136
+            }
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.969,
+          "keypoints": {
+            "nose": {
+              "x": 69.6,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.4,
+              "y": 9.5,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 66.7,
+              "y": 8.7,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 71.4,
+              "y": 10.7,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 62.6,
+              "y": 9.7,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 75.2,
+              "y": 24.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.9,
+              "y": 23.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.9,
+              "y": 37.5,
+              "v": 0.954
+            },
+            "rightElbow": {
+              "x": 44.5,
+              "y": 43.2,
+              "v": 0.959
+            },
+            "leftWrist": {
+              "x": 90,
+              "y": 24.6,
+              "v": 0.986
+            },
+            "rightWrist": {
+              "x": 45.3,
+              "y": 61.7,
+              "v": 0.939
+            },
+            "leftIndex": {
+              "x": 89.4,
+              "y": 17.2,
+              "v": 0.98
+            },
+            "rightIndex": {
+              "x": 47.9,
+              "y": 66.4,
+              "v": 0.912
+            },
+            "leftHip": {
+              "x": 71.1,
+              "y": 65.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.6,
+              "y": 66.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.2,
+              "y": 90.4,
+              "v": 0.907
+            },
+            "rightKnee": {
+              "x": 54.5,
+              "y": 91,
+              "v": 0.98
+            },
+            "leftAnkle": {
+              "x": 70.4,
+              "y": 115.2,
+              "v": 0.972
+            },
+            "rightAnkle": {
+              "x": 49.7,
+              "y": 117.2,
+              "v": 0.987
+            },
+            "leftHeel": {
+              "x": 67.9,
+              "y": 120,
+              "v": 0.911
+            },
+            "rightHeel": {
+              "x": 48.6,
+              "y": 121,
+              "v": 0.861
+            },
+            "leftFootIndex": {
+              "x": 81.3,
+              "y": 120.6,
+              "v": 0.968
+            },
+            "rightFootIndex": {
+              "x": 51.7,
+              "y": 126,
+              "v": 0.975
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.1,
+                "y": 9.1
+              },
+              "roll": 170.3,
+              "yaw": 0.115,
+              "pitch": 0.566
+            },
+            "torso": {
+              "center": {
+                "x": 63.6,
+                "y": 23.9
+              },
+              "angle": 91.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90,
+                "y": 24.6
+              },
+              "angle": 94.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 45.3,
+                "y": 61.7
+              },
+              "angle": -61
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.9,
+                "y": 120
+              },
+              "angle": -2.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.6,
+                "y": 121
+              },
+              "angle": -58.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.98,
+          "keypoints": {
+            "nose": {
+              "x": 70.4,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.4,
+              "y": 16.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68,
+              "y": 16.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.5,
+              "y": 16.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.9,
+              "y": 16.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.1,
+              "y": 26.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.1,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 90.2,
+              "y": 24.1,
+              "v": 0.977
+            },
+            "rightElbow": {
+              "x": 41.4,
+              "y": 45.7,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 93.5,
+              "y": 8.3,
+              "v": 0.99
+            },
+            "rightWrist": {
+              "x": 40.4,
+              "y": 63.9,
+              "v": 0.971
+            },
+            "leftIndex": {
+              "x": 91.8,
+              "y": 3,
+              "v": 0.983
+            },
+            "rightIndex": {
+              "x": 40.6,
+              "y": 68.3,
+              "v": 0.941
+            },
+            "leftHip": {
+              "x": 70.1,
+              "y": 60.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.6,
+              "y": 63.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 88,
+              "y": 74.6,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 49.7,
+              "y": 91.4,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 74.4,
+              "y": 93.2,
+              "v": 0.95
+            },
+            "rightAnkle": {
+              "x": 42.3,
+              "y": 115.1,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 69.7,
+              "y": 95.1,
+              "v": 0.906
+            },
+            "rightHeel": {
+              "x": 41.3,
+              "y": 116.8,
+              "v": 0.921
+            },
+            "leftFootIndex": {
+              "x": 77.2,
+              "y": 106.1,
+              "v": 0.944
+            },
+            "rightFootIndex": {
+              "x": 42.2,
+              "y": 123.4,
+              "v": 0.98
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.2,
+                "y": 16.3
+              },
+              "roll": 175.2,
+              "yaw": 0.498,
+              "pitch": 1.038
+            },
+            "torso": {
+              "center": {
+                "x": 63.1,
+                "y": 27.4
+              },
+              "angle": 90.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.5,
+                "y": 8.3
+              },
+              "angle": 107.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40.4,
+                "y": 63.9
+              },
+              "angle": -87.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.7,
+                "y": 95.1
+              },
+              "angle": -55.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.3,
+                "y": 116.8
+              },
+              "angle": -82.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.953,
+          "keypoints": {
+            "nose": {
+              "x": 67.9,
+              "y": 17,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.2,
+              "y": 14.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.6,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.7,
+              "y": 15.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.4,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.6,
+              "y": 26.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.2,
+              "y": 27.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 90.3,
+              "y": 23.3,
+              "v": 0.968
+            },
+            "rightElbow": {
+              "x": 41.4,
+              "y": 45.3,
+              "v": 0.984
+            },
+            "leftWrist": {
+              "x": 93.2,
+              "y": 7.2,
+              "v": 0.977
+            },
+            "rightWrist": {
+              "x": 41.4,
+              "y": 63.8,
+              "v": 0.939
+            },
+            "leftIndex": {
+              "x": 90.9,
+              "y": 2.4,
+              "v": 0.96
+            },
+            "rightIndex": {
+              "x": 42.9,
+              "y": 67.9,
+              "v": 0.882
+            },
+            "leftHip": {
+              "x": 71.6,
+              "y": 60.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.7,
+              "y": 63.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 88.9,
+              "y": 71.7,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 51.5,
+              "y": 89.9,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 77.3,
+              "y": 90.1,
+              "v": 0.838
+            },
+            "rightAnkle": {
+              "x": 45.3,
+              "y": 115.6,
+              "v": 0.99
+            },
+            "leftHeel": {
+              "x": 72.4,
+              "y": 91.7,
+              "v": 0.751
+            },
+            "rightHeel": {
+              "x": 44.7,
+              "y": 118.5,
+              "v": 0.862
+            },
+            "leftFootIndex": {
+              "x": 79.5,
+              "y": 102.6,
+              "v": 0.822
+            },
+            "rightFootIndex": {
+              "x": 45.2,
+              "y": 125.4,
+              "v": 0.966
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.9,
+                "y": 14.6
+              },
+              "roll": 171.3,
+              "yaw": 0,
+              "pitch": 0.527
+            },
+            "torso": {
+              "center": {
+                "x": 63.9,
+                "y": 26.7
+              },
+              "angle": 91.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.2,
+                "y": 7.2
+              },
+              "angle": 115.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.4,
+                "y": 63.8
+              },
+              "angle": -69.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.4,
+                "y": 91.7
+              },
+              "angle": -56.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.7,
+                "y": 118.5
+              },
+              "angle": -85.9
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.908,
+          "keypoints": {
+            "nose": {
+              "x": 55.2,
+              "y": 21.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.7,
+              "y": 18.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 52.4,
+              "y": 19.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.6,
+              "y": 19.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.1,
+              "y": 20.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.4,
+              "y": 26.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.7,
+              "y": 31.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.4,
+              "y": 21.3,
+              "v": 0.98
+            },
+            "rightElbow": {
+              "x": 33.7,
+              "y": 47.9,
+              "v": 0.891
+            },
+            "leftWrist": {
+              "x": 77.2,
+              "y": 7,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 46.3,
+              "y": 56.1,
+              "v": 0.474
+            },
+            "leftIndex": {
+              "x": 75.8,
+              "y": 2.6,
+              "v": 0.99
+            },
+            "rightIndex": {
+              "x": 49.7,
+              "y": 56.9,
+              "v": 0.438
+            },
+            "leftHip": {
+              "x": 68.5,
+              "y": 58.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.3,
+              "y": 64.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 92.7,
+              "y": 52.1,
+              "v": 0.962
+            },
+            "rightKnee": {
+              "x": 54.7,
+              "y": 89.2,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 82,
+              "y": 75.1,
+              "v": 0.766
+            },
+            "rightAnkle": {
+              "x": 49.2,
+              "y": 117.7,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 76.9,
+              "y": 77.1,
+              "v": 0.73
+            },
+            "rightHeel": {
+              "x": 48.1,
+              "y": 120.9,
+              "v": 0.939
+            },
+            "leftFootIndex": {
+              "x": 83.8,
+              "y": 87.4,
+              "v": 0.756
+            },
+            "rightFootIndex": {
+              "x": 50.9,
+              "y": 124.3,
+              "v": 0.982
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.6,
+                "y": 19.3
+              },
+              "roll": -170.8,
+              "yaw": 0.149,
+              "pitch": 0.471
+            },
+            "torso": {
+              "center": {
+                "x": 54.1,
+                "y": 29.1
+              },
+              "angle": 105.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 77.2,
+                "y": 7
+              },
+              "angle": 107.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 46.3,
+                "y": 56.1
+              },
+              "angle": -13.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.9,
+                "y": 77.1
+              },
+              "angle": -56.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.1,
+                "y": 120.9
+              },
+              "angle": -50.5
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.874,
+          "keypoints": {
+            "nose": {
+              "x": 82.1,
+              "y": 18,
+              "v": 0.997
+            },
+            "leftEye": {
+              "x": 84.1,
+              "y": 15.2,
+              "v": 0.993
+            },
+            "rightEye": {
+              "x": 82.9,
+              "y": 14.1,
+              "v": 0.997
+            },
+            "leftEar": {
+              "x": 82,
+              "y": 13.4,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 79.2,
+              "y": 10.7,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 72.4,
+              "y": 22.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.2,
+              "y": 18.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 68.4,
+              "y": 45.3,
+              "v": 0.074
+            },
+            "rightElbow": {
+              "x": 46.8,
+              "y": 38.8,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 75.8,
+              "y": 63,
+              "v": 0.284
+            },
+            "rightWrist": {
+              "x": 46.8,
+              "y": 59.5,
+              "v": 0.976
+            },
+            "leftIndex": {
+              "x": 77,
+              "y": 65.2,
+              "v": 0.356
+            },
+            "rightIndex": {
+              "x": 48.3,
+              "y": 63.9,
+              "v": 0.937
+            },
+            "leftHip": {
+              "x": 69.9,
+              "y": 61.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.2,
+              "y": 61.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.8,
+              "y": 89.7,
+              "v": 0.882
+            },
+            "rightKnee": {
+              "x": 53.4,
+              "y": 89,
+              "v": 0.982
+            },
+            "leftAnkle": {
+              "x": 66.6,
+              "y": 114,
+              "v": 0.975
+            },
+            "rightAnkle": {
+              "x": 44.8,
+              "y": 113.6,
+              "v": 0.976
+            },
+            "leftHeel": {
+              "x": 63.8,
+              "y": 118.9,
+              "v": 0.948
+            },
+            "rightHeel": {
+              "x": 45.4,
+              "y": 117,
+              "v": 0.783
+            },
+            "leftFootIndex": {
+              "x": 76.4,
+              "y": 119.4,
+              "v": 0.98
+            },
+            "rightFootIndex": {
+              "x": 45.5,
+              "y": 123.3,
+              "v": 0.966
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 83.5,
+                "y": 14.7
+              },
+              "roll": 137.5,
+              "yaw": -0.86,
+              "pitch": 2.058
+            },
+            "torso": {
+              "center": {
+                "x": 64.8,
+                "y": 20.5
+              },
+              "angle": 89.6
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 46.8,
+                "y": 59.5
+              },
+              "angle": -71.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 63.8,
+                "y": 118.9
+              },
+              "angle": -2.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45.4,
+                "y": 117
+              },
+              "angle": -89.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.817,
+          "keypoints": {
+            "nose": {
+              "x": 83.9,
+              "y": 19.1,
+              "v": 0.996
+            },
+            "leftEye": {
+              "x": 85.9,
+              "y": 16.8,
+              "v": 0.985
+            },
+            "rightEye": {
+              "x": 84.6,
+              "y": 16.7,
+              "v": 0.997
+            },
+            "leftEar": {
+              "x": 82.8,
+              "y": 13.5,
+              "v": 0.995
+            },
+            "rightEar": {
+              "x": 80.6,
+              "y": 12.6,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 72,
+              "y": 19.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 62.7,
+              "y": 36.5,
+              "v": 0.015
+            },
+            "rightElbow": {
+              "x": 45.8,
+              "y": 34.3,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 67.3,
+              "y": 48.7,
+              "v": 0.055
+            },
+            "rightWrist": {
+              "x": 42.1,
+              "y": 52.9,
+              "v": 0.978
+            },
+            "leftIndex": {
+              "x": 70.2,
+              "y": 51.4,
+              "v": 0.08
+            },
+            "rightIndex": {
+              "x": 43.1,
+              "y": 58,
+              "v": 0.932
+            },
+            "leftHip": {
+              "x": 69.2,
+              "y": 56.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.3,
+              "y": 57.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.6,
+              "y": 86.6,
+              "v": 0.635
+            },
+            "rightKnee": {
+              "x": 54,
+              "y": 85.9,
+              "v": 0.98
+            },
+            "leftAnkle": {
+              "x": 69.9,
+              "y": 112.8,
+              "v": 0.896
+            },
+            "rightAnkle": {
+              "x": 45.5,
+              "y": 114.8,
+              "v": 0.965
+            },
+            "leftHeel": {
+              "x": 66.9,
+              "y": 116.8,
+              "v": 0.818
+            },
+            "rightHeel": {
+              "x": 43,
+              "y": 118.4,
+              "v": 0.61
+            },
+            "leftFootIndex": {
+              "x": 74.9,
+              "y": 122.1,
+              "v": 0.918
+            },
+            "rightFootIndex": {
+              "x": 44.5,
+              "y": 124.7,
+              "v": 0.945
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 85.3,
+                "y": 16.8
+              },
+              "roll": 175.6,
+              "yaw": -1.035,
+              "pitch": 1.802
+            },
+            "torso": {
+              "center": {
+                "x": 67.5,
+                "y": 19
+              },
+              "angle": 87.4
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 42.1,
+                "y": 52.9
+              },
+              "angle": -78.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 66.9,
+                "y": 116.8
+              },
+              "angle": -33.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43,
+                "y": 118.4
+              },
+              "angle": -76.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.752,
+          "keypoints": {
+            "nose": {
+              "x": 81.3,
+              "y": 21.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 83.8,
+              "y": 20,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 80.8,
+              "y": 18.1,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 81.3,
+              "y": 17.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 73.7,
+              "y": 15.7,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 78.1,
+              "y": 18.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.5,
+              "y": 22.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.8,
+              "y": 22.4,
+              "v": 0.417
+            },
+            "rightElbow": {
+              "x": 43.5,
+              "y": 36.7,
+              "v": 0.964
+            },
+            "leftWrist": {
+              "x": 82.1,
+              "y": 33.1,
+              "v": 0.352
+            },
+            "rightWrist": {
+              "x": 41.3,
+              "y": 55.3,
+              "v": 0.784
+            },
+            "leftIndex": {
+              "x": 81.4,
+              "y": 37.2,
+              "v": 0.264
+            },
+            "rightIndex": {
+              "x": 41.8,
+              "y": 60.2,
+              "v": 0.583
+            },
+            "leftHip": {
+              "x": 77.5,
+              "y": 54.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64.4,
+              "y": 55.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82,
+              "y": 85.8,
+              "v": 0.388
+            },
+            "rightKnee": {
+              "x": 54.7,
+              "y": 84.5,
+              "v": 0.73
+            },
+            "leftAnkle": {
+              "x": 81.1,
+              "y": 113.9,
+              "v": 0.748
+            },
+            "rightAnkle": {
+              "x": 46.5,
+              "y": 112,
+              "v": 0.754
+            },
+            "leftHeel": {
+              "x": 78.9,
+              "y": 119.1,
+              "v": 0.508
+            },
+            "rightHeel": {
+              "x": 46.7,
+              "y": 115.4,
+              "v": 0.275
+            },
+            "leftFootIndex": {
+              "x": 92.1,
+              "y": 120.4,
+              "v": 0.789
+            },
+            "rightFootIndex": {
+              "x": 44.8,
+              "y": 122.5,
+              "v": 0.753
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 82.3,
+                "y": 19.1
+              },
+              "roll": 147.7,
+              "yaw": -0.282,
+              "pitch": 0.746
+            },
+            "torso": {
+              "center": {
+                "x": 67.3,
+                "y": 20.6
+              },
+              "angle": 96.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.1,
+                "y": 33.1
+              },
+              "angle": -88.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.3,
+                "y": 55.3
+              },
+              "angle": -84.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.9,
+                "y": 119.1
+              },
+              "angle": -5.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 46.5,
+                "y": 112
+              },
+              "angle": -99.2
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.976,
+          "keypoints": {
+            "nose": {
+              "x": 71,
+              "y": 13,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.7,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.6,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.5,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.7,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75,
+              "y": 22.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.9,
+              "y": 20.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.5,
+              "y": 38.4,
+              "v": 0.891
+            },
+            "rightElbow": {
+              "x": 41.6,
+              "y": 38.6,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 90.6,
+              "y": 24.4,
+              "v": 0.987
+            },
+            "rightWrist": {
+              "x": 39.7,
+              "y": 57.7,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 90.8,
+              "y": 17.4,
+              "v": 0.981
+            },
+            "rightIndex": {
+              "x": 39.6,
+              "y": 62.5,
+              "v": 0.995
+            },
+            "leftHip": {
+              "x": 70.9,
+              "y": 56.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.3,
+              "y": 59.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 92.8,
+              "y": 61.1,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 54.1,
+              "y": 87,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 75.1,
+              "y": 81.2,
+              "v": 0.902
+            },
+            "rightAnkle": {
+              "x": 40.3,
+              "y": 108.6,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 69.3,
+              "y": 82.4,
+              "v": 0.883
+            },
+            "rightHeel": {
+              "x": 36.7,
+              "y": 110.8,
+              "v": 0.921
+            },
+            "leftFootIndex": {
+              "x": 73.4,
+              "y": 95.7,
+              "v": 0.928
+            },
+            "rightFootIndex": {
+              "x": 38.8,
+              "y": 121.2,
+              "v": 0.985
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.7,
+                "y": 10.5
+              },
+              "roll": 169,
+              "yaw": 0.084,
+              "pitch": 0.598
+            },
+            "torso": {
+              "center": {
+                "x": 64.5,
+                "y": 21.7
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.6,
+                "y": 24.4
+              },
+              "angle": 88.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.7,
+                "y": 57.7
+              },
+              "angle": -91.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.3,
+                "y": 82.4
+              },
+              "angle": -72.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.7,
+                "y": 110.8
+              },
+              "angle": -78.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.981,
+          "keypoints": {
+            "nose": {
+              "x": 70.5,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.4,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.1,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.7,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.9,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.2,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.9,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.1,
+              "y": 37.5,
+              "v": 0.932
+            },
+            "rightElbow": {
+              "x": 41.2,
+              "y": 38.7,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 90.5,
+              "y": 23.4,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 38.7,
+              "y": 56.9,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 90.8,
+              "y": 17.3,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 39.2,
+              "y": 62.1,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 70.3,
+              "y": 57,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.7,
+              "y": 60.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 92.5,
+              "y": 61.1,
+              "v": 0.986
+            },
+            "rightKnee": {
+              "x": 53.3,
+              "y": 86.9,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 74.5,
+              "y": 81.9,
+              "v": 0.911
+            },
+            "rightAnkle": {
+              "x": 41.7,
+              "y": 111.4,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 68.4,
+              "y": 82.2,
+              "v": 0.897
+            },
+            "rightHeel": {
+              "x": 38.1,
+              "y": 113.7,
+              "v": 0.939
+            },
+            "leftFootIndex": {
+              "x": 74.3,
+              "y": 96,
+              "v": 0.929
+            },
+            "rightFootIndex": {
+              "x": 41.3,
+              "y": 124.1,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.8,
+                "y": 10.6
+              },
+              "roll": -180,
+              "yaw": 0.227,
+              "pitch": 0.909
+            },
+            "torso": {
+              "center": {
+                "x": 63.1,
+                "y": 22.6
+              },
+              "angle": 91.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.5,
+                "y": 23.4
+              },
+              "angle": 87.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.7,
+                "y": 56.9
+              },
+              "angle": -84.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.4,
+                "y": 82.2
+              },
+              "angle": -66.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.1,
+                "y": 113.7
+              },
+              "angle": -72.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.982,
+          "keypoints": {
+            "nose": {
+              "x": 68.1,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.3,
+              "y": 9.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.2,
+              "y": 8.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.5,
+              "y": 10,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.6,
+              "y": 23.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50,
+              "y": 22.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.3,
+              "y": 39.6,
+              "v": 0.934
+            },
+            "rightElbow": {
+              "x": 39.9,
+              "y": 41.2,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 90.8,
+              "y": 27.2,
+              "v": 0.989
+            },
+            "rightWrist": {
+              "x": 39.4,
+              "y": 59.7,
+              "v": 0.991
+            },
+            "leftIndex": {
+              "x": 91.8,
+              "y": 20.4,
+              "v": 0.984
+            },
+            "rightIndex": {
+              "x": 39.3,
+              "y": 64.2,
+              "v": 0.983
+            },
+            "leftHip": {
+              "x": 69.9,
+              "y": 57.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.3,
+              "y": 60.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 93.6,
+              "y": 62,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 50.5,
+              "y": 88.3,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 74.6,
+              "y": 82.6,
+              "v": 0.946
+            },
+            "rightAnkle": {
+              "x": 43.1,
+              "y": 111.2,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 69,
+              "y": 83.4,
+              "v": 0.919
+            },
+            "rightHeel": {
+              "x": 41.5,
+              "y": 114.3,
+              "v": 0.921
+            },
+            "leftFootIndex": {
+              "x": 73.8,
+              "y": 97.3,
+              "v": 0.949
+            },
+            "rightFootIndex": {
+              "x": 42.7,
+              "y": 124,
+              "v": 0.983
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.8,
+                "y": 9
+              },
+              "roll": 175.5,
+              "yaw": 0.264,
+              "pitch": 0.489
+            },
+            "torso": {
+              "center": {
+                "x": 61.8,
+                "y": 23.3
+              },
+              "angle": 92.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.8,
+                "y": 27.2
+              },
+              "angle": 81.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.4,
+                "y": 59.7
+              },
+              "angle": -91.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69,
+                "y": 83.4
+              },
+              "angle": -70.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.5,
+                "y": 114.3
+              },
+              "angle": -82.9
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/jeka/poses.json
+++ b/public/assets/fighters/jeka/poses.json
@@ -1,0 +1,8252 @@
+{
+  "version": 1,
+  "fighter": "jeka",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:39:43.402Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.828,
+          "keypoints": {
+            "nose": {
+              "x": 71.3,
+              "y": 31.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.1,
+              "y": 29,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68,
+              "y": 28.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.4,
+              "y": 29.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.2,
+              "y": 29.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.4,
+              "y": 43.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.8,
+              "y": 40.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73,
+              "y": 58.4,
+              "v": 0.562
+            },
+            "rightElbow": {
+              "x": 46.2,
+              "y": 51.9,
+              "v": 0.961
+            },
+            "leftWrist": {
+              "x": 74.7,
+              "y": 54.6,
+              "v": 0.861
+            },
+            "rightWrist": {
+              "x": 58.1,
+              "y": 45,
+              "v": 0.943
+            },
+            "leftIndex": {
+              "x": 75.5,
+              "y": 51.7,
+              "v": 0.863
+            },
+            "rightIndex": {
+              "x": 62.1,
+              "y": 41.1,
+              "v": 0.9
+            },
+            "leftHip": {
+              "x": 63.4,
+              "y": 71.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.4,
+              "y": 70.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.7,
+              "y": 84.6,
+              "v": 0.814
+            },
+            "rightKnee": {
+              "x": 53.4,
+              "y": 92.2,
+              "v": 0.786
+            },
+            "leftAnkle": {
+              "x": 64.6,
+              "y": 107.7,
+              "v": 0.543
+            },
+            "rightAnkle": {
+              "x": 46.3,
+              "y": 111.9,
+              "v": 0.674
+            },
+            "leftHeel": {
+              "x": 59.8,
+              "y": 110.4,
+              "v": 0.639
+            },
+            "rightHeel": {
+              "x": 45.1,
+              "y": 115.5,
+              "v": 0.397
+            },
+            "leftFootIndex": {
+              "x": 67.9,
+              "y": 116.6,
+              "v": 0.561
+            },
+            "rightFootIndex": {
+              "x": 46.1,
+              "y": 118.2,
+              "v": 0.538
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.1,
+                "y": 28.8
+              },
+              "roll": 173,
+              "yaw": 0.303,
+              "pitch": 0.642
+            },
+            "torso": {
+              "center": {
+                "x": 63.1,
+                "y": 42.1
+              },
+              "angle": 79.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 74.7,
+                "y": 54.6
+              },
+              "angle": 74.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 58.1,
+                "y": 45
+              },
+              "angle": 44.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 59.8,
+                "y": 110.4
+              },
+              "angle": -37.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45.1,
+                "y": 115.5
+              },
+              "angle": -69.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.794,
+          "keypoints": {
+            "nose": {
+              "x": 70.8,
+              "y": 31.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.6,
+              "y": 28.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.5,
+              "y": 28.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.8,
+              "y": 29.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.5,
+              "y": 29.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72,
+              "y": 42,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.5,
+              "y": 39.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.2,
+              "y": 52.6,
+              "v": 0.412
+            },
+            "rightElbow": {
+              "x": 51.8,
+              "y": 50.4,
+              "v": 0.949
+            },
+            "leftWrist": {
+              "x": 77.8,
+              "y": 50.7,
+              "v": 0.592
+            },
+            "rightWrist": {
+              "x": 60.5,
+              "y": 43.2,
+              "v": 0.927
+            },
+            "leftIndex": {
+              "x": 76.9,
+              "y": 48.7,
+              "v": 0.62
+            },
+            "rightIndex": {
+              "x": 63.4,
+              "y": 39.6,
+              "v": 0.893
+            },
+            "leftHip": {
+              "x": 67.6,
+              "y": 69.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.8,
+              "y": 70,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.2,
+              "y": 85.6,
+              "v": 0.641
+            },
+            "rightKnee": {
+              "x": 58.4,
+              "y": 92.3,
+              "v": 0.85
+            },
+            "leftAnkle": {
+              "x": 66.2,
+              "y": 105.5,
+              "v": 0.341
+            },
+            "rightAnkle": {
+              "x": 46.6,
+              "y": 112.1,
+              "v": 0.817
+            },
+            "leftHeel": {
+              "x": 61.8,
+              "y": 107.5,
+              "v": 0.535
+            },
+            "rightHeel": {
+              "x": 44.2,
+              "y": 115.5,
+              "v": 0.577
+            },
+            "leftFootIndex": {
+              "x": 68.2,
+              "y": 114,
+              "v": 0.401
+            },
+            "rightFootIndex": {
+              "x": 47.5,
+              "y": 120.5,
+              "v": 0.718
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.1,
+                "y": 28.7
+              },
+              "roll": 172.6,
+              "yaw": 0.24,
+              "pitch": 0.768
+            },
+            "torso": {
+              "center": {
+                "x": 64.8,
+                "y": 40.6
+              },
+              "angle": 85
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 77.8,
+                "y": 50.7
+              },
+              "angle": 114.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 60.5,
+                "y": 43.2
+              },
+              "angle": 51.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.8,
+                "y": 107.5
+              },
+              "angle": -45.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.2,
+                "y": 115.5
+              },
+              "angle": -56.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.756,
+          "keypoints": {
+            "nose": {
+              "x": 102.3,
+              "y": 29.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 103.5,
+              "y": 27.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 99.3,
+              "y": 27.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 103.6,
+              "y": 28.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 95.6,
+              "y": 28.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 105.9,
+              "y": 39.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 90.9,
+              "y": 38.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 108.8,
+              "y": 51.2,
+              "v": 0.233
+            },
+            "rightElbow": {
+              "x": 84.7,
+              "y": 47.6,
+              "v": 0.741
+            },
+            "leftWrist": {
+              "x": 109.8,
+              "y": 50.6,
+              "v": 0.555
+            },
+            "rightWrist": {
+              "x": 94.6,
+              "y": 45.3,
+              "v": 0.493
+            },
+            "leftIndex": {
+              "x": 110.1,
+              "y": 49.1,
+              "v": 0.647
+            },
+            "rightIndex": {
+              "x": 98.1,
+              "y": 43.7,
+              "v": 0.453
+            },
+            "leftHip": {
+              "x": 100.6,
+              "y": 70,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 91.9,
+              "y": 68.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 113,
+              "y": 91,
+              "v": 0.48
+            },
+            "rightKnee": {
+              "x": 101.9,
+              "y": 87.8,
+              "v": 0.86
+            },
+            "leftAnkle": {
+              "x": 98,
+              "y": 109.9,
+              "v": 0.485
+            },
+            "rightAnkle": {
+              "x": 86.5,
+              "y": 112.2,
+              "v": 0.874
+            },
+            "leftHeel": {
+              "x": 94,
+              "y": 111.9,
+              "v": 0.531
+            },
+            "rightHeel": {
+              "x": 82.8,
+              "y": 115.4,
+              "v": 0.634
+            },
+            "leftFootIndex": {
+              "x": 99.5,
+              "y": 119.7,
+              "v": 0.559
+            },
+            "rightFootIndex": {
+              "x": 88.3,
+              "y": 123.4,
+              "v": 0.849
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 101.4,
+                "y": 27.6
+              },
+              "roll": -177.3,
+              "yaw": 0.214,
+              "pitch": 0.547
+            },
+            "torso": {
+              "center": {
+                "x": 98.4,
+                "y": 38.8
+              },
+              "angle": 86
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 109.8,
+                "y": 50.6
+              },
+              "angle": 78.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 94.6,
+                "y": 45.3
+              },
+              "angle": 24.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 94,
+                "y": 111.9
+              },
+              "angle": -54.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 82.8,
+                "y": 115.4
+              },
+              "angle": -55.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.692,
+          "keypoints": {
+            "nose": {
+              "x": 71.9,
+              "y": 30.2,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 71.5,
+              "y": 28.6,
+              "v": 0.997
+            },
+            "rightEye": {
+              "x": 69.1,
+              "y": 29,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 71,
+              "y": 29.9,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 66.1,
+              "y": 31.1,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 75.5,
+              "y": 43,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.8,
+              "y": 41.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.5,
+              "y": 55.2,
+              "v": 0.295
+            },
+            "rightElbow": {
+              "x": 57.3,
+              "y": 53,
+              "v": 0.558
+            },
+            "leftWrist": {
+              "x": 74.2,
+              "y": 47.5,
+              "v": 0.472
+            },
+            "rightWrist": {
+              "x": 63.8,
+              "y": 44.2,
+              "v": 0.605
+            },
+            "leftIndex": {
+              "x": 74.2,
+              "y": 43.9,
+              "v": 0.528
+            },
+            "rightIndex": {
+              "x": 65.6,
+              "y": 40.1,
+              "v": 0.637
+            },
+            "leftHip": {
+              "x": 70.1,
+              "y": 70.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.9,
+              "y": 70,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.6,
+              "y": 85.7,
+              "v": 0.531
+            },
+            "rightKnee": {
+              "x": 69.8,
+              "y": 87.7,
+              "v": 0.663
+            },
+            "leftAnkle": {
+              "x": 64.4,
+              "y": 102.6,
+              "v": 0.276
+            },
+            "rightAnkle": {
+              "x": 59,
+              "y": 106.8,
+              "v": 0.708
+            },
+            "leftHeel": {
+              "x": 60.5,
+              "y": 102.8,
+              "v": 0.297
+            },
+            "rightHeel": {
+              "x": 56.5,
+              "y": 108.9,
+              "v": 0.39
+            },
+            "leftFootIndex": {
+              "x": 63.1,
+              "y": 112.4,
+              "v": 0.321
+            },
+            "rightFootIndex": {
+              "x": 59.7,
+              "y": 116.4,
+              "v": 0.631
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.3,
+                "y": 28.8
+              },
+              "roll": -170.5,
+              "yaw": 0.658,
+              "pitch": 0.575
+            },
+            "torso": {
+              "center": {
+                "x": 68.2,
+                "y": 42.3
+              },
+              "angle": 85.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 74.2,
+                "y": 47.5
+              },
+              "angle": 90
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 63.8,
+                "y": 44.2
+              },
+              "angle": 66.3
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 56.5,
+                "y": 108.9
+              },
+              "angle": -66.9
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.789,
+          "keypoints": {
+            "nose": {
+              "x": 71.3,
+              "y": 31,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.8,
+              "y": 28.5,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 68.4,
+              "y": 28.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.3,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.9,
+              "y": 30.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.4,
+              "y": 42.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60,
+              "y": 40.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.4,
+              "y": 55.4,
+              "v": 0.271
+            },
+            "rightElbow": {
+              "x": 55.7,
+              "y": 51.5,
+              "v": 0.839
+            },
+            "leftWrist": {
+              "x": 72.2,
+              "y": 50.4,
+              "v": 0.611
+            },
+            "rightWrist": {
+              "x": 62.3,
+              "y": 42.9,
+              "v": 0.889
+            },
+            "leftIndex": {
+              "x": 72.8,
+              "y": 47.5,
+              "v": 0.675
+            },
+            "rightIndex": {
+              "x": 64.1,
+              "y": 38.9,
+              "v": 0.864
+            },
+            "leftHip": {
+              "x": 68.1,
+              "y": 71.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.8,
+              "y": 69.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.8,
+              "y": 86.5,
+              "v": 0.814
+            },
+            "rightKnee": {
+              "x": 57.3,
+              "y": 89.8,
+              "v": 0.821
+            },
+            "leftAnkle": {
+              "x": 65.6,
+              "y": 100.4,
+              "v": 0.411
+            },
+            "rightAnkle": {
+              "x": 49.4,
+              "y": 109.5,
+              "v": 0.824
+            },
+            "leftHeel": {
+              "x": 62.1,
+              "y": 101.1,
+              "v": 0.486
+            },
+            "rightHeel": {
+              "x": 48.5,
+              "y": 112.5,
+              "v": 0.531
+            },
+            "leftFootIndex": {
+              "x": 65,
+              "y": 109.5,
+              "v": 0.414
+            },
+            "rightFootIndex": {
+              "x": 46.9,
+              "y": 117.5,
+              "v": 0.698
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.1,
+                "y": 28.6
+              },
+              "roll": -176.6,
+              "yaw": 0.352,
+              "pitch": 0.705
+            },
+            "torso": {
+              "center": {
+                "x": 66.7,
+                "y": 41.4
+              },
+              "angle": 83.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 72.2,
+                "y": 50.4
+              },
+              "angle": 78.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 62.3,
+                "y": 42.9
+              },
+              "angle": 65.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 62.1,
+                "y": 101.1
+              },
+              "angle": -71
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.5,
+                "y": 112.5
+              },
+              "angle": -107.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.801,
+          "keypoints": {
+            "nose": {
+              "x": 72.2,
+              "y": 30.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.7,
+              "y": 28.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.1,
+              "y": 29.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.9,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66,
+              "y": 31.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.9,
+              "y": 42.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.2,
+              "y": 41.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.6,
+              "y": 51.4,
+              "v": 0.646
+            },
+            "rightElbow": {
+              "x": 50.8,
+              "y": 50.8,
+              "v": 0.815
+            },
+            "leftWrist": {
+              "x": 84.1,
+              "y": 44.1,
+              "v": 0.928
+            },
+            "rightWrist": {
+              "x": 55.8,
+              "y": 45.8,
+              "v": 0.715
+            },
+            "leftIndex": {
+              "x": 86.8,
+              "y": 38.8,
+              "v": 0.93
+            },
+            "rightIndex": {
+              "x": 58,
+              "y": 42.9,
+              "v": 0.718
+            },
+            "leftHip": {
+              "x": 70.8,
+              "y": 71,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.2,
+              "y": 70.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.9,
+              "y": 84.6,
+              "v": 0.784
+            },
+            "rightKnee": {
+              "x": 60.6,
+              "y": 92.1,
+              "v": 0.753
+            },
+            "leftAnkle": {
+              "x": 66.4,
+              "y": 101.9,
+              "v": 0.381
+            },
+            "rightAnkle": {
+              "x": 51.4,
+              "y": 111.5,
+              "v": 0.794
+            },
+            "leftHeel": {
+              "x": 62.3,
+              "y": 102.7,
+              "v": 0.448
+            },
+            "rightHeel": {
+              "x": 50.2,
+              "y": 114.2,
+              "v": 0.465
+            },
+            "leftFootIndex": {
+              "x": 67.2,
+              "y": 111.3,
+              "v": 0.399
+            },
+            "rightFootIndex": {
+              "x": 50.2,
+              "y": 119.7,
+              "v": 0.657
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.4,
+                "y": 29
+              },
+              "roll": -173.4,
+              "yaw": 0.688,
+              "pitch": 0.63
+            },
+            "torso": {
+              "center": {
+                "x": 67.1,
+                "y": 42
+              },
+              "angle": 87.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.1,
+                "y": 44.1
+              },
+              "angle": 63
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 55.8,
+                "y": 45.8
+              },
+              "angle": 52.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 62.3,
+                "y": 102.7
+              },
+              "angle": -60.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 50.2,
+                "y": 114.2
+              },
+              "angle": -90
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.773,
+          "keypoints": {
+            "nose": {
+              "x": 71.4,
+              "y": 30.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.4,
+              "y": 28.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.3,
+              "y": 28.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.9,
+              "y": 29.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.9,
+              "y": 30.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75,
+              "y": 42.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 62,
+              "y": 41.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.3,
+              "y": 54.7,
+              "v": 0.097
+            },
+            "rightElbow": {
+              "x": 56.5,
+              "y": 53.4,
+              "v": 0.838
+            },
+            "leftWrist": {
+              "x": 73.4,
+              "y": 51.1,
+              "v": 0.33
+            },
+            "rightWrist": {
+              "x": 61.6,
+              "y": 44.7,
+              "v": 0.931
+            },
+            "leftIndex": {
+              "x": 74,
+              "y": 48.8,
+              "v": 0.442
+            },
+            "rightIndex": {
+              "x": 63,
+              "y": 40.4,
+              "v": 0.922
+            },
+            "leftHip": {
+              "x": 68.8,
+              "y": 70.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.3,
+              "y": 69.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.1,
+              "y": 85,
+              "v": 0.72
+            },
+            "rightKnee": {
+              "x": 61,
+              "y": 90.5,
+              "v": 0.834
+            },
+            "leftAnkle": {
+              "x": 64.4,
+              "y": 97.6,
+              "v": 0.385
+            },
+            "rightAnkle": {
+              "x": 52.7,
+              "y": 111,
+              "v": 0.89
+            },
+            "leftHeel": {
+              "x": 60.6,
+              "y": 96.6,
+              "v": 0.519
+            },
+            "rightHeel": {
+              "x": 51.4,
+              "y": 114.1,
+              "v": 0.649
+            },
+            "leftFootIndex": {
+              "x": 65.1,
+              "y": 105.9,
+              "v": 0.424
+            },
+            "rightFootIndex": {
+              "x": 51.4,
+              "y": 118.7,
+              "v": 0.789
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.9,
+                "y": 28.5
+              },
+              "roll": -174.5,
+              "yaw": 0.498,
+              "pitch": 0.594
+            },
+            "torso": {
+              "center": {
+                "x": 68.5,
+                "y": 42
+              },
+              "angle": 82
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.4,
+                "y": 51.1
+              },
+              "angle": 75.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 61.6,
+                "y": 44.7
+              },
+              "angle": 72
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.6,
+                "y": 96.6
+              },
+              "angle": -64.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 51.4,
+                "y": 114.1
+              },
+              "angle": -90
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.637,
+          "keypoints": {
+            "nose": {
+              "x": 72.5,
+              "y": 30.8,
+              "v": 0.998
+            },
+            "leftEye": {
+              "x": 71.7,
+              "y": 28.6,
+              "v": 0.996
+            },
+            "rightEye": {
+              "x": 69.1,
+              "y": 29.2,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 70.6,
+              "y": 29.4,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 65.5,
+              "y": 31.2,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 75.6,
+              "y": 42.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.3,
+              "y": 41.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.5,
+              "y": 53.8,
+              "v": 0.413
+            },
+            "rightElbow": {
+              "x": 54.3,
+              "y": 54.3,
+              "v": 0.454
+            },
+            "leftWrist": {
+              "x": 67.5,
+              "y": 41.2,
+              "v": 0.574
+            },
+            "rightWrist": {
+              "x": 58.8,
+              "y": 45.3,
+              "v": 0.621
+            },
+            "leftIndex": {
+              "x": 67.1,
+              "y": 39.4,
+              "v": 0.574
+            },
+            "rightIndex": {
+              "x": 60.1,
+              "y": 41.1,
+              "v": 0.663
+            },
+            "leftHip": {
+              "x": 70.5,
+              "y": 70,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.3,
+              "y": 70.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.1,
+              "y": 84.6,
+              "v": 0.37
+            },
+            "rightKnee": {
+              "x": 64.4,
+              "y": 89.3,
+              "v": 0.375
+            },
+            "leftAnkle": {
+              "x": 64.8,
+              "y": 101.7,
+              "v": 0.121
+            },
+            "rightAnkle": {
+              "x": 55.8,
+              "y": 110.9,
+              "v": 0.52
+            },
+            "leftHeel": {
+              "x": 61,
+              "y": 102.2,
+              "v": 0.179
+            },
+            "rightHeel": {
+              "x": 54.5,
+              "y": 113.6,
+              "v": 0.246
+            },
+            "leftFootIndex": {
+              "x": 64.2,
+              "y": 111.3,
+              "v": 0.154
+            },
+            "rightFootIndex": {
+              "x": 55,
+              "y": 120.3,
+              "v": 0.408
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.4,
+                "y": 28.9
+              },
+              "roll": -167,
+              "yaw": 0.787,
+              "pitch": 0.712
+            },
+            "torso": {
+              "center": {
+                "x": 67.4,
+                "y": 41.9
+              },
+              "angle": 86.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 67.5,
+                "y": 41.2
+              },
+              "angle": 102.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 58.8,
+                "y": 45.3
+              },
+              "angle": 72.8
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 55.8,
+                "y": 110.9
+              },
+              "angle": -94.9
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.955,
+          "keypoints": {
+            "nose": {
+              "x": 61.1,
+              "y": 26.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.4,
+              "y": 24.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.8,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.6,
+              "y": 25,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.7,
+              "y": 24.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 60.8,
+              "y": 36.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.6,
+              "y": 36.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.4,
+              "y": 42.5,
+              "v": 0.731
+            },
+            "rightElbow": {
+              "x": 44.1,
+              "y": 46.9,
+              "v": 0.939
+            },
+            "leftWrist": {
+              "x": 84.8,
+              "y": 42.1,
+              "v": 0.924
+            },
+            "rightWrist": {
+              "x": 48.5,
+              "y": 44.1,
+              "v": 0.928
+            },
+            "leftIndex": {
+              "x": 88.9,
+              "y": 41,
+              "v": 0.93
+            },
+            "rightIndex": {
+              "x": 50.6,
+              "y": 41.9,
+              "v": 0.92
+            },
+            "leftHip": {
+              "x": 59.9,
+              "y": 66.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.4,
+              "y": 67,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.3,
+              "y": 87.6,
+              "v": 0.903
+            },
+            "rightKnee": {
+              "x": 41.5,
+              "y": 92.4,
+              "v": 0.985
+            },
+            "leftAnkle": {
+              "x": 71.3,
+              "y": 107.9,
+              "v": 0.967
+            },
+            "rightAnkle": {
+              "x": 30.7,
+              "y": 113.3,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 68.9,
+              "y": 111.5,
+              "v": 0.911
+            },
+            "rightHeel": {
+              "x": 29,
+              "y": 115.6,
+              "v": 0.879
+            },
+            "leftFootIndex": {
+              "x": 78.8,
+              "y": 114.3,
+              "v": 0.971
+            },
+            "rightFootIndex": {
+              "x": 29.6,
+              "y": 123.8,
+              "v": 0.987
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.6,
+                "y": 24.2
+              },
+              "roll": 176.8,
+              "yaw": 0.416,
+              "pitch": 0.749
+            },
+            "torso": {
+              "center": {
+                "x": 53.2,
+                "y": 36.6
+              },
+              "angle": 92.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.8,
+                "y": 42.1
+              },
+              "angle": 15
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48.5,
+                "y": 44.1
+              },
+              "angle": 46.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.9,
+                "y": 111.5
+              },
+              "angle": -15.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29,
+                "y": 115.6
+              },
+              "angle": -85.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.958,
+          "keypoints": {
+            "nose": {
+              "x": 60.5,
+              "y": 27.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.2,
+              "y": 25,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.8,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.8,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.2,
+              "y": 25,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.3,
+              "y": 37,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.8,
+              "y": 36.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.6,
+              "y": 39.8,
+              "v": 0.843
+            },
+            "rightElbow": {
+              "x": 36.4,
+              "y": 48.3,
+              "v": 0.973
+            },
+            "leftWrist": {
+              "x": 87.3,
+              "y": 41.4,
+              "v": 0.938
+            },
+            "rightWrist": {
+              "x": 45.4,
+              "y": 44.7,
+              "v": 0.937
+            },
+            "leftIndex": {
+              "x": 91.3,
+              "y": 40.6,
+              "v": 0.94
+            },
+            "rightIndex": {
+              "x": 48.6,
+              "y": 42,
+              "v": 0.912
+            },
+            "leftHip": {
+              "x": 59.9,
+              "y": 68.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.6,
+              "y": 68.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.3,
+              "y": 88.7,
+              "v": 0.936
+            },
+            "rightKnee": {
+              "x": 41,
+              "y": 92,
+              "v": 0.978
+            },
+            "leftAnkle": {
+              "x": 70.8,
+              "y": 110.8,
+              "v": 0.975
+            },
+            "rightAnkle": {
+              "x": 30.8,
+              "y": 112.9,
+              "v": 0.985
+            },
+            "leftHeel": {
+              "x": 68.5,
+              "y": 114.4,
+              "v": 0.909
+            },
+            "rightHeel": {
+              "x": 28.8,
+              "y": 115.5,
+              "v": 0.761
+            },
+            "leftFootIndex": {
+              "x": 77.5,
+              "y": 117.8,
+              "v": 0.976
+            },
+            "rightFootIndex": {
+              "x": 30.2,
+              "y": 124.9,
+              "v": 0.973
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.5,
+                "y": 24.8
+              },
+              "roll": 171.6,
+              "yaw": 0.291,
+              "pitch": 0.771
+            },
+            "torso": {
+              "center": {
+                "x": 53.1,
+                "y": 36.7
+              },
+              "angle": 91.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.3,
+                "y": 41.4
+              },
+              "angle": 11.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 45.4,
+                "y": 44.7
+              },
+              "angle": 40.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.5,
+                "y": 114.4
+              },
+              "angle": -20.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 28.8,
+                "y": 115.5
+              },
+              "angle": -81.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.71,
+          "keypoints": {
+            "nose": {
+              "x": 59.3,
+              "y": 30.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.7,
+              "y": 28.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.6,
+              "y": 28.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.8,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.8,
+              "y": 29.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 61.3,
+              "y": 40.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.5,
+              "y": 41.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 66.4,
+              "y": 50.9,
+              "v": 0.209
+            },
+            "rightElbow": {
+              "x": 54.1,
+              "y": 55.3,
+              "v": 0.815
+            },
+            "leftWrist": {
+              "x": 72.8,
+              "y": 43.8,
+              "v": 0.449
+            },
+            "rightWrist": {
+              "x": 63.2,
+              "y": 44.5,
+              "v": 0.921
+            },
+            "leftIndex": {
+              "x": 74.7,
+              "y": 40.2,
+              "v": 0.547
+            },
+            "rightIndex": {
+              "x": 64.4,
+              "y": 41.5,
+              "v": 0.898
+            },
+            "leftHip": {
+              "x": 58.6,
+              "y": 69.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49,
+              "y": 70.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.9,
+              "y": 85.2,
+              "v": 0.578
+            },
+            "rightKnee": {
+              "x": 48.1,
+              "y": 91.3,
+              "v": 0.678
+            },
+            "leftAnkle": {
+              "x": 54.5,
+              "y": 99.8,
+              "v": 0.186
+            },
+            "rightAnkle": {
+              "x": 39.6,
+              "y": 112.4,
+              "v": 0.655
+            },
+            "leftHeel": {
+              "x": 50.2,
+              "y": 102.6,
+              "v": 0.294
+            },
+            "rightHeel": {
+              "x": 38.6,
+              "y": 115.3,
+              "v": 0.376
+            },
+            "leftFootIndex": {
+              "x": 54.8,
+              "y": 111.2,
+              "v": 0.218
+            },
+            "rightFootIndex": {
+              "x": 37.7,
+              "y": 120.7,
+              "v": 0.519
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58.2,
+                "y": 28.7
+              },
+              "roll": 170.8,
+              "yaw": 0.366,
+              "pitch": 0.717
+            },
+            "torso": {
+              "center": {
+                "x": 54.4,
+                "y": 40.7
+              },
+              "angle": 88.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 72.8,
+                "y": 43.8
+              },
+              "angle": 62.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 63.2,
+                "y": 44.5
+              },
+              "angle": 68.2
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 38.6,
+                "y": 115.3
+              },
+              "angle": -99.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.696,
+          "keypoints": {
+            "nose": {
+              "x": 61.4,
+              "y": 31,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.9,
+              "y": 28.8,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 57.8,
+              "y": 28.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.7,
+              "y": 29.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 54.9,
+              "y": 30.1,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 64.4,
+              "y": 39.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.8,
+              "y": 39.6,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 73.1,
+              "y": 45.3,
+              "v": 0.319
+            },
+            "rightElbow": {
+              "x": 51.8,
+              "y": 50.2,
+              "v": 0.623
+            },
+            "leftWrist": {
+              "x": 82.8,
+              "y": 42.7,
+              "v": 0.682
+            },
+            "rightWrist": {
+              "x": 58.8,
+              "y": 43.8,
+              "v": 0.828
+            },
+            "leftIndex": {
+              "x": 85.8,
+              "y": 40.8,
+              "v": 0.721
+            },
+            "rightIndex": {
+              "x": 60.5,
+              "y": 39.9,
+              "v": 0.824
+            },
+            "leftHip": {
+              "x": 60.2,
+              "y": 68.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.7,
+              "y": 68.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.1,
+              "y": 84.9,
+              "v": 0.386
+            },
+            "rightKnee": {
+              "x": 49.3,
+              "y": 89.1,
+              "v": 0.538
+            },
+            "leftAnkle": {
+              "x": 57.4,
+              "y": 98.6,
+              "v": 0.194
+            },
+            "rightAnkle": {
+              "x": 41.7,
+              "y": 108.7,
+              "v": 0.625
+            },
+            "leftHeel": {
+              "x": 53.1,
+              "y": 99.2,
+              "v": 0.216
+            },
+            "rightHeel": {
+              "x": 41,
+              "y": 111.6,
+              "v": 0.341
+            },
+            "leftFootIndex": {
+              "x": 58.1,
+              "y": 110.1,
+              "v": 0.204
+            },
+            "rightFootIndex": {
+              "x": 39.8,
+              "y": 116.8,
+              "v": 0.515
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.9,
+                "y": 28.9
+              },
+              "roll": -178.6,
+              "yaw": 0.378,
+              "pitch": 0.524
+            },
+            "torso": {
+              "center": {
+                "x": 57.1,
+                "y": 39.4
+              },
+              "angle": 86.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.8,
+                "y": 42.7
+              },
+              "angle": 32.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 58.8,
+                "y": 43.8
+              },
+              "angle": 66.4
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 41,
+                "y": 111.6
+              },
+              "angle": -103
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.862,
+          "keypoints": {
+            "nose": {
+              "x": 57,
+              "y": 30.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.6,
+              "y": 28.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.6,
+              "y": 28.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.7,
+              "y": 29.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.5,
+              "y": 29.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 58.7,
+              "y": 41.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.4,
+              "y": 40.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.9,
+              "y": 42.6,
+              "v": 0.83
+            },
+            "rightElbow": {
+              "x": 33.4,
+              "y": 47.1,
+              "v": 0.971
+            },
+            "leftWrist": {
+              "x": 86.7,
+              "y": 42.4,
+              "v": 0.939
+            },
+            "rightWrist": {
+              "x": 42.7,
+              "y": 42.9,
+              "v": 0.968
+            },
+            "leftIndex": {
+              "x": 93.2,
+              "y": 42.3,
+              "v": 0.933
+            },
+            "rightIndex": {
+              "x": 45.9,
+              "y": 39.6,
+              "v": 0.955
+            },
+            "leftHip": {
+              "x": 54.5,
+              "y": 70.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.5,
+              "y": 70.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 66.3,
+              "y": 86.4,
+              "v": 0.584
+            },
+            "rightKnee": {
+              "x": 44.7,
+              "y": 92.2,
+              "v": 0.792
+            },
+            "leftAnkle": {
+              "x": 52.5,
+              "y": 107.2,
+              "v": 0.515
+            },
+            "rightAnkle": {
+              "x": 34.5,
+              "y": 112.5,
+              "v": 0.842
+            },
+            "leftHeel": {
+              "x": 48.6,
+              "y": 109.1,
+              "v": 0.554
+            },
+            "rightHeel": {
+              "x": 33,
+              "y": 115.5,
+              "v": 0.582
+            },
+            "leftFootIndex": {
+              "x": 54.5,
+              "y": 115.2,
+              "v": 0.586
+            },
+            "rightFootIndex": {
+              "x": 33.9,
+              "y": 120.1,
+              "v": 0.772
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55.6,
+                "y": 28.6
+              },
+              "roll": 174.3,
+              "yaw": 0.697,
+              "pitch": 1.045
+            },
+            "torso": {
+              "center": {
+                "x": 51.1,
+                "y": 41.3
+              },
+              "angle": 87
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.7,
+                "y": 42.4
+              },
+              "angle": 0.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 42.7,
+                "y": 42.9
+              },
+              "angle": 45.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 48.6,
+                "y": 109.1
+              },
+              "angle": -46
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33,
+                "y": 115.5
+              },
+              "angle": -78.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.781,
+          "keypoints": {
+            "nose": {
+              "x": 58.5,
+              "y": 31.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.1,
+              "y": 29.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.9,
+              "y": 29.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.3,
+              "y": 30.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.9,
+              "y": 30.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.9,
+              "y": 41,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.8,
+              "y": 40.2,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 71.3,
+              "y": 42.7,
+              "v": 0.62
+            },
+            "rightElbow": {
+              "x": 46.2,
+              "y": 48.2,
+              "v": 0.801
+            },
+            "leftWrist": {
+              "x": 85.7,
+              "y": 41.1,
+              "v": 0.874
+            },
+            "rightWrist": {
+              "x": 48.2,
+              "y": 41.3,
+              "v": 0.712
+            },
+            "leftIndex": {
+              "x": 90.3,
+              "y": 41.2,
+              "v": 0.885
+            },
+            "rightIndex": {
+              "x": 49.3,
+              "y": 38,
+              "v": 0.733
+            },
+            "leftHip": {
+              "x": 56.9,
+              "y": 69.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.7,
+              "y": 68.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 66.4,
+              "y": 86.9,
+              "v": 0.113
+            },
+            "rightKnee": {
+              "x": 66.1,
+              "y": 84.4,
+              "v": 0.651
+            },
+            "leftAnkle": {
+              "x": 51.5,
+              "y": 105.7,
+              "v": 0.365
+            },
+            "rightAnkle": {
+              "x": 48.9,
+              "y": 105.7,
+              "v": 0.831
+            },
+            "leftHeel": {
+              "x": 48.1,
+              "y": 107.2,
+              "v": 0.432
+            },
+            "rightHeel": {
+              "x": 45.5,
+              "y": 107.5,
+              "v": 0.633
+            },
+            "leftFootIndex": {
+              "x": 52.3,
+              "y": 114,
+              "v": 0.496
+            },
+            "rightFootIndex": {
+              "x": 50.8,
+              "y": 115.7,
+              "v": 0.828
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57,
+                "y": 29.6
+              },
+              "roll": -177.4,
+              "yaw": 0.681,
+              "pitch": 0.704
+            },
+            "torso": {
+              "center": {
+                "x": 53.9,
+                "y": 40.6
+              },
+              "angle": 89.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.7,
+                "y": 41.1
+              },
+              "angle": -1.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48.2,
+                "y": 41.3
+              },
+              "angle": 71.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 48.1,
+                "y": 107.2
+              },
+              "angle": -58.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45.5,
+                "y": 107.5
+              },
+              "angle": -57.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.952,
+          "keypoints": {
+            "nose": {
+              "x": 60.2,
+              "y": 24.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.4,
+              "y": 21.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.2,
+              "y": 22.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 56.6,
+              "y": 22.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.6,
+              "y": 22.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 61.4,
+              "y": 32.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42.6,
+              "y": 35.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.2,
+              "y": 34.7,
+              "v": 0.913
+            },
+            "rightElbow": {
+              "x": 30,
+              "y": 48.3,
+              "v": 0.979
+            },
+            "leftWrist": {
+              "x": 89.8,
+              "y": 34.7,
+              "v": 0.975
+            },
+            "rightWrist": {
+              "x": 44.3,
+              "y": 46.2,
+              "v": 0.979
+            },
+            "leftIndex": {
+              "x": 95,
+              "y": 36.5,
+              "v": 0.974
+            },
+            "rightIndex": {
+              "x": 50.5,
+              "y": 43.1,
+              "v": 0.968
+            },
+            "leftHip": {
+              "x": 56.6,
+              "y": 66.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.3,
+              "y": 65.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.9,
+              "y": 87.2,
+              "v": 0.895
+            },
+            "rightKnee": {
+              "x": 34.8,
+              "y": 91,
+              "v": 0.978
+            },
+            "leftAnkle": {
+              "x": 65,
+              "y": 105.6,
+              "v": 0.852
+            },
+            "rightAnkle": {
+              "x": 24.5,
+              "y": 115.3,
+              "v": 0.985
+            },
+            "leftHeel": {
+              "x": 60.3,
+              "y": 107.1,
+              "v": 0.757
+            },
+            "rightHeel": {
+              "x": 22.5,
+              "y": 118.4,
+              "v": 0.799
+            },
+            "leftFootIndex": {
+              "x": 68.6,
+              "y": 115,
+              "v": 0.877
+            },
+            "rightFootIndex": {
+              "x": 24.7,
+              "y": 124.5,
+              "v": 0.967
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58.3,
+                "y": 22.1
+              },
+              "roll": -169.7,
+              "yaw": 0.85,
+              "pitch": 0.984
+            },
+            "torso": {
+              "center": {
+                "x": 52,
+                "y": 33.8
+              },
+              "angle": 87.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.8,
+                "y": 34.7
+              },
+              "angle": -19.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.3,
+                "y": 46.2
+              },
+              "angle": 26.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.3,
+                "y": 107.1
+              },
+              "angle": -43.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 22.5,
+                "y": 118.4
+              },
+              "angle": -70.2
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.778,
+          "keypoints": {
+            "nose": {
+              "x": 55.3,
+              "y": 30.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.2,
+              "y": 28.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 52.5,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.4,
+              "y": 29.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.5,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 58.6,
+              "y": 38.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.1,
+              "y": 37,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 68.8,
+              "y": 43.4,
+              "v": 0.438
+            },
+            "rightElbow": {
+              "x": 31.6,
+              "y": 51.4,
+              "v": 0.893
+            },
+            "leftWrist": {
+              "x": 82.7,
+              "y": 43,
+              "v": 0.659
+            },
+            "rightWrist": {
+              "x": 45.6,
+              "y": 48.4,
+              "v": 0.875
+            },
+            "leftIndex": {
+              "x": 86.8,
+              "y": 41.8,
+              "v": 0.722
+            },
+            "rightIndex": {
+              "x": 51.2,
+              "y": 46.1,
+              "v": 0.842
+            },
+            "leftHip": {
+              "x": 53.8,
+              "y": 68.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.5,
+              "y": 68.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 68.7,
+              "y": 88.3,
+              "v": 0.379
+            },
+            "rightKnee": {
+              "x": 39.8,
+              "y": 92.9,
+              "v": 0.732
+            },
+            "leftAnkle": {
+              "x": 62.2,
+              "y": 110.9,
+              "v": 0.515
+            },
+            "rightAnkle": {
+              "x": 28.7,
+              "y": 114.5,
+              "v": 0.821
+            },
+            "leftHeel": {
+              "x": 59.5,
+              "y": 110.6,
+              "v": 0.398
+            },
+            "rightHeel": {
+              "x": 25.9,
+              "y": 116.7,
+              "v": 0.336
+            },
+            "leftFootIndex": {
+              "x": 64.6,
+              "y": 119.1,
+              "v": 0.574
+            },
+            "rightFootIndex": {
+              "x": 29.3,
+              "y": 124.5,
+              "v": 0.721
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.4,
+                "y": 28.3
+              },
+              "roll": 167.8,
+              "yaw": 0.251,
+              "pitch": 0.581
+            },
+            "torso": {
+              "center": {
+                "x": 48.9,
+                "y": 37.6
+              },
+              "angle": 88.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.7,
+                "y": 43
+              },
+              "angle": 16.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 45.6,
+                "y": 48.4
+              },
+              "angle": 22.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 59.5,
+                "y": 110.6
+              },
+              "angle": -59
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25.9,
+                "y": 116.7
+              },
+              "angle": -66.4
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.738,
+          "keypoints": {
+            "nose": {
+              "x": 57.5,
+              "y": 31.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.3,
+              "y": 29,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.1,
+              "y": 28.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.9,
+              "y": 29.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 55.2,
+              "y": 39.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.3,
+              "y": 39.2,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 62.4,
+              "y": 47.7,
+              "v": 0.052
+            },
+            "rightElbow": {
+              "x": 52.1,
+              "y": 48.2,
+              "v": 0.924
+            },
+            "leftWrist": {
+              "x": 68.9,
+              "y": 47.3,
+              "v": 0.142
+            },
+            "rightWrist": {
+              "x": 70.7,
+              "y": 43.2,
+              "v": 0.829
+            },
+            "leftIndex": {
+              "x": 70.5,
+              "y": 46.2,
+              "v": 0.249
+            },
+            "rightIndex": {
+              "x": 76.3,
+              "y": 40.8,
+              "v": 0.778
+            },
+            "leftHip": {
+              "x": 51.7,
+              "y": 70.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.4,
+              "y": 69.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 61.1,
+              "y": 88.6,
+              "v": 0.118
+            },
+            "rightKnee": {
+              "x": 63.9,
+              "y": 87.9,
+              "v": 0.786
+            },
+            "leftAnkle": {
+              "x": 41.6,
+              "y": 108.4,
+              "v": 0.51
+            },
+            "rightAnkle": {
+              "x": 44.5,
+              "y": 108.3,
+              "v": 0.839
+            },
+            "leftHeel": {
+              "x": 37.7,
+              "y": 110.3,
+              "v": 0.569
+            },
+            "rightHeel": {
+              "x": 40,
+              "y": 109.8,
+              "v": 0.722
+            },
+            "leftFootIndex": {
+              "x": 41.1,
+              "y": 115.2,
+              "v": 0.623
+            },
+            "rightFootIndex": {
+              "x": 45.7,
+              "y": 117.5,
+              "v": 0.844
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.7,
+                "y": 28.8
+              },
+              "roll": 172.9,
+              "yaw": 0.248,
+              "pitch": 0.868
+            },
+            "torso": {
+              "center": {
+                "x": 52.3,
+                "y": 39.5
+              },
+              "angle": 85
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 70.7,
+                "y": 43.2
+              },
+              "angle": 23.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 37.7,
+                "y": 110.3
+              },
+              "angle": -55.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40,
+                "y": 109.8
+              },
+              "angle": -53.5
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.775,
+          "keypoints": {
+            "nose": {
+              "x": 71.3,
+              "y": 31.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.9,
+              "y": 28.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68,
+              "y": 28.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.6,
+              "y": 29.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.3,
+              "y": 29.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.8,
+              "y": 42.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.9,
+              "y": 40.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.9,
+              "y": 56.1,
+              "v": 0.131
+            },
+            "rightElbow": {
+              "x": 51.4,
+              "y": 53.1,
+              "v": 0.87
+            },
+            "leftWrist": {
+              "x": 70.3,
+              "y": 49.9,
+              "v": 0.225
+            },
+            "rightWrist": {
+              "x": 60.4,
+              "y": 43.4,
+              "v": 0.859
+            },
+            "leftIndex": {
+              "x": 70.2,
+              "y": 46.3,
+              "v": 0.312
+            },
+            "rightIndex": {
+              "x": 63.1,
+              "y": 38.6,
+              "v": 0.815
+            },
+            "leftHip": {
+              "x": 64,
+              "y": 70.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54.5,
+              "y": 69.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 88.2,
+              "y": 74.5,
+              "v": 0.685
+            },
+            "rightKnee": {
+              "x": 61,
+              "y": 82,
+              "v": 0.954
+            },
+            "leftAnkle": {
+              "x": 69,
+              "y": 86.2,
+              "v": 0.404
+            },
+            "rightAnkle": {
+              "x": 47.4,
+              "y": 107.6,
+              "v": 0.934
+            },
+            "leftHeel": {
+              "x": 64.7,
+              "y": 86.7,
+              "v": 0.531
+            },
+            "rightHeel": {
+              "x": 44.8,
+              "y": 111.2,
+              "v": 0.755
+            },
+            "leftFootIndex": {
+              "x": 68.8,
+              "y": 90.6,
+              "v": 0.483
+            },
+            "rightFootIndex": {
+              "x": 47.3,
+              "y": 116.4,
+              "v": 0.876
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70,
+                "y": 28.7
+              },
+              "roll": 178.5,
+              "yaw": 0.346,
+              "pitch": 0.628
+            },
+            "torso": {
+              "center": {
+                "x": 65.4,
+                "y": 41.4
+              },
+              "angle": 78
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 60.4,
+                "y": 43.4
+              },
+              "angle": 60.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 64.7,
+                "y": 86.7
+              },
+              "angle": -43.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.8,
+                "y": 111.2
+              },
+              "angle": -64.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.654,
+          "keypoints": {
+            "nose": {
+              "x": 71.4,
+              "y": 29.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.3,
+              "y": 27.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.8,
+              "y": 28,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.3,
+              "y": 29.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.3,
+              "y": 39.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.3,
+              "y": 40.7,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 71.2,
+              "y": 48,
+              "v": 0.022
+            },
+            "rightElbow": {
+              "x": 55,
+              "y": 51.8,
+              "v": 0.656
+            },
+            "leftWrist": {
+              "x": 67.5,
+              "y": 43.2,
+              "v": 0.029
+            },
+            "rightWrist": {
+              "x": 59.6,
+              "y": 44.8,
+              "v": 0.323
+            },
+            "leftIndex": {
+              "x": 66.3,
+              "y": 40.8,
+              "v": 0.058
+            },
+            "rightIndex": {
+              "x": 61.1,
+              "y": 41.7,
+              "v": 0.303
+            },
+            "leftHip": {
+              "x": 62.7,
+              "y": 71.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.5,
+              "y": 71.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81,
+              "y": 71.5,
+              "v": 0.21
+            },
+            "rightKnee": {
+              "x": 85.4,
+              "y": 66,
+              "v": 0.769
+            },
+            "leftAnkle": {
+              "x": 64.3,
+              "y": 88.1,
+              "v": 0.415
+            },
+            "rightAnkle": {
+              "x": 70.6,
+              "y": 86.6,
+              "v": 0.831
+            },
+            "leftHeel": {
+              "x": 60.8,
+              "y": 88.6,
+              "v": 0.406
+            },
+            "rightHeel": {
+              "x": 66.1,
+              "y": 88.4,
+              "v": 0.692
+            },
+            "leftFootIndex": {
+              "x": 62.7,
+              "y": 95.6,
+              "v": 0.511
+            },
+            "rightFootIndex": {
+              "x": 75,
+              "y": 96.9,
+              "v": 0.822
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.7,
+                "y": 27.7
+              },
+              "roll": -173.1,
+              "yaw": 0.526,
+              "pitch": 0.602
+            },
+            "torso": {
+              "center": {
+                "x": 65.3,
+                "y": 40
+              },
+              "angle": 82.4
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 59.6,
+                "y": 44.8
+              },
+              "angle": 64.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.8,
+                "y": 88.6
+              },
+              "angle": -74.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 66.1,
+                "y": 88.4
+              },
+              "angle": -43.7
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.781,
+          "keypoints": {
+            "nose": {
+              "x": 70.4,
+              "y": 30.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.9,
+              "y": 28.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.9,
+              "y": 28.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.8,
+              "y": 29.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.7,
+              "y": 30.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.3,
+              "y": 41.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.5,
+              "y": 41.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 69.7,
+              "y": 54.3,
+              "v": 0.066
+            },
+            "rightElbow": {
+              "x": 63.5,
+              "y": 55,
+              "v": 0.958
+            },
+            "leftWrist": {
+              "x": 64.8,
+              "y": 50,
+              "v": 0.167
+            },
+            "rightWrist": {
+              "x": 75.1,
+              "y": 45.8,
+              "v": 0.965
+            },
+            "leftIndex": {
+              "x": 63.9,
+              "y": 47.6,
+              "v": 0.249
+            },
+            "rightIndex": {
+              "x": 78.1,
+              "y": 42.8,
+              "v": 0.944
+            },
+            "leftHip": {
+              "x": 67.8,
+              "y": 71.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.9,
+              "y": 70.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.3,
+              "y": 87.5,
+              "v": 0.717
+            },
+            "rightKnee": {
+              "x": 61.3,
+              "y": 92.9,
+              "v": 0.917
+            },
+            "leftAnkle": {
+              "x": 65,
+              "y": 104.4,
+              "v": 0.437
+            },
+            "rightAnkle": {
+              "x": 47,
+              "y": 111.4,
+              "v": 0.915
+            },
+            "leftHeel": {
+              "x": 61.5,
+              "y": 105.6,
+              "v": 0.563
+            },
+            "rightHeel": {
+              "x": 43.7,
+              "y": 113.8,
+              "v": 0.621
+            },
+            "leftFootIndex": {
+              "x": 65.3,
+              "y": 113.6,
+              "v": 0.559
+            },
+            "rightFootIndex": {
+              "x": 48.9,
+              "y": 120.4,
+              "v": 0.881
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.4,
+                "y": 28.7
+              },
+              "roll": -174.3,
+              "yaw": 0.663,
+              "pitch": 0.647
+            },
+            "torso": {
+              "center": {
+                "x": 65.9,
+                "y": 41.2
+              },
+              "angle": 85.1
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 75.1,
+                "y": 45.8
+              },
+              "angle": 45
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.5,
+                "y": 105.6
+              },
+              "angle": -64.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.7,
+                "y": 113.8
+              },
+              "angle": -51.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.783,
+          "keypoints": {
+            "nose": {
+              "x": 73.2,
+              "y": 30.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.1,
+              "y": 28.8,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 70.6,
+              "y": 28.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.8,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.8,
+              "y": 30,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 74.1,
+              "y": 42.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.7,
+              "y": 41.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.2,
+              "y": 53.1,
+              "v": 0.293
+            },
+            "rightElbow": {
+              "x": 53.6,
+              "y": 51.6,
+              "v": 0.903
+            },
+            "leftWrist": {
+              "x": 74,
+              "y": 50.6,
+              "v": 0.57
+            },
+            "rightWrist": {
+              "x": 58.3,
+              "y": 44.9,
+              "v": 0.831
+            },
+            "leftIndex": {
+              "x": 73.8,
+              "y": 48.1,
+              "v": 0.661
+            },
+            "rightIndex": {
+              "x": 59.7,
+              "y": 41.2,
+              "v": 0.813
+            },
+            "leftHip": {
+              "x": 69.6,
+              "y": 70.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.5,
+              "y": 70.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.5,
+              "y": 86.2,
+              "v": 0.774
+            },
+            "rightKnee": {
+              "x": 60.5,
+              "y": 90.8,
+              "v": 0.845
+            },
+            "leftAnkle": {
+              "x": 68.1,
+              "y": 102.9,
+              "v": 0.395
+            },
+            "rightAnkle": {
+              "x": 51,
+              "y": 108.6,
+              "v": 0.828
+            },
+            "leftHeel": {
+              "x": 64.8,
+              "y": 103.7,
+              "v": 0.433
+            },
+            "rightHeel": {
+              "x": 49.7,
+              "y": 111.1,
+              "v": 0.524
+            },
+            "leftFootIndex": {
+              "x": 67.8,
+              "y": 112,
+              "v": 0.431
+            },
+            "rightFootIndex": {
+              "x": 49.2,
+              "y": 116.2,
+              "v": 0.716
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.4,
+                "y": 28.8
+              },
+              "roll": 176.2,
+              "yaw": 1.231,
+              "pitch": 1.43
+            },
+            "torso": {
+              "center": {
+                "x": 66.9,
+                "y": 42.2
+              },
+              "angle": 86.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 74,
+                "y": 50.6
+              },
+              "angle": 94.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 58.3,
+                "y": 44.9
+              },
+              "angle": 69.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 64.8,
+                "y": 103.7
+              },
+              "angle": -70.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 49.7,
+                "y": 111.1
+              },
+              "angle": -95.6
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.847,
+          "keypoints": {
+            "nose": {
+              "x": 73.5,
+              "y": 26.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.1,
+              "y": 24.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.7,
+              "y": 24.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69,
+              "y": 25.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.8,
+              "y": 25.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.8,
+              "y": 37.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 62.8,
+              "y": 36.2,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 73.2,
+              "y": 50.2,
+              "v": 0.163
+            },
+            "rightElbow": {
+              "x": 68.4,
+              "y": 50,
+              "v": 0.916
+            },
+            "leftWrist": {
+              "x": 82,
+              "y": 44.2,
+              "v": 0.45
+            },
+            "rightWrist": {
+              "x": 81.1,
+              "y": 43.7,
+              "v": 0.725
+            },
+            "leftIndex": {
+              "x": 83.5,
+              "y": 41.6,
+              "v": 0.543
+            },
+            "rightIndex": {
+              "x": 84.2,
+              "y": 40.5,
+              "v": 0.668
+            },
+            "leftHip": {
+              "x": 63.2,
+              "y": 66.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.2,
+              "y": 64.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.1,
+              "y": 83.8,
+              "v": 0.732
+            },
+            "rightKnee": {
+              "x": 91.7,
+              "y": 59.2,
+              "v": 0.941
+            },
+            "leftAnkle": {
+              "x": 62.5,
+              "y": 105.1,
+              "v": 0.889
+            },
+            "rightAnkle": {
+              "x": 79.8,
+              "y": 79.8,
+              "v": 0.906
+            },
+            "leftHeel": {
+              "x": 59.3,
+              "y": 107.3,
+              "v": 0.88
+            },
+            "rightHeel": {
+              "x": 75.1,
+              "y": 82,
+              "v": 0.838
+            },
+            "leftFootIndex": {
+              "x": 65.4,
+              "y": 112.3,
+              "v": 0.9
+            },
+            "rightFootIndex": {
+              "x": 83.4,
+              "y": 89.4,
+              "v": 0.923
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.4,
+                "y": 24.6
+              },
+              "roll": -175.9,
+              "yaw": 1.496,
+              "pitch": 1.176
+            },
+            "torso": {
+              "center": {
+                "x": 65.3,
+                "y": 37
+              },
+              "angle": 85.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82,
+                "y": 44.2
+              },
+              "angle": 60
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 81.1,
+                "y": 43.7
+              },
+              "angle": 45.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 59.3,
+                "y": 107.3
+              },
+              "angle": -39.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 75.1,
+                "y": 82
+              },
+              "angle": -41.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.822,
+          "keypoints": {
+            "nose": {
+              "x": 73,
+              "y": 27.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.1,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.4,
+              "y": 25.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.4,
+              "y": 26.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.8,
+              "y": 26.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66.7,
+              "y": 37.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.4,
+              "y": 34,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.3,
+              "y": 50,
+              "v": 0.07
+            },
+            "rightElbow": {
+              "x": 58.7,
+              "y": 43.4,
+              "v": 0.873
+            },
+            "leftWrist": {
+              "x": 80.1,
+              "y": 44,
+              "v": 0.288
+            },
+            "rightWrist": {
+              "x": 61,
+              "y": 33.9,
+              "v": 0.699
+            },
+            "leftIndex": {
+              "x": 82.4,
+              "y": 41.8,
+              "v": 0.437
+            },
+            "rightIndex": {
+              "x": 61.2,
+              "y": 29.5,
+              "v": 0.685
+            },
+            "leftHip": {
+              "x": 62.5,
+              "y": 67,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63,
+              "y": 63.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.1,
+              "y": 85.4,
+              "v": 0.774
+            },
+            "rightKnee": {
+              "x": 91.5,
+              "y": 59.2,
+              "v": 0.856
+            },
+            "leftAnkle": {
+              "x": 59.4,
+              "y": 105.6,
+              "v": 0.886
+            },
+            "rightAnkle": {
+              "x": 80.1,
+              "y": 79.7,
+              "v": 0.851
+            },
+            "leftHeel": {
+              "x": 56.1,
+              "y": 107.2,
+              "v": 0.906
+            },
+            "rightHeel": {
+              "x": 75.6,
+              "y": 81.5,
+              "v": 0.795
+            },
+            "leftFootIndex": {
+              "x": 61.3,
+              "y": 113.7,
+              "v": 0.915
+            },
+            "rightFootIndex": {
+              "x": 83,
+              "y": 88.7,
+              "v": 0.87
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.3,
+                "y": 25.5
+              },
+              "roll": 176.6,
+              "yaw": 1.028,
+              "pitch": 1.028
+            },
+            "torso": {
+              "center": {
+                "x": 63.6,
+                "y": 35.9
+              },
+              "angle": 88.4
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 61,
+                "y": 33.9
+              },
+              "angle": 87.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 56.1,
+                "y": 107.2
+              },
+              "angle": -51.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 75.6,
+                "y": 81.5
+              },
+              "angle": -44.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.751,
+          "keypoints": {
+            "nose": {
+              "x": 72.4,
+              "y": 30.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.7,
+              "y": 28.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.6,
+              "y": 29.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.5,
+              "y": 29.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.6,
+              "y": 31.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.4,
+              "y": 39.2,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 68.1,
+              "y": 42.6,
+              "v": 0.998
+            },
+            "leftElbow": {
+              "x": 72.2,
+              "y": 49.5,
+              "v": 0.027
+            },
+            "rightElbow": {
+              "x": 66.7,
+              "y": 53.7,
+              "v": 0.789
+            },
+            "leftWrist": {
+              "x": 68.2,
+              "y": 49.1,
+              "v": 0.087
+            },
+            "rightWrist": {
+              "x": 69.3,
+              "y": 47.5,
+              "v": 0.795
+            },
+            "leftIndex": {
+              "x": 66.5,
+              "y": 47.8,
+              "v": 0.18
+            },
+            "rightIndex": {
+              "x": 69.4,
+              "y": 44.6,
+              "v": 0.797
+            },
+            "leftHip": {
+              "x": 66.3,
+              "y": 68.1,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 64.8,
+              "y": 68,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 73.1,
+              "y": 76.1,
+              "v": 0.414
+            },
+            "rightKnee": {
+              "x": 87.6,
+              "y": 61.7,
+              "v": 0.838
+            },
+            "leftAnkle": {
+              "x": 61.6,
+              "y": 96,
+              "v": 0.665
+            },
+            "rightAnkle": {
+              "x": 79.3,
+              "y": 81.2,
+              "v": 0.813
+            },
+            "leftHeel": {
+              "x": 59.1,
+              "y": 97.6,
+              "v": 0.622
+            },
+            "rightHeel": {
+              "x": 75.7,
+              "y": 85,
+              "v": 0.773
+            },
+            "leftFootIndex": {
+              "x": 60.2,
+              "y": 104.1,
+              "v": 0.664
+            },
+            "rightFootIndex": {
+              "x": 80.2,
+              "y": 89.7,
+              "v": 0.809
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.7,
+                "y": 29
+              },
+              "roll": -146.3,
+              "yaw": 1.09,
+              "pitch": 0.436
+            },
+            "torso": {
+              "center": {
+                "x": 69.8,
+                "y": 40.9
+              },
+              "angle": 81.2
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 69.3,
+                "y": 47.5
+              },
+              "angle": 88
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 59.1,
+                "y": 97.6
+              },
+              "angle": -80.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 75.7,
+                "y": 85
+              },
+              "angle": -46.2
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.787,
+          "keypoints": {
+            "nose": {
+              "x": 57.3,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 57.2,
+              "y": 22,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.3,
+              "y": 21.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.5,
+              "y": 22.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.2,
+              "y": 22.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 51.5,
+              "y": 33.8,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 46.7,
+              "y": 31.8,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 58.7,
+              "y": 49.1,
+              "v": 0.029
+            },
+            "rightElbow": {
+              "x": 50.7,
+              "y": 48,
+              "v": 0.828
+            },
+            "leftWrist": {
+              "x": 61.3,
+              "y": 45,
+              "v": 0.091
+            },
+            "rightWrist": {
+              "x": 65,
+              "y": 40.1,
+              "v": 0.816
+            },
+            "leftIndex": {
+              "x": 61.5,
+              "y": 41.5,
+              "v": 0.182
+            },
+            "rightIndex": {
+              "x": 68.4,
+              "y": 35.8,
+              "v": 0.796
+            },
+            "leftHip": {
+              "x": 52.9,
+              "y": 65.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.8,
+              "y": 62.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 55.9,
+              "y": 85.9,
+              "v": 0.581
+            },
+            "rightKnee": {
+              "x": 79.5,
+              "y": 50.5,
+              "v": 0.706
+            },
+            "leftAnkle": {
+              "x": 45.6,
+              "y": 114,
+              "v": 0.775
+            },
+            "rightAnkle": {
+              "x": 105.3,
+              "y": 47.6,
+              "v": 0.881
+            },
+            "leftHeel": {
+              "x": 42.9,
+              "y": 117.1,
+              "v": 0.846
+            },
+            "rightHeel": {
+              "x": 106.3,
+              "y": 56.7,
+              "v": 0.924
+            },
+            "leftFootIndex": {
+              "x": 46.6,
+              "y": 123.5,
+              "v": 0.752
+            },
+            "rightFootIndex": {
+              "x": 114.5,
+              "y": 39.3,
+              "v": 0.89
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55.8,
+                "y": 22
+              },
+              "roll": 178,
+              "yaw": 0.534,
+              "pitch": 0.534
+            },
+            "torso": {
+              "center": {
+                "x": 49.1,
+                "y": 32.8
+              },
+              "angle": 95.9
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 65,
+                "y": 40.1
+              },
+              "angle": 51.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 42.9,
+                "y": 117.1
+              },
+              "angle": -60
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 106.3,
+                "y": 56.7
+              },
+              "angle": 64.8
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.72,
+          "keypoints": {
+            "nose": {
+              "x": 50.2,
+              "y": 25.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 48.8,
+              "y": 22.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 46.1,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 45.1,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 39.9,
+              "y": 24.3,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 45.4,
+              "y": 34.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 31.3,
+              "y": 36.2,
+              "v": 0.996
+            },
+            "leftElbow": {
+              "x": 62,
+              "y": 34.1,
+              "v": 0.462
+            },
+            "rightElbow": {
+              "x": 41.3,
+              "y": 48.3,
+              "v": 0.103
+            },
+            "leftWrist": {
+              "x": 81.8,
+              "y": 31.6,
+              "v": 0.645
+            },
+            "rightWrist": {
+              "x": 59.1,
+              "y": 50.9,
+              "v": 0.071
+            },
+            "leftIndex": {
+              "x": 89.8,
+              "y": 28.5,
+              "v": 0.684
+            },
+            "rightIndex": {
+              "x": 64.8,
+              "y": 49.8,
+              "v": 0.109
+            },
+            "leftHip": {
+              "x": 39.2,
+              "y": 65.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 31.3,
+              "y": 66.7,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 50,
+              "y": 77.9,
+              "v": 0.568
+            },
+            "rightKnee": {
+              "x": 58.6,
+              "y": 53.8,
+              "v": 0.379
+            },
+            "leftAnkle": {
+              "x": 46.8,
+              "y": 109.6,
+              "v": 0.784
+            },
+            "rightAnkle": {
+              "x": 92.3,
+              "y": 53.9,
+              "v": 0.679
+            },
+            "leftHeel": {
+              "x": 41.8,
+              "y": 116.4,
+              "v": 0.804
+            },
+            "rightHeel": {
+              "x": 96,
+              "y": 56.8,
+              "v": 0.719
+            },
+            "leftFootIndex": {
+              "x": 50.7,
+              "y": 118.9,
+              "v": 0.768
+            },
+            "rightFootIndex": {
+              "x": 105.5,
+              "y": 46.6,
+              "v": 0.78
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 47.5,
+                "y": 22.9
+              },
+              "roll": -180,
+              "yaw": 1.019,
+              "pitch": 0.926
+            },
+            "torso": {
+              "center": {
+                "x": 38.4,
+                "y": 35.4
+              },
+              "angle": 84.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 81.8,
+                "y": 31.6
+              },
+              "angle": 21.2
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 41.8,
+                "y": 116.4
+              },
+              "angle": -15.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 96,
+                "y": 56.8
+              },
+              "angle": 47
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.623,
+          "keypoints": {
+            "nose": {
+              "x": 72.3,
+              "y": 30.1,
+              "v": 0.997
+            },
+            "leftEye": {
+              "x": 71.7,
+              "y": 28.5,
+              "v": 0.994
+            },
+            "rightEye": {
+              "x": 68.9,
+              "y": 29.1,
+              "v": 0.998
+            },
+            "leftEar": {
+              "x": 70.8,
+              "y": 29.8,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 65.9,
+              "y": 31.3,
+              "v": 0.997
+            },
+            "leftShoulder": {
+              "x": 75.7,
+              "y": 42.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.8,
+              "y": 42.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.8,
+              "y": 53.5,
+              "v": 0.295
+            },
+            "rightElbow": {
+              "x": 63.8,
+              "y": 55.7,
+              "v": 0.601
+            },
+            "leftWrist": {
+              "x": 67.8,
+              "y": 41,
+              "v": 0.405
+            },
+            "rightWrist": {
+              "x": 72.8,
+              "y": 46.1,
+              "v": 0.623
+            },
+            "leftIndex": {
+              "x": 65.7,
+              "y": 36.9,
+              "v": 0.398
+            },
+            "rightIndex": {
+              "x": 75,
+              "y": 42.3,
+              "v": 0.531
+            },
+            "leftHip": {
+              "x": 71.1,
+              "y": 70,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.9,
+              "y": 70.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81,
+              "y": 86,
+              "v": 0.608
+            },
+            "rightKnee": {
+              "x": 60.7,
+              "y": 91.6,
+              "v": 0.487
+            },
+            "leftAnkle": {
+              "x": 64.7,
+              "y": 102.2,
+              "v": 0.12
+            },
+            "rightAnkle": {
+              "x": 56.9,
+              "y": 110.5,
+              "v": 0.462
+            },
+            "leftHeel": {
+              "x": 61.3,
+              "y": 102.3,
+              "v": 0.142
+            },
+            "rightHeel": {
+              "x": 56.5,
+              "y": 113,
+              "v": 0.208
+            },
+            "leftFootIndex": {
+              "x": 63,
+              "y": 111.8,
+              "v": 0.128
+            },
+            "rightFootIndex": {
+              "x": 55.9,
+              "y": 118.4,
+              "v": 0.332
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.3,
+                "y": 28.8
+              },
+              "roll": -167.9,
+              "yaw": 0.698,
+              "pitch": 0.454
+            },
+            "torso": {
+              "center": {
+                "x": 68.3,
+                "y": 42.3
+              },
+              "angle": 86.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 67.8,
+                "y": 41
+              },
+              "angle": 117.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72.8,
+                "y": 46.1
+              },
+              "angle": 59.9
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 56.9,
+                "y": 110.5
+              },
+              "angle": -97.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.836,
+          "keypoints": {
+            "nose": {
+              "x": 49.7,
+              "y": 30.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 50.9,
+              "y": 28.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 46.6,
+              "y": 27.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 51.2,
+              "y": 29.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 43,
+              "y": 28.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 53.5,
+              "y": 40.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.2,
+              "y": 39.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 52.6,
+              "y": 55.8,
+              "v": 0.05
+            },
+            "rightElbow": {
+              "x": 34.7,
+              "y": 50.8,
+              "v": 0.914
+            },
+            "leftWrist": {
+              "x": 52.6,
+              "y": 66.5,
+              "v": 0.039
+            },
+            "rightWrist": {
+              "x": 44.1,
+              "y": 42.4,
+              "v": 0.91
+            },
+            "leftIndex": {
+              "x": 53.3,
+              "y": 69.1,
+              "v": 0.061
+            },
+            "rightIndex": {
+              "x": 47,
+              "y": 38.2,
+              "v": 0.877
+            },
+            "leftHip": {
+              "x": 49.9,
+              "y": 67.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 40.9,
+              "y": 68.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63.6,
+              "y": 84.5,
+              "v": 0.954
+            },
+            "rightKnee": {
+              "x": 37,
+              "y": 93.2,
+              "v": 0.983
+            },
+            "leftAnkle": {
+              "x": 48.8,
+              "y": 97.5,
+              "v": 0.904
+            },
+            "rightAnkle": {
+              "x": 24.8,
+              "y": 111.9,
+              "v": 0.992
+            },
+            "leftHeel": {
+              "x": 44.1,
+              "y": 97.1,
+              "v": 0.799
+            },
+            "rightHeel": {
+              "x": 21.7,
+              "y": 113.7,
+              "v": 0.867
+            },
+            "leftFootIndex": {
+              "x": 46.8,
+              "y": 107.6,
+              "v": 0.906
+            },
+            "rightFootIndex": {
+              "x": 26.9,
+              "y": 124,
+              "v": 0.984
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 48.8,
+                "y": 27.9
+              },
+              "roll": 173.4,
+              "yaw": 0.219,
+              "pitch": 0.566
+            },
+            "torso": {
+              "center": {
+                "x": 45.9,
+                "y": 39.7
+              },
+              "angle": 89.1
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 44.1,
+                "y": 42.4
+              },
+              "angle": 55.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 44.1,
+                "y": 97.1
+              },
+              "angle": -75.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 21.7,
+                "y": 113.7
+              },
+              "angle": -63.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.804,
+          "keypoints": {
+            "nose": {
+              "x": 56.8,
+              "y": 31.4,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 58.7,
+              "y": 29.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 54.7,
+              "y": 28.3,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 58.2,
+              "y": 30.9,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 50.6,
+              "y": 28.6,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 56.9,
+              "y": 43,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.4,
+              "y": 36.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 62.4,
+              "y": 57.9,
+              "v": 0.241
+            },
+            "rightElbow": {
+              "x": 37.6,
+              "y": 48.2,
+              "v": 0.82
+            },
+            "leftWrist": {
+              "x": 62.5,
+              "y": 49.9,
+              "v": 0.48
+            },
+            "rightWrist": {
+              "x": 55.1,
+              "y": 44.2,
+              "v": 0.832
+            },
+            "leftIndex": {
+              "x": 62.4,
+              "y": 45.7,
+              "v": 0.549
+            },
+            "rightIndex": {
+              "x": 60.6,
+              "y": 41.9,
+              "v": 0.789
+            },
+            "leftHip": {
+              "x": 49.8,
+              "y": 72.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 38.9,
+              "y": 69.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69,
+              "y": 93.8,
+              "v": 0.693
+            },
+            "rightKnee": {
+              "x": 50.6,
+              "y": 91.9,
+              "v": 0.848
+            },
+            "leftAnkle": {
+              "x": 49.8,
+              "y": 112.2,
+              "v": 0.722
+            },
+            "rightAnkle": {
+              "x": 38.8,
+              "y": 111.9,
+              "v": 0.796
+            },
+            "leftHeel": {
+              "x": 44.5,
+              "y": 110,
+              "v": 0.665
+            },
+            "rightHeel": {
+              "x": 35.6,
+              "y": 113.9,
+              "v": 0.598
+            },
+            "leftFootIndex": {
+              "x": 50.5,
+              "y": 123.8,
+              "v": 0.711
+            },
+            "rightFootIndex": {
+              "x": 40,
+              "y": 123.9,
+              "v": 0.742
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.7,
+                "y": 29
+              },
+              "roll": 162,
+              "yaw": 0.024,
+              "pitch": 0.583
+            },
+            "torso": {
+              "center": {
+                "x": 49.2,
+                "y": 39.9
+              },
+              "angle": 81.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 62.5,
+                "y": 49.9
+              },
+              "angle": 91.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 55.1,
+                "y": 44.2
+              },
+              "angle": 22.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 44.5,
+                "y": 110
+              },
+              "angle": -66.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.6,
+                "y": 113.9
+              },
+              "angle": -66.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.614,
+          "keypoints": {
+            "nose": {
+              "x": 57.7,
+              "y": 30.4,
+              "v": 0.998
+            },
+            "leftEye": {
+              "x": 57.1,
+              "y": 28.3,
+              "v": 0.996
+            },
+            "rightEye": {
+              "x": 54.2,
+              "y": 29,
+              "v": 0.998
+            },
+            "leftEar": {
+              "x": 56.4,
+              "y": 29.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 50.8,
+              "y": 31.5,
+              "v": 0.997
+            },
+            "leftShoulder": {
+              "x": 62.1,
+              "y": 42.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.4,
+              "y": 41.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 58.1,
+              "y": 53.3,
+              "v": 0.34
+            },
+            "rightElbow": {
+              "x": 42.2,
+              "y": 50.6,
+              "v": 0.444
+            },
+            "leftWrist": {
+              "x": 53.3,
+              "y": 41.7,
+              "v": 0.435
+            },
+            "rightWrist": {
+              "x": 49.5,
+              "y": 40.6,
+              "v": 0.301
+            },
+            "leftIndex": {
+              "x": 52.2,
+              "y": 35.7,
+              "v": 0.418
+            },
+            "rightIndex": {
+              "x": 51.2,
+              "y": 36.8,
+              "v": 0.282
+            },
+            "leftHip": {
+              "x": 56.9,
+              "y": 71.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.9,
+              "y": 70.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 68.4,
+              "y": 89.5,
+              "v": 0.351
+            },
+            "rightKnee": {
+              "x": 52.5,
+              "y": 83.7,
+              "v": 0.578
+            },
+            "leftAnkle": {
+              "x": 53.2,
+              "y": 107.2,
+              "v": 0.209
+            },
+            "rightAnkle": {
+              "x": 37.8,
+              "y": 103.4,
+              "v": 0.513
+            },
+            "leftHeel": {
+              "x": 49.4,
+              "y": 108.7,
+              "v": 0.245
+            },
+            "rightHeel": {
+              "x": 34.8,
+              "y": 105.6,
+              "v": 0.227
+            },
+            "leftFootIndex": {
+              "x": 53.9,
+              "y": 116.3,
+              "v": 0.268
+            },
+            "rightFootIndex": {
+              "x": 38.1,
+              "y": 113.4,
+              "v": 0.529
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55.7,
+                "y": 28.7
+              },
+              "roll": -166.4,
+              "yaw": 0.687,
+              "pitch": 0.587
+            },
+            "torso": {
+              "center": {
+                "x": 53.8,
+                "y": 42
+              },
+              "angle": 87.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 53.3,
+                "y": 41.7
+              },
+              "angle": 100.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 49.5,
+                "y": 40.6
+              },
+              "angle": 53.9
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 37.8,
+                "y": 103.4
+              },
+              "angle": -88.3
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.737,
+          "keypoints": {
+            "nose": {
+              "x": 56.1,
+              "y": 30.2,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 55,
+              "y": 28.5,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 53.3,
+              "y": 28.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 53.4,
+              "y": 29.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50,
+              "y": 30,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 56.3,
+              "y": 42.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44.1,
+              "y": 40.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 59.3,
+              "y": 54.2,
+              "v": 0.394
+            },
+            "rightElbow": {
+              "x": 40.1,
+              "y": 50.9,
+              "v": 0.792
+            },
+            "leftWrist": {
+              "x": 56,
+              "y": 51.2,
+              "v": 0.512
+            },
+            "rightWrist": {
+              "x": 47.9,
+              "y": 45,
+              "v": 0.728
+            },
+            "leftIndex": {
+              "x": 54.7,
+              "y": 48.7,
+              "v": 0.572
+            },
+            "rightIndex": {
+              "x": 50.2,
+              "y": 41.8,
+              "v": 0.697
+            },
+            "leftHip": {
+              "x": 52.4,
+              "y": 70.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.9,
+              "y": 69.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63.5,
+              "y": 85.6,
+              "v": 0.607
+            },
+            "rightKnee": {
+              "x": 44.8,
+              "y": 90.4,
+              "v": 0.698
+            },
+            "leftAnkle": {
+              "x": 51.3,
+              "y": 103.2,
+              "v": 0.323
+            },
+            "rightAnkle": {
+              "x": 38.3,
+              "y": 111.2,
+              "v": 0.809
+            },
+            "leftHeel": {
+              "x": 48.1,
+              "y": 104.1,
+              "v": 0.305
+            },
+            "rightHeel": {
+              "x": 37.8,
+              "y": 114.4,
+              "v": 0.498
+            },
+            "leftFootIndex": {
+              "x": 50.8,
+              "y": 112.5,
+              "v": 0.35
+            },
+            "rightFootIndex": {
+              "x": 36.4,
+              "y": 118.4,
+              "v": 0.676
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.2,
+                "y": 28.6
+              },
+              "roll": -176.6,
+              "yaw": 1.145,
+              "pitch": 0.969
+            },
+            "torso": {
+              "center": {
+                "x": 50.2,
+                "y": 41.6
+              },
+              "angle": 85.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 56,
+                "y": 51.2
+              },
+              "angle": 117.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.9,
+                "y": 45
+              },
+              "angle": 54.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 48.1,
+                "y": 104.1
+              },
+              "angle": -72.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.8,
+                "y": 114.4
+              },
+              "angle": -109.3
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.753,
+          "keypoints": {
+            "nose": {
+              "x": 72.2,
+              "y": 30.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72,
+              "y": 28.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.6,
+              "y": 28.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.3,
+              "y": 29.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65,
+              "y": 30.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.2,
+              "y": 41.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59,
+              "y": 40.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.3,
+              "y": 55.3,
+              "v": 0.602
+            },
+            "rightElbow": {
+              "x": 54.8,
+              "y": 52.8,
+              "v": 0.924
+            },
+            "leftWrist": {
+              "x": 82.6,
+              "y": 45.3,
+              "v": 0.921
+            },
+            "rightWrist": {
+              "x": 66.4,
+              "y": 45.6,
+              "v": 0.865
+            },
+            "leftIndex": {
+              "x": 85.3,
+              "y": 39.2,
+              "v": 0.913
+            },
+            "rightIndex": {
+              "x": 70.1,
+              "y": 42.2,
+              "v": 0.79
+            },
+            "leftHip": {
+              "x": 68.4,
+              "y": 69.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60,
+              "y": 69.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.7,
+              "y": 86.7,
+              "v": 0.255
+            },
+            "rightKnee": {
+              "x": 70.3,
+              "y": 87.7,
+              "v": 0.683
+            },
+            "leftAnkle": {
+              "x": 66.4,
+              "y": 103.2,
+              "v": 0.17
+            },
+            "rightAnkle": {
+              "x": 56.8,
+              "y": 108,
+              "v": 0.675
+            },
+            "leftHeel": {
+              "x": 62.4,
+              "y": 104.8,
+              "v": 0.256
+            },
+            "rightHeel": {
+              "x": 53.3,
+              "y": 110.8,
+              "v": 0.394
+            },
+            "leftFootIndex": {
+              "x": 68.2,
+              "y": 111.7,
+              "v": 0.245
+            },
+            "rightFootIndex": {
+              "x": 59.6,
+              "y": 116.6,
+              "v": 0.62
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.3,
+                "y": 28.8
+              },
+              "roll": -175,
+              "yaw": 0.557,
+              "pitch": 0.542
+            },
+            "torso": {
+              "center": {
+                "x": 66.6,
+                "y": 41.1
+              },
+              "angle": 85.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.6,
+                "y": 45.3
+              },
+              "angle": 66.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 66.4,
+                "y": 45.6
+              },
+              "angle": 42.6
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 53.3,
+                "y": 110.8
+              },
+              "angle": -42.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.776,
+          "keypoints": {
+            "nose": {
+              "x": 72.3,
+              "y": 30.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.4,
+              "y": 28.4,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 69,
+              "y": 29,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.2,
+              "y": 29.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.1,
+              "y": 31.1,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 73.7,
+              "y": 41,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.2,
+              "y": 41.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.6,
+              "y": 53,
+              "v": 0.207
+            },
+            "rightElbow": {
+              "x": 52.2,
+              "y": 52.4,
+              "v": 0.872
+            },
+            "leftWrist": {
+              "x": 69.2,
+              "y": 46.8,
+              "v": 0.345
+            },
+            "rightWrist": {
+              "x": 59.4,
+              "y": 45.7,
+              "v": 0.768
+            },
+            "leftIndex": {
+              "x": 68,
+              "y": 43.6,
+              "v": 0.413
+            },
+            "rightIndex": {
+              "x": 62,
+              "y": 42.1,
+              "v": 0.754
+            },
+            "leftHip": {
+              "x": 68.7,
+              "y": 70.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.4,
+              "y": 69.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.2,
+              "y": 84.2,
+              "v": 0.657
+            },
+            "rightKnee": {
+              "x": 69.6,
+              "y": 89.3,
+              "v": 0.898
+            },
+            "leftAnkle": {
+              "x": 64.6,
+              "y": 98.8,
+              "v": 0.423
+            },
+            "rightAnkle": {
+              "x": 59.5,
+              "y": 109.9,
+              "v": 0.922
+            },
+            "leftHeel": {
+              "x": 60.6,
+              "y": 100.6,
+              "v": 0.526
+            },
+            "rightHeel": {
+              "x": 56.7,
+              "y": 112.2,
+              "v": 0.688
+            },
+            "leftFootIndex": {
+              "x": 65.8,
+              "y": 110.1,
+              "v": 0.51
+            },
+            "rightFootIndex": {
+              "x": 62.7,
+              "y": 119.9,
+              "v": 0.86
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.2,
+                "y": 28.7
+              },
+              "roll": -166,
+              "yaw": 0.849,
+              "pitch": 0.768
+            },
+            "torso": {
+              "center": {
+                "x": 66.5,
+                "y": 41.2
+              },
+              "angle": 86.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 69.2,
+                "y": 46.8
+              },
+              "angle": 110.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 59.4,
+                "y": 45.7
+              },
+              "angle": 54.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.6,
+                "y": 100.6
+              },
+              "angle": -61.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 56.7,
+                "y": 112.2
+              },
+              "angle": -52.1
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.559,
+          "keypoints": {
+            "nose": {
+              "x": 66.8,
+              "y": 19.5,
+              "v": 0.998
+            },
+            "leftEye": {
+              "x": 66.7,
+              "y": 17.5,
+              "v": 0.996
+            },
+            "rightEye": {
+              "x": 63.5,
+              "y": 17.2,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 65,
+              "y": 19,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 59.7,
+              "y": 19.6,
+              "v": 0.996
+            },
+            "leftShoulder": {
+              "x": 68.9,
+              "y": 31.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.5,
+              "y": 33.1,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 73.9,
+              "y": 37.3,
+              "v": 0.203
+            },
+            "rightElbow": {
+              "x": 53.3,
+              "y": 47.7,
+              "v": 0.553
+            },
+            "leftWrist": {
+              "x": 65.6,
+              "y": 35.3,
+              "v": 0.258
+            },
+            "rightWrist": {
+              "x": 56.9,
+              "y": 37.5,
+              "v": 0.783
+            },
+            "leftIndex": {
+              "x": 61.8,
+              "y": 33.3,
+              "v": 0.255
+            },
+            "rightIndex": {
+              "x": 57.1,
+              "y": 32.9,
+              "v": 0.78
+            },
+            "leftHip": {
+              "x": 66.4,
+              "y": 65.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.7,
+              "y": 64.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.6,
+              "y": 81.9,
+              "v": 0.087
+            },
+            "rightKnee": {
+              "x": 60.2,
+              "y": 84.8,
+              "v": 0.14
+            },
+            "leftAnkle": {
+              "x": 59.7,
+              "y": 99.8,
+              "v": 0.05
+            },
+            "rightAnkle": {
+              "x": 48.6,
+              "y": 104.8,
+              "v": 0.251
+            },
+            "leftHeel": {
+              "x": 56.3,
+              "y": 101,
+              "v": 0.07
+            },
+            "rightHeel": {
+              "x": 46.4,
+              "y": 107.9,
+              "v": 0.115
+            },
+            "leftFootIndex": {
+              "x": 58,
+              "y": 108.6,
+              "v": 0.086
+            },
+            "rightFootIndex": {
+              "x": 48.6,
+              "y": 112.4,
+              "v": 0.231
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.1,
+                "y": 17.4
+              },
+              "roll": 174.6,
+              "yaw": 0.529,
+              "pitch": 0.669
+            },
+            "torso": {
+              "center": {
+                "x": 62.7,
+                "y": 32.1
+              },
+              "angle": 88
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 56.9,
+                "y": 37.5
+              },
+              "angle": 87.5
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.514,
+          "keypoints": {
+            "nose": {
+              "x": 70.6,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.4,
+              "y": 17.1,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 67.3,
+              "y": 17.4,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 70.7,
+              "y": 18.3,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 63.4,
+              "y": 19.2,
+              "v": 0.997
+            },
+            "leftShoulder": {
+              "x": 73,
+              "y": 29.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.1,
+              "y": 30.9,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 83.8,
+              "y": 31.9,
+              "v": 0.157
+            },
+            "rightElbow": {
+              "x": 60.3,
+              "y": 36.1,
+              "v": 0.249
+            },
+            "leftWrist": {
+              "x": 75.1,
+              "y": 22.5,
+              "v": 0.178
+            },
+            "rightWrist": {
+              "x": 60.4,
+              "y": 37.1,
+              "v": 0.109
+            },
+            "leftIndex": {
+              "x": 72.1,
+              "y": 18.8,
+              "v": 0.151
+            },
+            "rightIndex": {
+              "x": 60.2,
+              "y": 36.5,
+              "v": 0.118
+            },
+            "leftHip": {
+              "x": 65.4,
+              "y": 64.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.2,
+              "y": 64.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.3,
+              "y": 85.4,
+              "v": 0.034
+            },
+            "rightKnee": {
+              "x": 65.8,
+              "y": 89.2,
+              "v": 0.296
+            },
+            "leftAnkle": {
+              "x": 59.8,
+              "y": 104.3,
+              "v": 0.061
+            },
+            "rightAnkle": {
+              "x": 46.6,
+              "y": 109.2,
+              "v": 0.497
+            },
+            "leftHeel": {
+              "x": 56.1,
+              "y": 106.1,
+              "v": 0.113
+            },
+            "rightHeel": {
+              "x": 41.7,
+              "y": 110.9,
+              "v": 0.264
+            },
+            "leftFootIndex": {
+              "x": 61.5,
+              "y": 113.9,
+              "v": 0.12
+            },
+            "rightFootIndex": {
+              "x": 47.6,
+              "y": 120.5,
+              "v": 0.489
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.4,
+                "y": 17.3
+              },
+              "roll": -175.8,
+              "yaw": 0.304,
+              "pitch": 0.693
+            },
+            "torso": {
+              "center": {
+                "x": 66.6,
+                "y": 30.3
+              },
+              "angle": 83.7
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 46.6,
+                "y": 109.2
+              },
+              "angle": -84.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.809,
+          "keypoints": {
+            "nose": {
+              "x": 64.1,
+              "y": 25.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.9,
+              "y": 24.4,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 63.1,
+              "y": 23,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 70.8,
+              "y": 26.7,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 61.5,
+              "y": 23,
+              "v": 0.997
+            },
+            "leftShoulder": {
+              "x": 72.9,
+              "y": 33.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.8,
+              "y": 31.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.9,
+              "y": 44.5,
+              "v": 0.84
+            },
+            "rightElbow": {
+              "x": 52.7,
+              "y": 40.5,
+              "v": 0.468
+            },
+            "leftWrist": {
+              "x": 65.2,
+              "y": 44.3,
+              "v": 0.872
+            },
+            "rightWrist": {
+              "x": 54.6,
+              "y": 40.2,
+              "v": 0.803
+            },
+            "leftIndex": {
+              "x": 61.6,
+              "y": 43.4,
+              "v": 0.856
+            },
+            "rightIndex": {
+              "x": 56.1,
+              "y": 39.1,
+              "v": 0.833
+            },
+            "leftHip": {
+              "x": 69.5,
+              "y": 60.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.5,
+              "y": 59.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.5,
+              "y": 84.5,
+              "v": 0.673
+            },
+            "rightKnee": {
+              "x": 51,
+              "y": 77.1,
+              "v": 0.684
+            },
+            "leftAnkle": {
+              "x": 82.6,
+              "y": 108,
+              "v": 0.807
+            },
+            "rightAnkle": {
+              "x": 47.6,
+              "y": 102,
+              "v": 0.646
+            },
+            "leftHeel": {
+              "x": 80.2,
+              "y": 112.4,
+              "v": 0.482
+            },
+            "rightHeel": {
+              "x": 49.2,
+              "y": 105.7,
+              "v": 0.37
+            },
+            "leftFootIndex": {
+              "x": 86.3,
+              "y": 119.3,
+              "v": 0.729
+            },
+            "rightFootIndex": {
+              "x": 42.7,
+              "y": 111.1,
+              "v": 0.561
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.5,
+                "y": 23.7
+              },
+              "roll": 163.7,
+              "yaw": -0.28,
+              "pitch": 0.42
+            },
+            "torso": {
+              "center": {
+                "x": 64.9,
+                "y": 32.7
+              },
+              "angle": 87.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 65.2,
+                "y": 44.3
+              },
+              "angle": 166
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 54.6,
+                "y": 40.2
+              },
+              "angle": 36.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80.2,
+                "y": 112.4
+              },
+              "angle": -48.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 49.2,
+                "y": 105.7
+              },
+              "angle": -140.3
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.686,
+          "keypoints": {
+            "nose": {
+              "x": 67.8,
+              "y": 30.6,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 68.9,
+              "y": 28.8,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 65.6,
+              "y": 27.8,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 68.1,
+              "y": 30.2,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 61.7,
+              "y": 29.3,
+              "v": 0.997
+            },
+            "leftShoulder": {
+              "x": 70.4,
+              "y": 41.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.2,
+              "y": 40.1,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 70.6,
+              "y": 54.6,
+              "v": 0.282
+            },
+            "rightElbow": {
+              "x": 60.5,
+              "y": 52.1,
+              "v": 0.524
+            },
+            "leftWrist": {
+              "x": 60.2,
+              "y": 44.4,
+              "v": 0.271
+            },
+            "rightWrist": {
+              "x": 68.1,
+              "y": 43.3,
+              "v": 0.372
+            },
+            "leftIndex": {
+              "x": 57.8,
+              "y": 41.3,
+              "v": 0.3
+            },
+            "rightIndex": {
+              "x": 69.1,
+              "y": 39.4,
+              "v": 0.358
+            },
+            "leftHip": {
+              "x": 65.6,
+              "y": 70.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55,
+              "y": 70.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.1,
+              "y": 84.7,
+              "v": 0.669
+            },
+            "rightKnee": {
+              "x": 54.2,
+              "y": 93.1,
+              "v": 0.799
+            },
+            "leftAnkle": {
+              "x": 64.6,
+              "y": 99.1,
+              "v": 0.351
+            },
+            "rightAnkle": {
+              "x": 41.7,
+              "y": 111.5,
+              "v": 0.864
+            },
+            "leftHeel": {
+              "x": 60.9,
+              "y": 100,
+              "v": 0.373
+            },
+            "rightHeel": {
+              "x": 38.4,
+              "y": 112.9,
+              "v": 0.418
+            },
+            "leftFootIndex": {
+              "x": 65.5,
+              "y": 109.2,
+              "v": 0.441
+            },
+            "rightFootIndex": {
+              "x": 43.9,
+              "y": 123,
+              "v": 0.774
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.3,
+                "y": 28.3
+              },
+              "roll": 163.1,
+              "yaw": 0.16,
+              "pitch": 0.667
+            },
+            "torso": {
+              "center": {
+                "x": 63.3,
+                "y": 40.8
+              },
+              "angle": 84.2
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 68.1,
+                "y": 43.3
+              },
+              "angle": 75.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.9,
+                "y": 100
+              },
+              "angle": -63.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.4,
+                "y": 112.9
+              },
+              "angle": -61.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.651,
+          "keypoints": {
+            "nose": {
+              "x": 71.4,
+              "y": 31.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.2,
+              "y": 28.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.3,
+              "y": 28.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.3,
+              "y": 29.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.8,
+              "y": 30.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.2,
+              "y": 41.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.2,
+              "y": 41.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.9,
+              "y": 53.7,
+              "v": 0.105
+            },
+            "rightElbow": {
+              "x": 56.6,
+              "y": 53.7,
+              "v": 0.724
+            },
+            "leftWrist": {
+              "x": 70.2,
+              "y": 48.5,
+              "v": 0.271
+            },
+            "rightWrist": {
+              "x": 63.7,
+              "y": 43.1,
+              "v": 0.774
+            },
+            "leftIndex": {
+              "x": 70.2,
+              "y": 45.7,
+              "v": 0.349
+            },
+            "rightIndex": {
+              "x": 65.4,
+              "y": 38.1,
+              "v": 0.755
+            },
+            "leftHip": {
+              "x": 67.5,
+              "y": 70,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.6,
+              "y": 69.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.1,
+              "y": 86,
+              "v": 0.332
+            },
+            "rightKnee": {
+              "x": 61.9,
+              "y": 90.7,
+              "v": 0.569
+            },
+            "leftAnkle": {
+              "x": 61.3,
+              "y": 101.4,
+              "v": 0.133
+            },
+            "rightAnkle": {
+              "x": 52.9,
+              "y": 110.1,
+              "v": 0.639
+            },
+            "leftHeel": {
+              "x": 57,
+              "y": 101.9,
+              "v": 0.239
+            },
+            "rightHeel": {
+              "x": 51.1,
+              "y": 113,
+              "v": 0.383
+            },
+            "leftFootIndex": {
+              "x": 61.5,
+              "y": 110.7,
+              "v": 0.183
+            },
+            "rightFootIndex": {
+              "x": 53.4,
+              "y": 118,
+              "v": 0.53
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.8,
+                "y": 28.8
+              },
+              "roll": -178,
+              "yaw": 0.569,
+              "pitch": 0.81
+            },
+            "torso": {
+              "center": {
+                "x": 65.7,
+                "y": 41.6
+              },
+              "angle": 84.6
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 63.7,
+                "y": 43.1
+              },
+              "angle": 71.2
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 51.1,
+                "y": 113
+              },
+              "angle": -65.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.682,
+          "keypoints": {
+            "nose": {
+              "x": 69.8,
+              "y": 31,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.5,
+              "y": 28.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.3,
+              "y": 28,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.5,
+              "y": 29.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.5,
+              "y": 28.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.6,
+              "y": 41.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.8,
+              "y": 39.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.3,
+              "y": 56.3,
+              "v": 0.15
+            },
+            "rightElbow": {
+              "x": 53.4,
+              "y": 49,
+              "v": 0.678
+            },
+            "leftWrist": {
+              "x": 74.5,
+              "y": 47.6,
+              "v": 0.435
+            },
+            "rightWrist": {
+              "x": 64.4,
+              "y": 43.1,
+              "v": 0.492
+            },
+            "leftIndex": {
+              "x": 77.1,
+              "y": 46.9,
+              "v": 0.512
+            },
+            "rightIndex": {
+              "x": 67.8,
+              "y": 40.5,
+              "v": 0.438
+            },
+            "leftHip": {
+              "x": 68.9,
+              "y": 70.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.3,
+              "y": 69.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.2,
+              "y": 91.6,
+              "v": 0.375
+            },
+            "rightKnee": {
+              "x": 66.9,
+              "y": 91.6,
+              "v": 0.73
+            },
+            "leftAnkle": {
+              "x": 60.7,
+              "y": 105.5,
+              "v": 0.309
+            },
+            "rightAnkle": {
+              "x": 51.7,
+              "y": 109.9,
+              "v": 0.651
+            },
+            "leftHeel": {
+              "x": 55.8,
+              "y": 108.1,
+              "v": 0.395
+            },
+            "rightHeel": {
+              "x": 47.9,
+              "y": 112.1,
+              "v": 0.55
+            },
+            "leftFootIndex": {
+              "x": 59.1,
+              "y": 118.3,
+              "v": 0.35
+            },
+            "rightFootIndex": {
+              "x": 52.9,
+              "y": 120,
+              "v": 0.616
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.4,
+                "y": 28.3
+              },
+              "roll": 173.2,
+              "yaw": 0.095,
+              "pitch": 0.65
+            },
+            "torso": {
+              "center": {
+                "x": 65.2,
+                "y": 40.6
+              },
+              "angle": 88.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 74.5,
+                "y": 47.6
+              },
+              "angle": 15.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 64.4,
+                "y": 43.1
+              },
+              "angle": 37.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 55.8,
+                "y": 108.1
+              },
+              "angle": -72.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.9,
+                "y": 112.1
+              },
+              "angle": -57.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.635,
+          "keypoints": {
+            "nose": {
+              "x": 66.1,
+              "y": 19.3,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 65,
+              "y": 17.4,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 62.5,
+              "y": 18.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.6,
+              "y": 18.5,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 59.6,
+              "y": 20.6,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 64.5,
+              "y": 30.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.3,
+              "y": 32.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 66.2,
+              "y": 43.4,
+              "v": 0.011
+            },
+            "rightElbow": {
+              "x": 65,
+              "y": 47.7,
+              "v": 0.96
+            },
+            "leftWrist": {
+              "x": 66.1,
+              "y": 51.2,
+              "v": 0.043
+            },
+            "rightWrist": {
+              "x": 79.8,
+              "y": 46,
+              "v": 0.972
+            },
+            "leftIndex": {
+              "x": 66,
+              "y": 52.9,
+              "v": 0.084
+            },
+            "rightIndex": {
+              "x": 84.4,
+              "y": 44.8,
+              "v": 0.953
+            },
+            "leftHip": {
+              "x": 64.2,
+              "y": 61.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.4,
+              "y": 61.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.8,
+              "y": 79.8,
+              "v": 0.139
+            },
+            "rightKnee": {
+              "x": 55.4,
+              "y": 82.5,
+              "v": 0.58
+            },
+            "leftAnkle": {
+              "x": 65.5,
+              "y": 95.6,
+              "v": 0.125
+            },
+            "rightAnkle": {
+              "x": 47,
+              "y": 100.5,
+              "v": 0.582
+            },
+            "leftHeel": {
+              "x": 62.4,
+              "y": 97.5,
+              "v": 0.186
+            },
+            "rightHeel": {
+              "x": 45,
+              "y": 103.5,
+              "v": 0.305
+            },
+            "leftFootIndex": {
+              "x": 68.8,
+              "y": 102.9,
+              "v": 0.173
+            },
+            "rightFootIndex": {
+              "x": 48.4,
+              "y": 107.7,
+              "v": 0.505
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.8,
+                "y": 17.8
+              },
+              "roll": -162.3,
+              "yaw": 0.895,
+              "pitch": 0.571
+            },
+            "torso": {
+              "center": {
+                "x": 60.9,
+                "y": 31.4
+              },
+              "angle": 89.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 79.8,
+                "y": 46
+              },
+              "angle": 14.6
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 45,
+                "y": 103.5
+              },
+              "angle": -51
+            }
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.595,
+          "keypoints": {
+            "nose": {
+              "x": 64.6,
+              "y": 30.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63.9,
+              "y": 28.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.7,
+              "y": 28.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.6,
+              "y": 29.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.3,
+              "y": 29.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.1,
+              "y": 39.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.1,
+              "y": 40.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.4,
+              "y": 36.7,
+              "v": 0.474
+            },
+            "rightElbow": {
+              "x": 47.7,
+              "y": 51.2,
+              "v": 0.59
+            },
+            "leftWrist": {
+              "x": 84.6,
+              "y": 28.3,
+              "v": 0.892
+            },
+            "rightWrist": {
+              "x": 52.7,
+              "y": 51.6,
+              "v": 0.4
+            },
+            "leftIndex": {
+              "x": 87.3,
+              "y": 24.8,
+              "v": 0.909
+            },
+            "rightIndex": {
+              "x": 55.2,
+              "y": 50.6,
+              "v": 0.447
+            },
+            "leftHip": {
+              "x": 63,
+              "y": 69.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54.9,
+              "y": 69.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.9,
+              "y": 84.7,
+              "v": 0.052
+            },
+            "rightKnee": {
+              "x": 59.5,
+              "y": 88.9,
+              "v": 0.101
+            },
+            "leftAnkle": {
+              "x": 57.4,
+              "y": 102.8,
+              "v": 0.064
+            },
+            "rightAnkle": {
+              "x": 46.7,
+              "y": 107.5,
+              "v": 0.202
+            },
+            "leftHeel": {
+              "x": 53.8,
+              "y": 104.7,
+              "v": 0.13
+            },
+            "rightHeel": {
+              "x": 44,
+              "y": 110.2,
+              "v": 0.139
+            },
+            "leftFootIndex": {
+              "x": 58.8,
+              "y": 109.6,
+              "v": 0.103
+            },
+            "rightFootIndex": {
+              "x": 47.1,
+              "y": 114.9,
+              "v": 0.196
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.8,
+                "y": 28.6
+              },
+              "roll": -177.4,
+              "yaw": 0.817,
+              "pitch": 0.976
+            },
+            "torso": {
+              "center": {
+                "x": 57.6,
+                "y": 39.7
+              },
+              "angle": 92.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.6,
+                "y": 28.3
+              },
+              "angle": 52.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52.7,
+                "y": 51.6
+              },
+              "angle": 21.8
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.591,
+          "keypoints": {
+            "nose": {
+              "x": 68.6,
+              "y": 30.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.6,
+              "y": 28.4,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 65.4,
+              "y": 29,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.4,
+              "y": 29.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63,
+              "y": 31.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.3,
+              "y": 39.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.7,
+              "y": 41.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.6,
+              "y": 44.6,
+              "v": 0.199
+            },
+            "rightElbow": {
+              "x": 59.3,
+              "y": 53.5,
+              "v": 0.356
+            },
+            "leftWrist": {
+              "x": 73.9,
+              "y": 37.9,
+              "v": 0.298
+            },
+            "rightWrist": {
+              "x": 61.7,
+              "y": 44.8,
+              "v": 0.513
+            },
+            "leftIndex": {
+              "x": 72.6,
+              "y": 35.3,
+              "v": 0.351
+            },
+            "rightIndex": {
+              "x": 61.9,
+              "y": 40.8,
+              "v": 0.595
+            },
+            "leftHip": {
+              "x": 69.5,
+              "y": 69.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.3,
+              "y": 67.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.4,
+              "y": 85.8,
+              "v": 0.184
+            },
+            "rightKnee": {
+              "x": 64,
+              "y": 84.8,
+              "v": 0.418
+            },
+            "leftAnkle": {
+              "x": 62.8,
+              "y": 102.6,
+              "v": 0.066
+            },
+            "rightAnkle": {
+              "x": 49.8,
+              "y": 106.2,
+              "v": 0.553
+            },
+            "leftHeel": {
+              "x": 58.9,
+              "y": 103.2,
+              "v": 0.123
+            },
+            "rightHeel": {
+              "x": 46.8,
+              "y": 109.2,
+              "v": 0.304
+            },
+            "leftFootIndex": {
+              "x": 61,
+              "y": 111.9,
+              "v": 0.105
+            },
+            "rightFootIndex": {
+              "x": 49.8,
+              "y": 115.3,
+              "v": 0.524
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.5,
+                "y": 28.7
+              },
+              "roll": -171.9,
+              "yaw": 0.259,
+              "pitch": 0.424
+            },
+            "torso": {
+              "center": {
+                "x": 67,
+                "y": 40.6
+              },
+              "angle": 85.7
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 61.7,
+                "y": 44.8
+              },
+              "angle": 87.1
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 46.8,
+                "y": 109.2
+              },
+              "angle": -63.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.625,
+          "keypoints": {
+            "nose": {
+              "x": 66.4,
+              "y": 32.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.5,
+              "y": 30,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62.9,
+              "y": 29.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.1,
+              "y": 30.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.2,
+              "y": 31.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.5,
+              "y": 40.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.3,
+              "y": 42.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 68.7,
+              "y": 43.9,
+              "v": 0.052
+            },
+            "rightElbow": {
+              "x": 61,
+              "y": 54.6,
+              "v": 0.879
+            },
+            "leftWrist": {
+              "x": 73.7,
+              "y": 37.4,
+              "v": 0.482
+            },
+            "rightWrist": {
+              "x": 74,
+              "y": 50.4,
+              "v": 0.885
+            },
+            "leftIndex": {
+              "x": 75.1,
+              "y": 34.8,
+              "v": 0.602
+            },
+            "rightIndex": {
+              "x": 78.1,
+              "y": 48.2,
+              "v": 0.843
+            },
+            "leftHip": {
+              "x": 62.4,
+              "y": 68.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.9,
+              "y": 68.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.1,
+              "y": 85.2,
+              "v": 0.027
+            },
+            "rightKnee": {
+              "x": 63,
+              "y": 86.1,
+              "v": 0.315
+            },
+            "leftAnkle": {
+              "x": 60.7,
+              "y": 97.7,
+              "v": 0.028
+            },
+            "rightAnkle": {
+              "x": 48.8,
+              "y": 103.4,
+              "v": 0.425
+            },
+            "leftHeel": {
+              "x": 57.7,
+              "y": 98.5,
+              "v": 0.074
+            },
+            "rightHeel": {
+              "x": 45.3,
+              "y": 105.4,
+              "v": 0.278
+            },
+            "leftFootIndex": {
+              "x": 60.6,
+              "y": 105.3,
+              "v": 0.054
+            },
+            "rightFootIndex": {
+              "x": 49.2,
+              "y": 112.5,
+              "v": 0.433
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.7,
+                "y": 29.9
+              },
+              "roll": 176.8,
+              "yaw": 0.471,
+              "pitch": 0.61
+            },
+            "torso": {
+              "center": {
+                "x": 60.9,
+                "y": 41.5
+              },
+              "angle": 87.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.7,
+                "y": 37.4
+              },
+              "angle": 61.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 74,
+                "y": 50.4
+              },
+              "angle": 28.2
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 48.8,
+                "y": 103.4
+              },
+              "angle": -87.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.771,
+          "keypoints": {
+            "nose": {
+              "x": 72.7,
+              "y": 31.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.7,
+              "y": 29,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 70.2,
+              "y": 28.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.2,
+              "y": 29.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.1,
+              "y": 30.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.3,
+              "y": 42,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.9,
+              "y": 41.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.5,
+              "y": 53.3,
+              "v": 0.428
+            },
+            "rightElbow": {
+              "x": 57.6,
+              "y": 52,
+              "v": 0.858
+            },
+            "leftWrist": {
+              "x": 76,
+              "y": 49.5,
+              "v": 0.713
+            },
+            "rightWrist": {
+              "x": 64.2,
+              "y": 43.2,
+              "v": 0.812
+            },
+            "leftIndex": {
+              "x": 76,
+              "y": 46.7,
+              "v": 0.755
+            },
+            "rightIndex": {
+              "x": 65.5,
+              "y": 38.9,
+              "v": 0.776
+            },
+            "leftHip": {
+              "x": 70.3,
+              "y": 69,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.4,
+              "y": 69.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.7,
+              "y": 87.5,
+              "v": 0.663
+            },
+            "rightKnee": {
+              "x": 62.7,
+              "y": 88,
+              "v": 0.838
+            },
+            "leftAnkle": {
+              "x": 69.5,
+              "y": 102.1,
+              "v": 0.333
+            },
+            "rightAnkle": {
+              "x": 56.8,
+              "y": 106.7,
+              "v": 0.759
+            },
+            "leftHeel": {
+              "x": 66,
+              "y": 102.9,
+              "v": 0.341
+            },
+            "rightHeel": {
+              "x": 55.9,
+              "y": 109.2,
+              "v": 0.456
+            },
+            "leftFootIndex": {
+              "x": 70.5,
+              "y": 110.7,
+              "v": 0.366
+            },
+            "rightFootIndex": {
+              "x": 57.1,
+              "y": 114.2,
+              "v": 0.637
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71,
+                "y": 29
+              },
+              "roll": 176.2,
+              "yaw": 1.164,
+              "pitch": 1.43
+            },
+            "torso": {
+              "center": {
+                "x": 66.6,
+                "y": 41.7
+              },
+              "angle": 88.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76,
+                "y": 49.5
+              },
+              "angle": 90
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 64.2,
+                "y": 43.2
+              },
+              "angle": 73.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 66,
+                "y": 102.9
+              },
+              "angle": -60
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 55.9,
+                "y": 109.2
+              },
+              "angle": -76.5
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.747,
+          "keypoints": {
+            "nose": {
+              "x": 73.4,
+              "y": 30.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.5,
+              "y": 28.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70,
+              "y": 29,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.9,
+              "y": 29.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.2,
+              "y": 30.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.7,
+              "y": 40.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.9,
+              "y": 40.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77,
+              "y": 51.9,
+              "v": 0.35
+            },
+            "rightElbow": {
+              "x": 53.6,
+              "y": 51.5,
+              "v": 0.857
+            },
+            "leftWrist": {
+              "x": 78.5,
+              "y": 47.8,
+              "v": 0.645
+            },
+            "rightWrist": {
+              "x": 62.9,
+              "y": 45.5,
+              "v": 0.783
+            },
+            "leftIndex": {
+              "x": 79,
+              "y": 45.2,
+              "v": 0.702
+            },
+            "rightIndex": {
+              "x": 66.1,
+              "y": 42.4,
+              "v": 0.745
+            },
+            "leftHip": {
+              "x": 69.3,
+              "y": 70.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.2,
+              "y": 69.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.5,
+              "y": 84.4,
+              "v": 0.577
+            },
+            "rightKnee": {
+              "x": 68.1,
+              "y": 86.7,
+              "v": 0.642
+            },
+            "leftAnkle": {
+              "x": 62.5,
+              "y": 100,
+              "v": 0.326
+            },
+            "rightAnkle": {
+              "x": 54.9,
+              "y": 106,
+              "v": 0.733
+            },
+            "leftHeel": {
+              "x": 58.4,
+              "y": 100.3,
+              "v": 0.373
+            },
+            "rightHeel": {
+              "x": 52.3,
+              "y": 108.5,
+              "v": 0.435
+            },
+            "leftFootIndex": {
+              "x": 60.4,
+              "y": 109.8,
+              "v": 0.37
+            },
+            "rightFootIndex": {
+              "x": 54.7,
+              "y": 115.3,
+              "v": 0.651
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.3,
+                "y": 28.8
+              },
+              "roll": -170.9,
+              "yaw": 0.849,
+              "pitch": 0.711
+            },
+            "torso": {
+              "center": {
+                "x": 66.8,
+                "y": 40.8
+              },
+              "angle": 86
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 78.5,
+                "y": 47.8
+              },
+              "angle": 79.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 62.9,
+                "y": 45.5
+              },
+              "angle": 44.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 58.4,
+                "y": 100.3
+              },
+              "angle": -78.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 52.3,
+                "y": 108.5
+              },
+              "angle": -70.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.607,
+          "keypoints": {
+            "nose": {
+              "x": 74.9,
+              "y": 32,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.9,
+              "y": 30.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.5,
+              "y": 29.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.8,
+              "y": 31.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 69.5,
+              "y": 30.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.2,
+              "y": 38.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 68.7,
+              "y": 42.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.8,
+              "y": 46.2,
+              "v": 0.031
+            },
+            "rightElbow": {
+              "x": 71,
+              "y": 63.6,
+              "v": 0.814
+            },
+            "leftWrist": {
+              "x": 78.3,
+              "y": 45.2,
+              "v": 0.162
+            },
+            "rightWrist": {
+              "x": 78.2,
+              "y": 78.5,
+              "v": 0.521
+            },
+            "leftIndex": {
+              "x": 79.3,
+              "y": 43.7,
+              "v": 0.214
+            },
+            "rightIndex": {
+              "x": 80.3,
+              "y": 82.5,
+              "v": 0.402
+            },
+            "leftHip": {
+              "x": 63.4,
+              "y": 70.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.6,
+              "y": 71.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.8,
+              "y": 94.6,
+              "v": 0.039
+            },
+            "rightKnee": {
+              "x": 67.5,
+              "y": 94.4,
+              "v": 0.379
+            },
+            "leftAnkle": {
+              "x": 55.7,
+              "y": 111.9,
+              "v": 0.173
+            },
+            "rightAnkle": {
+              "x": 52.4,
+              "y": 113.5,
+              "v": 0.606
+            },
+            "leftHeel": {
+              "x": 52.2,
+              "y": 113.9,
+              "v": 0.284
+            },
+            "rightHeel": {
+              "x": 48.3,
+              "y": 115.1,
+              "v": 0.53
+            },
+            "leftFootIndex": {
+              "x": 57.4,
+              "y": 119.5,
+              "v": 0.234
+            },
+            "rightFootIndex": {
+              "x": 53.5,
+              "y": 124,
+              "v": 0.586
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.7,
+                "y": 30.2
+              },
+              "roll": 157.4,
+              "yaw": 0.462,
+              "pitch": 0.692
+            },
+            "torso": {
+              "center": {
+                "x": 68.5,
+                "y": 40.7
+              },
+              "angle": 79.9
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 78.2,
+                "y": 78.5
+              },
+              "angle": -62.3
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 48.3,
+                "y": 115.1
+              },
+              "angle": -59.7
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.75,
+          "keypoints": {
+            "nose": {
+              "x": 61.9,
+              "y": 31.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.7,
+              "y": 29.4,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 59,
+              "y": 28.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60.6,
+              "y": 30.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 55.2,
+              "y": 29.9,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 62.3,
+              "y": 41.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.6,
+              "y": 40.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.8,
+              "y": 55.2,
+              "v": 0.047
+            },
+            "rightElbow": {
+              "x": 46.5,
+              "y": 51.6,
+              "v": 0.913
+            },
+            "leftWrist": {
+              "x": 61.7,
+              "y": 66,
+              "v": 0.049
+            },
+            "rightWrist": {
+              "x": 51.2,
+              "y": 45.2,
+              "v": 0.952
+            },
+            "leftIndex": {
+              "x": 61.3,
+              "y": 69.1,
+              "v": 0.067
+            },
+            "rightIndex": {
+              "x": 52.6,
+              "y": 42,
+              "v": 0.937
+            },
+            "leftHip": {
+              "x": 62.2,
+              "y": 68.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.7,
+              "y": 68.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.2,
+              "y": 84.9,
+              "v": 0.715
+            },
+            "rightKnee": {
+              "x": 47,
+              "y": 88.4,
+              "v": 0.796
+            },
+            "leftAnkle": {
+              "x": 56.7,
+              "y": 96.9,
+              "v": 0.437
+            },
+            "rightAnkle": {
+              "x": 38.4,
+              "y": 107.5,
+              "v": 0.928
+            },
+            "leftHeel": {
+              "x": 53.7,
+              "y": 99,
+              "v": 0.431
+            },
+            "rightHeel": {
+              "x": 37.5,
+              "y": 110.6,
+              "v": 0.65
+            },
+            "leftFootIndex": {
+              "x": 57.7,
+              "y": 107.1,
+              "v": 0.457
+            },
+            "rightFootIndex": {
+              "x": 35.7,
+              "y": 115.5,
+              "v": 0.88
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.4,
+                "y": 29.1
+              },
+              "roll": 167.5,
+              "yaw": 0.56,
+              "pitch": 0.759
+            },
+            "torso": {
+              "center": {
+                "x": 56,
+                "y": 41
+              },
+              "angle": 93.1
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 51.2,
+                "y": 45.2
+              },
+              "angle": 66.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 53.7,
+                "y": 99
+              },
+              "angle": -63.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.5,
+                "y": 110.6
+              },
+              "angle": -110.2
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.795,
+          "keypoints": {
+            "nose": {
+              "x": 72.1,
+              "y": 31.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.2,
+              "y": 28.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.9,
+              "y": 28.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.8,
+              "y": 29.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.8,
+              "y": 29.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.7,
+              "y": 40.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.7,
+              "y": 39.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.2,
+              "y": 53.6,
+              "v": 0.616
+            },
+            "rightElbow": {
+              "x": 52.2,
+              "y": 49.5,
+              "v": 0.952
+            },
+            "leftWrist": {
+              "x": 79.3,
+              "y": 50.8,
+              "v": 0.897
+            },
+            "rightWrist": {
+              "x": 64.1,
+              "y": 45.5,
+              "v": 0.902
+            },
+            "leftIndex": {
+              "x": 80.1,
+              "y": 48.2,
+              "v": 0.903
+            },
+            "rightIndex": {
+              "x": 68.1,
+              "y": 43.1,
+              "v": 0.832
+            },
+            "leftHip": {
+              "x": 68.9,
+              "y": 69.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60,
+              "y": 70.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81,
+              "y": 86.2,
+              "v": 0.673
+            },
+            "rightKnee": {
+              "x": 63.8,
+              "y": 93.2,
+              "v": 0.788
+            },
+            "leftAnkle": {
+              "x": 64.3,
+              "y": 103.1,
+              "v": 0.28
+            },
+            "rightAnkle": {
+              "x": 55.6,
+              "y": 112.9,
+              "v": 0.728
+            },
+            "leftHeel": {
+              "x": 60.2,
+              "y": 103.8,
+              "v": 0.353
+            },
+            "rightHeel": {
+              "x": 54.1,
+              "y": 116.2,
+              "v": 0.465
+            },
+            "leftFootIndex": {
+              "x": 63.7,
+              "y": 112.2,
+              "v": 0.303
+            },
+            "rightFootIndex": {
+              "x": 56,
+              "y": 119.8,
+              "v": 0.582
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.6,
+                "y": 28.6
+              },
+              "roll": 176.5,
+              "yaw": 0.469,
+              "pitch": 0.786
+            },
+            "torso": {
+              "center": {
+                "x": 64.7,
+                "y": 39.8
+              },
+              "angle": 89.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 79.3,
+                "y": 50.8
+              },
+              "angle": 72.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 64.1,
+                "y": 45.5
+              },
+              "angle": 31
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.2,
+                "y": 103.8
+              },
+              "angle": -67.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 54.1,
+                "y": 116.2
+              },
+              "angle": -62.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.627,
+          "keypoints": {
+            "nose": {
+              "x": 70.8,
+              "y": 29.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.4,
+              "y": 27.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.2,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.9,
+              "y": 27.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.5,
+              "y": 29.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.7,
+              "y": 38.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.9,
+              "y": 39.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.4,
+              "y": 49.8,
+              "v": 0.156
+            },
+            "rightElbow": {
+              "x": 65,
+              "y": 55,
+              "v": 0.484
+            },
+            "leftWrist": {
+              "x": 75.5,
+              "y": 45.1,
+              "v": 0.266
+            },
+            "rightWrist": {
+              "x": 72.7,
+              "y": 45.3,
+              "v": 0.446
+            },
+            "leftIndex": {
+              "x": 74.6,
+              "y": 42.3,
+              "v": 0.343
+            },
+            "rightIndex": {
+              "x": 74.6,
+              "y": 41.2,
+              "v": 0.455
+            },
+            "leftHip": {
+              "x": 68.4,
+              "y": 68.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.7,
+              "y": 68.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82,
+              "y": 84.7,
+              "v": 0.486
+            },
+            "rightKnee": {
+              "x": 60.1,
+              "y": 91.7,
+              "v": 0.681
+            },
+            "leftAnkle": {
+              "x": 64.5,
+              "y": 102.7,
+              "v": 0.138
+            },
+            "rightAnkle": {
+              "x": 49.4,
+              "y": 111.1,
+              "v": 0.655
+            },
+            "leftHeel": {
+              "x": 60.6,
+              "y": 103.3,
+              "v": 0.21
+            },
+            "rightHeel": {
+              "x": 47.4,
+              "y": 114.1,
+              "v": 0.389
+            },
+            "leftFootIndex": {
+              "x": 63,
+              "y": 111.9,
+              "v": 0.163
+            },
+            "rightFootIndex": {
+              "x": 49,
+              "y": 118.9,
+              "v": 0.546
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.3,
+                "y": 27.5
+              },
+              "roll": -169.2,
+              "yaw": 0.351,
+              "pitch": 0.491
+            },
+            "torso": {
+              "center": {
+                "x": 67.8,
+                "y": 39.1
+              },
+              "angle": 81.7
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 72.7,
+                "y": 45.3
+              },
+              "angle": 65.1
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 47.4,
+                "y": 114.1
+              },
+              "angle": -71.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.861,
+          "keypoints": {
+            "nose": {
+              "x": 73.8,
+              "y": 30.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.5,
+              "y": 28.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71,
+              "y": 28.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.3,
+              "y": 29.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.3,
+              "y": 30,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.9,
+              "y": 43.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.2,
+              "y": 40.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.2,
+              "y": 54.1,
+              "v": 0.547
+            },
+            "rightElbow": {
+              "x": 50.7,
+              "y": 48.5,
+              "v": 0.962
+            },
+            "leftWrist": {
+              "x": 79.5,
+              "y": 46.6,
+              "v": 0.857
+            },
+            "rightWrist": {
+              "x": 58.4,
+              "y": 42.5,
+              "v": 0.838
+            },
+            "leftIndex": {
+              "x": 82.6,
+              "y": 43.4,
+              "v": 0.886
+            },
+            "rightIndex": {
+              "x": 60.9,
+              "y": 39.4,
+              "v": 0.794
+            },
+            "leftHip": {
+              "x": 69.2,
+              "y": 71.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.5,
+              "y": 71.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.6,
+              "y": 84.3,
+              "v": 0.9
+            },
+            "rightKnee": {
+              "x": 57.9,
+              "y": 93.2,
+              "v": 0.947
+            },
+            "leftAnkle": {
+              "x": 65.8,
+              "y": 97.2,
+              "v": 0.548
+            },
+            "rightAnkle": {
+              "x": 46.3,
+              "y": 110.8,
+              "v": 0.907
+            },
+            "leftHeel": {
+              "x": 61.7,
+              "y": 99.1,
+              "v": 0.551
+            },
+            "rightHeel": {
+              "x": 44.5,
+              "y": 112.8,
+              "v": 0.671
+            },
+            "leftFootIndex": {
+              "x": 63.9,
+              "y": 107.5,
+              "v": 0.585
+            },
+            "rightFootIndex": {
+              "x": 45.1,
+              "y": 118.5,
+              "v": 0.82
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.8,
+                "y": 28.3
+              },
+              "roll": -180,
+              "yaw": 1.367,
+              "pitch": 1.2
+            },
+            "torso": {
+              "center": {
+                "x": 66.1,
+                "y": 41.9
+              },
+              "angle": 86.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 79.5,
+                "y": 46.6
+              },
+              "angle": 45.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 58.4,
+                "y": 42.5
+              },
+              "angle": 51.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.7,
+                "y": 99.1
+              },
+              "angle": -75.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.5,
+                "y": 112.8
+              },
+              "angle": -84
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/lini/poses.json
+++ b/public/assets/fighters/lini/poses.json
@@ -1,0 +1,8109 @@
+{
+  "version": 1,
+  "fighter": "lini",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:40:50.282Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.662,
+          "keypoints": {
+            "nose": {
+              "x": 67.2,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.5,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.2,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.9,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.2,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.9,
+              "y": 28.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.4,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.1,
+              "y": 45.8,
+              "v": 0.512
+            },
+            "rightElbow": {
+              "x": 48,
+              "y": 44.6,
+              "v": 0.718
+            },
+            "leftWrist": {
+              "x": 90.8,
+              "y": 39,
+              "v": 0.91
+            },
+            "rightWrist": {
+              "x": 38.2,
+              "y": 39.4,
+              "v": 0.917
+            },
+            "leftIndex": {
+              "x": 95.9,
+              "y": 33.2,
+              "v": 0.905
+            },
+            "rightIndex": {
+              "x": 33.1,
+              "y": 35.2,
+              "v": 0.911
+            },
+            "leftHip": {
+              "x": 69.3,
+              "y": 63.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.4,
+              "y": 63.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.6,
+              "y": 90.9,
+              "v": 0.186
+            },
+            "rightKnee": {
+              "x": 58.2,
+              "y": 88.2,
+              "v": 0.164
+            },
+            "leftAnkle": {
+              "x": 72.7,
+              "y": 112.2,
+              "v": 0.177
+            },
+            "rightAnkle": {
+              "x": 52.7,
+              "y": 111.9,
+              "v": 0.181
+            },
+            "leftHeel": {
+              "x": 71,
+              "y": 115.4,
+              "v": 0.157
+            },
+            "rightHeel": {
+              "x": 52,
+              "y": 115.6,
+              "v": 0.073
+            },
+            "leftFootIndex": {
+              "x": 76.3,
+              "y": 119.3,
+              "v": 0.257
+            },
+            "rightFootIndex": {
+              "x": 53.5,
+              "y": 119.8,
+              "v": 0.165
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.4,
+                "y": 11.7
+              },
+              "roll": 174.7,
+              "yaw": 0.197,
+              "pitch": 0.695
+            },
+            "torso": {
+              "center": {
+                "x": 63.7,
+                "y": 28.1
+              },
+              "angle": 91.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.8,
+                "y": 39
+              },
+              "angle": 48.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.2,
+                "y": 39.4
+              },
+              "angle": 140.5
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.695,
+          "keypoints": {
+            "nose": {
+              "x": 67.6,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.7,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.5,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.3,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.1,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.7,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.1,
+              "y": 28.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.4,
+              "y": 44.7,
+              "v": 0.498
+            },
+            "rightElbow": {
+              "x": 47.7,
+              "y": 47.1,
+              "v": 0.763
+            },
+            "leftWrist": {
+              "x": 90.5,
+              "y": 38.3,
+              "v": 0.891
+            },
+            "rightWrist": {
+              "x": 37.9,
+              "y": 40.9,
+              "v": 0.943
+            },
+            "leftIndex": {
+              "x": 95.6,
+              "y": 33.3,
+              "v": 0.883
+            },
+            "rightIndex": {
+              "x": 33.4,
+              "y": 36,
+              "v": 0.947
+            },
+            "leftHip": {
+              "x": 69.3,
+              "y": 63.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.4,
+              "y": 63.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.5,
+              "y": 90.9,
+              "v": 0.229
+            },
+            "rightKnee": {
+              "x": 59.8,
+              "y": 89.3,
+              "v": 0.345
+            },
+            "leftAnkle": {
+              "x": 70.7,
+              "y": 112.7,
+              "v": 0.19
+            },
+            "rightAnkle": {
+              "x": 51.8,
+              "y": 113.2,
+              "v": 0.349
+            },
+            "leftHeel": {
+              "x": 68.9,
+              "y": 116.1,
+              "v": 0.197
+            },
+            "rightHeel": {
+              "x": 49.8,
+              "y": 116.7,
+              "v": 0.128
+            },
+            "leftFootIndex": {
+              "x": 75,
+              "y": 119.1,
+              "v": 0.307
+            },
+            "rightFootIndex": {
+              "x": 55.3,
+              "y": 121,
+              "v": 0.324
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.6,
+                "y": 11.2
+              },
+              "roll": 174.6,
+              "yaw": 0.237,
+              "pitch": 0.711
+            },
+            "torso": {
+              "center": {
+                "x": 62.9,
+                "y": 27.8
+              },
+              "angle": 92.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.5,
+                "y": 38.3
+              },
+              "angle": 44.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.9,
+                "y": 40.9
+              },
+              "angle": 132.6
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 51.8,
+                "y": 113.2
+              },
+              "angle": -65.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.76,
+          "keypoints": {
+            "nose": {
+              "x": 66.9,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.8,
+              "y": 11,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.1,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.2,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.5,
+              "y": 27.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.1,
+              "y": 27.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.3,
+              "y": 46.6,
+              "v": 0.746
+            },
+            "rightElbow": {
+              "x": 48.1,
+              "y": 42.8,
+              "v": 0.913
+            },
+            "leftWrist": {
+              "x": 89.4,
+              "y": 38.1,
+              "v": 0.975
+            },
+            "rightWrist": {
+              "x": 39.8,
+              "y": 39.4,
+              "v": 0.987
+            },
+            "leftIndex": {
+              "x": 95.2,
+              "y": 32.3,
+              "v": 0.971
+            },
+            "rightIndex": {
+              "x": 34.5,
+              "y": 33.8,
+              "v": 0.983
+            },
+            "leftHip": {
+              "x": 70.1,
+              "y": 64.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.5,
+              "y": 63.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70,
+              "y": 91.6,
+              "v": 0.335
+            },
+            "rightKnee": {
+              "x": 56.1,
+              "y": 89.2,
+              "v": 0.45
+            },
+            "leftAnkle": {
+              "x": 67.3,
+              "y": 112.5,
+              "v": 0.328
+            },
+            "rightAnkle": {
+              "x": 52.2,
+              "y": 115.6,
+              "v": 0.458
+            },
+            "leftHeel": {
+              "x": 65.3,
+              "y": 117,
+              "v": 0.26
+            },
+            "rightHeel": {
+              "x": 51.8,
+              "y": 119.3,
+              "v": 0.199
+            },
+            "leftFootIndex": {
+              "x": 69.9,
+              "y": 121.8,
+              "v": 0.437
+            },
+            "rightFootIndex": {
+              "x": 52.1,
+              "y": 125.1,
+              "v": 0.442
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.5,
+                "y": 11.2
+              },
+              "roll": -176.3,
+              "yaw": 0.308,
+              "pitch": 0.563
+            },
+            "torso": {
+              "center": {
+                "x": 64.3,
+                "y": 27.5
+              },
+              "angle": 90.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.4,
+                "y": 38.1
+              },
+              "angle": 45
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.8,
+                "y": 39.4
+              },
+              "angle": 133.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.3,
+                "y": 112.5
+              },
+              "angle": -74.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 52.2,
+                "y": 115.6
+              },
+              "angle": -90.6
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.731,
+          "keypoints": {
+            "nose": {
+              "x": 67.8,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.8,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.6,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.7,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.8,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.1,
+              "y": 30.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.1,
+              "y": 28.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.8,
+              "y": 48.5,
+              "v": 0.547
+            },
+            "rightElbow": {
+              "x": 48.3,
+              "y": 48.2,
+              "v": 0.792
+            },
+            "leftWrist": {
+              "x": 89.5,
+              "y": 39.3,
+              "v": 0.921
+            },
+            "rightWrist": {
+              "x": 50.2,
+              "y": 36.2,
+              "v": 0.958
+            },
+            "leftIndex": {
+              "x": 94.4,
+              "y": 33.2,
+              "v": 0.935
+            },
+            "rightIndex": {
+              "x": 50.2,
+              "y": 30.9,
+              "v": 0.951
+            },
+            "leftHip": {
+              "x": 68.6,
+              "y": 67.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.5,
+              "y": 67.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.8,
+              "y": 94.9,
+              "v": 0.3
+            },
+            "rightKnee": {
+              "x": 56.9,
+              "y": 92.8,
+              "v": 0.32
+            },
+            "leftAnkle": {
+              "x": 71,
+              "y": 115.7,
+              "v": 0.347
+            },
+            "rightAnkle": {
+              "x": 51.4,
+              "y": 117.4,
+              "v": 0.464
+            },
+            "leftHeel": {
+              "x": 69.6,
+              "y": 118.7,
+              "v": 0.272
+            },
+            "rightHeel": {
+              "x": 51,
+              "y": 121.2,
+              "v": 0.193
+            },
+            "leftFootIndex": {
+              "x": 72.3,
+              "y": 121.5,
+              "v": 0.422
+            },
+            "rightFootIndex": {
+              "x": 50.6,
+              "y": 126.5,
+              "v": 0.382
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.2,
+                "y": 11.6
+              },
+              "roll": 177.8,
+              "yaw": 0.307,
+              "pitch": 0.596
+            },
+            "torso": {
+              "center": {
+                "x": 62.6,
+                "y": 29.5
+              },
+              "angle": 90.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.5,
+                "y": 39.3
+              },
+              "angle": 51.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.2,
+                "y": 36.2
+              },
+              "angle": 90
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71,
+                "y": 115.7
+              },
+              "angle": -77.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 51.4,
+                "y": 117.4
+              },
+              "angle": -95
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.7,
+          "keypoints": {
+            "nose": {
+              "x": 67,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.5,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.4,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.8,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.4,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.2,
+              "y": 27.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.5,
+              "y": 28.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79,
+              "y": 44.5,
+              "v": 0.588
+            },
+            "rightElbow": {
+              "x": 47.7,
+              "y": 46.9,
+              "v": 0.862
+            },
+            "leftWrist": {
+              "x": 91.2,
+              "y": 38,
+              "v": 0.92
+            },
+            "rightWrist": {
+              "x": 39.5,
+              "y": 40.4,
+              "v": 0.97
+            },
+            "leftIndex": {
+              "x": 96.5,
+              "y": 32.8,
+              "v": 0.916
+            },
+            "rightIndex": {
+              "x": 33.9,
+              "y": 35.3,
+              "v": 0.968
+            },
+            "leftHip": {
+              "x": 69.5,
+              "y": 63.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.9,
+              "y": 63.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.5,
+              "y": 90.9,
+              "v": 0.266
+            },
+            "rightKnee": {
+              "x": 59,
+              "y": 88.4,
+              "v": 0.261
+            },
+            "leftAnkle": {
+              "x": 73.1,
+              "y": 112.3,
+              "v": 0.206
+            },
+            "rightAnkle": {
+              "x": 54.7,
+              "y": 112.8,
+              "v": 0.269
+            },
+            "leftHeel": {
+              "x": 71.4,
+              "y": 115.8,
+              "v": 0.198
+            },
+            "rightHeel": {
+              "x": 54,
+              "y": 116.7,
+              "v": 0.119
+            },
+            "leftFootIndex": {
+              "x": 77.3,
+              "y": 118.8,
+              "v": 0.303
+            },
+            "rightFootIndex": {
+              "x": 56.2,
+              "y": 120,
+              "v": 0.244
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66,
+                "y": 11
+              },
+              "roll": 173.3,
+              "yaw": 0.204,
+              "pitch": 0.545
+            },
+            "torso": {
+              "center": {
+                "x": 62.4,
+                "y": 28
+              },
+              "angle": 93
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.2,
+                "y": 38
+              },
+              "angle": 44.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.5,
+                "y": 40.4
+              },
+              "angle": 137.7
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.75,
+          "keypoints": {
+            "nose": {
+              "x": 68.2,
+              "y": 15.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.4,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.6,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.2,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.1,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72,
+              "y": 28.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.6,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.9,
+              "y": 50,
+              "v": 0.539
+            },
+            "rightElbow": {
+              "x": 50.9,
+              "y": 45.2,
+              "v": 0.873
+            },
+            "leftWrist": {
+              "x": 90,
+              "y": 39.4,
+              "v": 0.944
+            },
+            "rightWrist": {
+              "x": 43.8,
+              "y": 37.9,
+              "v": 0.989
+            },
+            "leftIndex": {
+              "x": 95.7,
+              "y": 32.7,
+              "v": 0.956
+            },
+            "rightIndex": {
+              "x": 39.7,
+              "y": 32.9,
+              "v": 0.99
+            },
+            "leftHip": {
+              "x": 70.9,
+              "y": 65.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.4,
+              "y": 64.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.7,
+              "y": 95.1,
+              "v": 0.33
+            },
+            "rightKnee": {
+              "x": 56.6,
+              "y": 90.8,
+              "v": 0.358
+            },
+            "leftAnkle": {
+              "x": 71.1,
+              "y": 112.6,
+              "v": 0.358
+            },
+            "rightAnkle": {
+              "x": 53.5,
+              "y": 115.7,
+              "v": 0.473
+            },
+            "leftHeel": {
+              "x": 69.4,
+              "y": 117.1,
+              "v": 0.33
+            },
+            "rightHeel": {
+              "x": 53.2,
+              "y": 119.8,
+              "v": 0.216
+            },
+            "leftFootIndex": {
+              "x": 72.4,
+              "y": 121.4,
+              "v": 0.474
+            },
+            "rightFootIndex": {
+              "x": 53.7,
+              "y": 125.3,
+              "v": 0.426
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67,
+                "y": 11.6
+              },
+              "roll": 178.8,
+              "yaw": 0.25,
+              "pitch": 0.719
+            },
+            "torso": {
+              "center": {
+                "x": 63.3,
+                "y": 28.4
+              },
+              "angle": 92.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90,
+                "y": 39.4
+              },
+              "angle": 49.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.8,
+                "y": 37.9
+              },
+              "angle": 129.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.4,
+                "y": 117.1
+              },
+              "angle": -55.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 53.5,
+                "y": 115.7
+              },
+              "angle": -88.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.706,
+          "keypoints": {
+            "nose": {
+              "x": 67.4,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.1,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.1,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.7,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.5,
+              "y": 27.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.3,
+              "y": 27.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.5,
+              "y": 45.3,
+              "v": 0.362
+            },
+            "rightElbow": {
+              "x": 51.5,
+              "y": 45.9,
+              "v": 0.776
+            },
+            "leftWrist": {
+              "x": 88.9,
+              "y": 38.4,
+              "v": 0.91
+            },
+            "rightWrist": {
+              "x": 42.8,
+              "y": 38.7,
+              "v": 0.981
+            },
+            "leftIndex": {
+              "x": 94.8,
+              "y": 32.4,
+              "v": 0.939
+            },
+            "rightIndex": {
+              "x": 42.7,
+              "y": 32.1,
+              "v": 0.983
+            },
+            "leftHip": {
+              "x": 69.6,
+              "y": 63.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.3,
+              "y": 62.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.9,
+              "y": 91.3,
+              "v": 0.143
+            },
+            "rightKnee": {
+              "x": 55.5,
+              "y": 90.2,
+              "v": 0.282
+            },
+            "leftAnkle": {
+              "x": 65.7,
+              "y": 113.8,
+              "v": 0.226
+            },
+            "rightAnkle": {
+              "x": 51.1,
+              "y": 117.3,
+              "v": 0.458
+            },
+            "leftHeel": {
+              "x": 63.9,
+              "y": 118.4,
+              "v": 0.218
+            },
+            "rightHeel": {
+              "x": 50.3,
+              "y": 122.8,
+              "v": 0.195
+            },
+            "leftFootIndex": {
+              "x": 66.5,
+              "y": 121.9,
+              "v": 0.351
+            },
+            "rightFootIndex": {
+              "x": 53,
+              "y": 128.6,
+              "v": 0.418
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.6,
+                "y": 10.9
+              },
+              "roll": -176.5,
+              "yaw": 0.377,
+              "pitch": 0.581
+            },
+            "torso": {
+              "center": {
+                "x": 63.9,
+                "y": 27.4
+              },
+              "angle": 90.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.9,
+                "y": 38.4
+              },
+              "angle": 45.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 42.8,
+                "y": 38.7
+              },
+              "angle": 90.9
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 51.1,
+                "y": 117.3
+              },
+              "angle": -80.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.712,
+          "keypoints": {
+            "nose": {
+              "x": 67.5,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.1,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.3,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.6,
+              "y": 12.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.9,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.5,
+              "y": 27.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.5,
+              "y": 28.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.1,
+              "y": 44.7,
+              "v": 0.521
+            },
+            "rightElbow": {
+              "x": 47.8,
+              "y": 45.7,
+              "v": 0.743
+            },
+            "leftWrist": {
+              "x": 89.8,
+              "y": 38.9,
+              "v": 0.807
+            },
+            "rightWrist": {
+              "x": 37,
+              "y": 38.9,
+              "v": 0.909
+            },
+            "leftIndex": {
+              "x": 96,
+              "y": 33.8,
+              "v": 0.818
+            },
+            "rightIndex": {
+              "x": 32.6,
+              "y": 34.4,
+              "v": 0.914
+            },
+            "leftHip": {
+              "x": 68.8,
+              "y": 63.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.6,
+              "y": 63.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.6,
+              "y": 90.7,
+              "v": 0.396
+            },
+            "rightKnee": {
+              "x": 57.6,
+              "y": 88.7,
+              "v": 0.341
+            },
+            "leftAnkle": {
+              "x": 72.8,
+              "y": 112.2,
+              "v": 0.332
+            },
+            "rightAnkle": {
+              "x": 51.8,
+              "y": 112.9,
+              "v": 0.393
+            },
+            "leftHeel": {
+              "x": 71.5,
+              "y": 115.5,
+              "v": 0.259
+            },
+            "rightHeel": {
+              "x": 51.2,
+              "y": 116.6,
+              "v": 0.171
+            },
+            "leftFootIndex": {
+              "x": 75.6,
+              "y": 119.2,
+              "v": 0.415
+            },
+            "rightFootIndex": {
+              "x": 51.2,
+              "y": 120.9,
+              "v": 0.352
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.7,
+                "y": 11.5
+              },
+              "roll": 170.5,
+              "yaw": 0.164,
+              "pitch": 0.658
+            },
+            "torso": {
+              "center": {
+                "x": 62.5,
+                "y": 28.2
+              },
+              "angle": 91.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.8,
+                "y": 38.9
+              },
+              "angle": 39.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37,
+                "y": 38.9
+              },
+              "angle": 134.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.8,
+                "y": 112.2
+              },
+              "angle": -68.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 51.8,
+                "y": 112.9
+              },
+              "angle": -94.3
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.639,
+          "keypoints": {
+            "nose": {
+              "x": 59.6,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.7,
+              "y": 12,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.4,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.8,
+              "y": 12.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.2,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.4,
+              "y": 26.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44.3,
+              "y": 26,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.6,
+              "y": 31.1,
+              "v": 0.819
+            },
+            "rightElbow": {
+              "x": 39.2,
+              "y": 40.3,
+              "v": 0.827
+            },
+            "leftWrist": {
+              "x": 90.1,
+              "y": 28.4,
+              "v": 0.94
+            },
+            "rightWrist": {
+              "x": 41.6,
+              "y": 43.5,
+              "v": 0.87
+            },
+            "leftIndex": {
+              "x": 94.7,
+              "y": 27.9,
+              "v": 0.943
+            },
+            "rightIndex": {
+              "x": 43,
+              "y": 42.1,
+              "v": 0.868
+            },
+            "leftHip": {
+              "x": 60,
+              "y": 62.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.6,
+              "y": 63.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.6,
+              "y": 89.7,
+              "v": 0.061
+            },
+            "rightKnee": {
+              "x": 46.7,
+              "y": 89.2,
+              "v": 0.072
+            },
+            "leftAnkle": {
+              "x": 63.8,
+              "y": 113.5,
+              "v": 0.041
+            },
+            "rightAnkle": {
+              "x": 41.8,
+              "y": 114.8,
+              "v": 0.069
+            },
+            "leftHeel": {
+              "x": 62,
+              "y": 117,
+              "v": 0.037
+            },
+            "rightHeel": {
+              "x": 41.4,
+              "y": 118.5,
+              "v": 0.03
+            },
+            "leftFootIndex": {
+              "x": 67.4,
+              "y": 121,
+              "v": 0.055
+            },
+            "rightFootIndex": {
+              "x": 42.3,
+              "y": 123.1,
+              "v": 0.055
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58.1,
+                "y": 11.9
+              },
+              "roll": 176.5,
+              "yaw": 0.469,
+              "pitch": 0.726
+            },
+            "torso": {
+              "center": {
+                "x": 53.9,
+                "y": 26.5
+              },
+              "angle": 90.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.1,
+                "y": 28.4
+              },
+              "angle": 6.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.6,
+                "y": 43.5
+              },
+              "angle": 45
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.756,
+          "keypoints": {
+            "nose": {
+              "x": 59.6,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 60.2,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.3,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.7,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.3,
+              "y": 12,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.8,
+              "y": 26.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48,
+              "y": 28,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.4,
+              "y": 31.3,
+              "v": 0.84
+            },
+            "rightElbow": {
+              "x": 44.6,
+              "y": 38,
+              "v": 0.916
+            },
+            "leftWrist": {
+              "x": 88.4,
+              "y": 29,
+              "v": 0.908
+            },
+            "rightWrist": {
+              "x": 43.5,
+              "y": 35.4,
+              "v": 0.77
+            },
+            "leftIndex": {
+              "x": 93.5,
+              "y": 28.1,
+              "v": 0.914
+            },
+            "rightIndex": {
+              "x": 43.6,
+              "y": 33.5,
+              "v": 0.746
+            },
+            "leftHip": {
+              "x": 59.6,
+              "y": 61.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.1,
+              "y": 61.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 62.1,
+              "y": 85.9,
+              "v": 0.34
+            },
+            "rightKnee": {
+              "x": 54.6,
+              "y": 83.3,
+              "v": 0.613
+            },
+            "leftAnkle": {
+              "x": 61.6,
+              "y": 110,
+              "v": 0.332
+            },
+            "rightAnkle": {
+              "x": 50.3,
+              "y": 109.9,
+              "v": 0.556
+            },
+            "leftHeel": {
+              "x": 60.5,
+              "y": 114.1,
+              "v": 0.278
+            },
+            "rightHeel": {
+              "x": 49.2,
+              "y": 114,
+              "v": 0.339
+            },
+            "leftFootIndex": {
+              "x": 65,
+              "y": 116.3,
+              "v": 0.373
+            },
+            "rightFootIndex": {
+              "x": 52.6,
+              "y": 117.9,
+              "v": 0.474
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58.3,
+                "y": 10.2
+              },
+              "roll": 168.4,
+              "yaw": 0.339,
+              "pitch": 0.653
+            },
+            "torso": {
+              "center": {
+                "x": 55.4,
+                "y": 27.2
+              },
+              "angle": 89.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.4,
+                "y": 29
+              },
+              "angle": 10
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.5,
+                "y": 35.4
+              },
+              "angle": 87
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.6,
+                "y": 110
+              },
+              "angle": -61.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 49.2,
+                "y": 114
+              },
+              "angle": -48.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.712,
+          "keypoints": {
+            "nose": {
+              "x": 61.3,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.2,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.2,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.1,
+              "y": 13.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.4,
+              "y": 26.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.4,
+              "y": 27.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.4,
+              "y": 36.4,
+              "v": 0.862
+            },
+            "rightElbow": {
+              "x": 34.1,
+              "y": 40.9,
+              "v": 0.975
+            },
+            "leftWrist": {
+              "x": 88.5,
+              "y": 29.5,
+              "v": 0.941
+            },
+            "rightWrist": {
+              "x": 41.4,
+              "y": 41.8,
+              "v": 0.986
+            },
+            "leftIndex": {
+              "x": 94.1,
+              "y": 27.9,
+              "v": 0.961
+            },
+            "rightIndex": {
+              "x": 45,
+              "y": 40,
+              "v": 0.984
+            },
+            "leftHip": {
+              "x": 61.3,
+              "y": 60.5,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 50.2,
+              "y": 60.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63.1,
+              "y": 84.8,
+              "v": 0.203
+            },
+            "rightKnee": {
+              "x": 49.6,
+              "y": 82.9,
+              "v": 0.296
+            },
+            "leftAnkle": {
+              "x": 61.3,
+              "y": 108.7,
+              "v": 0.219
+            },
+            "rightAnkle": {
+              "x": 43.8,
+              "y": 106.5,
+              "v": 0.238
+            },
+            "leftHeel": {
+              "x": 60.1,
+              "y": 112.6,
+              "v": 0.182
+            },
+            "rightHeel": {
+              "x": 43.1,
+              "y": 110.3,
+              "v": 0.14
+            },
+            "leftFootIndex": {
+              "x": 62.7,
+              "y": 116.8,
+              "v": 0.226
+            },
+            "rightFootIndex": {
+              "x": 44.1,
+              "y": 114.4,
+              "v": 0.168
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.2,
+                "y": 11.1
+              },
+              "roll": -175.7,
+              "yaw": 0.524,
+              "pitch": 0.686
+            },
+            "torso": {
+              "center": {
+                "x": 56.4,
+                "y": 26.9
+              },
+              "angle": 88.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.5,
+                "y": 29.5
+              },
+              "angle": 15.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.4,
+                "y": 41.8
+              },
+              "angle": 26.6
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.782,
+          "keypoints": {
+            "nose": {
+              "x": 58,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.4,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.7,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.8,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.7,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.2,
+              "y": 26.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.6,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.9,
+              "y": 30.7,
+              "v": 0.863
+            },
+            "rightElbow": {
+              "x": 31,
+              "y": 42.6,
+              "v": 0.962
+            },
+            "leftWrist": {
+              "x": 89.2,
+              "y": 28.9,
+              "v": 0.923
+            },
+            "rightWrist": {
+              "x": 38.4,
+              "y": 44.8,
+              "v": 0.923
+            },
+            "leftIndex": {
+              "x": 95.5,
+              "y": 28.1,
+              "v": 0.919
+            },
+            "rightIndex": {
+              "x": 42.7,
+              "y": 43.8,
+              "v": 0.891
+            },
+            "leftHip": {
+              "x": 60,
+              "y": 62.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49,
+              "y": 62.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 64,
+              "y": 89,
+              "v": 0.426
+            },
+            "rightKnee": {
+              "x": 45.7,
+              "y": 86.8,
+              "v": 0.576
+            },
+            "leftAnkle": {
+              "x": 64.3,
+              "y": 112.7,
+              "v": 0.44
+            },
+            "rightAnkle": {
+              "x": 36.1,
+              "y": 112,
+              "v": 0.587
+            },
+            "leftHeel": {
+              "x": 62.9,
+              "y": 116.4,
+              "v": 0.33
+            },
+            "rightHeel": {
+              "x": 35.1,
+              "y": 115.8,
+              "v": 0.257
+            },
+            "leftFootIndex": {
+              "x": 70.2,
+              "y": 119.4,
+              "v": 0.428
+            },
+            "rightFootIndex": {
+              "x": 34.9,
+              "y": 120.7,
+              "v": 0.452
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.1,
+                "y": 11.3
+              },
+              "roll": 172.7,
+              "yaw": 0.201,
+              "pitch": 0.654
+            },
+            "torso": {
+              "center": {
+                "x": 52.9,
+                "y": 27.3
+              },
+              "angle": 92.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.2,
+                "y": 28.9
+              },
+              "angle": 7.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.4,
+                "y": 44.8
+              },
+              "angle": 13.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 62.9,
+                "y": 116.4
+              },
+              "angle": -22.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.1,
+                "y": 112
+              },
+              "angle": -97.9
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.843,
+          "keypoints": {
+            "nose": {
+              "x": 59.7,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 60.8,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.7,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.5,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.6,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 61.9,
+              "y": 25.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.6,
+              "y": 26.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.1,
+              "y": 33,
+              "v": 0.964
+            },
+            "rightElbow": {
+              "x": 39.4,
+              "y": 42.1,
+              "v": 0.927
+            },
+            "leftWrist": {
+              "x": 90.9,
+              "y": 30.2,
+              "v": 0.983
+            },
+            "rightWrist": {
+              "x": 28.4,
+              "y": 38.6,
+              "v": 0.961
+            },
+            "leftIndex": {
+              "x": 96.8,
+              "y": 29.5,
+              "v": 0.979
+            },
+            "rightIndex": {
+              "x": 24,
+              "y": 34.1,
+              "v": 0.963
+            },
+            "leftHip": {
+              "x": 61.5,
+              "y": 60.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.9,
+              "y": 60.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63,
+              "y": 87.6,
+              "v": 0.85
+            },
+            "rightKnee": {
+              "x": 48.8,
+              "y": 85.9,
+              "v": 0.616
+            },
+            "leftAnkle": {
+              "x": 60.7,
+              "y": 113,
+              "v": 0.61
+            },
+            "rightAnkle": {
+              "x": 44.8,
+              "y": 112.2,
+              "v": 0.544
+            },
+            "leftHeel": {
+              "x": 59.3,
+              "y": 116.7,
+              "v": 0.461
+            },
+            "rightHeel": {
+              "x": 45,
+              "y": 116.6,
+              "v": 0.353
+            },
+            "leftFootIndex": {
+              "x": 62.2,
+              "y": 120.2,
+              "v": 0.656
+            },
+            "rightFootIndex": {
+              "x": 42.3,
+              "y": 118.2,
+              "v": 0.516
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58.8,
+                "y": 12.2
+              },
+              "roll": 170.3,
+              "yaw": 0.228,
+              "pitch": 0.781
+            },
+            "torso": {
+              "center": {
+                "x": 53.8,
+                "y": 26.3
+              },
+              "angle": 94.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.9,
+                "y": 30.2
+              },
+              "angle": 6.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.4,
+                "y": 38.6
+              },
+              "angle": 134.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 59.3,
+                "y": 116.7
+              },
+              "angle": -50.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45,
+                "y": 116.6
+              },
+              "angle": -149.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.697,
+          "keypoints": {
+            "nose": {
+              "x": 57.9,
+              "y": 14,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 57.8,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.6,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 56.4,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.9,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 60.4,
+              "y": 26.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44.8,
+              "y": 27.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 68.9,
+              "y": 33.9,
+              "v": 0.518
+            },
+            "rightElbow": {
+              "x": 38.8,
+              "y": 38.5,
+              "v": 0.894
+            },
+            "leftWrist": {
+              "x": 80.1,
+              "y": 33.4,
+              "v": 0.859
+            },
+            "rightWrist": {
+              "x": 26.7,
+              "y": 36.9,
+              "v": 0.956
+            },
+            "leftIndex": {
+              "x": 83,
+              "y": 30.9,
+              "v": 0.866
+            },
+            "rightIndex": {
+              "x": 21.7,
+              "y": 33.1,
+              "v": 0.955
+            },
+            "leftHip": {
+              "x": 59.5,
+              "y": 61.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49,
+              "y": 61.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60.7,
+              "y": 87,
+              "v": 0.144
+            },
+            "rightKnee": {
+              "x": 46.8,
+              "y": 86.5,
+              "v": 0.334
+            },
+            "leftAnkle": {
+              "x": 59.1,
+              "y": 112,
+              "v": 0.15
+            },
+            "rightAnkle": {
+              "x": 42.5,
+              "y": 113.8,
+              "v": 0.386
+            },
+            "leftHeel": {
+              "x": 57.1,
+              "y": 115.5,
+              "v": 0.165
+            },
+            "rightHeel": {
+              "x": 40.9,
+              "y": 117.5,
+              "v": 0.171
+            },
+            "leftFootIndex": {
+              "x": 62.9,
+              "y": 118.7,
+              "v": 0.253
+            },
+            "rightFootIndex": {
+              "x": 44.9,
+              "y": 122.7,
+              "v": 0.39
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.2,
+                "y": 11.3
+              },
+              "roll": 172.9,
+              "yaw": 0.527,
+              "pitch": 0.837
+            },
+            "torso": {
+              "center": {
+                "x": 52.6,
+                "y": 27.1
+              },
+              "angle": 92.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.1,
+                "y": 33.4
+              },
+              "angle": 40.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 26.7,
+                "y": 36.9
+              },
+              "angle": 142.8
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 42.5,
+                "y": 113.8
+              },
+              "angle": -74.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.736,
+          "keypoints": {
+            "nose": {
+              "x": 55,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.2,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51.5,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 56,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46.7,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 57.2,
+              "y": 26.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 69.8,
+              "y": 33.6,
+              "v": 0.679
+            },
+            "rightElbow": {
+              "x": 27.9,
+              "y": 42.6,
+              "v": 0.944
+            },
+            "leftWrist": {
+              "x": 84.1,
+              "y": 31.7,
+              "v": 0.941
+            },
+            "rightWrist": {
+              "x": 36.4,
+              "y": 42,
+              "v": 0.881
+            },
+            "leftIndex": {
+              "x": 90.5,
+              "y": 29.5,
+              "v": 0.944
+            },
+            "rightIndex": {
+              "x": 39.9,
+              "y": 40.3,
+              "v": 0.833
+            },
+            "leftHip": {
+              "x": 57.2,
+              "y": 63.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.5,
+              "y": 64.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 61.2,
+              "y": 91.7,
+              "v": 0.167
+            },
+            "rightKnee": {
+              "x": 47.6,
+              "y": 89.4,
+              "v": 0.441
+            },
+            "leftAnkle": {
+              "x": 59.3,
+              "y": 114,
+              "v": 0.288
+            },
+            "rightAnkle": {
+              "x": 43.1,
+              "y": 115.6,
+              "v": 0.482
+            },
+            "leftHeel": {
+              "x": 57.4,
+              "y": 117.9,
+              "v": 0.289
+            },
+            "rightHeel": {
+              "x": 41.8,
+              "y": 119.5,
+              "v": 0.232
+            },
+            "leftFootIndex": {
+              "x": 64.5,
+              "y": 120.7,
+              "v": 0.386
+            },
+            "rightFootIndex": {
+              "x": 46.7,
+              "y": 124.4,
+              "v": 0.415
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.9,
+                "y": 11.2
+              },
+              "roll": -173.9,
+              "yaw": 0.243,
+              "pitch": 0.666
+            },
+            "torso": {
+              "center": {
+                "x": 49.6,
+                "y": 27.3
+              },
+              "angle": 93.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.1,
+                "y": 31.7
+              },
+              "angle": 19
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.4,
+                "y": 42
+              },
+              "angle": 25.9
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 43.1,
+                "y": 115.6
+              },
+              "angle": -67.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.865,
+          "keypoints": {
+            "nose": {
+              "x": 87.4,
+              "y": 30.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 88.4,
+              "y": 30.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 88.4,
+              "y": 29.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 88.2,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 87.7,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 81.7,
+              "y": 30.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 81.1,
+              "y": 27.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.8,
+              "y": 35.9,
+              "v": 0.147
+            },
+            "rightElbow": {
+              "x": 75.4,
+              "y": 35.5,
+              "v": 0.888
+            },
+            "leftWrist": {
+              "x": 75,
+              "y": 41.7,
+              "v": 0.446
+            },
+            "rightWrist": {
+              "x": 75.3,
+              "y": 44.1,
+              "v": 0.687
+            },
+            "leftIndex": {
+              "x": 75,
+              "y": 43.3,
+              "v": 0.557
+            },
+            "rightIndex": {
+              "x": 76.1,
+              "y": 46.6,
+              "v": 0.566
+            },
+            "leftHip": {
+              "x": 66.1,
+              "y": 33.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64.2,
+              "y": 30.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 64.2,
+              "y": 39,
+              "v": 0.884
+            },
+            "rightKnee": {
+              "x": 53.5,
+              "y": 32.2,
+              "v": 0.981
+            },
+            "leftAnkle": {
+              "x": 58.4,
+              "y": 48.6,
+              "v": 0.976
+            },
+            "rightAnkle": {
+              "x": 42.8,
+              "y": 31.5,
+              "v": 0.986
+            },
+            "leftHeel": {
+              "x": 56.6,
+              "y": 49.7,
+              "v": 0.946
+            },
+            "rightHeel": {
+              "x": 41.4,
+              "y": 31.4,
+              "v": 0.889
+            },
+            "leftFootIndex": {
+              "x": 58,
+              "y": 51.9,
+              "v": 0.976
+            },
+            "rightFootIndex": {
+              "x": 38.6,
+              "y": 32.5,
+              "v": 0.969
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 88.4,
+                "y": 29.8
+              },
+              "roll": 90,
+              "yaw": -1.667,
+              "pitch": 1.167
+            },
+            "torso": {
+              "center": {
+                "x": 81.4,
+                "y": 29.1
+              },
+              "angle": 9.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 75,
+                "y": 41.7
+              },
+              "angle": -90
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 75.3,
+                "y": 44.1
+              },
+              "angle": -72.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 56.6,
+                "y": 49.7
+              },
+              "angle": -57.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.4,
+                "y": 31.4
+              },
+              "angle": -158.6
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.75,
+          "keypoints": {
+            "nose": {
+              "x": 53.5,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.4,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 50,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.1,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 45.6,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 58.2,
+              "y": 26.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.6,
+              "y": 28.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.9,
+              "y": 31.9,
+              "v": 0.898
+            },
+            "rightElbow": {
+              "x": 32.9,
+              "y": 42.2,
+              "v": 0.846
+            },
+            "leftWrist": {
+              "x": 87.6,
+              "y": 30.2,
+              "v": 0.955
+            },
+            "rightWrist": {
+              "x": 22.8,
+              "y": 38.2,
+              "v": 0.941
+            },
+            "leftIndex": {
+              "x": 93.3,
+              "y": 29.3,
+              "v": 0.955
+            },
+            "rightIndex": {
+              "x": 17.8,
+              "y": 33.6,
+              "v": 0.945
+            },
+            "leftHip": {
+              "x": 56.3,
+              "y": 63.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.2,
+              "y": 63.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 57.7,
+              "y": 90,
+              "v": 0.443
+            },
+            "rightKnee": {
+              "x": 41,
+              "y": 87.6,
+              "v": 0.3
+            },
+            "leftAnkle": {
+              "x": 57.5,
+              "y": 112.7,
+              "v": 0.37
+            },
+            "rightAnkle": {
+              "x": 38.2,
+              "y": 112.7,
+              "v": 0.348
+            },
+            "leftHeel": {
+              "x": 55.7,
+              "y": 115.7,
+              "v": 0.309
+            },
+            "rightHeel": {
+              "x": 38.3,
+              "y": 116.3,
+              "v": 0.18
+            },
+            "leftFootIndex": {
+              "x": 61,
+              "y": 120.5,
+              "v": 0.444
+            },
+            "rightFootIndex": {
+              "x": 37.5,
+              "y": 121.3,
+              "v": 0.309
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 52.2,
+                "y": 11.4
+              },
+              "roll": -180,
+              "yaw": 0.295,
+              "pitch": 0.659
+            },
+            "torso": {
+              "center": {
+                "x": 48.9,
+                "y": 27.5
+              },
+              "angle": 92.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.6,
+                "y": 30.2
+              },
+              "angle": 9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 22.8,
+                "y": 38.2
+              },
+              "angle": 137.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 55.7,
+                "y": 115.7
+              },
+              "angle": -42.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.2,
+                "y": 112.7
+              },
+              "angle": -94.7
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.817,
+          "keypoints": {
+            "nose": {
+              "x": 54.1,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.8,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51.5,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.1,
+              "y": 13,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.1,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 53.8,
+              "y": 26.8,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 42,
+              "y": 26.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 59.5,
+              "y": 42.6,
+              "v": 0.066
+            },
+            "rightElbow": {
+              "x": 51.1,
+              "y": 44.9,
+              "v": 0.985
+            },
+            "leftWrist": {
+              "x": 69.9,
+              "y": 36.3,
+              "v": 0.185
+            },
+            "rightWrist": {
+              "x": 66,
+              "y": 36.7,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 74.7,
+              "y": 32.5,
+              "v": 0.324
+            },
+            "rightIndex": {
+              "x": 72,
+              "y": 33,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 55.2,
+              "y": 63.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48,
+              "y": 65.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 66.6,
+              "y": 84.9,
+              "v": 0.686
+            },
+            "rightKnee": {
+              "x": 67.4,
+              "y": 77.7,
+              "v": 0.935
+            },
+            "leftAnkle": {
+              "x": 67.6,
+              "y": 107,
+              "v": 0.737
+            },
+            "rightAnkle": {
+              "x": 77.5,
+              "y": 102.3,
+              "v": 0.847
+            },
+            "leftHeel": {
+              "x": 65.7,
+              "y": 111.3,
+              "v": 0.731
+            },
+            "rightHeel": {
+              "x": 76.9,
+              "y": 107.3,
+              "v": 0.731
+            },
+            "leftFootIndex": {
+              "x": 74.3,
+              "y": 111.5,
+              "v": 0.772
+            },
+            "rightFootIndex": {
+              "x": 88.1,
+              "y": 105.7,
+              "v": 0.802
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.2,
+                "y": 11.3
+              },
+              "roll": 160,
+              "yaw": 0.271,
+              "pitch": 0.797
+            },
+            "torso": {
+              "center": {
+                "x": 47.9,
+                "y": 26.7
+              },
+              "angle": 95.6
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 66,
+                "y": 36.7
+              },
+              "angle": 31.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 65.7,
+                "y": 111.3
+              },
+              "angle": -1.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 76.9,
+                "y": 107.3
+              },
+              "angle": 8.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.766,
+          "keypoints": {
+            "nose": {
+              "x": 69.2,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.1,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.5,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.7,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 69.9,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.6,
+              "y": 28.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.9,
+              "y": 45.1,
+              "v": 0.699
+            },
+            "rightElbow": {
+              "x": 51.6,
+              "y": 49.6,
+              "v": 0.888
+            },
+            "leftWrist": {
+              "x": 89.1,
+              "y": 39.1,
+              "v": 0.971
+            },
+            "rightWrist": {
+              "x": 40.1,
+              "y": 39.9,
+              "v": 0.985
+            },
+            "leftIndex": {
+              "x": 94.8,
+              "y": 33.8,
+              "v": 0.974
+            },
+            "rightIndex": {
+              "x": 34.4,
+              "y": 34.3,
+              "v": 0.986
+            },
+            "leftHip": {
+              "x": 69.7,
+              "y": 63.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.5,
+              "y": 63.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.2,
+              "y": 90.7,
+              "v": 0.494
+            },
+            "rightKnee": {
+              "x": 56.2,
+              "y": 87.6,
+              "v": 0.37
+            },
+            "leftAnkle": {
+              "x": 72.5,
+              "y": 112.2,
+              "v": 0.447
+            },
+            "rightAnkle": {
+              "x": 54.7,
+              "y": 111.9,
+              "v": 0.376
+            },
+            "leftHeel": {
+              "x": 70.7,
+              "y": 115.3,
+              "v": 0.347
+            },
+            "rightHeel": {
+              "x": 54.9,
+              "y": 115.4,
+              "v": 0.171
+            },
+            "leftFootIndex": {
+              "x": 76.3,
+              "y": 119.9,
+              "v": 0.546
+            },
+            "rightFootIndex": {
+              "x": 54,
+              "y": 120.1,
+              "v": 0.37
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.3,
+                "y": 10.8
+              },
+              "roll": -178.4,
+              "yaw": 0.528,
+              "pitch": 0.68
+            },
+            "torso": {
+              "center": {
+                "x": 62.3,
+                "y": 28.2
+              },
+              "angle": 93
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.1,
+                "y": 39.1
+              },
+              "angle": 42.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40.1,
+                "y": 39.9
+              },
+              "angle": 135.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.7,
+                "y": 115.3
+              },
+              "angle": -39.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 54.7,
+                "y": 111.9
+              },
+              "angle": -94.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.75,
+          "keypoints": {
+            "nose": {
+              "x": 61.2,
+              "y": 15.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.2,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.8,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.1,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.3,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.3,
+              "y": 24.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.5,
+              "y": 25.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 69.2,
+              "y": 43.6,
+              "v": 0.293
+            },
+            "rightElbow": {
+              "x": 39.8,
+              "y": 40.2,
+              "v": 0.904
+            },
+            "leftWrist": {
+              "x": 78.8,
+              "y": 34.7,
+              "v": 0.685
+            },
+            "rightWrist": {
+              "x": 30.6,
+              "y": 36.6,
+              "v": 0.959
+            },
+            "leftIndex": {
+              "x": 84.1,
+              "y": 30.7,
+              "v": 0.739
+            },
+            "rightIndex": {
+              "x": 25.3,
+              "y": 32.6,
+              "v": 0.968
+            },
+            "leftHip": {
+              "x": 57.9,
+              "y": 62.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.6,
+              "y": 60.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63.7,
+              "y": 87,
+              "v": 0.298
+            },
+            "rightKnee": {
+              "x": 81.1,
+              "y": 73.6,
+              "v": 0.557
+            },
+            "leftAnkle": {
+              "x": 55,
+              "y": 112.4,
+              "v": 0.427
+            },
+            "rightAnkle": {
+              "x": 67.5,
+              "y": 101.9,
+              "v": 0.444
+            },
+            "leftHeel": {
+              "x": 51,
+              "y": 115.5,
+              "v": 0.519
+            },
+            "rightHeel": {
+              "x": 62.8,
+              "y": 105.7,
+              "v": 0.341
+            },
+            "leftFootIndex": {
+              "x": 57.1,
+              "y": 119.3,
+              "v": 0.57
+            },
+            "rightFootIndex": {
+              "x": 72.3,
+              "y": 110.9,
+              "v": 0.548
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60,
+                "y": 11.8
+              },
+              "roll": -178.7,
+              "yaw": 0.273,
+              "pitch": 0.761
+            },
+            "torso": {
+              "center": {
+                "x": 54.9,
+                "y": 24.9
+              },
+              "angle": 90.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 78.8,
+                "y": 34.7
+              },
+              "angle": 37
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 30.6,
+                "y": 36.6
+              },
+              "angle": 143
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 51,
+                "y": 115.5
+              },
+              "angle": -31.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 62.8,
+                "y": 105.7
+              },
+              "angle": -28.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.758,
+          "keypoints": {
+            "nose": {
+              "x": 55.6,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.5,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 52.7,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.6,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 55.9,
+              "y": 26.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 65.2,
+              "y": 44.4,
+              "v": 0.418
+            },
+            "rightElbow": {
+              "x": 33.9,
+              "y": 45.8,
+              "v": 0.83
+            },
+            "leftWrist": {
+              "x": 77.5,
+              "y": 37,
+              "v": 0.835
+            },
+            "rightWrist": {
+              "x": 28.1,
+              "y": 38.6,
+              "v": 0.948
+            },
+            "leftIndex": {
+              "x": 81.9,
+              "y": 31.8,
+              "v": 0.846
+            },
+            "rightIndex": {
+              "x": 23.2,
+              "y": 33.6,
+              "v": 0.954
+            },
+            "leftHip": {
+              "x": 51.4,
+              "y": 63.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.3,
+              "y": 63.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60.7,
+              "y": 88.6,
+              "v": 0.408
+            },
+            "rightKnee": {
+              "x": 77.8,
+              "y": 70.6,
+              "v": 0.466
+            },
+            "leftAnkle": {
+              "x": 52.6,
+              "y": 112.9,
+              "v": 0.447
+            },
+            "rightAnkle": {
+              "x": 68.3,
+              "y": 100.4,
+              "v": 0.416
+            },
+            "leftHeel": {
+              "x": 47,
+              "y": 114.2,
+              "v": 0.483
+            },
+            "rightHeel": {
+              "x": 64,
+              "y": 105.2,
+              "v": 0.343
+            },
+            "leftFootIndex": {
+              "x": 54,
+              "y": 121,
+              "v": 0.552
+            },
+            "rightFootIndex": {
+              "x": 74.7,
+              "y": 108.3,
+              "v": 0.485
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.6,
+                "y": 11.6
+              },
+              "roll": 177,
+              "yaw": 0.263,
+              "pitch": 0.736
+            },
+            "torso": {
+              "center": {
+                "x": 50,
+                "y": 27.2
+              },
+              "angle": 89.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 77.5,
+                "y": 37
+              },
+              "angle": 49.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.1,
+                "y": 38.6
+              },
+              "angle": 134.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 47,
+                "y": 114.2
+              },
+              "angle": -44.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 64,
+                "y": 105.2
+              },
+              "angle": -16.2
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.709,
+          "keypoints": {
+            "nose": {
+              "x": 46.4,
+              "y": 15.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 47.6,
+              "y": 12,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 41.8,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 46,
+              "y": 13.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 37.1,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 48.6,
+              "y": 27.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 32.3,
+              "y": 29.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 58.4,
+              "y": 39.2,
+              "v": 0.155
+            },
+            "rightElbow": {
+              "x": 19.9,
+              "y": 41.6,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 69.4,
+              "y": 32.5,
+              "v": 0.331
+            },
+            "rightWrist": {
+              "x": 29.9,
+              "y": 49,
+              "v": 0.987
+            },
+            "leftIndex": {
+              "x": 73.8,
+              "y": 27.8,
+              "v": 0.4
+            },
+            "rightIndex": {
+              "x": 34.3,
+              "y": 49,
+              "v": 0.976
+            },
+            "leftHip": {
+              "x": 57,
+              "y": 55.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.1,
+              "y": 59.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.9,
+              "y": 64.2,
+              "v": 0.307
+            },
+            "rightKnee": {
+              "x": 56.4,
+              "y": 76.9,
+              "v": 0.683
+            },
+            "leftAnkle": {
+              "x": 81.4,
+              "y": 83.9,
+              "v": 0.371
+            },
+            "rightAnkle": {
+              "x": 57.6,
+              "y": 99.9,
+              "v": 0.518
+            },
+            "leftHeel": {
+              "x": 80.9,
+              "y": 89.3,
+              "v": 0.489
+            },
+            "rightHeel": {
+              "x": 58.3,
+              "y": 103.7,
+              "v": 0.241
+            },
+            "leftFootIndex": {
+              "x": 91.2,
+              "y": 84.1,
+              "v": 0.443
+            },
+            "rightFootIndex": {
+              "x": 59.2,
+              "y": 106.1,
+              "v": 0.401
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 44.7,
+                "y": 12.1
+              },
+              "roll": -178,
+              "yaw": 0.293,
+              "pitch": 0.551
+            },
+            "torso": {
+              "center": {
+                "x": 40.5,
+                "y": 28.7
+              },
+              "angle": 112.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 69.4,
+                "y": 32.5
+              },
+              "angle": 46.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.9,
+                "y": 49
+              },
+              "angle": 0
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80.9,
+                "y": 89.3
+              },
+              "angle": 26.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 57.6,
+                "y": 99.9
+              },
+              "angle": -75.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.715,
+          "keypoints": {
+            "nose": {
+              "x": 46.4,
+              "y": 15.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 48,
+              "y": 13,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 43.3,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 47,
+              "y": 14,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 38,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 48,
+              "y": 28.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 31.2,
+              "y": 28.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 61.2,
+              "y": 41.9,
+              "v": 0.463
+            },
+            "rightElbow": {
+              "x": 21.9,
+              "y": 43.5,
+              "v": 0.885
+            },
+            "leftWrist": {
+              "x": 70.8,
+              "y": 33.2,
+              "v": 0.747
+            },
+            "rightWrist": {
+              "x": 31.8,
+              "y": 49.4,
+              "v": 0.711
+            },
+            "leftIndex": {
+              "x": 75.1,
+              "y": 28,
+              "v": 0.727
+            },
+            "rightIndex": {
+              "x": 35.6,
+              "y": 49,
+              "v": 0.613
+            },
+            "leftHip": {
+              "x": 50.8,
+              "y": 60.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.7,
+              "y": 63.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63.4,
+              "y": 78.3,
+              "v": 0.361
+            },
+            "rightKnee": {
+              "x": 48.8,
+              "y": 83.9,
+              "v": 0.442
+            },
+            "leftAnkle": {
+              "x": 68.1,
+              "y": 95.5,
+              "v": 0.374
+            },
+            "rightAnkle": {
+              "x": 49.2,
+              "y": 104.8,
+              "v": 0.527
+            },
+            "leftHeel": {
+              "x": 67,
+              "y": 99.1,
+              "v": 0.453
+            },
+            "rightHeel": {
+              "x": 48.9,
+              "y": 108.2,
+              "v": 0.281
+            },
+            "leftFootIndex": {
+              "x": 74.7,
+              "y": 100.1,
+              "v": 0.463
+            },
+            "rightFootIndex": {
+              "x": 52.8,
+              "y": 111.7,
+              "v": 0.401
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 45.7,
+                "y": 12.5
+              },
+              "roll": 166.8,
+              "yaw": 0.155,
+              "pitch": 0.549
+            },
+            "torso": {
+              "center": {
+                "x": 39.6,
+                "y": 28.5
+              },
+              "angle": 102.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 70.8,
+                "y": 33.2
+              },
+              "angle": 50.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31.8,
+                "y": 49.4
+              },
+              "angle": 6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67,
+                "y": 99.1
+              },
+              "angle": -7.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 49.2,
+                "y": 104.8
+              },
+              "angle": -62.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.797,
+          "keypoints": {
+            "nose": {
+              "x": 39.3,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 41.4,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 35.8,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 41.3,
+              "y": 13.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 31.6,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 42.1,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 25.7,
+              "y": 29.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 57,
+              "y": 38,
+              "v": 0.591
+            },
+            "rightElbow": {
+              "x": 16.8,
+              "y": 48.4,
+              "v": 0.976
+            },
+            "leftWrist": {
+              "x": 67.7,
+              "y": 26.3,
+              "v": 0.954
+            },
+            "rightWrist": {
+              "x": 10.9,
+              "y": 30,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 70.8,
+              "y": 19.7,
+              "v": 0.974
+            },
+            "rightIndex": {
+              "x": 10.5,
+              "y": 22.1,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 49.7,
+              "y": 57.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 40.9,
+              "y": 61.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 67.6,
+              "y": 70.4,
+              "v": 0.167
+            },
+            "rightKnee": {
+              "x": 58.4,
+              "y": 75.1,
+              "v": 0.51
+            },
+            "leftAnkle": {
+              "x": 67.8,
+              "y": 92.3,
+              "v": 0.296
+            },
+            "rightAnkle": {
+              "x": 54.3,
+              "y": 104.2,
+              "v": 0.716
+            },
+            "leftHeel": {
+              "x": 66,
+              "y": 97,
+              "v": 0.503
+            },
+            "rightHeel": {
+              "x": 52.5,
+              "y": 109.3,
+              "v": 0.504
+            },
+            "leftFootIndex": {
+              "x": 75.3,
+              "y": 97.6,
+              "v": 0.481
+            },
+            "rightFootIndex": {
+              "x": 59,
+              "y": 111.7,
+              "v": 0.655
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 38.6,
+                "y": 12
+              },
+              "roll": 168.9,
+              "yaw": 0.123,
+              "pitch": 0.499
+            },
+            "torso": {
+              "center": {
+                "x": 33.9,
+                "y": 27.3
+              },
+              "angle": 109.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 67.7,
+                "y": 26.3
+              },
+              "angle": 64.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 10.9,
+                "y": 30
+              },
+              "angle": 92.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 66,
+                "y": 97
+              },
+              "angle": -3.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 52.5,
+                "y": 109.3
+              },
+              "angle": -20.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.676,
+          "keypoints": {
+            "nose": {
+              "x": 45.3,
+              "y": 16.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 45.9,
+              "y": 13.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 41.8,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 44.4,
+              "y": 13.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 36.7,
+              "y": 15.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 44.7,
+              "y": 27.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 31.5,
+              "y": 32.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 58.5,
+              "y": 38.5,
+              "v": 0.348
+            },
+            "rightElbow": {
+              "x": 22.6,
+              "y": 49.9,
+              "v": 0.97
+            },
+            "leftWrist": {
+              "x": 69.7,
+              "y": 28.4,
+              "v": 0.809
+            },
+            "rightWrist": {
+              "x": 17.7,
+              "y": 31,
+              "v": 0.955
+            },
+            "leftIndex": {
+              "x": 73,
+              "y": 22.3,
+              "v": 0.846
+            },
+            "rightIndex": {
+              "x": 17.8,
+              "y": 23.8,
+              "v": 0.915
+            },
+            "leftHip": {
+              "x": 56.2,
+              "y": 58.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.8,
+              "y": 64.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.1,
+              "y": 64,
+              "v": 0.202
+            },
+            "rightKnee": {
+              "x": 60.6,
+              "y": 79.7,
+              "v": 0.306
+            },
+            "leftAnkle": {
+              "x": 88,
+              "y": 84.8,
+              "v": 0.175
+            },
+            "rightAnkle": {
+              "x": 51.7,
+              "y": 105.9,
+              "v": 0.238
+            },
+            "leftHeel": {
+              "x": 88.4,
+              "y": 89.1,
+              "v": 0.239
+            },
+            "rightHeel": {
+              "x": 50.2,
+              "y": 110.4,
+              "v": 0.129
+            },
+            "leftFootIndex": {
+              "x": 94.6,
+              "y": 89.4,
+              "v": 0.229
+            },
+            "rightFootIndex": {
+              "x": 52.7,
+              "y": 112.5,
+              "v": 0.193
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 43.8,
+                "y": 13.4
+              },
+              "roll": -171.7,
+              "yaw": 0.35,
+              "pitch": 0.724
+            },
+            "torso": {
+              "center": {
+                "x": 38.1,
+                "y": 29.7
+              },
+              "angle": 113.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 69.7,
+                "y": 28.4
+              },
+              "angle": 61.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 17.7,
+                "y": 31
+              },
+              "angle": 89.2
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.898,
+          "keypoints": {
+            "nose": {
+              "x": 44.7,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 45.5,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 42.6,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 43.2,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 37.2,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 46.6,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 29.6,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 57.4,
+              "y": 32.9,
+              "v": 0.683
+            },
+            "rightElbow": {
+              "x": 20.8,
+              "y": 42.2,
+              "v": 0.99
+            },
+            "leftWrist": {
+              "x": 70.3,
+              "y": 25.6,
+              "v": 0.918
+            },
+            "rightWrist": {
+              "x": 16.7,
+              "y": 27.9,
+              "v": 0.979
+            },
+            "leftIndex": {
+              "x": 73.3,
+              "y": 19.7,
+              "v": 0.906
+            },
+            "rightIndex": {
+              "x": 17.7,
+              "y": 21.9,
+              "v": 0.956
+            },
+            "leftHip": {
+              "x": 56.9,
+              "y": 46,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.1,
+              "y": 52.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82,
+              "y": 44.9,
+              "v": 0.593
+            },
+            "rightKnee": {
+              "x": 75.6,
+              "y": 48.6,
+              "v": 0.916
+            },
+            "leftAnkle": {
+              "x": 100.4,
+              "y": 44.3,
+              "v": 0.647
+            },
+            "rightAnkle": {
+              "x": 101.4,
+              "y": 44.1,
+              "v": 0.915
+            },
+            "leftHeel": {
+              "x": 102.3,
+              "y": 46.5,
+              "v": 0.735
+            },
+            "rightHeel": {
+              "x": 105.6,
+              "y": 44.9,
+              "v": 0.867
+            },
+            "leftFootIndex": {
+              "x": 108.7,
+              "y": 39.6,
+              "v": 0.7
+            },
+            "rightFootIndex": {
+              "x": 107.9,
+              "y": 37.9,
+              "v": 0.858
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 44.1,
+                "y": 12
+              },
+              "roll": -168.3,
+              "yaw": 0.219,
+              "pitch": 1.148
+            },
+            "torso": {
+              "center": {
+                "x": 38.1,
+                "y": 25.8
+              },
+              "angle": 124.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 70.3,
+                "y": 25.6
+              },
+              "angle": 63
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 16.7,
+                "y": 27.9
+              },
+              "angle": 80.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 102.3,
+                "y": 46.5
+              },
+              "angle": 47.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 105.6,
+                "y": 44.9
+              },
+              "angle": 71.8
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.722,
+          "keypoints": {
+            "nose": {
+              "x": 68.6,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.8,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.9,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.8,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.4,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.7,
+              "y": 24.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.7,
+              "y": 27.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.3,
+              "y": 41.5,
+              "v": 0.597
+            },
+            "rightElbow": {
+              "x": 47.7,
+              "y": 45.8,
+              "v": 0.883
+            },
+            "leftWrist": {
+              "x": 89.5,
+              "y": 39.2,
+              "v": 0.906
+            },
+            "rightWrist": {
+              "x": 38.4,
+              "y": 40.1,
+              "v": 0.965
+            },
+            "leftIndex": {
+              "x": 95.1,
+              "y": 34.5,
+              "v": 0.908
+            },
+            "rightIndex": {
+              "x": 33.4,
+              "y": 35.1,
+              "v": 0.965
+            },
+            "leftHip": {
+              "x": 69.6,
+              "y": 60.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.8,
+              "y": 60.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.9,
+              "y": 87.2,
+              "v": 0.434
+            },
+            "rightKnee": {
+              "x": 56.7,
+              "y": 84,
+              "v": 0.282
+            },
+            "leftAnkle": {
+              "x": 74.5,
+              "y": 109.9,
+              "v": 0.397
+            },
+            "rightAnkle": {
+              "x": 53.5,
+              "y": 109.2,
+              "v": 0.201
+            },
+            "leftHeel": {
+              "x": 72.7,
+              "y": 113.4,
+              "v": 0.299
+            },
+            "rightHeel": {
+              "x": 53.4,
+              "y": 112.6,
+              "v": 0.089
+            },
+            "leftFootIndex": {
+              "x": 78.8,
+              "y": 116.3,
+              "v": 0.474
+            },
+            "rightFootIndex": {
+              "x": 52.9,
+              "y": 117,
+              "v": 0.209
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.4,
+                "y": 11.1
+              },
+              "roll": -175.3,
+              "yaw": 0.254,
+              "pitch": 0.61
+            },
+            "torso": {
+              "center": {
+                "x": 62.7,
+                "y": 26
+              },
+              "angle": 92.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.5,
+                "y": 39.2
+              },
+              "angle": 40
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.4,
+                "y": 40.1
+              },
+              "angle": 135
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.5,
+                "y": 109.9
+              },
+              "angle": -56.1
+            },
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.734,
+          "keypoints": {
+            "nose": {
+              "x": 56.4,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.3,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 52,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 56.1,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 60.4,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42.4,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.8,
+              "y": 42.8,
+              "v": 0.161
+            },
+            "rightElbow": {
+              "x": 34.6,
+              "y": 44.4,
+              "v": 0.87
+            },
+            "leftWrist": {
+              "x": 70.1,
+              "y": 42,
+              "v": 0.276
+            },
+            "rightWrist": {
+              "x": 25.3,
+              "y": 40,
+              "v": 0.977
+            },
+            "leftIndex": {
+              "x": 70.9,
+              "y": 43.4,
+              "v": 0.368
+            },
+            "rightIndex": {
+              "x": 21.2,
+              "y": 35.3,
+              "v": 0.979
+            },
+            "leftHip": {
+              "x": 57.4,
+              "y": 65.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.5,
+              "y": 64.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 61,
+              "y": 92.9,
+              "v": 0.591
+            },
+            "rightKnee": {
+              "x": 46.1,
+              "y": 91.1,
+              "v": 0.632
+            },
+            "leftAnkle": {
+              "x": 62.1,
+              "y": 115.7,
+              "v": 0.503
+            },
+            "rightAnkle": {
+              "x": 41.6,
+              "y": 116.3,
+              "v": 0.643
+            },
+            "leftHeel": {
+              "x": 60.5,
+              "y": 118.9,
+              "v": 0.414
+            },
+            "rightHeel": {
+              "x": 41.4,
+              "y": 120.2,
+              "v": 0.314
+            },
+            "leftFootIndex": {
+              "x": 65.8,
+              "y": 121.8,
+              "v": 0.576
+            },
+            "rightFootIndex": {
+              "x": 41.2,
+              "y": 124.7,
+              "v": 0.572
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.2,
+                "y": 11.6
+              },
+              "roll": -178.7,
+              "yaw": 0.523,
+              "pitch": 0.639
+            },
+            "torso": {
+              "center": {
+                "x": 51.4,
+                "y": 27.7
+              },
+              "angle": 90.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 25.3,
+                "y": 40
+              },
+              "angle": 131.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.5,
+                "y": 118.9
+              },
+              "angle": -28.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.4,
+                "y": 120.2
+              },
+              "angle": -92.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.746,
+          "keypoints": {
+            "nose": {
+              "x": 56.6,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.4,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 52.8,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.9,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.9,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 56.6,
+              "y": 23.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.1,
+              "y": 25.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 60.8,
+              "y": 38.8,
+              "v": 0.204
+            },
+            "rightElbow": {
+              "x": 42.2,
+              "y": 39.9,
+              "v": 0.815
+            },
+            "leftWrist": {
+              "x": 63.7,
+              "y": 39.5,
+              "v": 0.3
+            },
+            "rightWrist": {
+              "x": 44.4,
+              "y": 33.2,
+              "v": 0.76
+            },
+            "leftIndex": {
+              "x": 64.6,
+              "y": 38.3,
+              "v": 0.372
+            },
+            "rightIndex": {
+              "x": 44.6,
+              "y": 29.4,
+              "v": 0.755
+            },
+            "leftHip": {
+              "x": 56.9,
+              "y": 56.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.3,
+              "y": 56.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 61.1,
+              "y": 78.1,
+              "v": 0.662
+            },
+            "rightKnee": {
+              "x": 49.8,
+              "y": 78.3,
+              "v": 0.741
+            },
+            "leftAnkle": {
+              "x": 61.4,
+              "y": 102.6,
+              "v": 0.662
+            },
+            "rightAnkle": {
+              "x": 44.3,
+              "y": 104.6,
+              "v": 0.709
+            },
+            "leftHeel": {
+              "x": 60,
+              "y": 106.5,
+              "v": 0.521
+            },
+            "rightHeel": {
+              "x": 43.6,
+              "y": 108.4,
+              "v": 0.332
+            },
+            "leftFootIndex": {
+              "x": 65.4,
+              "y": 109.8,
+              "v": 0.675
+            },
+            "rightFootIndex": {
+              "x": 44.3,
+              "y": 113.1,
+              "v": 0.644
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.6,
+                "y": 11.8
+              },
+              "roll": 176.8,
+              "yaw": 0.555,
+              "pitch": 0.721
+            },
+            "torso": {
+              "center": {
+                "x": 49.9,
+                "y": 24.6
+              },
+              "angle": 94.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 63.7,
+                "y": 39.5
+              },
+              "angle": 53.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.4,
+                "y": 33.2
+              },
+              "angle": 87
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60,
+                "y": 106.5
+              },
+              "angle": -31.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.6,
+                "y": 108.4
+              },
+              "angle": -81.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.639,
+          "keypoints": {
+            "nose": {
+              "x": 53.2,
+              "y": 14.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 50.4,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.7,
+              "y": 13.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46.3,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 56.3,
+              "y": 23.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.9,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 60.1,
+              "y": 34.7,
+              "v": 0.41
+            },
+            "rightElbow": {
+              "x": 48.2,
+              "y": 35.4,
+              "v": 0.838
+            },
+            "leftWrist": {
+              "x": 60.9,
+              "y": 36.8,
+              "v": 0.299
+            },
+            "rightWrist": {
+              "x": 57,
+              "y": 31.6,
+              "v": 0.779
+            },
+            "leftIndex": {
+              "x": 60.8,
+              "y": 36.3,
+              "v": 0.38
+            },
+            "rightIndex": {
+              "x": 59.6,
+              "y": 29.2,
+              "v": 0.762
+            },
+            "leftHip": {
+              "x": 53.3,
+              "y": 48.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.1,
+              "y": 49.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60.3,
+              "y": 63.2,
+              "v": 0.271
+            },
+            "rightKnee": {
+              "x": 47.1,
+              "y": 67.8,
+              "v": 0.295
+            },
+            "leftAnkle": {
+              "x": 60.3,
+              "y": 82,
+              "v": 0.206
+            },
+            "rightAnkle": {
+              "x": 42.9,
+              "y": 87.9,
+              "v": 0.407
+            },
+            "leftHeel": {
+              "x": 58.9,
+              "y": 85.2,
+              "v": 0.263
+            },
+            "rightHeel": {
+              "x": 42.5,
+              "y": 91.6,
+              "v": 0.242
+            },
+            "leftFootIndex": {
+              "x": 63.2,
+              "y": 87.9,
+              "v": 0.229
+            },
+            "rightFootIndex": {
+              "x": 42.2,
+              "y": 93.9,
+              "v": 0.323
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 52.7,
+                "y": 12.3
+              },
+              "roll": 175,
+              "yaw": 0.108,
+              "pitch": 0.498
+            },
+            "torso": {
+              "center": {
+                "x": 50.1,
+                "y": 23.8
+              },
+              "angle": 88
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 57,
+                "y": 31.6
+              },
+              "angle": 42.7
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 42.9,
+                "y": 87.9
+              },
+              "angle": -96.7
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.677,
+          "keypoints": {
+            "nose": {
+              "x": 47.6,
+              "y": 14.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 49,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 44.5,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 48.9,
+              "y": 13.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 40.5,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 50.8,
+              "y": 28,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 34.7,
+              "y": 27.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 56.4,
+              "y": 43.5,
+              "v": 0.267
+            },
+            "rightElbow": {
+              "x": 26.9,
+              "y": 45,
+              "v": 0.829
+            },
+            "leftWrist": {
+              "x": 66.4,
+              "y": 40.8,
+              "v": 0.661
+            },
+            "rightWrist": {
+              "x": 20.8,
+              "y": 39.2,
+              "v": 0.958
+            },
+            "leftIndex": {
+              "x": 69.5,
+              "y": 37.9,
+              "v": 0.716
+            },
+            "rightIndex": {
+              "x": 15.7,
+              "y": 34.4,
+              "v": 0.957
+            },
+            "leftHip": {
+              "x": 49.2,
+              "y": 64.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 38.5,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 53.3,
+              "y": 93.2,
+              "v": 0.238
+            },
+            "rightKnee": {
+              "x": 37.8,
+              "y": 89.9,
+              "v": 0.294
+            },
+            "leftAnkle": {
+              "x": 50.8,
+              "y": 113.9,
+              "v": 0.248
+            },
+            "rightAnkle": {
+              "x": 33.2,
+              "y": 115.3,
+              "v": 0.379
+            },
+            "leftHeel": {
+              "x": 48.7,
+              "y": 116.8,
+              "v": 0.22
+            },
+            "rightHeel": {
+              "x": 32.3,
+              "y": 118.8,
+              "v": 0.156
+            },
+            "leftFootIndex": {
+              "x": 54.6,
+              "y": 120.2,
+              "v": 0.331
+            },
+            "rightFootIndex": {
+              "x": 34.3,
+              "y": 124.8,
+              "v": 0.327
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 46.8,
+                "y": 11.9
+              },
+              "roll": 173.7,
+              "yaw": 0.188,
+              "pitch": 0.607
+            },
+            "torso": {
+              "center": {
+                "x": 42.8,
+                "y": 27.6
+              },
+              "angle": 91.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 66.4,
+                "y": 40.8
+              },
+              "angle": 43.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 20.8,
+                "y": 39.2
+              },
+              "angle": 136.7
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 33.2,
+                "y": 115.3
+              },
+              "angle": -83.4
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.682,
+          "keypoints": {
+            "nose": {
+              "x": 68.5,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.8,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.2,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.5,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.8,
+              "y": 29,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78,
+              "y": 45.4,
+              "v": 0.457
+            },
+            "rightElbow": {
+              "x": 49.9,
+              "y": 49.9,
+              "v": 0.793
+            },
+            "leftWrist": {
+              "x": 90.3,
+              "y": 38.9,
+              "v": 0.91
+            },
+            "rightWrist": {
+              "x": 38.2,
+              "y": 40.3,
+              "v": 0.985
+            },
+            "leftIndex": {
+              "x": 95.3,
+              "y": 32.9,
+              "v": 0.943
+            },
+            "rightIndex": {
+              "x": 33.2,
+              "y": 35.5,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 68.6,
+              "y": 65.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.4,
+              "y": 65,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.1,
+              "y": 93.2,
+              "v": 0.136
+            },
+            "rightKnee": {
+              "x": 59.2,
+              "y": 90.7,
+              "v": 0.248
+            },
+            "leftAnkle": {
+              "x": 70.8,
+              "y": 113.6,
+              "v": 0.14
+            },
+            "rightAnkle": {
+              "x": 51.1,
+              "y": 115.1,
+              "v": 0.28
+            },
+            "leftHeel": {
+              "x": 69.2,
+              "y": 117,
+              "v": 0.185
+            },
+            "rightHeel": {
+              "x": 49.2,
+              "y": 118.9,
+              "v": 0.119
+            },
+            "leftFootIndex": {
+              "x": 74.8,
+              "y": 120.1,
+              "v": 0.261
+            },
+            "rightFootIndex": {
+              "x": 54.5,
+              "y": 123.1,
+              "v": 0.245
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.9,
+                "y": 11.1
+              },
+              "roll": 178.6,
+              "yaw": 0.381,
+              "pitch": 0.774
+            },
+            "torso": {
+              "center": {
+                "x": 63.2,
+                "y": 28.2
+              },
+              "angle": 91.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.3,
+                "y": 38.9
+              },
+              "angle": 50.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.2,
+                "y": 40.3
+              },
+              "angle": 136.2
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.696,
+          "keypoints": {
+            "nose": {
+              "x": 66.7,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.2,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62.4,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.7,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 58.9,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.3,
+              "y": 28.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.7,
+              "y": 29.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.6,
+              "y": 47,
+              "v": 0.533
+            },
+            "rightElbow": {
+              "x": 46.5,
+              "y": 47.8,
+              "v": 0.754
+            },
+            "leftWrist": {
+              "x": 90.4,
+              "y": 38.9,
+              "v": 0.89
+            },
+            "rightWrist": {
+              "x": 37.1,
+              "y": 40.7,
+              "v": 0.971
+            },
+            "leftIndex": {
+              "x": 95.9,
+              "y": 33.5,
+              "v": 0.903
+            },
+            "rightIndex": {
+              "x": 32.7,
+              "y": 35.1,
+              "v": 0.975
+            },
+            "leftHip": {
+              "x": 69.3,
+              "y": 64.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.7,
+              "y": 64.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.1,
+              "y": 92.5,
+              "v": 0.262
+            },
+            "rightKnee": {
+              "x": 55.5,
+              "y": 88.9,
+              "v": 0.212
+            },
+            "leftAnkle": {
+              "x": 72,
+              "y": 113.6,
+              "v": 0.255
+            },
+            "rightAnkle": {
+              "x": 51,
+              "y": 113.2,
+              "v": 0.269
+            },
+            "leftHeel": {
+              "x": 70.2,
+              "y": 116.9,
+              "v": 0.243
+            },
+            "rightHeel": {
+              "x": 50.2,
+              "y": 116.8,
+              "v": 0.116
+            },
+            "leftFootIndex": {
+              "x": 75.6,
+              "y": 120.8,
+              "v": 0.368
+            },
+            "rightFootIndex": {
+              "x": 51.6,
+              "y": 121.2,
+              "v": 0.247
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.3,
+                "y": 11.4
+              },
+              "roll": 178,
+              "yaw": 0.241,
+              "pitch": 0.569
+            },
+            "torso": {
+              "center": {
+                "x": 62.5,
+                "y": 28.8
+              },
+              "angle": 91.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.4,
+                "y": 38.9
+              },
+              "angle": 44.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.1,
+                "y": 40.7
+              },
+              "angle": 128.2
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.78,
+          "keypoints": {
+            "nose": {
+              "x": 72.2,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.3,
+              "y": 13.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.5,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.6,
+              "y": 15.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.5,
+              "y": 15.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.1,
+              "y": 30.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.9,
+              "y": 29.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 95.7,
+              "y": 41.5,
+              "v": 0.939
+            },
+            "rightElbow": {
+              "x": 46.8,
+              "y": 40.1,
+              "v": 0.933
+            },
+            "leftWrist": {
+              "x": 92.8,
+              "y": 21.7,
+              "v": 0.968
+            },
+            "rightWrist": {
+              "x": 32.3,
+              "y": 40.7,
+              "v": 0.967
+            },
+            "leftIndex": {
+              "x": 95.4,
+              "y": 15.5,
+              "v": 0.937
+            },
+            "rightIndex": {
+              "x": 27.2,
+              "y": 40.7,
+              "v": 0.956
+            },
+            "leftHip": {
+              "x": 73.5,
+              "y": 61.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.5,
+              "y": 61.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 88.6,
+              "y": 80.2,
+              "v": 0.388
+            },
+            "rightKnee": {
+              "x": 69.3,
+              "y": 81.8,
+              "v": 0.761
+            },
+            "leftAnkle": {
+              "x": 92,
+              "y": 106.4,
+              "v": 0.22
+            },
+            "rightAnkle": {
+              "x": 51.8,
+              "y": 108,
+              "v": 0.528
+            },
+            "leftHeel": {
+              "x": 88.9,
+              "y": 109,
+              "v": 0.275
+            },
+            "rightHeel": {
+              "x": 47.8,
+              "y": 111.5,
+              "v": 0.263
+            },
+            "leftFootIndex": {
+              "x": 99.5,
+              "y": 112.9,
+              "v": 0.332
+            },
+            "rightFootIndex": {
+              "x": 53.7,
+              "y": 117.4,
+              "v": 0.477
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.9,
+                "y": 13.7
+              },
+              "roll": 177.6,
+              "yaw": 0.271,
+              "pitch": 0.354
+            },
+            "torso": {
+              "center": {
+                "x": 69.5,
+                "y": 29.7
+              },
+              "angle": 87.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92.8,
+                "y": 21.7
+              },
+              "angle": 67.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.3,
+                "y": 40.7
+              },
+              "angle": -180
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 51.8,
+                "y": 108
+              },
+              "angle": -78.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.783,
+          "keypoints": {
+            "nose": {
+              "x": 85.2,
+              "y": 17.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 85,
+              "y": 14.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 81.9,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 83.4,
+              "y": 15.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 76.9,
+              "y": 15.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.7,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 68.8,
+              "y": 27.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.6,
+              "y": 43.1,
+              "v": 0.329
+            },
+            "rightElbow": {
+              "x": 54,
+              "y": 36.5,
+              "v": 0.979
+            },
+            "leftWrist": {
+              "x": 98.1,
+              "y": 39.3,
+              "v": 0.471
+            },
+            "rightWrist": {
+              "x": 39.8,
+              "y": 37.5,
+              "v": 0.979
+            },
+            "leftIndex": {
+              "x": 104.2,
+              "y": 36,
+              "v": 0.578
+            },
+            "rightIndex": {
+              "x": 32.6,
+              "y": 35.5,
+              "v": 0.976
+            },
+            "leftHip": {
+              "x": 72.7,
+              "y": 61.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64.9,
+              "y": 61.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.5,
+              "y": 85.3,
+              "v": 0.32
+            },
+            "rightKnee": {
+              "x": 81.7,
+              "y": 82.4,
+              "v": 0.78
+            },
+            "leftAnkle": {
+              "x": 53.8,
+              "y": 105.8,
+              "v": 0.287
+            },
+            "rightAnkle": {
+              "x": 64.7,
+              "y": 114.5,
+              "v": 0.81
+            },
+            "leftHeel": {
+              "x": 50,
+              "y": 108.2,
+              "v": 0.502
+            },
+            "rightHeel": {
+              "x": 60.5,
+              "y": 118.9,
+              "v": 0.694
+            },
+            "leftFootIndex": {
+              "x": 54.5,
+              "y": 114,
+              "v": 0.493
+            },
+            "rightFootIndex": {
+              "x": 66.9,
+              "y": 125.3,
+              "v": 0.808
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 83.5,
+                "y": 14.6
+              },
+              "roll": 169,
+              "yaw": 0.554,
+              "pitch": 0.95
+            },
+            "torso": {
+              "center": {
+                "x": 74.8,
+                "y": 27.5
+              },
+              "angle": 80
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.1,
+                "y": 39.3
+              },
+              "angle": 28.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.8,
+                "y": 37.5
+              },
+              "angle": 164.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 50,
+                "y": 108.2
+              },
+              "angle": -52.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 60.5,
+                "y": 118.9
+              },
+              "angle": -45
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.923,
+          "keypoints": {
+            "nose": {
+              "x": 100.9,
+              "y": 21.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 102.5,
+              "y": 19.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 99.7,
+              "y": 17.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 100.3,
+              "y": 18.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 94.8,
+              "y": 14.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 91.7,
+              "y": 29.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 77.5,
+              "y": 21.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.6,
+              "y": 51.2,
+              "v": 0.762
+            },
+            "rightElbow": {
+              "x": 55.9,
+              "y": 33.7,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 93.7,
+              "y": 69.1,
+              "v": 0.95
+            },
+            "rightWrist": {
+              "x": 37.8,
+              "y": 47.1,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 99.1,
+              "y": 75.4,
+              "v": 0.945
+            },
+            "rightIndex": {
+              "x": 32.3,
+              "y": 52.3,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 70.9,
+              "y": 58.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.5,
+              "y": 55.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.1,
+              "y": 84.1,
+              "v": 0.777
+            },
+            "rightKnee": {
+              "x": 68.9,
+              "y": 82.3,
+              "v": 0.949
+            },
+            "leftAnkle": {
+              "x": 60.1,
+              "y": 111.5,
+              "v": 0.76
+            },
+            "rightAnkle": {
+              "x": 51.7,
+              "y": 108,
+              "v": 0.879
+            },
+            "leftHeel": {
+              "x": 56,
+              "y": 114.2,
+              "v": 0.767
+            },
+            "rightHeel": {
+              "x": 47.4,
+              "y": 110.1,
+              "v": 0.702
+            },
+            "leftFootIndex": {
+              "x": 62.2,
+              "y": 123.1,
+              "v": 0.851
+            },
+            "rightFootIndex": {
+              "x": 52.6,
+              "y": 121.8,
+              "v": 0.885
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 101.1,
+                "y": 18.2
+              },
+              "roll": 143.1,
+              "yaw": -0.057,
+              "pitch": 0.986
+            },
+            "torso": {
+              "center": {
+                "x": 84.6,
+                "y": 25.4
+              },
+              "angle": 59.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.7,
+                "y": 69.1
+              },
+              "angle": -49.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.8,
+                "y": 47.1
+              },
+              "angle": -136.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 56,
+                "y": 114.2
+              },
+              "angle": -55.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.4,
+                "y": 110.1
+              },
+              "angle": -66
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.718,
+          "keypoints": {
+            "nose": {
+              "x": 71.4,
+              "y": 16.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.8,
+              "y": 14.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.7,
+              "y": 14,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.8,
+              "y": 15,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.7,
+              "y": 14.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 69.6,
+              "y": 27,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60,
+              "y": 27.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.4,
+              "y": 37.6,
+              "v": 0.568
+            },
+            "rightElbow": {
+              "x": 50.9,
+              "y": 43.8,
+              "v": 0.924
+            },
+            "leftWrist": {
+              "x": 88.6,
+              "y": 24.8,
+              "v": 0.929
+            },
+            "rightWrist": {
+              "x": 52,
+              "y": 52.2,
+              "v": 0.622
+            },
+            "leftIndex": {
+              "x": 93.7,
+              "y": 20.4,
+              "v": 0.92
+            },
+            "rightIndex": {
+              "x": 50.2,
+              "y": 51.4,
+              "v": 0.489
+            },
+            "leftHip": {
+              "x": 71.3,
+              "y": 60.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 68.1,
+              "y": 62.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.9,
+              "y": 78.9,
+              "v": 0.141
+            },
+            "rightKnee": {
+              "x": 81.6,
+              "y": 77.1,
+              "v": 0.539
+            },
+            "leftAnkle": {
+              "x": 73.2,
+              "y": 102,
+              "v": 0.185
+            },
+            "rightAnkle": {
+              "x": 72.6,
+              "y": 104.1,
+              "v": 0.508
+            },
+            "leftHeel": {
+              "x": 70.7,
+              "y": 105.7,
+              "v": 0.355
+            },
+            "rightHeel": {
+              "x": 69.6,
+              "y": 108.5,
+              "v": 0.481
+            },
+            "leftFootIndex": {
+              "x": 79.3,
+              "y": 108.6,
+              "v": 0.321
+            },
+            "rightFootIndex": {
+              "x": 76.5,
+              "y": 111.7,
+              "v": 0.54
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.3,
+                "y": 14.3
+              },
+              "roll": 170.8,
+              "yaw": 0.366,
+              "pitch": 0.844
+            },
+            "torso": {
+              "center": {
+                "x": 64.8,
+                "y": 27.2
+              },
+              "angle": 98.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.6,
+                "y": 24.8
+              },
+              "angle": 40.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52,
+                "y": 52.2
+              },
+              "angle": 156
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.7,
+                "y": 105.7
+              },
+              "angle": -18.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 69.6,
+                "y": 108.5
+              },
+              "angle": -24.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.707,
+          "keypoints": {
+            "nose": {
+              "x": 73.6,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.1,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.1,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.4,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.1,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.6,
+              "y": 27.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.9,
+              "y": 25.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.2,
+              "y": 43,
+              "v": 0.581
+            },
+            "rightElbow": {
+              "x": 49.9,
+              "y": 40.8,
+              "v": 0.949
+            },
+            "leftWrist": {
+              "x": 93,
+              "y": 32.9,
+              "v": 0.967
+            },
+            "rightWrist": {
+              "x": 40.1,
+              "y": 49.5,
+              "v": 0.966
+            },
+            "leftIndex": {
+              "x": 99,
+              "y": 29,
+              "v": 0.964
+            },
+            "rightIndex": {
+              "x": 34,
+              "y": 52.4,
+              "v": 0.944
+            },
+            "leftHip": {
+              "x": 72.9,
+              "y": 63.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.3,
+              "y": 62.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72,
+              "y": 88.9,
+              "v": 0.155
+            },
+            "rightKnee": {
+              "x": 57,
+              "y": 87,
+              "v": 0.161
+            },
+            "leftAnkle": {
+              "x": 63.3,
+              "y": 113.7,
+              "v": 0.233
+            },
+            "rightAnkle": {
+              "x": 48.2,
+              "y": 111.5,
+              "v": 0.273
+            },
+            "leftHeel": {
+              "x": 61,
+              "y": 117.1,
+              "v": 0.218
+            },
+            "rightHeel": {
+              "x": 45.3,
+              "y": 115.7,
+              "v": 0.155
+            },
+            "leftFootIndex": {
+              "x": 63,
+              "y": 122.2,
+              "v": 0.359
+            },
+            "rightFootIndex": {
+              "x": 47.6,
+              "y": 120.2,
+              "v": 0.336
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.6,
+                "y": 10.4
+              },
+              "roll": 170.5,
+              "yaw": 0.658,
+              "pitch": 0.773
+            },
+            "torso": {
+              "center": {
+                "x": 67.3,
+                "y": 26.9
+              },
+              "angle": 91.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93,
+                "y": 32.9
+              },
+              "angle": 33
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40.1,
+                "y": 49.5
+              },
+              "angle": -154.6
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.755,
+          "keypoints": {
+            "nose": {
+              "x": 102.6,
+              "y": 66,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 104.6,
+              "y": 69,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 105.2,
+              "y": 66.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 103.1,
+              "y": 72.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 104.6,
+              "y": 68.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 93.6,
+              "y": 78.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 91.6,
+              "y": 69.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.3,
+              "y": 82,
+              "v": 0.977
+            },
+            "rightElbow": {
+              "x": 77.9,
+              "y": 67,
+              "v": 0.148
+            },
+            "leftWrist": {
+              "x": 85,
+              "y": 87.8,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 80.4,
+              "y": 56.7,
+              "v": 0.964
+            },
+            "leftIndex": {
+              "x": 87.8,
+              "y": 91.3,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 84.1,
+              "y": 52.5,
+              "v": 0.967
+            },
+            "leftHip": {
+              "x": 58.5,
+              "y": 76.4,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 58.1,
+              "y": 70.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 34,
+              "y": 72.1,
+              "v": 0.581
+            },
+            "rightKnee": {
+              "x": 36.3,
+              "y": 70.4,
+              "v": 0.056
+            },
+            "leftAnkle": {
+              "x": 10.9,
+              "y": 77.2,
+              "v": 0.605
+            },
+            "rightAnkle": {
+              "x": 10.2,
+              "y": 78,
+              "v": 0.107
+            },
+            "leftHeel": {
+              "x": 8.6,
+              "y": 79.4,
+              "v": 0.647
+            },
+            "rightHeel": {
+              "x": 9.5,
+              "y": 79.5,
+              "v": 0.295
+            },
+            "leftFootIndex": {
+              "x": 3.1,
+              "y": 71.8,
+              "v": 0.753
+            },
+            "rightFootIndex": {
+              "x": 4.6,
+              "y": 71.7,
+              "v": 0.265
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 104.9,
+                "y": 68
+              },
+              "roll": 74.1,
+              "yaw": -1.053,
+              "pitch": -0.893
+            },
+            "torso": {
+              "center": {
+                "x": 92.6,
+                "y": 73.9
+              },
+              "angle": -0.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85,
+                "y": 87.8
+              },
+              "angle": -51.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 80.4,
+                "y": 56.7
+              },
+              "angle": 48.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 8.6,
+                "y": 79.4
+              },
+              "angle": 125.9
+            },
+            "rightFoot": null
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.731,
+          "keypoints": {
+            "nose": {
+              "x": 69.8,
+              "y": 14.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.4,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.8,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.2,
+              "y": 12.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.1,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.4,
+              "y": 28.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.9,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.5,
+              "y": 46.2,
+              "v": 0.532
+            },
+            "rightElbow": {
+              "x": 48.2,
+              "y": 48.1,
+              "v": 0.928
+            },
+            "leftWrist": {
+              "x": 90.3,
+              "y": 37.6,
+              "v": 0.947
+            },
+            "rightWrist": {
+              "x": 51.6,
+              "y": 35,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 95.2,
+              "y": 31.9,
+              "v": 0.953
+            },
+            "rightIndex": {
+              "x": 53.4,
+              "y": 28.5,
+              "v": 0.982
+            },
+            "leftHip": {
+              "x": 68.5,
+              "y": 66.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.2,
+              "y": 66.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.3,
+              "y": 93.8,
+              "v": 0.234
+            },
+            "rightKnee": {
+              "x": 57.1,
+              "y": 92.3,
+              "v": 0.356
+            },
+            "leftAnkle": {
+              "x": 72.1,
+              "y": 114.7,
+              "v": 0.28
+            },
+            "rightAnkle": {
+              "x": 51.2,
+              "y": 117.1,
+              "v": 0.456
+            },
+            "leftHeel": {
+              "x": 70.5,
+              "y": 117.8,
+              "v": 0.225
+            },
+            "rightHeel": {
+              "x": 50.3,
+              "y": 120.8,
+              "v": 0.198
+            },
+            "leftFootIndex": {
+              "x": 73.5,
+              "y": 121.2,
+              "v": 0.356
+            },
+            "rightFootIndex": {
+              "x": 51.3,
+              "y": 126.1,
+              "v": 0.388
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.6,
+                "y": 11.4
+              },
+              "roll": 173.7,
+              "yaw": 0.607,
+              "pitch": 0.856
+            },
+            "torso": {
+              "center": {
+                "x": 62.7,
+                "y": 28.3
+              },
+              "angle": 91
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.3,
+                "y": 37.6
+              },
+              "angle": 49.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 51.6,
+                "y": 35
+              },
+              "angle": 74.5
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 51.2,
+                "y": 117.1
+              },
+              "angle": -89.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.685,
+          "keypoints": {
+            "nose": {
+              "x": 67.9,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.8,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.1,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.3,
+              "y": 12,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.2,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 69.5,
+              "y": 27.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.4,
+              "y": 28.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.1,
+              "y": 46.2,
+              "v": 0.287
+            },
+            "rightElbow": {
+              "x": 45.6,
+              "y": 45.8,
+              "v": 0.801
+            },
+            "leftWrist": {
+              "x": 89.7,
+              "y": 38.3,
+              "v": 0.858
+            },
+            "rightWrist": {
+              "x": 39.3,
+              "y": 40.3,
+              "v": 0.966
+            },
+            "leftIndex": {
+              "x": 95.3,
+              "y": 32.7,
+              "v": 0.909
+            },
+            "rightIndex": {
+              "x": 33.7,
+              "y": 35.4,
+              "v": 0.971
+            },
+            "leftHip": {
+              "x": 68.4,
+              "y": 65.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.2,
+              "y": 65.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.4,
+              "y": 93.1,
+              "v": 0.153
+            },
+            "rightKnee": {
+              "x": 56.9,
+              "y": 89.6,
+              "v": 0.195
+            },
+            "leftAnkle": {
+              "x": 70.3,
+              "y": 113.5,
+              "v": 0.202
+            },
+            "rightAnkle": {
+              "x": 51.5,
+              "y": 113.9,
+              "v": 0.332
+            },
+            "leftHeel": {
+              "x": 68.1,
+              "y": 116.9,
+              "v": 0.249
+            },
+            "rightHeel": {
+              "x": 50,
+              "y": 117.7,
+              "v": 0.159
+            },
+            "leftFootIndex": {
+              "x": 75.1,
+              "y": 120.7,
+              "v": 0.355
+            },
+            "rightFootIndex": {
+              "x": 54,
+              "y": 122.2,
+              "v": 0.309
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.4,
+                "y": 10.8
+              },
+              "roll": -177.6,
+              "yaw": 0.308,
+              "pitch": 0.701
+            },
+            "torso": {
+              "center": {
+                "x": 62,
+                "y": 28.2
+              },
+              "angle": 91.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.7,
+                "y": 38.3
+              },
+              "angle": 45
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.3,
+                "y": 40.3
+              },
+              "angle": 138.8
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 51.5,
+                "y": 113.9
+              },
+              "angle": -73.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.669,
+          "keypoints": {
+            "nose": {
+              "x": 71.4,
+              "y": 25.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.3,
+              "y": 22.4,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 68.3,
+              "y": 22.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.9,
+              "y": 22.9,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 64.4,
+              "y": 23.2,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 74.2,
+              "y": 34,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.5,
+              "y": 37,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.4,
+              "y": 43.2,
+              "v": 0.876
+            },
+            "rightElbow": {
+              "x": 50.2,
+              "y": 51.1,
+              "v": 0.769
+            },
+            "leftWrist": {
+              "x": 88.2,
+              "y": 22,
+              "v": 0.982
+            },
+            "rightWrist": {
+              "x": 40.6,
+              "y": 51.4,
+              "v": 0.948
+            },
+            "leftIndex": {
+              "x": 90.7,
+              "y": 15.9,
+              "v": 0.973
+            },
+            "rightIndex": {
+              "x": 35.1,
+              "y": 48.6,
+              "v": 0.944
+            },
+            "leftHip": {
+              "x": 71.5,
+              "y": 68,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.8,
+              "y": 68.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.7,
+              "y": 92.7,
+              "v": 0.096
+            },
+            "rightKnee": {
+              "x": 56.5,
+              "y": 92.1,
+              "v": 0.116
+            },
+            "leftAnkle": {
+              "x": 70.8,
+              "y": 114.4,
+              "v": 0.081
+            },
+            "rightAnkle": {
+              "x": 53,
+              "y": 115.9,
+              "v": 0.158
+            },
+            "leftHeel": {
+              "x": 68.3,
+              "y": 117.4,
+              "v": 0.102
+            },
+            "rightHeel": {
+              "x": 51.4,
+              "y": 119.2,
+              "v": 0.076
+            },
+            "leftFootIndex": {
+              "x": 75.2,
+              "y": 120.9,
+              "v": 0.12
+            },
+            "rightFootIndex": {
+              "x": 54.9,
+              "y": 124.2,
+              "v": 0.145
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.8,
+                "y": 22.5
+              },
+              "roll": -174.3,
+              "yaw": 0.531,
+              "pitch": 0.879
+            },
+            "torso": {
+              "center": {
+                "x": 65.9,
+                "y": 35.5
+              },
+              "angle": 91.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.2,
+                "y": 22
+              },
+              "angle": 67.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40.6,
+                "y": 51.4
+              },
+              "angle": 153
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.707,
+          "keypoints": {
+            "nose": {
+              "x": 66.5,
+              "y": 14.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.7,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62.9,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.6,
+              "y": 13,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.1,
+              "y": 25.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.1,
+              "y": 29,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.8,
+              "y": 39.1,
+              "v": 0.758
+            },
+            "rightElbow": {
+              "x": 47.5,
+              "y": 46,
+              "v": 0.716
+            },
+            "leftWrist": {
+              "x": 87.5,
+              "y": 17.5,
+              "v": 0.937
+            },
+            "rightWrist": {
+              "x": 38,
+              "y": 39.4,
+              "v": 0.94
+            },
+            "leftIndex": {
+              "x": 92.8,
+              "y": 10.6,
+              "v": 0.939
+            },
+            "rightIndex": {
+              "x": 33.8,
+              "y": 33.9,
+              "v": 0.947
+            },
+            "leftHip": {
+              "x": 70,
+              "y": 63.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.4,
+              "y": 63.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.1,
+              "y": 89.8,
+              "v": 0.143
+            },
+            "rightKnee": {
+              "x": 56,
+              "y": 88.8,
+              "v": 0.19
+            },
+            "leftAnkle": {
+              "x": 68.6,
+              "y": 112.1,
+              "v": 0.235
+            },
+            "rightAnkle": {
+              "x": 51.8,
+              "y": 114.5,
+              "v": 0.359
+            },
+            "leftHeel": {
+              "x": 66.4,
+              "y": 115.3,
+              "v": 0.256
+            },
+            "rightHeel": {
+              "x": 51.1,
+              "y": 118.2,
+              "v": 0.188
+            },
+            "leftFootIndex": {
+              "x": 71.1,
+              "y": 119.4,
+              "v": 0.33
+            },
+            "rightFootIndex": {
+              "x": 51.8,
+              "y": 123.9,
+              "v": 0.323
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.3,
+                "y": 11.6
+              },
+              "roll": -172.9,
+              "yaw": 0.248,
+              "pitch": 0.6
+            },
+            "torso": {
+              "center": {
+                "x": 64.1,
+                "y": 27.4
+              },
+              "angle": 91
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.5,
+                "y": 17.5
+              },
+              "angle": 52.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38,
+                "y": 39.4
+              },
+              "angle": 127.4
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 51.8,
+                "y": 114.5
+              },
+              "angle": -90
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.833,
+          "keypoints": {
+            "nose": {
+              "x": 77.3,
+              "y": 17.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 78.2,
+              "y": 14.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 74.9,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 77.4,
+              "y": 14.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 71.1,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78.2,
+              "y": 26.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61.4,
+              "y": 25.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.9,
+              "y": 47.2,
+              "v": 0.927
+            },
+            "rightElbow": {
+              "x": 55.8,
+              "y": 44.6,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 86,
+              "y": 63.6,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 53.1,
+              "y": 63.2,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 87.1,
+              "y": 69.6,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 52.6,
+              "y": 69,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 74.7,
+              "y": 62.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.8,
+              "y": 62.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.9,
+              "y": 88.9,
+              "v": 0.415
+            },
+            "rightKnee": {
+              "x": 61.7,
+              "y": 89.4,
+              "v": 0.66
+            },
+            "leftAnkle": {
+              "x": 69.9,
+              "y": 113.7,
+              "v": 0.516
+            },
+            "rightAnkle": {
+              "x": 55.5,
+              "y": 116,
+              "v": 0.68
+            },
+            "leftHeel": {
+              "x": 67.6,
+              "y": 116.6,
+              "v": 0.341
+            },
+            "rightHeel": {
+              "x": 53.6,
+              "y": 118.1,
+              "v": 0.288
+            },
+            "leftFootIndex": {
+              "x": 72.2,
+              "y": 120.5,
+              "v": 0.669
+            },
+            "rightFootIndex": {
+              "x": 57.8,
+              "y": 124.8,
+              "v": 0.697
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 76.6,
+                "y": 14.3
+              },
+              "roll": 173.1,
+              "yaw": 0.226,
+              "pitch": 0.963
+            },
+            "torso": {
+              "center": {
+                "x": 69.8,
+                "y": 26.2
+              },
+              "angle": 89.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86,
+                "y": 63.6
+              },
+              "angle": -79.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 53.1,
+                "y": 63.2
+              },
+              "angle": -94.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.6,
+                "y": 116.6
+              },
+              "angle": -40.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 55.5,
+                "y": 116
+              },
+              "angle": -75.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.91,
+          "keypoints": {
+            "nose": {
+              "x": 87.8,
+              "y": 19.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 89.2,
+              "y": 16.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 86.3,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 87.3,
+              "y": 16.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 81.2,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 83.1,
+              "y": 29,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 66.6,
+              "y": 25.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.8,
+              "y": 48.9,
+              "v": 0.859
+            },
+            "rightElbow": {
+              "x": 56.2,
+              "y": 45.3,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 86.2,
+              "y": 63.2,
+              "v": 0.963
+            },
+            "rightWrist": {
+              "x": 52.3,
+              "y": 64.4,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 88.7,
+              "y": 68.9,
+              "v": 0.956
+            },
+            "rightIndex": {
+              "x": 52.3,
+              "y": 70.4,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 71,
+              "y": 64.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.2,
+              "y": 64,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.6,
+              "y": 92.4,
+              "v": 0.716
+            },
+            "rightKnee": {
+              "x": 60.3,
+              "y": 90.9,
+              "v": 0.891
+            },
+            "leftAnkle": {
+              "x": 68.6,
+              "y": 115.1,
+              "v": 0.763
+            },
+            "rightAnkle": {
+              "x": 54.2,
+              "y": 115.1,
+              "v": 0.883
+            },
+            "leftHeel": {
+              "x": 66.7,
+              "y": 118.4,
+              "v": 0.636
+            },
+            "rightHeel": {
+              "x": 52.4,
+              "y": 118.9,
+              "v": 0.619
+            },
+            "leftFootIndex": {
+              "x": 71.9,
+              "y": 123.7,
+              "v": 0.807
+            },
+            "rightFootIndex": {
+              "x": 58.2,
+              "y": 124,
+              "v": 0.831
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 87.8,
+                "y": 16.4
+              },
+              "roll": 159.2,
+              "yaw": 0.016,
+              "pitch": 1.048
+            },
+            "torso": {
+              "center": {
+                "x": 74.9,
+                "y": 27.3
+              },
+              "angle": 76
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.2,
+                "y": 63.2
+              },
+              "angle": -66.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52.3,
+                "y": 64.4
+              },
+              "angle": -90
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 66.7,
+                "y": 118.4
+              },
+              "angle": -45.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 52.4,
+                "y": 118.9
+              },
+              "angle": -41.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.844,
+          "keypoints": {
+            "nose": {
+              "x": 82.1,
+              "y": 17,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 83.8,
+              "y": 14.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 79.4,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 83.3,
+              "y": 15.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 75.5,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.6,
+              "y": 28.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63.7,
+              "y": 24,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.3,
+              "y": 48.9,
+              "v": 0.81
+            },
+            "rightElbow": {
+              "x": 53.9,
+              "y": 44.1,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 88.1,
+              "y": 64.2,
+              "v": 0.975
+            },
+            "rightWrist": {
+              "x": 50.5,
+              "y": 64.6,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 90,
+              "y": 70.3,
+              "v": 0.97
+            },
+            "rightIndex": {
+              "x": 50.8,
+              "y": 71,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 73.6,
+              "y": 64.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.5,
+              "y": 63.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.9,
+              "y": 90.4,
+              "v": 0.519
+            },
+            "rightKnee": {
+              "x": 60.4,
+              "y": 89.4,
+              "v": 0.783
+            },
+            "leftAnkle": {
+              "x": 69.7,
+              "y": 115.3,
+              "v": 0.527
+            },
+            "rightAnkle": {
+              "x": 55,
+              "y": 114.8,
+              "v": 0.707
+            },
+            "leftHeel": {
+              "x": 67.3,
+              "y": 118.6,
+              "v": 0.455
+            },
+            "rightHeel": {
+              "x": 52.5,
+              "y": 120,
+              "v": 0.367
+            },
+            "leftFootIndex": {
+              "x": 73.8,
+              "y": 121,
+              "v": 0.647
+            },
+            "rightFootIndex": {
+              "x": 58.5,
+              "y": 123.3,
+              "v": 0.66
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 81.6,
+                "y": 13.6
+              },
+              "roll": 155.6,
+              "yaw": 0.103,
+              "pitch": 0.703
+            },
+            "torso": {
+              "center": {
+                "x": 71.7,
+                "y": 26.4
+              },
+              "angle": 83.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.1,
+                "y": 64.2
+              },
+              "angle": -72.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.5,
+                "y": 64.6
+              },
+              "angle": -87.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.3,
+                "y": 118.6
+              },
+              "angle": -20.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 52.5,
+                "y": 120
+              },
+              "angle": -28.8
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.843,
+          "keypoints": {
+            "nose": {
+              "x": 69.1,
+              "y": 14.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.6,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.7,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.9,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.2,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 69.7,
+              "y": 27.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.6,
+              "y": 28.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.6,
+              "y": 44.6,
+              "v": 0.453
+            },
+            "rightElbow": {
+              "x": 47.8,
+              "y": 45.5,
+              "v": 0.851
+            },
+            "leftWrist": {
+              "x": 89.6,
+              "y": 38.8,
+              "v": 0.867
+            },
+            "rightWrist": {
+              "x": 38.4,
+              "y": 39.2,
+              "v": 0.96
+            },
+            "leftIndex": {
+              "x": 94.7,
+              "y": 34.3,
+              "v": 0.88
+            },
+            "rightIndex": {
+              "x": 33.1,
+              "y": 34.8,
+              "v": 0.963
+            },
+            "leftHip": {
+              "x": 68.7,
+              "y": 61.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.2,
+              "y": 62.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.3,
+              "y": 84.3,
+              "v": 0.601
+            },
+            "rightKnee": {
+              "x": 60.4,
+              "y": 86,
+              "v": 0.711
+            },
+            "leftAnkle": {
+              "x": 69.8,
+              "y": 107.3,
+              "v": 0.717
+            },
+            "rightAnkle": {
+              "x": 43.3,
+              "y": 105,
+              "v": 0.746
+            },
+            "leftHeel": {
+              "x": 66,
+              "y": 109.2,
+              "v": 0.682
+            },
+            "rightHeel": {
+              "x": 39.8,
+              "y": 107.2,
+              "v": 0.396
+            },
+            "leftFootIndex": {
+              "x": 72.1,
+              "y": 117.3,
+              "v": 0.81
+            },
+            "rightFootIndex": {
+              "x": 46.3,
+              "y": 115.7,
+              "v": 0.755
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.7,
+                "y": 11.7
+              },
+              "roll": 172.7,
+              "yaw": 0.369,
+              "pitch": 0.75
+            },
+            "torso": {
+              "center": {
+                "x": 62.2,
+                "y": 28
+              },
+              "angle": 93
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.6,
+                "y": 38.8
+              },
+              "angle": 41.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.4,
+                "y": 39.2
+              },
+              "angle": 140.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 66,
+                "y": 109.2
+              },
+              "angle": -53
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.8,
+                "y": 107.2
+              },
+              "angle": -52.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.788,
+          "keypoints": {
+            "nose": {
+              "x": 82.4,
+              "y": 14.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 81,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 79.8,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 78.2,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 75,
+              "y": 13,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 81.5,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 67.8,
+              "y": 26.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.8,
+              "y": 43,
+              "v": 0.611
+            },
+            "rightElbow": {
+              "x": 60.5,
+              "y": 41.2,
+              "v": 0.944
+            },
+            "leftWrist": {
+              "x": 94.6,
+              "y": 33.4,
+              "v": 0.919
+            },
+            "rightWrist": {
+              "x": 46.1,
+              "y": 33.7,
+              "v": 0.962
+            },
+            "leftIndex": {
+              "x": 97.7,
+              "y": 28.5,
+              "v": 0.902
+            },
+            "rightIndex": {
+              "x": 41,
+              "y": 30,
+              "v": 0.961
+            },
+            "leftHip": {
+              "x": 80.9,
+              "y": 59.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 71,
+              "y": 58.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 87.8,
+              "y": 77.5,
+              "v": 0.478
+            },
+            "rightKnee": {
+              "x": 74.9,
+              "y": 75.1,
+              "v": 0.513
+            },
+            "leftAnkle": {
+              "x": 77.6,
+              "y": 99.1,
+              "v": 0.491
+            },
+            "rightAnkle": {
+              "x": 64.2,
+              "y": 97.8,
+              "v": 0.426
+            },
+            "leftHeel": {
+              "x": 74.3,
+              "y": 102.3,
+              "v": 0.606
+            },
+            "rightHeel": {
+              "x": 62.3,
+              "y": 101.2,
+              "v": 0.298
+            },
+            "leftFootIndex": {
+              "x": 81.2,
+              "y": 106.2,
+              "v": 0.608
+            },
+            "rightFootIndex": {
+              "x": 64.2,
+              "y": 106.1,
+              "v": 0.409
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 80.4,
+                "y": 12.1
+              },
+              "roll": 175.2,
+              "yaw": 1.661,
+              "pitch": 2.035
+            },
+            "torso": {
+              "center": {
+                "x": 74.7,
+                "y": 26.8
+              },
+              "angle": 92.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.6,
+                "y": 33.4
+              },
+              "angle": 57.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 46.1,
+                "y": 33.7
+              },
+              "angle": 144
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.3,
+                "y": 102.3
+              },
+              "angle": -29.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 64.2,
+                "y": 97.8
+              },
+              "angle": -90
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.748,
+          "keypoints": {
+            "nose": {
+              "x": 79.4,
+              "y": 13,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.9,
+              "y": 11,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 77,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.6,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 74.3,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 81.2,
+              "y": 25.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 67.3,
+              "y": 24.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.3,
+              "y": 40,
+              "v": 0.679
+            },
+            "rightElbow": {
+              "x": 57,
+              "y": 36.9,
+              "v": 0.939
+            },
+            "leftWrist": {
+              "x": 94.4,
+              "y": 32.5,
+              "v": 0.904
+            },
+            "rightWrist": {
+              "x": 46.1,
+              "y": 33.4,
+              "v": 0.964
+            },
+            "leftIndex": {
+              "x": 97.5,
+              "y": 28.6,
+              "v": 0.91
+            },
+            "rightIndex": {
+              "x": 40.8,
+              "y": 30,
+              "v": 0.963
+            },
+            "leftHip": {
+              "x": 82.2,
+              "y": 57.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 71.7,
+              "y": 57,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.6,
+              "y": 79.3,
+              "v": 0.394
+            },
+            "rightKnee": {
+              "x": 70.4,
+              "y": 76.6,
+              "v": 0.535
+            },
+            "leftAnkle": {
+              "x": 74.6,
+              "y": 101.3,
+              "v": 0.256
+            },
+            "rightAnkle": {
+              "x": 59.1,
+              "y": 103.1,
+              "v": 0.378
+            },
+            "leftHeel": {
+              "x": 72.8,
+              "y": 104.6,
+              "v": 0.299
+            },
+            "rightHeel": {
+              "x": 58.1,
+              "y": 107.5,
+              "v": 0.273
+            },
+            "leftFootIndex": {
+              "x": 73.6,
+              "y": 107.2,
+              "v": 0.335
+            },
+            "rightFootIndex": {
+              "x": 54.8,
+              "y": 109.9,
+              "v": 0.38
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 77.5,
+                "y": 11.1
+              },
+              "roll": -173.7,
+              "yaw": 2.153,
+              "pitch": 2.153
+            },
+            "torso": {
+              "center": {
+                "x": 74.3,
+                "y": 25.4
+              },
+              "angle": 94.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.4,
+                "y": 32.5
+              },
+              "angle": 51.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 46.1,
+                "y": 33.4
+              },
+              "angle": 147.3
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 59.1,
+                "y": 103.1
+              },
+              "angle": -122.3
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/mao/poses.json
+++ b/public/assets/fighters/mao/poses.json
@@ -1,0 +1,6452 @@
+{
+  "version": 1,
+  "fighter": "mao",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:40:28.301Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.968,
+          "keypoints": {
+            "nose": {
+              "x": 70.5,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.5,
+              "y": 10.8,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 67,
+              "y": 11,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 69.3,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.5,
+              "y": 11.2,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 76.4,
+              "y": 25.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.9,
+              "y": 23.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.6,
+              "y": 42.7,
+              "v": 0.981
+            },
+            "rightElbow": {
+              "x": 34.7,
+              "y": 40.4,
+              "v": 0.989
+            },
+            "leftWrist": {
+              "x": 97.1,
+              "y": 37.2,
+              "v": 0.993
+            },
+            "rightWrist": {
+              "x": 54.8,
+              "y": 35,
+              "v": 0.972
+            },
+            "leftIndex": {
+              "x": 99.2,
+              "y": 31.7,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 62.2,
+              "y": 33.1,
+              "v": 0.95
+            },
+            "leftHip": {
+              "x": 68,
+              "y": 64.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.3,
+              "y": 63.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.5,
+              "y": 88.3,
+              "v": 0.906
+            },
+            "rightKnee": {
+              "x": 42.1,
+              "y": 90.6,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 86.4,
+              "y": 117.6,
+              "v": 0.932
+            },
+            "rightAnkle": {
+              "x": 30.7,
+              "y": 119.5,
+              "v": 0.988
+            },
+            "leftHeel": {
+              "x": 83.5,
+              "y": 124.2,
+              "v": 0.844
+            },
+            "rightHeel": {
+              "x": 29.8,
+              "y": 123.7,
+              "v": 0.851
+            },
+            "leftFootIndex": {
+              "x": 99.5,
+              "y": 123.9,
+              "v": 0.905
+            },
+            "rightFootIndex": {
+              "x": 28.4,
+              "y": 133.3,
+              "v": 0.971
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.8,
+                "y": 10.9
+              },
+              "roll": -176.7,
+              "yaw": 0.499,
+              "pitch": 0.77
+            },
+            "torso": {
+              "center": {
+                "x": 63.7,
+                "y": 24.6
+              },
+              "angle": 84.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.1,
+                "y": 37.2
+              },
+              "angle": 69.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 54.8,
+                "y": 35
+              },
+              "angle": 14.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.5,
+                "y": 124.2
+              },
+              "angle": 1.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29.8,
+                "y": 123.7
+              },
+              "angle": -98.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.992,
+          "keypoints": {
+            "nose": {
+              "x": 71.1,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.5,
+              "y": 9.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.1,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.3,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63,
+              "y": 11,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.2,
+              "y": 26.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.3,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.4,
+              "y": 42.8,
+              "v": 0.961
+            },
+            "rightElbow": {
+              "x": 35.3,
+              "y": 41.2,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 98.3,
+              "y": 36.3,
+              "v": 0.991
+            },
+            "rightWrist": {
+              "x": 55.2,
+              "y": 35,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 99.5,
+              "y": 32.4,
+              "v": 0.985
+            },
+            "rightIndex": {
+              "x": 60.9,
+              "y": 31.5,
+              "v": 0.974
+            },
+            "leftHip": {
+              "x": 67.2,
+              "y": 66.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52,
+              "y": 65.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.1,
+              "y": 88.9,
+              "v": 0.987
+            },
+            "rightKnee": {
+              "x": 41.9,
+              "y": 91.1,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 86.3,
+              "y": 116.3,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 29.7,
+              "y": 121.6,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 82.4,
+              "y": 123.1,
+              "v": 0.978
+            },
+            "rightHeel": {
+              "x": 28,
+              "y": 125.3,
+              "v": 0.979
+            },
+            "leftFootIndex": {
+              "x": 98.6,
+              "y": 123.3,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 30.7,
+              "y": 128.9,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.3,
+                "y": 9.5
+              },
+              "roll": -171,
+              "yaw": 0.404,
+              "pitch": 0.595
+            },
+            "torso": {
+              "center": {
+                "x": 63.8,
+                "y": 25.2
+              },
+              "angle": 84.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.3,
+                "y": 36.3
+              },
+              "angle": 72.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 55.2,
+                "y": 35
+              },
+              "angle": 31.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 82.4,
+                "y": 123.1
+              },
+              "angle": -0.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 28,
+                "y": 125.3
+              },
+              "angle": -53.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.975,
+          "keypoints": {
+            "nose": {
+              "x": 70.7,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.3,
+              "y": 9.7,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 67.4,
+              "y": 9.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.2,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.4,
+              "y": 10.6,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 76.4,
+              "y": 26.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.6,
+              "y": 23.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.3,
+              "y": 42.8,
+              "v": 0.979
+            },
+            "rightElbow": {
+              "x": 36.5,
+              "y": 39.9,
+              "v": 0.986
+            },
+            "leftWrist": {
+              "x": 97.1,
+              "y": 37.2,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 51.6,
+              "y": 32.7,
+              "v": 0.973
+            },
+            "leftIndex": {
+              "x": 99.6,
+              "y": 32.6,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 59.6,
+              "y": 30.8,
+              "v": 0.956
+            },
+            "leftHip": {
+              "x": 68.7,
+              "y": 65.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.7,
+              "y": 64.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.3,
+              "y": 90,
+              "v": 0.934
+            },
+            "rightKnee": {
+              "x": 41.3,
+              "y": 91,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 87.9,
+              "y": 118.1,
+              "v": 0.961
+            },
+            "rightAnkle": {
+              "x": 30.5,
+              "y": 121,
+              "v": 0.991
+            },
+            "leftHeel": {
+              "x": 85.1,
+              "y": 123.9,
+              "v": 0.876
+            },
+            "rightHeel": {
+              "x": 30.2,
+              "y": 125.3,
+              "v": 0.86
+            },
+            "leftFootIndex": {
+              "x": 98.9,
+              "y": 123.9,
+              "v": 0.948
+            },
+            "rightFootIndex": {
+              "x": 28.1,
+              "y": 133.6,
+              "v": 0.978
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.9,
+                "y": 9.6
+              },
+              "roll": 174.1,
+              "yaw": 0.635,
+              "pitch": 0.737
+            },
+            "torso": {
+              "center": {
+                "x": 64,
+                "y": 24.9
+              },
+              "angle": 85.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.1,
+                "y": 37.2
+              },
+              "angle": 61.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 51.6,
+                "y": 32.7
+              },
+              "angle": 13.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85.1,
+                "y": 123.9
+              },
+              "angle": 0
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.2,
+                "y": 125.3
+              },
+              "angle": -104.2
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.915,
+          "keypoints": {
+            "nose": {
+              "x": 69.8,
+              "y": 12,
+              "v": 0.998
+            },
+            "leftEye": {
+              "x": 71.8,
+              "y": 10.1,
+              "v": 0.996
+            },
+            "rightEye": {
+              "x": 67.4,
+              "y": 9.6,
+              "v": 0.998
+            },
+            "leftEar": {
+              "x": 71.4,
+              "y": 12.1,
+              "v": 0.997
+            },
+            "rightEar": {
+              "x": 62.8,
+              "y": 9.9,
+              "v": 0.995
+            },
+            "leftShoulder": {
+              "x": 75.5,
+              "y": 26.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.4,
+              "y": 21.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77,
+              "y": 45.9,
+              "v": 0.781
+            },
+            "rightElbow": {
+              "x": 36,
+              "y": 42.3,
+              "v": 0.971
+            },
+            "leftWrist": {
+              "x": 84.7,
+              "y": 61.5,
+              "v": 0.778
+            },
+            "rightWrist": {
+              "x": 54.7,
+              "y": 33.6,
+              "v": 0.961
+            },
+            "leftIndex": {
+              "x": 87.9,
+              "y": 63.8,
+              "v": 0.771
+            },
+            "rightIndex": {
+              "x": 60.9,
+              "y": 30.4,
+              "v": 0.936
+            },
+            "leftHip": {
+              "x": 68.1,
+              "y": 64.6,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 52.8,
+              "y": 64,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 80.3,
+              "y": 89.5,
+              "v": 0.855
+            },
+            "rightKnee": {
+              "x": 43.8,
+              "y": 92.3,
+              "v": 0.97
+            },
+            "leftAnkle": {
+              "x": 82.4,
+              "y": 118.6,
+              "v": 0.914
+            },
+            "rightAnkle": {
+              "x": 34.2,
+              "y": 120,
+              "v": 0.956
+            },
+            "leftHeel": {
+              "x": 78.8,
+              "y": 123.9,
+              "v": 0.759
+            },
+            "rightHeel": {
+              "x": 32.3,
+              "y": 123.6,
+              "v": 0.621
+            },
+            "leftFootIndex": {
+              "x": 93.4,
+              "y": 125,
+              "v": 0.877
+            },
+            "rightFootIndex": {
+              "x": 34.6,
+              "y": 129.7,
+              "v": 0.903
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.6,
+                "y": 9.9
+              },
+              "roll": 173.5,
+              "yaw": 0.045,
+              "pitch": 0.486
+            },
+            "torso": {
+              "center": {
+                "x": 62.5,
+                "y": 24.4
+              },
+              "angle": 87.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.7,
+                "y": 61.5
+              },
+              "angle": -35.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 54.7,
+                "y": 33.6
+              },
+              "angle": 27.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.8,
+                "y": 123.9
+              },
+              "angle": -4.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.3,
+                "y": 123.6
+              },
+              "angle": -69.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 72.4,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.4,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.3,
+              "y": 12,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.2,
+              "y": 12,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.9,
+              "y": 27,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.6,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.8,
+              "y": 42.9,
+              "v": 0.982
+            },
+            "rightElbow": {
+              "x": 36.2,
+              "y": 39.3,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 97.3,
+              "y": 36.6,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 51.8,
+              "y": 35.9,
+              "v": 0.99
+            },
+            "leftIndex": {
+              "x": 98.7,
+              "y": 32,
+              "v": 0.993
+            },
+            "rightIndex": {
+              "x": 58.2,
+              "y": 32.1,
+              "v": 0.982
+            },
+            "leftHip": {
+              "x": 67.4,
+              "y": 65.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.6,
+              "y": 65.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.6,
+              "y": 89.4,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 41.2,
+              "y": 91,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 86.7,
+              "y": 116.6,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 31.1,
+              "y": 119.5,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 83.6,
+              "y": 122.1,
+              "v": 0.989
+            },
+            "rightHeel": {
+              "x": 32.2,
+              "y": 121.7,
+              "v": 0.975
+            },
+            "leftFootIndex": {
+              "x": 98,
+              "y": 123.9,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 27.6,
+              "y": 128.8,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.2,
+                "y": 11.1
+              },
+              "roll": 172.9,
+              "yaw": 1.364,
+              "pitch": 1.923
+            },
+            "torso": {
+              "center": {
+                "x": 63.3,
+                "y": 25.8
+              },
+              "angle": 85.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.3,
+                "y": 36.6
+              },
+              "angle": 73.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 51.8,
+                "y": 35.9
+              },
+              "angle": 30.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.6,
+                "y": 122.1
+              },
+              "angle": -7.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.2,
+                "y": 121.7
+              },
+              "angle": -122.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.99,
+          "keypoints": {
+            "nose": {
+              "x": 72.1,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.5,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.8,
+              "y": 12,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.8,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.2,
+              "y": 26.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.3,
+              "y": 23.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.1,
+              "y": 42.3,
+              "v": 0.978
+            },
+            "rightElbow": {
+              "x": 37,
+              "y": 39.4,
+              "v": 0.991
+            },
+            "leftWrist": {
+              "x": 97.4,
+              "y": 36.7,
+              "v": 0.991
+            },
+            "rightWrist": {
+              "x": 47.6,
+              "y": 30,
+              "v": 0.977
+            },
+            "leftIndex": {
+              "x": 99.4,
+              "y": 32.5,
+              "v": 0.985
+            },
+            "rightIndex": {
+              "x": 51.9,
+              "y": 25.1,
+              "v": 0.968
+            },
+            "leftHip": {
+              "x": 68,
+              "y": 66.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.7,
+              "y": 66,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80,
+              "y": 88.7,
+              "v": 0.989
+            },
+            "rightKnee": {
+              "x": 42.3,
+              "y": 90.6,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 85.7,
+              "y": 116.4,
+              "v": 0.987
+            },
+            "rightAnkle": {
+              "x": 30.9,
+              "y": 121.4,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 82.8,
+              "y": 123.2,
+              "v": 0.967
+            },
+            "rightHeel": {
+              "x": 30.8,
+              "y": 125.3,
+              "v": 0.971
+            },
+            "leftFootIndex": {
+              "x": 97.4,
+              "y": 123.4,
+              "v": 0.983
+            },
+            "rightFootIndex": {
+              "x": 27.9,
+              "y": 131.7,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.8,
+                "y": 11.2
+              },
+              "roll": 172.4,
+              "yaw": 1.553,
+              "pitch": 1.652
+            },
+            "torso": {
+              "center": {
+                "x": 63.8,
+                "y": 25.4
+              },
+              "angle": 85.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.4,
+                "y": 36.7
+              },
+              "angle": 64.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.6,
+                "y": 30
+              },
+              "angle": 48.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 82.8,
+                "y": 123.2
+              },
+              "angle": -0.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.8,
+                "y": 125.3
+              },
+              "angle": -114.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.991,
+          "keypoints": {
+            "nose": {
+              "x": 71.8,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.8,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.3,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.2,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.9,
+              "y": 26.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.4,
+              "y": 24.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.4,
+              "y": 42.3,
+              "v": 0.976
+            },
+            "rightElbow": {
+              "x": 35.6,
+              "y": 40.8,
+              "v": 0.994
+            },
+            "leftWrist": {
+              "x": 96.7,
+              "y": 37.5,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 55.3,
+              "y": 35,
+              "v": 0.989
+            },
+            "leftIndex": {
+              "x": 99.1,
+              "y": 32.4,
+              "v": 0.99
+            },
+            "rightIndex": {
+              "x": 60.9,
+              "y": 31.7,
+              "v": 0.978
+            },
+            "leftHip": {
+              "x": 68.4,
+              "y": 66.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.3,
+              "y": 65.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81,
+              "y": 89,
+              "v": 0.986
+            },
+            "rightKnee": {
+              "x": 41.9,
+              "y": 90.4,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 86.3,
+              "y": 116.4,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 31.1,
+              "y": 119.7,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 83.5,
+              "y": 122.6,
+              "v": 0.967
+            },
+            "rightHeel": {
+              "x": 30.9,
+              "y": 124.4,
+              "v": 0.953
+            },
+            "leftFootIndex": {
+              "x": 97.9,
+              "y": 123.5,
+              "v": 0.985
+            },
+            "rightFootIndex": {
+              "x": 28,
+              "y": 128.2,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.4,
+                "y": 10.3
+              },
+              "roll": 178,
+              "yaw": 0.857,
+              "pitch": 0.767
+            },
+            "torso": {
+              "center": {
+                "x": 63.2,
+                "y": 25.5
+              },
+              "angle": 86.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.7,
+                "y": 37.5
+              },
+              "angle": 64.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 55.3,
+                "y": 35
+              },
+              "angle": 30.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.5,
+                "y": 122.6
+              },
+              "angle": -3.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.9,
+                "y": 124.4
+              },
+              "angle": -127.3
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.971,
+          "keypoints": {
+            "nose": {
+              "x": 64.5,
+              "y": 14.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.4,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 60.9,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.2,
+              "y": 13,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.2,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.5,
+              "y": 26.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.7,
+              "y": 25.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85,
+              "y": 29.7,
+              "v": 0.988
+            },
+            "rightElbow": {
+              "x": 31.9,
+              "y": 37.7,
+              "v": 0.986
+            },
+            "leftWrist": {
+              "x": 101.6,
+              "y": 30.1,
+              "v": 0.985
+            },
+            "rightWrist": {
+              "x": 47.7,
+              "y": 33.6,
+              "v": 0.95
+            },
+            "leftIndex": {
+              "x": 106.9,
+              "y": 31.2,
+              "v": 0.98
+            },
+            "rightIndex": {
+              "x": 52.9,
+              "y": 30.2,
+              "v": 0.912
+            },
+            "leftHip": {
+              "x": 59.1,
+              "y": 58.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.7,
+              "y": 57.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71,
+              "y": 82.6,
+              "v": 0.954
+            },
+            "rightKnee": {
+              "x": 37.7,
+              "y": 78.6,
+              "v": 0.98
+            },
+            "leftAnkle": {
+              "x": 72.6,
+              "y": 103,
+              "v": 0.978
+            },
+            "rightAnkle": {
+              "x": 32,
+              "y": 98,
+              "v": 0.977
+            },
+            "leftHeel": {
+              "x": 68.7,
+              "y": 110.3,
+              "v": 0.913
+            },
+            "rightHeel": {
+              "x": 32.1,
+              "y": 102.8,
+              "v": 0.843
+            },
+            "leftFootIndex": {
+              "x": 76.3,
+              "y": 113.2,
+              "v": 0.955
+            },
+            "rightFootIndex": {
+              "x": 28.5,
+              "y": 106.8,
+              "v": 0.941
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.7,
+                "y": 12.5
+              },
+              "roll": 178.4,
+              "yaw": 0.528,
+              "pitch": 0.7
+            },
+            "torso": {
+              "center": {
+                "x": 56.6,
+                "y": 26.1
+              },
+              "angle": 83.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 101.6,
+                "y": 30.1
+              },
+              "angle": -11.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.7,
+                "y": 33.6
+              },
+              "angle": 33.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.7,
+                "y": 110.3
+              },
+              "angle": -20.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.1,
+                "y": 102.8
+              },
+              "angle": -132
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.725,
+          "keypoints": {
+            "nose": {
+              "x": 35.3,
+              "y": 37,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 32.4,
+              "y": 35.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 34.6,
+              "y": 38.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 31.7,
+              "y": 34.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 35.2,
+              "y": 39.4,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 38.5,
+              "y": 22.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.6,
+              "y": 40.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 51.1,
+              "y": 15.8,
+              "v": 0.896
+            },
+            "rightElbow": {
+              "x": 52.4,
+              "y": 44.1,
+              "v": 0.446
+            },
+            "leftWrist": {
+              "x": 57.7,
+              "y": 16,
+              "v": 0.722
+            },
+            "rightWrist": {
+              "x": 54.1,
+              "y": 39.5,
+              "v": 0.259
+            },
+            "leftIndex": {
+              "x": 60.5,
+              "y": 17.4,
+              "v": 0.702
+            },
+            "rightIndex": {
+              "x": 53.2,
+              "y": 37,
+              "v": 0.263
+            },
+            "leftHip": {
+              "x": 64.5,
+              "y": 26,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64.6,
+              "y": 33.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.2,
+              "y": 29.7,
+              "v": 0.438
+            },
+            "rightKnee": {
+              "x": 82.9,
+              "y": 33.1,
+              "v": 0.288
+            },
+            "leftAnkle": {
+              "x": 103.4,
+              "y": 32.3,
+              "v": 0.747
+            },
+            "rightAnkle": {
+              "x": 103.3,
+              "y": 32.8,
+              "v": 0.665
+            },
+            "leftHeel": {
+              "x": 106.2,
+              "y": 32,
+              "v": 0.425
+            },
+            "rightHeel": {
+              "x": 106,
+              "y": 32.3,
+              "v": 0.398
+            },
+            "leftFootIndex": {
+              "x": 108.2,
+              "y": 34.7,
+              "v": 0.762
+            },
+            "rightFootIndex": {
+              "x": 107.8,
+              "y": 33.9,
+              "v": 0.674
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 33.5,
+                "y": 37.3
+              },
+              "roll": -51.8,
+              "yaw": 0.505,
+              "pitch": -0.084
+            },
+            "torso": {
+              "center": {
+                "x": 40.1,
+                "y": 31.5
+              },
+              "angle": -176.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 57.7,
+                "y": 16
+              },
+              "angle": -26.6
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 106.2,
+                "y": 32
+              },
+              "angle": -53.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 106,
+                "y": 32.3
+              },
+              "angle": -41.6
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 65.2,
+              "y": 16.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.9,
+              "y": 13.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62.9,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 62.1,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.6,
+              "y": 13.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.3,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44.6,
+              "y": 25.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.6,
+              "y": 27.5,
+              "v": 0.997
+            },
+            "rightElbow": {
+              "x": 30.1,
+              "y": 39.5,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 103.5,
+              "y": 28.5,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 47.1,
+              "y": 36.4,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 108.8,
+              "y": 29.1,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 52.7,
+              "y": 32.8,
+              "v": 0.987
+            },
+            "leftHip": {
+              "x": 61.1,
+              "y": 63.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.8,
+              "y": 63.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.6,
+              "y": 89,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 35.3,
+              "y": 90.8,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 79.6,
+              "y": 118.3,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 25.9,
+              "y": 115.1,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 76.7,
+              "y": 123.5,
+              "v": 0.982
+            },
+            "rightHeel": {
+              "x": 24.3,
+              "y": 123.5,
+              "v": 0.942
+            },
+            "leftFootIndex": {
+              "x": 91.3,
+              "y": 123.1,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 22.2,
+              "y": 126.3,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.9,
+                "y": 13.5
+              },
+              "roll": -174.3,
+              "yaw": 0.647,
+              "pitch": 1.443
+            },
+            "torso": {
+              "center": {
+                "x": 56.5,
+                "y": 25.3
+              },
+              "angle": 86.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.5,
+                "y": 28.5
+              },
+              "angle": -6.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.1,
+                "y": 36.4
+              },
+              "angle": 32.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.7,
+                "y": 123.5
+              },
+              "angle": 1.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 24.3,
+                "y": 123.5
+              },
+              "angle": -126.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.818,
+          "keypoints": {
+            "nose": {
+              "x": 62.3,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.7,
+              "y": 13.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60.2,
+              "y": 13.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.3,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.2,
+              "y": 23.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.3,
+              "y": 33.1,
+              "v": 0.287
+            },
+            "rightElbow": {
+              "x": 43.6,
+              "y": 36,
+              "v": 0.89
+            },
+            "leftWrist": {
+              "x": 63.7,
+              "y": 36.4,
+              "v": 0.277
+            },
+            "rightWrist": {
+              "x": 36.7,
+              "y": 39.4,
+              "v": 0.887
+            },
+            "leftIndex": {
+              "x": 63.4,
+              "y": 36.4,
+              "v": 0.336
+            },
+            "rightIndex": {
+              "x": 34.4,
+              "y": 39.2,
+              "v": 0.876
+            },
+            "leftHip": {
+              "x": 57.1,
+              "y": 49.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.8,
+              "y": 51.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.6,
+              "y": 67.6,
+              "v": 0.744
+            },
+            "rightKnee": {
+              "x": 67,
+              "y": 66.7,
+              "v": 0.786
+            },
+            "leftAnkle": {
+              "x": 70.3,
+              "y": 86.8,
+              "v": 0.888
+            },
+            "rightAnkle": {
+              "x": 71.5,
+              "y": 84.2,
+              "v": 0.841
+            },
+            "leftHeel": {
+              "x": 69.8,
+              "y": 89.9,
+              "v": 0.729
+            },
+            "rightHeel": {
+              "x": 71.2,
+              "y": 86.8,
+              "v": 0.606
+            },
+            "leftFootIndex": {
+              "x": 73.8,
+              "y": 92.9,
+              "v": 0.877
+            },
+            "rightFootIndex": {
+              "x": 76.1,
+              "y": 89.6,
+              "v": 0.782
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 61.4,
+                "y": 13.6
+              },
+              "roll": -150.3,
+              "yaw": 1.178,
+              "pitch": 2.605
+            },
+            "torso": {
+              "center": {
+                "x": 54.6,
+                "y": 23.9
+              },
+              "angle": 89.7
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 36.7,
+                "y": 39.4
+              },
+              "angle": 175
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.8,
+                "y": 89.9
+              },
+              "angle": -36.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 71.2,
+                "y": 86.8
+              },
+              "angle": -29.7
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 64.8,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64,
+              "y": 9.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62.7,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.2,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.7,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.3,
+              "y": 24.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.5,
+              "y": 25,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.5,
+              "y": 25.5,
+              "v": 0.999
+            },
+            "rightElbow": {
+              "x": 37.8,
+              "y": 35.2,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 103.5,
+              "y": 26.3,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 31.2,
+              "y": 39.7,
+              "v": 0.969
+            },
+            "leftIndex": {
+              "x": 108.4,
+              "y": 27.1,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 29.1,
+              "y": 40.2,
+              "v": 0.96
+            },
+            "leftHip": {
+              "x": 60.8,
+              "y": 53.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.5,
+              "y": 52.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.6,
+              "y": 78.7,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 44,
+              "y": 73.1,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 72.3,
+              "y": 102.6,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 33.2,
+              "y": 93.7,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 71,
+              "y": 102,
+              "v": 0.99
+            },
+            "rightHeel": {
+              "x": 33.3,
+              "y": 97.7,
+              "v": 0.974
+            },
+            "leftFootIndex": {
+              "x": 78,
+              "y": 110.1,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 29.6,
+              "y": 103.4,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.4,
+                "y": 10.1
+              },
+              "roll": -162.9,
+              "yaw": 1.066,
+              "pitch": 1.691
+            },
+            "torso": {
+              "center": {
+                "x": 57.4,
+                "y": 24.6
+              },
+              "angle": 84.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.5,
+                "y": 26.3
+              },
+              "angle": -9.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31.2,
+                "y": 39.7
+              },
+              "angle": -166.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71,
+                "y": 102
+              },
+              "angle": -49.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33.3,
+                "y": 97.7
+              },
+              "angle": -123
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.444,
+          "keypoints": {
+            "nose": {
+              "x": 64.3,
+              "y": 16,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64,
+              "y": 14.1,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 62.6,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.3,
+              "y": 15.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 58.2,
+              "y": 14.5,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 61.2,
+              "y": 23.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.8,
+              "y": 21.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 62.6,
+              "y": 28.9,
+              "v": 0.064
+            },
+            "rightElbow": {
+              "x": 47.5,
+              "y": 26.1,
+              "v": 0.398
+            },
+            "leftWrist": {
+              "x": 60.4,
+              "y": 30.7,
+              "v": 0.052
+            },
+            "rightWrist": {
+              "x": 53,
+              "y": 28.2,
+              "v": 0.214
+            },
+            "leftIndex": {
+              "x": 59.3,
+              "y": 29.9,
+              "v": 0.075
+            },
+            "rightIndex": {
+              "x": 55.6,
+              "y": 27.9,
+              "v": 0.205
+            },
+            "leftHip": {
+              "x": 57.9,
+              "y": 43.2,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 50.7,
+              "y": 42.5,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 64.9,
+              "y": 42.4,
+              "v": 0.07
+            },
+            "rightKnee": {
+              "x": 42.9,
+              "y": 35.6,
+              "v": 0.013
+            },
+            "leftAnkle": {
+              "x": 58.1,
+              "y": 46.7,
+              "v": 0.016
+            },
+            "rightAnkle": {
+              "x": 45.9,
+              "y": 39.8,
+              "v": 0.013
+            },
+            "leftHeel": {
+              "x": 56.9,
+              "y": 47.5,
+              "v": 0.034
+            },
+            "rightHeel": {
+              "x": 47.1,
+              "y": 41.5,
+              "v": 0.019
+            },
+            "leftFootIndex": {
+              "x": 56,
+              "y": 48,
+              "v": 0.025
+            },
+            "rightFootIndex": {
+              "x": 45.7,
+              "y": 39.7,
+              "v": 0.014
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.3,
+                "y": 14.2
+              },
+              "roll": -171.9,
+              "yaw": 0.707,
+              "pitch": 1.273
+            },
+            "torso": {
+              "center": {
+                "x": 56,
+                "y": 22.4
+              },
+              "angle": 85.3
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.992,
+          "keypoints": {
+            "nose": {
+              "x": 64.3,
+              "y": 16.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63.3,
+              "y": 13.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.8,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60.1,
+              "y": 13.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.5,
+              "y": 14.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.5,
+              "y": 26.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44.5,
+              "y": 27.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.8,
+              "y": 27.4,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 29.8,
+              "y": 37.3,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 103.6,
+              "y": 28.4,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 46.9,
+              "y": 34.1,
+              "v": 0.984
+            },
+            "leftIndex": {
+              "x": 109.5,
+              "y": 29.1,
+              "v": 0.993
+            },
+            "rightIndex": {
+              "x": 51.2,
+              "y": 29.9,
+              "v": 0.968
+            },
+            "leftHip": {
+              "x": 59.1,
+              "y": 61.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.1,
+              "y": 60.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.1,
+              "y": 86.9,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 35.1,
+              "y": 86.3,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 73.9,
+              "y": 110.1,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 27.2,
+              "y": 110.6,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 70.9,
+              "y": 119.7,
+              "v": 0.972
+            },
+            "rightHeel": {
+              "x": 27.7,
+              "y": 114.7,
+              "v": 0.935
+            },
+            "leftFootIndex": {
+              "x": 79.3,
+              "y": 120.5,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 22.8,
+              "y": 118.2,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.6,
+                "y": 14
+              },
+              "roll": -165.1,
+              "yaw": 1.127,
+              "pitch": 1.546
+            },
+            "torso": {
+              "center": {
+                "x": 55,
+                "y": 26.8
+              },
+              "angle": 86
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.6,
+                "y": 28.4
+              },
+              "angle": -6.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 46.9,
+                "y": 34.1
+              },
+              "angle": 44.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.9,
+                "y": 119.7
+              },
+              "angle": -5.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27.7,
+                "y": 114.7
+              },
+              "angle": -144.5
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.971,
+          "keypoints": {
+            "nose": {
+              "x": 71.1,
+              "y": 14,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 71.4,
+              "y": 11.3,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 68.3,
+              "y": 10.9,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 69.9,
+              "y": 12,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 64,
+              "y": 11.2,
+              "v": 0.997
+            },
+            "leftShoulder": {
+              "x": 76.3,
+              "y": 27.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52,
+              "y": 23,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.2,
+              "y": 46.2,
+              "v": 0.926
+            },
+            "rightElbow": {
+              "x": 36.4,
+              "y": 41,
+              "v": 0.985
+            },
+            "leftWrist": {
+              "x": 89.4,
+              "y": 60.5,
+              "v": 0.931
+            },
+            "rightWrist": {
+              "x": 53.4,
+              "y": 33.9,
+              "v": 0.966
+            },
+            "leftIndex": {
+              "x": 92.2,
+              "y": 64.4,
+              "v": 0.916
+            },
+            "rightIndex": {
+              "x": 59.9,
+              "y": 31,
+              "v": 0.941
+            },
+            "leftHip": {
+              "x": 68.7,
+              "y": 65.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.1,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.3,
+              "y": 89.8,
+              "v": 0.953
+            },
+            "rightKnee": {
+              "x": 44,
+              "y": 90.5,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 87.6,
+              "y": 117.5,
+              "v": 0.983
+            },
+            "rightAnkle": {
+              "x": 32.4,
+              "y": 118.8,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 84.7,
+              "y": 123.2,
+              "v": 0.92
+            },
+            "rightHeel": {
+              "x": 32.1,
+              "y": 123.2,
+              "v": 0.87
+            },
+            "leftFootIndex": {
+              "x": 99.5,
+              "y": 123.6,
+              "v": 0.977
+            },
+            "rightFootIndex": {
+              "x": 30,
+              "y": 131.9,
+              "v": 0.984
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.9,
+                "y": 11.1
+              },
+              "roll": 172.6,
+              "yaw": 0.4,
+              "pitch": 0.928
+            },
+            "torso": {
+              "center": {
+                "x": 64.2,
+                "y": 25.1
+              },
+              "angle": 85.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.4,
+                "y": 60.5
+              },
+              "angle": -54.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 53.4,
+                "y": 33.9
+              },
+              "angle": 24
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 84.7,
+                "y": 123.2
+              },
+              "angle": -1.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.1,
+                "y": 123.2
+              },
+              "angle": -103.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.99,
+          "keypoints": {
+            "nose": {
+              "x": 73.4,
+              "y": 17.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.5,
+              "y": 14.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.8,
+              "y": 15,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.7,
+              "y": 14,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.9,
+              "y": 15.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.8,
+              "y": 27.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.5,
+              "y": 26,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.7,
+              "y": 42.3,
+              "v": 0.938
+            },
+            "rightElbow": {
+              "x": 40.4,
+              "y": 39.6,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 94.2,
+              "y": 33.3,
+              "v": 0.989
+            },
+            "rightWrist": {
+              "x": 57.7,
+              "y": 34,
+              "v": 0.989
+            },
+            "leftIndex": {
+              "x": 95.3,
+              "y": 29.1,
+              "v": 0.985
+            },
+            "rightIndex": {
+              "x": 62.9,
+              "y": 30.7,
+              "v": 0.979
+            },
+            "leftHip": {
+              "x": 69.4,
+              "y": 59.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.8,
+              "y": 60.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 93.6,
+              "y": 66.1,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 50.3,
+              "y": 82.3,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 85.5,
+              "y": 92.1,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 37.3,
+              "y": 106.7,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 80.4,
+              "y": 95.6,
+              "v": 0.985
+            },
+            "rightHeel": {
+              "x": 36.4,
+              "y": 111.2,
+              "v": 0.963
+            },
+            "leftFootIndex": {
+              "x": 94.1,
+              "y": 103.6,
+              "v": 0.986
+            },
+            "rightFootIndex": {
+              "x": 32.7,
+              "y": 114.2,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.7,
+                "y": 14.7
+              },
+              "roll": -160.6,
+              "yaw": 0.971,
+              "pitch": 1.331
+            },
+            "torso": {
+              "center": {
+                "x": 64.7,
+                "y": 26.6
+              },
+              "angle": 86.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.2,
+                "y": 33.3
+              },
+              "angle": 75.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 57.7,
+                "y": 34
+              },
+              "angle": 32.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80.4,
+                "y": 95.6
+              },
+              "angle": -30.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.4,
+                "y": 111.2
+              },
+              "angle": -141
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.91,
+          "keypoints": {
+            "nose": {
+              "x": 47.8,
+              "y": 14.5,
+              "v": 0.998
+            },
+            "leftEye": {
+              "x": 46.8,
+              "y": 12.1,
+              "v": 0.997
+            },
+            "rightEye": {
+              "x": 45.1,
+              "y": 12.9,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 43.9,
+              "y": 12.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 39.4,
+              "y": 14.4,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 49.6,
+              "y": 24,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 30.5,
+              "y": 25.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.5,
+              "y": 35.2,
+              "v": 0.907
+            },
+            "rightElbow": {
+              "x": 17.9,
+              "y": 41.4,
+              "v": 0.881
+            },
+            "leftWrist": {
+              "x": 68.6,
+              "y": 26.1,
+              "v": 0.987
+            },
+            "rightWrist": {
+              "x": 31.8,
+              "y": 34.8,
+              "v": 0.928
+            },
+            "leftIndex": {
+              "x": 66.8,
+              "y": 21.7,
+              "v": 0.981
+            },
+            "rightIndex": {
+              "x": 36.7,
+              "y": 30,
+              "v": 0.901
+            },
+            "leftHip": {
+              "x": 47.9,
+              "y": 56,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 38.6,
+              "y": 56.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 51.7,
+              "y": 78.9,
+              "v": 0.848
+            },
+            "rightKnee": {
+              "x": 52.5,
+              "y": 67.9,
+              "v": 0.787
+            },
+            "leftAnkle": {
+              "x": 41.5,
+              "y": 98.9,
+              "v": 0.892
+            },
+            "rightAnkle": {
+              "x": 61.4,
+              "y": 82.5,
+              "v": 0.797
+            },
+            "leftHeel": {
+              "x": 38.8,
+              "y": 101.6,
+              "v": 0.816
+            },
+            "rightHeel": {
+              "x": 61.8,
+              "y": 85.3,
+              "v": 0.642
+            },
+            "leftFootIndex": {
+              "x": 42.7,
+              "y": 105.8,
+              "v": 0.855
+            },
+            "rightFootIndex": {
+              "x": 69.1,
+              "y": 85.9,
+              "v": 0.723
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 46,
+                "y": 12.5
+              },
+              "roll": -154.8,
+              "yaw": 0.985,
+              "pitch": 1.064
+            },
+            "torso": {
+              "center": {
+                "x": 40.1,
+                "y": 25
+              },
+              "angle": 95.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 68.6,
+                "y": 26.1
+              },
+              "angle": 112.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31.8,
+                "y": 34.8
+              },
+              "angle": 44.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 38.8,
+                "y": 101.6
+              },
+              "angle": -47.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 61.8,
+                "y": 85.3
+              },
+              "angle": -4.7
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.422,
+          "keypoints": {
+            "nose": {
+              "x": 60.7,
+              "y": 29.5,
+              "v": 0.997
+            },
+            "leftEye": {
+              "x": 62,
+              "y": 30.1,
+              "v": 0.996
+            },
+            "rightEye": {
+              "x": 61.7,
+              "y": 29.9,
+              "v": 0.996
+            },
+            "leftEar": {
+              "x": 63.4,
+              "y": 31.9,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 62.2,
+              "y": 31.6,
+              "v": 0.992
+            },
+            "leftShoulder": {
+              "x": 65.3,
+              "y": 39.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.6,
+              "y": 37.4,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 62.8,
+              "y": 46.6,
+              "v": 0.159
+            },
+            "rightElbow": {
+              "x": 53.4,
+              "y": 40,
+              "v": 0.026
+            },
+            "leftWrist": {
+              "x": 60.1,
+              "y": 45.9,
+              "v": 0.062
+            },
+            "rightWrist": {
+              "x": 56.2,
+              "y": 39.3,
+              "v": 0.045
+            },
+            "leftIndex": {
+              "x": 60,
+              "y": 44.9,
+              "v": 0.093
+            },
+            "rightIndex": {
+              "x": 58.1,
+              "y": 38.7,
+              "v": 0.079
+            },
+            "leftHip": {
+              "x": 54.7,
+              "y": 56.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.3,
+              "y": 54.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 44.4,
+              "y": 67.5,
+              "v": 0.039
+            },
+            "rightKnee": {
+              "x": 41.3,
+              "y": 62.9,
+              "v": 0.009
+            },
+            "leftAnkle": {
+              "x": 45.1,
+              "y": 79.5,
+              "v": 0.05
+            },
+            "rightAnkle": {
+              "x": 45.6,
+              "y": 71.4,
+              "v": 0.005
+            },
+            "leftHeel": {
+              "x": 46.1,
+              "y": 81.3,
+              "v": 0.059
+            },
+            "rightHeel": {
+              "x": 47.3,
+              "y": 72.5,
+              "v": 0.024
+            },
+            "leftFootIndex": {
+              "x": 41.5,
+              "y": 82.4,
+              "v": 0.067
+            },
+            "rightFootIndex": {
+              "x": 43.1,
+              "y": 74.4,
+              "v": 0.011
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 61.9,
+                "y": 30
+              },
+              "roll": 146.3,
+              "yaw": -3.19,
+              "pitch": -1.387
+            },
+            "torso": {
+              "center": {
+                "x": 62.5,
+                "y": 38.6
+              },
+              "angle": 60.8
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.532,
+          "keypoints": {
+            "nose": {
+              "x": 66.4,
+              "y": 18.3,
+              "v": 0.995
+            },
+            "leftEye": {
+              "x": 66.4,
+              "y": 18.9,
+              "v": 0.989
+            },
+            "rightEye": {
+              "x": 67.1,
+              "y": 19,
+              "v": 0.996
+            },
+            "leftEar": {
+              "x": 67.4,
+              "y": 19,
+              "v": 0.994
+            },
+            "rightEar": {
+              "x": 68.5,
+              "y": 19,
+              "v": 0.994
+            },
+            "leftShoulder": {
+              "x": 64.9,
+              "y": 14.3,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 72.7,
+              "y": 15,
+              "v": 0.998
+            },
+            "leftElbow": {
+              "x": 64.7,
+              "y": 9.3,
+              "v": 0.397
+            },
+            "rightElbow": {
+              "x": 75.6,
+              "y": 8.4,
+              "v": 0.789
+            },
+            "leftWrist": {
+              "x": 67.1,
+              "y": 7.2,
+              "v": 0.21
+            },
+            "rightWrist": {
+              "x": 70.2,
+              "y": 7.6,
+              "v": 0.705
+            },
+            "leftIndex": {
+              "x": 67.9,
+              "y": 6.9,
+              "v": 0.263
+            },
+            "rightIndex": {
+              "x": 68.2,
+              "y": 7.9,
+              "v": 0.638
+            },
+            "leftHip": {
+              "x": 68,
+              "y": 1.6,
+              "v": 0.963
+            },
+            "rightHip": {
+              "x": 73,
+              "y": 1.5,
+              "v": 0.97
+            },
+            "leftKnee": {
+              "x": 66.4,
+              "y": -3.3,
+              "v": 0.06
+            },
+            "rightKnee": {
+              "x": 71.3,
+              "y": -5,
+              "v": 0.169
+            },
+            "leftAnkle": {
+              "x": 67,
+              "y": -14,
+              "v": 0.018
+            },
+            "rightAnkle": {
+              "x": 71.4,
+              "y": -14.1,
+              "v": 0.019
+            },
+            "leftHeel": {
+              "x": 67.4,
+              "y": -15.7,
+              "v": 0.025
+            },
+            "rightHeel": {
+              "x": 71.8,
+              "y": -15.4,
+              "v": 0.02
+            },
+            "leftFootIndex": {
+              "x": 67.2,
+              "y": -16.9,
+              "v": 0.017
+            },
+            "rightFootIndex": {
+              "x": 69.5,
+              "y": -17,
+              "v": 0.014
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.8,
+                "y": 19
+              },
+              "roll": -8.1,
+              "yaw": -0.495,
+              "pitch": -0.919
+            },
+            "torso": {
+              "center": {
+                "x": 68.8,
+                "y": 14.7
+              },
+              "angle": -97.4
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 70.2,
+                "y": 7.6
+              },
+              "angle": -171.5
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 4,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.991,
+          "keypoints": {
+            "nose": {
+              "x": 64.4,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63.4,
+              "y": 11,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.8,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.4,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.5,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.9,
+              "y": 27.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.5,
+              "y": 22.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.8,
+              "y": 45.7,
+              "v": 0.956
+            },
+            "rightElbow": {
+              "x": 28.3,
+              "y": 34.3,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 82.9,
+              "y": 58.3,
+              "v": 0.982
+            },
+            "rightWrist": {
+              "x": 41.9,
+              "y": 42.4,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 86.5,
+              "y": 61.5,
+              "v": 0.977
+            },
+            "rightIndex": {
+              "x": 47.5,
+              "y": 42,
+              "v": 0.992
+            },
+            "leftHip": {
+              "x": 57.6,
+              "y": 64.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.9,
+              "y": 64.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.9,
+              "y": 87.7,
+              "v": 0.974
+            },
+            "rightKnee": {
+              "x": 37.9,
+              "y": 90.8,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 79.4,
+              "y": 116.8,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 26.7,
+              "y": 120.6,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 76.9,
+              "y": 122.7,
+              "v": 0.968
+            },
+            "rightHeel": {
+              "x": 24.8,
+              "y": 124.2,
+              "v": 0.969
+            },
+            "leftFootIndex": {
+              "x": 91.2,
+              "y": 123.4,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 27.4,
+              "y": 130,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.6,
+                "y": 11.1
+              },
+              "roll": -176.4,
+              "yaw": 1.123,
+              "pitch": 1.591
+            },
+            "torso": {
+              "center": {
+                "x": 56.7,
+                "y": 25.1
+              },
+              "angle": 82.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.9,
+                "y": 58.3
+              },
+              "angle": -41.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.9,
+                "y": 42.4
+              },
+              "angle": 4.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.9,
+                "y": 122.7
+              },
+              "angle": -2.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 24.8,
+                "y": 124.2
+              },
+              "angle": -65.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.974,
+          "keypoints": {
+            "nose": {
+              "x": 58.4,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.4,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.5,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.1,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.4,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 56.3,
+              "y": 25.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.1,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 65.8,
+              "y": 34.3,
+              "v": 0.686
+            },
+            "rightElbow": {
+              "x": 23.4,
+              "y": 39.5,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 80.1,
+              "y": 31.5,
+              "v": 0.906
+            },
+            "rightWrist": {
+              "x": 40.1,
+              "y": 36.2,
+              "v": 0.979
+            },
+            "leftIndex": {
+              "x": 83.9,
+              "y": 29.1,
+              "v": 0.922
+            },
+            "rightIndex": {
+              "x": 45.8,
+              "y": 32.5,
+              "v": 0.969
+            },
+            "leftHip": {
+              "x": 53.9,
+              "y": 64.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 41.4,
+              "y": 64.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.7,
+              "y": 88.3,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 29.6,
+              "y": 89.7,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 67.3,
+              "y": 117.9,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 16.3,
+              "y": 117.6,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 62.9,
+              "y": 122.2,
+              "v": 0.989
+            },
+            "rightHeel": {
+              "x": 15.3,
+              "y": 119.3,
+              "v": 0.972
+            },
+            "leftFootIndex": {
+              "x": 75.9,
+              "y": 128.9,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 15.1,
+              "y": 127.9,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.5,
+                "y": 12.6
+              },
+              "roll": 168.1,
+              "yaw": 0.489,
+              "pitch": 1.597
+            },
+            "torso": {
+              "center": {
+                "x": 46.7,
+                "y": 25.2
+              },
+              "angle": 91.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.1,
+                "y": 31.5
+              },
+              "angle": 32.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40.1,
+                "y": 36.2
+              },
+              "angle": 33
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 62.9,
+                "y": 122.2
+              },
+              "angle": -27.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 15.3,
+                "y": 119.3
+              },
+              "angle": -91.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.964,
+          "keypoints": {
+            "nose": {
+              "x": 56.4,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.6,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.3,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52.4,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.3,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 56.5,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.7,
+              "y": 26.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.3,
+              "y": 37.9,
+              "v": 0.7
+            },
+            "rightElbow": {
+              "x": 22.8,
+              "y": 38.1,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 69.1,
+              "y": 35.5,
+              "v": 0.788
+            },
+            "rightWrist": {
+              "x": 36.5,
+              "y": 35,
+              "v": 0.971
+            },
+            "leftIndex": {
+              "x": 70.6,
+              "y": 33.1,
+              "v": 0.81
+            },
+            "rightIndex": {
+              "x": 40,
+              "y": 31.5,
+              "v": 0.943
+            },
+            "leftHip": {
+              "x": 51.1,
+              "y": 63.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 37.5,
+              "y": 62.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.4,
+              "y": 88.6,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 26.7,
+              "y": 87.3,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 70,
+              "y": 115.7,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 17.7,
+              "y": 111.7,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 67,
+              "y": 118.9,
+              "v": 0.993
+            },
+            "rightHeel": {
+              "x": 17.4,
+              "y": 115.9,
+              "v": 0.978
+            },
+            "leftFootIndex": {
+              "x": 79.3,
+              "y": 121.9,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 14.1,
+              "y": 120.2,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55,
+                "y": 12.7
+              },
+              "roll": 171.3,
+              "yaw": 1.102,
+              "pitch": 2.053
+            },
+            "torso": {
+              "center": {
+                "x": 48.1,
+                "y": 26.8
+              },
+              "angle": 84
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 69.1,
+                "y": 35.5
+              },
+              "angle": 58
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.5,
+                "y": 35
+              },
+              "angle": 45
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67,
+                "y": 118.9
+              },
+              "angle": -13.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 17.4,
+                "y": 115.9
+              },
+              "angle": -127.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.971,
+          "keypoints": {
+            "nose": {
+              "x": 52.3,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 52.3,
+              "y": 13.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 50.3,
+              "y": 13.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 49.4,
+              "y": 13.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 44.2,
+              "y": 13.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 54.1,
+              "y": 26.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 30.9,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.7,
+              "y": 44.2,
+              "v": 0.899
+            },
+            "rightElbow": {
+              "x": 17.2,
+              "y": 40.2,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 71.8,
+              "y": 60.5,
+              "v": 0.761
+            },
+            "rightWrist": {
+              "x": 35.6,
+              "y": 36.2,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 72.4,
+              "y": 65.7,
+              "v": 0.718
+            },
+            "rightIndex": {
+              "x": 41.3,
+              "y": 32,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 47.6,
+              "y": 63.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 33.7,
+              "y": 63.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 61.3,
+              "y": 88.6,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 23.6,
+              "y": 90.1,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 67.2,
+              "y": 116.2,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 13,
+              "y": 118.7,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 64.4,
+              "y": 121.8,
+              "v": 0.993
+            },
+            "rightHeel": {
+              "x": 14,
+              "y": 120.7,
+              "v": 0.975
+            },
+            "leftFootIndex": {
+              "x": 78.6,
+              "y": 124,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 8.1,
+              "y": 127,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.3,
+                "y": 13.5
+              },
+              "roll": 171.5,
+              "yaw": 0.494,
+              "pitch": 1.409
+            },
+            "torso": {
+              "center": {
+                "x": 42.5,
+                "y": 25.7
+              },
+              "angle": 87.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 71.8,
+                "y": 60.5
+              },
+              "angle": -83.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.6,
+                "y": 36.2
+              },
+              "angle": 36.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 64.4,
+                "y": 121.8
+              },
+              "angle": -8.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 14,
+                "y": 120.7
+              },
+              "angle": -133.1
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 74.2,
+              "y": 13.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.7,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.9,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.7,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.8,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.3,
+              "y": 27.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.6,
+              "y": 24.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 88,
+              "y": 42,
+              "v": 0.975
+            },
+            "rightElbow": {
+              "x": 37.1,
+              "y": 40.7,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 92.8,
+              "y": 26.7,
+              "v": 0.991
+            },
+            "rightWrist": {
+              "x": 57,
+              "y": 32.1,
+              "v": 0.965
+            },
+            "leftIndex": {
+              "x": 91.1,
+              "y": 21.4,
+              "v": 0.979
+            },
+            "rightIndex": {
+              "x": 63.1,
+              "y": 29.5,
+              "v": 0.906
+            },
+            "leftHip": {
+              "x": 68.4,
+              "y": 66.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.9,
+              "y": 65.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.8,
+              "y": 90.1,
+              "v": 0.94
+            },
+            "rightKnee": {
+              "x": 43.3,
+              "y": 91.3,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 86.4,
+              "y": 117.2,
+              "v": 0.978
+            },
+            "rightAnkle": {
+              "x": 32.6,
+              "y": 121.4,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 83.3,
+              "y": 123,
+              "v": 0.951
+            },
+            "rightHeel": {
+              "x": 31.4,
+              "y": 125.9,
+              "v": 0.967
+            },
+            "leftFootIndex": {
+              "x": 98.2,
+              "y": 124,
+              "v": 0.976
+            },
+            "rightFootIndex": {
+              "x": 32.5,
+              "y": 131.9,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.8,
+                "y": 10.6
+              },
+              "roll": -180,
+              "yaw": 1.333,
+              "pitch": 1.5
+            },
+            "torso": {
+              "center": {
+                "x": 63,
+                "y": 26.3
+              },
+              "angle": 87.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92.8,
+                "y": 26.7
+              },
+              "angle": 107.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 57,
+                "y": 32.1
+              },
+              "angle": 23.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.3,
+                "y": 123
+              },
+              "angle": -3.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.4,
+                "y": 125.9
+              },
+              "angle": -79.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.881,
+          "keypoints": {
+            "nose": {
+              "x": 72.4,
+              "y": 15.1,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 72.4,
+              "y": 12.6,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 69.3,
+              "y": 12.2,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 70.9,
+              "y": 13.2,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 64.5,
+              "y": 12.5,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 76.1,
+              "y": 25.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.2,
+              "y": 22.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.9,
+              "y": 42.2,
+              "v": 0.711
+            },
+            "rightElbow": {
+              "x": 51.2,
+              "y": 36.5,
+              "v": 0.98
+            },
+            "leftWrist": {
+              "x": 69.3,
+              "y": 37.6,
+              "v": 0.357
+            },
+            "rightWrist": {
+              "x": 72.5,
+              "y": 29,
+              "v": 0.907
+            },
+            "leftIndex": {
+              "x": 64.3,
+              "y": 34.8,
+              "v": 0.249
+            },
+            "rightIndex": {
+              "x": 76.7,
+              "y": 25.7,
+              "v": 0.787
+            },
+            "leftHip": {
+              "x": 69.7,
+              "y": 65,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54.3,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.3,
+              "y": 88.3,
+              "v": 0.922
+            },
+            "rightKnee": {
+              "x": 44.9,
+              "y": 89.3,
+              "v": 0.992
+            },
+            "leftAnkle": {
+              "x": 87,
+              "y": 116.7,
+              "v": 0.891
+            },
+            "rightAnkle": {
+              "x": 33.2,
+              "y": 119.8,
+              "v": 0.981
+            },
+            "leftHeel": {
+              "x": 83.8,
+              "y": 123.4,
+              "v": 0.838
+            },
+            "rightHeel": {
+              "x": 31.6,
+              "y": 124,
+              "v": 0.806
+            },
+            "leftFootIndex": {
+              "x": 98.3,
+              "y": 124.1,
+              "v": 0.883
+            },
+            "rightFootIndex": {
+              "x": 30.9,
+              "y": 130.6,
+              "v": 0.961
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.9,
+                "y": 12.4
+              },
+              "roll": 172.6,
+              "yaw": 0.496,
+              "pitch": 0.864
+            },
+            "torso": {
+              "center": {
+                "x": 64.2,
+                "y": 23.8
+              },
+              "angle": 87
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 69.3,
+                "y": 37.6
+              },
+              "angle": 162.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72.5,
+                "y": 29
+              },
+              "angle": 38.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.8,
+                "y": 123.4
+              },
+              "angle": -2.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.6,
+                "y": 124
+              },
+              "angle": -96.1
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.925,
+          "keypoints": {
+            "nose": {
+              "x": 73.4,
+              "y": 18.5,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 74.3,
+              "y": 15.8,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 72.3,
+              "y": 14.8,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 70.9,
+              "y": 14.3,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 67.2,
+              "y": 12.4,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 73.9,
+              "y": 28.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.9,
+              "y": 21.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75,
+              "y": 48.5,
+              "v": 0.494
+            },
+            "rightElbow": {
+              "x": 36.4,
+              "y": 37.6,
+              "v": 0.993
+            },
+            "leftWrist": {
+              "x": 80.7,
+              "y": 62.3,
+              "v": 0.612
+            },
+            "rightWrist": {
+              "x": 51.9,
+              "y": 48.6,
+              "v": 0.968
+            },
+            "leftIndex": {
+              "x": 82.2,
+              "y": 68.9,
+              "v": 0.643
+            },
+            "rightIndex": {
+              "x": 58.1,
+              "y": 49.6,
+              "v": 0.953
+            },
+            "leftHip": {
+              "x": 64.4,
+              "y": 63.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.8,
+              "y": 62.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.6,
+              "y": 87.9,
+              "v": 0.875
+            },
+            "rightKnee": {
+              "x": 42.4,
+              "y": 90.6,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 78.6,
+              "y": 115.8,
+              "v": 0.96
+            },
+            "rightAnkle": {
+              "x": 29.5,
+              "y": 118.7,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 74.5,
+              "y": 121.3,
+              "v": 0.941
+            },
+            "rightHeel": {
+              "x": 27.8,
+              "y": 123,
+              "v": 0.887
+            },
+            "leftFootIndex": {
+              "x": 91.4,
+              "y": 122.5,
+              "v": 0.967
+            },
+            "rightFootIndex": {
+              "x": 30,
+              "y": 127.5,
+              "v": 0.988
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.3,
+                "y": 15.3
+              },
+              "roll": 153.4,
+              "yaw": 0.045,
+              "pitch": 1.431
+            },
+            "torso": {
+              "center": {
+                "x": 61.9,
+                "y": 25.2
+              },
+              "angle": 84.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.7,
+                "y": 62.3
+              },
+              "angle": -77.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 51.9,
+                "y": 48.6
+              },
+              "angle": -9.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.5,
+                "y": 121.3
+              },
+              "angle": -4.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27.8,
+                "y": 123
+              },
+              "angle": -63.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.916,
+          "keypoints": {
+            "nose": {
+              "x": 73.7,
+              "y": 17.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.9,
+              "y": 15.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.4,
+              "y": 13.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.8,
+              "y": 16.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.9,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.7,
+              "y": 30.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.2,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.8,
+              "y": 47.6,
+              "v": 0.797
+            },
+            "rightElbow": {
+              "x": 40.5,
+              "y": 34,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 82.5,
+              "y": 62.4,
+              "v": 0.435
+            },
+            "rightWrist": {
+              "x": 28.7,
+              "y": 50.1,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 82.6,
+              "y": 66.1,
+              "v": 0.405
+            },
+            "rightIndex": {
+              "x": 28.5,
+              "y": 55.9,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 70.3,
+              "y": 55,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.5,
+              "y": 54.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.7,
+              "y": 79.8,
+              "v": 0.959
+            },
+            "rightKnee": {
+              "x": 55.2,
+              "y": 80.6,
+              "v": 0.98
+            },
+            "leftAnkle": {
+              "x": 84.8,
+              "y": 103.4,
+              "v": 0.968
+            },
+            "rightAnkle": {
+              "x": 47.1,
+              "y": 100.6,
+              "v": 0.974
+            },
+            "leftHeel": {
+              "x": 83,
+              "y": 107.5,
+              "v": 0.88
+            },
+            "rightHeel": {
+              "x": 46.3,
+              "y": 103.2,
+              "v": 0.752
+            },
+            "leftFootIndex": {
+              "x": 89.7,
+              "y": 109.1,
+              "v": 0.967
+            },
+            "rightFootIndex": {
+              "x": 44.8,
+              "y": 109.4,
+              "v": 0.955
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.7,
+                "y": 14.7
+              },
+              "roll": 161.6,
+              "yaw": 0.011,
+              "pitch": 0.58
+            },
+            "torso": {
+              "center": {
+                "x": 68.5,
+                "y": 27.2
+              },
+              "angle": 80.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.5,
+                "y": 62.4
+              },
+              "angle": -88.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.7,
+                "y": 50.1
+              },
+              "angle": -92
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83,
+                "y": 107.5
+              },
+              "angle": -13.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 46.3,
+                "y": 103.2
+              },
+              "angle": -103.6
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.595,
+          "keypoints": {
+            "nose": {
+              "x": 93.3,
+              "y": 37.8,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 94.4,
+              "y": 39.4,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 93.7,
+              "y": 38.1,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 94.8,
+              "y": 41.5,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 93,
+              "y": 39.1,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 88.4,
+              "y": 48.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 85.1,
+              "y": 43.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.1,
+              "y": 50.7,
+              "v": 0.311
+            },
+            "rightElbow": {
+              "x": 79.4,
+              "y": 46.7,
+              "v": 0.121
+            },
+            "leftWrist": {
+              "x": 88.5,
+              "y": 47.2,
+              "v": 0.572
+            },
+            "rightWrist": {
+              "x": 90.2,
+              "y": 41.4,
+              "v": 0.511
+            },
+            "leftIndex": {
+              "x": 92.5,
+              "y": 46.4,
+              "v": 0.602
+            },
+            "rightIndex": {
+              "x": 93.3,
+              "y": 39.4,
+              "v": 0.557
+            },
+            "leftHip": {
+              "x": 68.8,
+              "y": 59.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 67.4,
+              "y": 55,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 61.2,
+              "y": 61.8,
+              "v": 0.341
+            },
+            "rightKnee": {
+              "x": 58.7,
+              "y": 49.8,
+              "v": 0.064
+            },
+            "leftAnkle": {
+              "x": 49.8,
+              "y": 71.3,
+              "v": 0.292
+            },
+            "rightAnkle": {
+              "x": 45.5,
+              "y": 50,
+              "v": 0.274
+            },
+            "leftHeel": {
+              "x": 48.7,
+              "y": 72.9,
+              "v": 0.162
+            },
+            "rightHeel": {
+              "x": 43.4,
+              "y": 51.8,
+              "v": 0.245
+            },
+            "leftFootIndex": {
+              "x": 43.7,
+              "y": 71.4,
+              "v": 0.328
+            },
+            "rightFootIndex": {
+              "x": 41,
+              "y": 46.3,
+              "v": 0.32
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 94.1,
+                "y": 38.8
+              },
+              "roll": 118.3,
+              "yaw": -0.508,
+              "pitch": -0.643
+            },
+            "torso": {
+              "center": {
+                "x": 86.8,
+                "y": 46.3
+              },
+              "angle": 30.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.5,
+                "y": 47.2
+              },
+              "angle": 11.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 90.2,
+                "y": 41.4
+              },
+              "angle": 32.8
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.97,
+          "keypoints": {
+            "nose": {
+              "x": 66.1,
+              "y": 17.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.2,
+              "y": 14.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.1,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60.5,
+              "y": 14.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.5,
+              "y": 15,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.8,
+              "y": 31.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.4,
+              "y": 30,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.1,
+              "y": 46.7,
+              "v": 0.693
+            },
+            "rightElbow": {
+              "x": 30,
+              "y": 52.4,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 100.9,
+              "y": 36.9,
+              "v": 0.893
+            },
+            "rightWrist": {
+              "x": 30.9,
+              "y": 76.9,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 105.9,
+              "y": 32.8,
+              "v": 0.903
+            },
+            "rightIndex": {
+              "x": 32.8,
+              "y": 83.5,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 66.1,
+              "y": 69.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.5,
+              "y": 73.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 100.4,
+              "y": 82.6,
+              "v": 0.989
+            },
+            "rightKnee": {
+              "x": 65.3,
+              "y": 106.2,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 96.7,
+              "y": 114.8,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 39.8,
+              "y": 99.4,
+              "v": 0.97
+            },
+            "leftHeel": {
+              "x": 91.7,
+              "y": 121.4,
+              "v": 0.995
+            },
+            "rightHeel": {
+              "x": 37,
+              "y": 95.5,
+              "v": 0.925
+            },
+            "leftFootIndex": {
+              "x": 111.5,
+              "y": 124.1,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 33.2,
+              "y": 114.8,
+              "v": 0.961
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.2,
+                "y": 14.3
+              },
+              "roll": -180,
+              "yaw": 0.929,
+              "pitch": 1.619
+            },
+            "torso": {
+              "center": {
+                "x": 55.6,
+                "y": 30.7
+              },
+              "angle": 95.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.9,
+                "y": 36.9
+              },
+              "angle": 39.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 30.9,
+                "y": 76.9
+              },
+              "angle": -73.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 91.7,
+                "y": 121.4
+              },
+              "angle": -7.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37,
+                "y": 95.5
+              },
+              "angle": -101.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.999,
+          "keypoints": {
+            "nose": {
+              "x": 100.6,
+              "y": 33.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 102.5,
+              "y": 31.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 99.1,
+              "y": 28.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 102.4,
+              "y": 32.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 94.7,
+              "y": 27.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 98.5,
+              "y": 44.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 79.3,
+              "y": 31.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 103.1,
+              "y": 61.2,
+              "v": 1
+            },
+            "rightElbow": {
+              "x": 60,
+              "y": 32.5,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 117.1,
+              "y": 75.9,
+              "v": 1
+            },
+            "rightWrist": {
+              "x": 41.5,
+              "y": 37.5,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 122.5,
+              "y": 78.2,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 35.8,
+              "y": 38.9,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 70.7,
+              "y": 67.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.1,
+              "y": 57.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.2,
+              "y": 91.4,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 32.6,
+              "y": 59.9,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 51.6,
+              "y": 101.5,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 9.4,
+              "y": 68.8,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 45.9,
+              "y": 101.1,
+              "v": 0.997
+            },
+            "rightHeel": {
+              "x": 7.8,
+              "y": 71.3,
+              "v": 0.996
+            },
+            "leftFootIndex": {
+              "x": 50.2,
+              "y": 114.4,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": -2.2,
+              "y": 71.4,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 100.8,
+                "y": 29.8
+              },
+              "roll": 140.5,
+              "yaw": -0.045,
+              "pitch": 0.749
+            },
+            "torso": {
+              "center": {
+                "x": 88.9,
+                "y": 38.2
+              },
+              "angle": 46.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 117.1,
+                "y": 75.9
+              },
+              "angle": -23.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.5,
+                "y": 37.5
+              },
+              "angle": -166.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 45.9,
+                "y": 101.1
+              },
+              "angle": -72.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 7.8,
+                "y": 71.3
+              },
+              "angle": -179.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 100.8,
+              "y": 22.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 100.3,
+              "y": 19.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 99.4,
+              "y": 19.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 96.9,
+              "y": 18.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 93.8,
+              "y": 17.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 99.9,
+              "y": 36.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 76.4,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 104.4,
+              "y": 58.2,
+              "v": 0.999
+            },
+            "rightElbow": {
+              "x": 59,
+              "y": 31.5,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 109.2,
+              "y": 75.3,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 45.8,
+              "y": 44.3,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 113.4,
+              "y": 80,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 41.2,
+              "y": 49.1,
+              "v": 0.993
+            },
+            "leftHip": {
+              "x": 76.5,
+              "y": 63.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.2,
+              "y": 56.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90.7,
+              "y": 86.6,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 45.3,
+              "y": 77.5,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 98.1,
+              "y": 115.7,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 25.7,
+              "y": 98.2,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 95.8,
+              "y": 120.8,
+              "v": 0.992
+            },
+            "rightHeel": {
+              "x": 23.4,
+              "y": 101.2,
+              "v": 0.973
+            },
+            "leftFootIndex": {
+              "x": 104.8,
+              "y": 122,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 19.9,
+              "y": 106.3,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 99.9,
+                "y": 19.5
+              },
+              "roll": 156,
+              "yaw": 0.965,
+              "pitch": 3.046
+            },
+            "torso": {
+              "center": {
+                "x": 88.2,
+                "y": 28.8
+              },
+              "angle": 59
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 109.2,
+                "y": 75.3
+              },
+              "angle": -48.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 45.8,
+                "y": 44.3
+              },
+              "angle": -133.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 95.8,
+                "y": 120.8
+              },
+              "angle": -7.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.4,
+                "y": 101.2
+              },
+              "angle": -124.5
+            }
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.962,
+          "keypoints": {
+            "nose": {
+              "x": 68.8,
+              "y": 9.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.5,
+              "y": 7.9,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 66.1,
+              "y": 7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.2,
+              "y": 10.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.9,
+              "y": 8.1,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 75.7,
+              "y": 27.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.6,
+              "y": 22.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.4,
+              "y": 48.5,
+              "v": 0.958
+            },
+            "rightElbow": {
+              "x": 35.3,
+              "y": 43.4,
+              "v": 0.971
+            },
+            "leftWrist": {
+              "x": 87,
+              "y": 62.4,
+              "v": 0.971
+            },
+            "rightWrist": {
+              "x": 31.7,
+              "y": 30.5,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 90.9,
+              "y": 66.7,
+              "v": 0.965
+            },
+            "rightIndex": {
+              "x": 31.6,
+              "y": 24.2,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 69.1,
+              "y": 64,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.9,
+              "y": 64.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.2,
+              "y": 89.5,
+              "v": 0.947
+            },
+            "rightKnee": {
+              "x": 44.1,
+              "y": 92.6,
+              "v": 0.987
+            },
+            "leftAnkle": {
+              "x": 87.6,
+              "y": 118.9,
+              "v": 0.94
+            },
+            "rightAnkle": {
+              "x": 33.2,
+              "y": 122.9,
+              "v": 0.98
+            },
+            "leftHeel": {
+              "x": 84.4,
+              "y": 124.2,
+              "v": 0.804
+            },
+            "rightHeel": {
+              "x": 31.6,
+              "y": 125.9,
+              "v": 0.75
+            },
+            "leftFootIndex": {
+              "x": 98.7,
+              "y": 125.1,
+              "v": 0.92
+            },
+            "rightFootIndex": {
+              "x": 33.5,
+              "y": 139,
+              "v": 0.951
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.3,
+                "y": 7.5
+              },
+              "roll": 168.4,
+              "yaw": 0.111,
+              "pitch": 0.367
+            },
+            "torso": {
+              "center": {
+                "x": 62.2,
+                "y": 24.9
+              },
+              "angle": 88.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87,
+                "y": 62.4
+              },
+              "angle": -47.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31.7,
+                "y": 30.5
+              },
+              "angle": 90.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 84.4,
+                "y": 124.2
+              },
+              "angle": -3.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.6,
+                "y": 125.9
+              },
+              "angle": -81.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.92,
+          "keypoints": {
+            "nose": {
+              "x": 71.6,
+              "y": 15.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.1,
+              "y": 12.5,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 68.7,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.2,
+              "y": 13.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.8,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.4,
+              "y": 25.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.3,
+              "y": 27.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 90.4,
+              "y": 22.6,
+              "v": 0.981
+            },
+            "rightElbow": {
+              "x": 38.8,
+              "y": 39.1,
+              "v": 0.964
+            },
+            "leftWrist": {
+              "x": 96.8,
+              "y": 8.9,
+              "v": 0.983
+            },
+            "rightWrist": {
+              "x": 57.2,
+              "y": 36.1,
+              "v": 0.824
+            },
+            "leftIndex": {
+              "x": 96,
+              "y": 3.8,
+              "v": 0.977
+            },
+            "rightIndex": {
+              "x": 61.3,
+              "y": 33,
+              "v": 0.75
+            },
+            "leftHip": {
+              "x": 68.2,
+              "y": 58.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.1,
+              "y": 58.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.7,
+              "y": 85.2,
+              "v": 0.886
+            },
+            "rightKnee": {
+              "x": 46.3,
+              "y": 83,
+              "v": 0.919
+            },
+            "leftAnkle": {
+              "x": 82,
+              "y": 106.7,
+              "v": 0.922
+            },
+            "rightAnkle": {
+              "x": 40.4,
+              "y": 101.2,
+              "v": 0.914
+            },
+            "leftHeel": {
+              "x": 79.2,
+              "y": 113.4,
+              "v": 0.795
+            },
+            "rightHeel": {
+              "x": 39.4,
+              "y": 108.7,
+              "v": 0.602
+            },
+            "leftFootIndex": {
+              "x": 87.9,
+              "y": 116.2,
+              "v": 0.858
+            },
+            "rightFootIndex": {
+              "x": 37.3,
+              "y": 113.2,
+              "v": 0.784
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.9,
+                "y": 12.9
+              },
+              "roll": -163.7,
+              "yaw": 0.68,
+              "pitch": 0.9
+            },
+            "torso": {
+              "center": {
+                "x": 63.9,
+                "y": 26.6
+              },
+              "angle": 86.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.8,
+                "y": 8.9
+              },
+              "angle": 98.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 57.2,
+                "y": 36.1
+              },
+              "angle": 37.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 79.2,
+                "y": 113.4
+              },
+              "angle": -17.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.4,
+                "y": 108.7
+              },
+              "angle": -115
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.933,
+          "keypoints": {
+            "nose": {
+              "x": 85.7,
+              "y": 31.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 87.4,
+              "y": 29.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 85.9,
+              "y": 28.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 86.3,
+              "y": 26.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 82.5,
+              "y": 25.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.4,
+              "y": 36.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 67.8,
+              "y": 26.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.3,
+              "y": 53.9,
+              "v": 0.691
+            },
+            "rightElbow": {
+              "x": 56.4,
+              "y": 45.3,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 73.5,
+              "y": 71,
+              "v": 0.403
+            },
+            "rightWrist": {
+              "x": 56.5,
+              "y": 68,
+              "v": 0.985
+            },
+            "leftIndex": {
+              "x": 73.9,
+              "y": 74,
+              "v": 0.437
+            },
+            "rightIndex": {
+              "x": 57.2,
+              "y": 73.7,
+              "v": 0.972
+            },
+            "leftHip": {
+              "x": 60.8,
+              "y": 57.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.6,
+              "y": 56.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73,
+              "y": 80.5,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 50.1,
+              "y": 83.6,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 74.9,
+              "y": 104.9,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 37.7,
+              "y": 106.9,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 72,
+              "y": 108.9,
+              "v": 0.992
+            },
+            "rightHeel": {
+              "x": 36.8,
+              "y": 108.9,
+              "v": 0.994
+            },
+            "leftFootIndex": {
+              "x": 83.1,
+              "y": 113.2,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 40.8,
+              "y": 115.4,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 86.7,
+                "y": 28.9
+              },
+              "roll": 149,
+              "yaw": -0.543,
+              "pitch": 1.343
+            },
+            "torso": {
+              "center": {
+                "x": 74.1,
+                "y": 31.5
+              },
+              "angle": 53.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.5,
+                "y": 71
+              },
+              "angle": -82.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 56.5,
+                "y": 68
+              },
+              "angle": -83
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72,
+                "y": 108.9
+              },
+              "angle": -21.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.8,
+                "y": 108.9
+              },
+              "angle": -58.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.976,
+          "keypoints": {
+            "nose": {
+              "x": 83.2,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 84.2,
+              "y": 13.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 81.7,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 82.3,
+              "y": 13.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 76.6,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 84.2,
+              "y": 28.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60,
+              "y": 19.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.4,
+              "y": 50.7,
+              "v": 0.906
+            },
+            "rightElbow": {
+              "x": 55.9,
+              "y": 44.3,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 84.1,
+              "y": 72,
+              "v": 0.938
+            },
+            "rightWrist": {
+              "x": 63,
+              "y": 66.4,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 85,
+              "y": 74.9,
+              "v": 0.933
+            },
+            "rightIndex": {
+              "x": 66.6,
+              "y": 73.7,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 70.7,
+              "y": 63.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54.8,
+              "y": 62.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.3,
+              "y": 88.8,
+              "v": 0.965
+            },
+            "rightKnee": {
+              "x": 42.4,
+              "y": 89.7,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 87.9,
+              "y": 118.4,
+              "v": 0.971
+            },
+            "rightAnkle": {
+              "x": 32.1,
+              "y": 119.9,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 85.4,
+              "y": 123.7,
+              "v": 0.912
+            },
+            "rightHeel": {
+              "x": 31,
+              "y": 124.5,
+              "v": 0.889
+            },
+            "leftFootIndex": {
+              "x": 99.4,
+              "y": 124.9,
+              "v": 0.97
+            },
+            "rightFootIndex": {
+              "x": 30.8,
+              "y": 136.3,
+              "v": 0.987
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 83,
+                "y": 13.1
+              },
+              "roll": 156.3,
+              "yaw": 0.092,
+              "pitch": 1.007
+            },
+            "torso": {
+              "center": {
+                "x": 72.1,
+                "y": 24.4
+              },
+              "angle": 76.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.1,
+                "y": 72
+              },
+              "angle": -72.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 63,
+                "y": 66.4
+              },
+              "angle": -63.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85.4,
+                "y": 123.7
+              },
+              "angle": -4.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31,
+                "y": 124.5
+              },
+              "angle": -91
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.962,
+          "keypoints": {
+            "nose": {
+              "x": 71.8,
+              "y": 15.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.4,
+              "y": 13.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.7,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.9,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.3,
+              "y": 26.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.9,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.4,
+              "y": 38.3,
+              "v": 0.95
+            },
+            "rightElbow": {
+              "x": 38.1,
+              "y": 37.5,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 89.4,
+              "y": 27,
+              "v": 0.992
+            },
+            "rightWrist": {
+              "x": 54.2,
+              "y": 33.2,
+              "v": 0.991
+            },
+            "leftIndex": {
+              "x": 89,
+              "y": 22.1,
+              "v": 0.986
+            },
+            "rightIndex": {
+              "x": 59.3,
+              "y": 29,
+              "v": 0.978
+            },
+            "leftHip": {
+              "x": 65.4,
+              "y": 59.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54.6,
+              "y": 58.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.1,
+              "y": 79.5,
+              "v": 0.939
+            },
+            "rightKnee": {
+              "x": 49.1,
+              "y": 81.9,
+              "v": 0.941
+            },
+            "leftAnkle": {
+              "x": 68.1,
+              "y": 100.8,
+              "v": 0.919
+            },
+            "rightAnkle": {
+              "x": 40.1,
+              "y": 103.4,
+              "v": 0.966
+            },
+            "leftHeel": {
+              "x": 63.9,
+              "y": 103.4,
+              "v": 0.891
+            },
+            "rightHeel": {
+              "x": 40.2,
+              "y": 105.2,
+              "v": 0.785
+            },
+            "leftFootIndex": {
+              "x": 72.2,
+              "y": 111.3,
+              "v": 0.894
+            },
+            "rightFootIndex": {
+              "x": 40.5,
+              "y": 113,
+              "v": 0.901
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.6,
+                "y": 13.2
+              },
+              "roll": -176.6,
+              "yaw": 0.734,
+              "pitch": 1.615
+            },
+            "torso": {
+              "center": {
+                "x": 61.1,
+                "y": 25.5
+              },
+              "angle": 88.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.4,
+                "y": 27
+              },
+              "angle": 94.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 54.2,
+                "y": 33.2
+              },
+              "angle": 39.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 63.9,
+                "y": 103.4
+              },
+              "angle": -43.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.2,
+                "y": 105.2
+              },
+              "angle": -87.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.954,
+          "keypoints": {
+            "nose": {
+              "x": 70.1,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.5,
+              "y": 12,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.8,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.2,
+              "y": 12,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.5,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.1,
+              "y": 24.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51,
+              "y": 24.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.8,
+              "y": 38.9,
+              "v": 0.86
+            },
+            "rightElbow": {
+              "x": 39,
+              "y": 38,
+              "v": 0.946
+            },
+            "leftWrist": {
+              "x": 93.3,
+              "y": 34.1,
+              "v": 0.983
+            },
+            "rightWrist": {
+              "x": 50.3,
+              "y": 29.7,
+              "v": 0.918
+            },
+            "leftIndex": {
+              "x": 95.9,
+              "y": 30.3,
+              "v": 0.981
+            },
+            "rightIndex": {
+              "x": 53.9,
+              "y": 24.6,
+              "v": 0.88
+            },
+            "leftHip": {
+              "x": 66.9,
+              "y": 58.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.8,
+              "y": 58.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 87.2,
+              "y": 76.9,
+              "v": 0.984
+            },
+            "rightKnee": {
+              "x": 44.6,
+              "y": 82.5,
+              "v": 0.98
+            },
+            "leftAnkle": {
+              "x": 69.5,
+              "y": 94.8,
+              "v": 0.907
+            },
+            "rightAnkle": {
+              "x": 36.9,
+              "y": 104.7,
+              "v": 0.98
+            },
+            "leftHeel": {
+              "x": 63.8,
+              "y": 95.1,
+              "v": 0.858
+            },
+            "rightHeel": {
+              "x": 36.9,
+              "y": 108.2,
+              "v": 0.872
+            },
+            "leftFootIndex": {
+              "x": 69.3,
+              "y": 107.8,
+              "v": 0.859
+            },
+            "rightFootIndex": {
+              "x": 33.6,
+              "y": 111,
+              "v": 0.939
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.7,
+                "y": 12.3
+              },
+              "roll": -160.6,
+              "yaw": 0.804,
+              "pitch": 1.387
+            },
+            "torso": {
+              "center": {
+                "x": 61.6,
+                "y": 24.6
+              },
+              "angle": 88
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.3,
+                "y": 34.1
+              },
+              "angle": 55.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.3,
+                "y": 29.7
+              },
+              "angle": 54.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 63.8,
+                "y": 95.1
+              },
+              "angle": -66.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.9,
+                "y": 108.2
+              },
+              "angle": -139.7
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.976,
+          "keypoints": {
+            "nose": {
+              "x": 71.1,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.6,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.7,
+              "y": 12,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.5,
+              "y": 12,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.2,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.3,
+              "y": 24.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.3,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83,
+              "y": 38.9,
+              "v": 0.944
+            },
+            "rightElbow": {
+              "x": 35,
+              "y": 33.7,
+              "v": 0.99
+            },
+            "leftWrist": {
+              "x": 85.5,
+              "y": 29.6,
+              "v": 0.99
+            },
+            "rightWrist": {
+              "x": 52,
+              "y": 29.6,
+              "v": 0.959
+            },
+            "leftIndex": {
+              "x": 84.7,
+              "y": 25.9,
+              "v": 0.986
+            },
+            "rightIndex": {
+              "x": 57.5,
+              "y": 27.9,
+              "v": 0.914
+            },
+            "leftHip": {
+              "x": 65.9,
+              "y": 59.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54.1,
+              "y": 60.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 91.7,
+              "y": 67,
+              "v": 0.985
+            },
+            "rightKnee": {
+              "x": 49,
+              "y": 85.7,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 69,
+              "y": 82,
+              "v": 0.918
+            },
+            "rightAnkle": {
+              "x": 38.6,
+              "y": 111.5,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 64,
+              "y": 80.8,
+              "v": 0.929
+            },
+            "rightHeel": {
+              "x": 36.2,
+              "y": 113.5,
+              "v": 0.959
+            },
+            "leftFootIndex": {
+              "x": 67.7,
+              "y": 95.5,
+              "v": 0.899
+            },
+            "rightFootIndex": {
+              "x": 39.7,
+              "y": 124.8,
+              "v": 0.986
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.7,
+                "y": 12
+              },
+              "roll": -177,
+              "yaw": 0.762,
+              "pitch": 1.498
+            },
+            "torso": {
+              "center": {
+                "x": 61.3,
+                "y": 24.2
+              },
+              "angle": 87.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.5,
+                "y": 29.6
+              },
+              "angle": 102.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52,
+                "y": 29.6
+              },
+              "angle": 17.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 64,
+                "y": 80.8
+              },
+              "angle": -75.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.2,
+                "y": 113.5
+              },
+              "angle": -72.8
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/migue/poses.json
+++ b/public/assets/fighters/migue/poses.json
@@ -1,0 +1,8426 @@
+{
+  "version": 1,
+  "fighter": "migue",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:41:51.455Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.921,
+          "keypoints": {
+            "nose": {
+              "x": 66.4,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.8,
+              "y": 10.1,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 63.9,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.8,
+              "y": 10.8,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 59,
+              "y": 10,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 71.4,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.3,
+              "y": 24,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 84,
+              "y": 27.6,
+              "v": 0.602
+            },
+            "rightElbow": {
+              "x": 36.7,
+              "y": 41.7,
+              "v": 0.866
+            },
+            "leftWrist": {
+              "x": 92.2,
+              "y": 29.9,
+              "v": 0.491
+            },
+            "rightWrist": {
+              "x": 29.4,
+              "y": 29.7,
+              "v": 0.973
+            },
+            "leftIndex": {
+              "x": 94.4,
+              "y": 29.3,
+              "v": 0.536
+            },
+            "rightIndex": {
+              "x": 29,
+              "y": 24.3,
+              "v": 0.977
+            },
+            "leftHip": {
+              "x": 67.6,
+              "y": 61.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.6,
+              "y": 61.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.7,
+              "y": 87.3,
+              "v": 0.993
+            },
+            "rightKnee": {
+              "x": 36.3,
+              "y": 82.8,
+              "v": 0.966
+            },
+            "leftAnkle": {
+              "x": 92.6,
+              "y": 115.2,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 36,
+              "y": 108,
+              "v": 0.985
+            },
+            "leftHeel": {
+              "x": 92.8,
+              "y": 119.3,
+              "v": 0.916
+            },
+            "rightHeel": {
+              "x": 39.2,
+              "y": 113.8,
+              "v": 0.922
+            },
+            "leftFootIndex": {
+              "x": 94,
+              "y": 124.6,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 24.1,
+              "y": 115.2,
+              "v": 0.968
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.4,
+                "y": 10
+              },
+              "roll": 176.1,
+              "yaw": 0.361,
+              "pitch": 0.86
+            },
+            "torso": {
+              "center": {
+                "x": 58.9,
+                "y": 23.6
+              },
+              "angle": 91.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92.2,
+                "y": 29.9
+              },
+              "angle": 15.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.4,
+                "y": 29.7
+              },
+              "angle": 94.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.8,
+                "y": 119.3
+              },
+              "angle": -77.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.2,
+                "y": 113.8
+              },
+              "angle": -174.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.873,
+          "keypoints": {
+            "nose": {
+              "x": 66.3,
+              "y": 11,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.4,
+              "y": 8,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 63.2,
+              "y": 8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.8,
+              "y": 9.1,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 58.5,
+              "y": 9,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 71.9,
+              "y": 22.3,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 46.6,
+              "y": 24.4,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 83.8,
+              "y": 32.8,
+              "v": 0.254
+            },
+            "rightElbow": {
+              "x": 35.9,
+              "y": 41.4,
+              "v": 0.806
+            },
+            "leftWrist": {
+              "x": 87.2,
+              "y": 30.3,
+              "v": 0.203
+            },
+            "rightWrist": {
+              "x": 28.7,
+              "y": 28.2,
+              "v": 0.986
+            },
+            "leftIndex": {
+              "x": 87.3,
+              "y": 27.7,
+              "v": 0.325
+            },
+            "rightIndex": {
+              "x": 28.4,
+              "y": 22.6,
+              "v": 0.99
+            },
+            "leftHip": {
+              "x": 67.9,
+              "y": 60.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.5,
+              "y": 61.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.6,
+              "y": 86.7,
+              "v": 0.984
+            },
+            "rightKnee": {
+              "x": 35.6,
+              "y": 83.3,
+              "v": 0.917
+            },
+            "leftAnkle": {
+              "x": 92.7,
+              "y": 115.1,
+              "v": 0.99
+            },
+            "rightAnkle": {
+              "x": 35.4,
+              "y": 107.9,
+              "v": 0.97
+            },
+            "leftHeel": {
+              "x": 93.7,
+              "y": 119.3,
+              "v": 0.869
+            },
+            "rightHeel": {
+              "x": 38.3,
+              "y": 113.4,
+              "v": 0.869
+            },
+            "leftFootIndex": {
+              "x": 92.6,
+              "y": 124.5,
+              "v": 0.981
+            },
+            "rightFootIndex": {
+              "x": 24.2,
+              "y": 114.4,
+              "v": 0.941
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.8,
+                "y": 8
+              },
+              "roll": -180,
+              "yaw": 0.469,
+              "pitch": 0.937
+            },
+            "torso": {
+              "center": {
+                "x": 59.3,
+                "y": 23.4
+              },
+              "angle": 91.4
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 28.7,
+                "y": 28.2
+              },
+              "angle": 93.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.7,
+                "y": 119.3
+              },
+              "angle": -101.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.3,
+                "y": 113.4
+              },
+              "angle": -175.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.889,
+          "keypoints": {
+            "nose": {
+              "x": 66.7,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.7,
+              "y": 9.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 64,
+              "y": 9.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.8,
+              "y": 10.4,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 59.1,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.2,
+              "y": 23,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 46.7,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.4,
+              "y": 32.2,
+              "v": 0.283
+            },
+            "rightElbow": {
+              "x": 36.1,
+              "y": 42.6,
+              "v": 0.816
+            },
+            "leftWrist": {
+              "x": 86.9,
+              "y": 31.6,
+              "v": 0.229
+            },
+            "rightWrist": {
+              "x": 29.2,
+              "y": 29.1,
+              "v": 0.991
+            },
+            "leftIndex": {
+              "x": 86.8,
+              "y": 29.7,
+              "v": 0.368
+            },
+            "rightIndex": {
+              "x": 28.8,
+              "y": 22.8,
+              "v": 0.994
+            },
+            "leftHip": {
+              "x": 67.8,
+              "y": 61.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.9,
+              "y": 61.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80,
+              "y": 87.5,
+              "v": 0.989
+            },
+            "rightKnee": {
+              "x": 36.7,
+              "y": 82.3,
+              "v": 0.972
+            },
+            "leftAnkle": {
+              "x": 92.4,
+              "y": 113.8,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 36.1,
+              "y": 108.3,
+              "v": 0.992
+            },
+            "leftHeel": {
+              "x": 93.4,
+              "y": 118.2,
+              "v": 0.909
+            },
+            "rightHeel": {
+              "x": 38.4,
+              "y": 113.6,
+              "v": 0.947
+            },
+            "leftFootIndex": {
+              "x": 92.9,
+              "y": 124.2,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 24.2,
+              "y": 114.5,
+              "v": 0.981
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.4,
+                "y": 9.6
+              },
+              "roll": -177.9,
+              "yaw": 0.5,
+              "pitch": 0.981
+            },
+            "torso": {
+              "center": {
+                "x": 59,
+                "y": 23.9
+              },
+              "angle": 92.1
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 29.2,
+                "y": 29.1
+              },
+              "angle": 93.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.4,
+                "y": 118.2
+              },
+              "angle": -94.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.4,
+                "y": 113.6
+              },
+              "angle": -176.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.895,
+          "keypoints": {
+            "nose": {
+              "x": 66.6,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67,
+              "y": 9.9,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 63.8,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.1,
+              "y": 10.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 59,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.6,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.1,
+              "y": 24,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 82.8,
+              "y": 29.3,
+              "v": 0.418
+            },
+            "rightElbow": {
+              "x": 36.7,
+              "y": 42.1,
+              "v": 0.853
+            },
+            "leftWrist": {
+              "x": 88.7,
+              "y": 29.2,
+              "v": 0.337
+            },
+            "rightWrist": {
+              "x": 29.2,
+              "y": 29.4,
+              "v": 0.986
+            },
+            "leftIndex": {
+              "x": 89.7,
+              "y": 28.3,
+              "v": 0.421
+            },
+            "rightIndex": {
+              "x": 28.8,
+              "y": 23.9,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 67.8,
+              "y": 61,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.7,
+              "y": 61.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.2,
+              "y": 87.3,
+              "v": 0.989
+            },
+            "rightKnee": {
+              "x": 37.1,
+              "y": 82.3,
+              "v": 0.928
+            },
+            "leftAnkle": {
+              "x": 92.7,
+              "y": 114.5,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 36.1,
+              "y": 108.1,
+              "v": 0.971
+            },
+            "leftHeel": {
+              "x": 94.2,
+              "y": 119,
+              "v": 0.891
+            },
+            "rightHeel": {
+              "x": 39,
+              "y": 113.8,
+              "v": 0.886
+            },
+            "leftFootIndex": {
+              "x": 93.3,
+              "y": 124.6,
+              "v": 0.983
+            },
+            "rightFootIndex": {
+              "x": 24.1,
+              "y": 115,
+              "v": 0.946
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.4,
+                "y": 9.9
+              },
+              "roll": 178.2,
+              "yaw": 0.375,
+              "pitch": 0.828
+            },
+            "torso": {
+              "center": {
+                "x": 58.9,
+                "y": 23.6
+              },
+              "angle": 92.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.7,
+                "y": 29.2
+              },
+              "angle": 42
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.2,
+                "y": 29.4
+              },
+              "angle": 94.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 94.2,
+                "y": 119
+              },
+              "angle": -99.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39,
+                "y": 113.8
+              },
+              "angle": -175.4
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.897,
+          "keypoints": {
+            "nose": {
+              "x": 66.6,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.1,
+              "y": 9.8,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 63.6,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.4,
+              "y": 10.4,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 58.9,
+              "y": 10,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 71.5,
+              "y": 23.3,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 46.3,
+              "y": 24.1,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 81.5,
+              "y": 32,
+              "v": 0.352
+            },
+            "rightElbow": {
+              "x": 36.3,
+              "y": 42.1,
+              "v": 0.849
+            },
+            "leftWrist": {
+              "x": 89.4,
+              "y": 30.9,
+              "v": 0.323
+            },
+            "rightWrist": {
+              "x": 29.8,
+              "y": 29.5,
+              "v": 0.978
+            },
+            "leftIndex": {
+              "x": 91.2,
+              "y": 29.2,
+              "v": 0.447
+            },
+            "rightIndex": {
+              "x": 29.7,
+              "y": 23.8,
+              "v": 0.983
+            },
+            "leftHip": {
+              "x": 67.8,
+              "y": 61.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.2,
+              "y": 61.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.9,
+              "y": 87.4,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 36.7,
+              "y": 82.3,
+              "v": 0.96
+            },
+            "leftAnkle": {
+              "x": 92.6,
+              "y": 114.7,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 36.3,
+              "y": 108.1,
+              "v": 0.985
+            },
+            "leftHeel": {
+              "x": 93.6,
+              "y": 118.4,
+              "v": 0.897
+            },
+            "rightHeel": {
+              "x": 39.3,
+              "y": 113.1,
+              "v": 0.921
+            },
+            "leftFootIndex": {
+              "x": 92.6,
+              "y": 125.4,
+              "v": 0.986
+            },
+            "rightFootIndex": {
+              "x": 24.1,
+              "y": 115.2,
+              "v": 0.968
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.4,
+                "y": 9.7
+              },
+              "roll": 175.1,
+              "yaw": 0.356,
+              "pitch": 0.726
+            },
+            "torso": {
+              "center": {
+                "x": 58.9,
+                "y": 23.7
+              },
+              "angle": 91.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.4,
+                "y": 30.9
+              },
+              "angle": 43.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.8,
+                "y": 29.5
+              },
+              "angle": 91
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.6,
+                "y": 118.4
+              },
+              "angle": -98.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.3,
+                "y": 113.1
+              },
+              "angle": -172.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.911,
+          "keypoints": {
+            "nose": {
+              "x": 66.5,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.2,
+              "y": 10.2,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 63.9,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.4,
+              "y": 10.7,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 58.8,
+              "y": 9.9,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 71.7,
+              "y": 23.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.1,
+              "y": 24.5,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 84.1,
+              "y": 29.1,
+              "v": 0.477
+            },
+            "rightElbow": {
+              "x": 36.4,
+              "y": 42.4,
+              "v": 0.898
+            },
+            "leftWrist": {
+              "x": 93.7,
+              "y": 31.2,
+              "v": 0.443
+            },
+            "rightWrist": {
+              "x": 29.6,
+              "y": 29.1,
+              "v": 0.984
+            },
+            "leftIndex": {
+              "x": 95.4,
+              "y": 28.8,
+              "v": 0.503
+            },
+            "rightIndex": {
+              "x": 29.4,
+              "y": 23.5,
+              "v": 0.986
+            },
+            "leftHip": {
+              "x": 67.9,
+              "y": 60.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.6,
+              "y": 61.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80,
+              "y": 87.2,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 36.8,
+              "y": 83.2,
+              "v": 0.94
+            },
+            "leftAnkle": {
+              "x": 93,
+              "y": 115.2,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 36.5,
+              "y": 108,
+              "v": 0.983
+            },
+            "leftHeel": {
+              "x": 93.2,
+              "y": 118.8,
+              "v": 0.896
+            },
+            "rightHeel": {
+              "x": 39.4,
+              "y": 112.8,
+              "v": 0.915
+            },
+            "leftFootIndex": {
+              "x": 92.3,
+              "y": 125.4,
+              "v": 0.986
+            },
+            "rightFootIndex": {
+              "x": 24.2,
+              "y": 115.3,
+              "v": 0.964
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.6,
+                "y": 10.1
+              },
+              "roll": 174.8,
+              "yaw": 0.287,
+              "pitch": 0.8
+            },
+            "torso": {
+              "center": {
+                "x": 58.9,
+                "y": 23.9
+              },
+              "angle": 92.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.7,
+                "y": 31.2
+              },
+              "angle": 54.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.6,
+                "y": 29.1
+              },
+              "angle": 92
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.2,
+                "y": 118.8
+              },
+              "angle": -97.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.4,
+                "y": 112.8
+              },
+              "angle": -170.7
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.897,
+          "keypoints": {
+            "nose": {
+              "x": 66.4,
+              "y": 12,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 66.8,
+              "y": 9.6,
+              "v": 0.996
+            },
+            "rightEye": {
+              "x": 63.7,
+              "y": 9.5,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 64.9,
+              "y": 10.3,
+              "v": 0.997
+            },
+            "rightEar": {
+              "x": 58.9,
+              "y": 9.9,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 71.8,
+              "y": 23,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 46.2,
+              "y": 24.2,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 83.1,
+              "y": 31.5,
+              "v": 0.42
+            },
+            "rightElbow": {
+              "x": 36.3,
+              "y": 42.2,
+              "v": 0.866
+            },
+            "leftWrist": {
+              "x": 88,
+              "y": 31,
+              "v": 0.299
+            },
+            "rightWrist": {
+              "x": 29.1,
+              "y": 29.3,
+              "v": 0.983
+            },
+            "leftIndex": {
+              "x": 88.5,
+              "y": 29.5,
+              "v": 0.382
+            },
+            "rightIndex": {
+              "x": 29.5,
+              "y": 23.4,
+              "v": 0.987
+            },
+            "leftHip": {
+              "x": 68.2,
+              "y": 61.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.7,
+              "y": 61.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.8,
+              "y": 88.6,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 36.8,
+              "y": 82.5,
+              "v": 0.968
+            },
+            "leftAnkle": {
+              "x": 92.4,
+              "y": 114.2,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 36.4,
+              "y": 108.5,
+              "v": 0.986
+            },
+            "leftHeel": {
+              "x": 92.6,
+              "y": 117.6,
+              "v": 0.906
+            },
+            "rightHeel": {
+              "x": 39.6,
+              "y": 113.2,
+              "v": 0.919
+            },
+            "leftFootIndex": {
+              "x": 93.3,
+              "y": 125.2,
+              "v": 0.983
+            },
+            "rightFootIndex": {
+              "x": 24.7,
+              "y": 115.1,
+              "v": 0.964
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.3,
+                "y": 9.6
+              },
+              "roll": 178.2,
+              "yaw": 0.371,
+              "pitch": 0.79
+            },
+            "torso": {
+              "center": {
+                "x": 59,
+                "y": 23.6
+              },
+              "angle": 92.2
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 29.1,
+                "y": 29.3
+              },
+              "angle": 86.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.6,
+                "y": 117.6
+              },
+              "angle": -84.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.6,
+                "y": 113.2
+              },
+              "angle": -172.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.886,
+          "keypoints": {
+            "nose": {
+              "x": 65.3,
+              "y": 11.2,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 65.9,
+              "y": 8.5,
+              "v": 0.996
+            },
+            "rightEye": {
+              "x": 62.6,
+              "y": 8.2,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 64.4,
+              "y": 9.2,
+              "v": 0.996
+            },
+            "rightEar": {
+              "x": 58,
+              "y": 8.4,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 71.5,
+              "y": 21.6,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 46.2,
+              "y": 23,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 83.9,
+              "y": 30.6,
+              "v": 0.335
+            },
+            "rightElbow": {
+              "x": 36.1,
+              "y": 41.5,
+              "v": 0.791
+            },
+            "leftWrist": {
+              "x": 89.2,
+              "y": 30.1,
+              "v": 0.238
+            },
+            "rightWrist": {
+              "x": 28.6,
+              "y": 28.8,
+              "v": 0.979
+            },
+            "leftIndex": {
+              "x": 89.7,
+              "y": 27.3,
+              "v": 0.361
+            },
+            "rightIndex": {
+              "x": 28.1,
+              "y": 22.5,
+              "v": 0.986
+            },
+            "leftHip": {
+              "x": 68.2,
+              "y": 60.6,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 53.2,
+              "y": 60.8,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 79.2,
+              "y": 87.9,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 36.7,
+              "y": 81.4,
+              "v": 0.956
+            },
+            "leftAnkle": {
+              "x": 92.6,
+              "y": 113.7,
+              "v": 0.99
+            },
+            "rightAnkle": {
+              "x": 36.2,
+              "y": 107.8,
+              "v": 0.986
+            },
+            "leftHeel": {
+              "x": 93.7,
+              "y": 116.8,
+              "v": 0.898
+            },
+            "rightHeel": {
+              "x": 39.2,
+              "y": 112.6,
+              "v": 0.925
+            },
+            "leftFootIndex": {
+              "x": 93,
+              "y": 124.6,
+              "v": 0.982
+            },
+            "rightFootIndex": {
+              "x": 24.3,
+              "y": 115,
+              "v": 0.967
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.3,
+                "y": 8.4
+              },
+              "roll": 174.8,
+              "yaw": 0.317,
+              "pitch": 0.86
+            },
+            "torso": {
+              "center": {
+                "x": 58.9,
+                "y": 22.3
+              },
+              "angle": 92.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 28.6,
+                "y": 28.8
+              },
+              "angle": 94.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.7,
+                "y": 116.8
+              },
+              "angle": -95.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.2,
+                "y": 112.6
+              },
+              "angle": -170.8
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.911,
+          "keypoints": {
+            "nose": {
+              "x": 66,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.5,
+              "y": 10,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 63.5,
+              "y": 9.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.7,
+              "y": 10.7,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 58.5,
+              "y": 9.9,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 71.7,
+              "y": 23.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.2,
+              "y": 24.4,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 84.1,
+              "y": 29.4,
+              "v": 0.47
+            },
+            "rightElbow": {
+              "x": 36.7,
+              "y": 42,
+              "v": 0.799
+            },
+            "leftWrist": {
+              "x": 90,
+              "y": 29.8,
+              "v": 0.45
+            },
+            "rightWrist": {
+              "x": 29.7,
+              "y": 30.2,
+              "v": 0.984
+            },
+            "leftIndex": {
+              "x": 91,
+              "y": 27.9,
+              "v": 0.564
+            },
+            "rightIndex": {
+              "x": 29.2,
+              "y": 24,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 67.8,
+              "y": 61.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.8,
+              "y": 61.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.3,
+              "y": 88.8,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 36.8,
+              "y": 82,
+              "v": 0.965
+            },
+            "leftAnkle": {
+              "x": 92.6,
+              "y": 114.2,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 36,
+              "y": 107.9,
+              "v": 0.987
+            },
+            "leftHeel": {
+              "x": 93.4,
+              "y": 118.3,
+              "v": 0.888
+            },
+            "rightHeel": {
+              "x": 38.6,
+              "y": 113.5,
+              "v": 0.93
+            },
+            "leftFootIndex": {
+              "x": 93.5,
+              "y": 124.4,
+              "v": 0.985
+            },
+            "rightFootIndex": {
+              "x": 24.8,
+              "y": 114.6,
+              "v": 0.973
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65,
+                "y": 9.9
+              },
+              "roll": 174.3,
+              "yaw": 0.332,
+              "pitch": 0.846
+            },
+            "torso": {
+              "center": {
+                "x": 59,
+                "y": 23.9
+              },
+              "angle": 92.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90,
+                "y": 29.8
+              },
+              "angle": 62.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.7,
+                "y": 30.2
+              },
+              "angle": 94.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.4,
+                "y": 118.3
+              },
+              "angle": -89.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.6,
+                "y": 113.5
+              },
+              "angle": -175.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 64.6,
+              "y": 13.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63.7,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.6,
+              "y": 10.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.5,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66.7,
+              "y": 22.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.9,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 89.6,
+              "y": 24,
+              "v": 0.993
+            },
+            "rightElbow": {
+              "x": 20,
+              "y": 37.6,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 111,
+              "y": 26.5,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 35.2,
+              "y": 31,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 116.6,
+              "y": 25.7,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 40.8,
+              "y": 29.3,
+              "v": 0.987
+            },
+            "leftHip": {
+              "x": 60.3,
+              "y": 63.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.7,
+              "y": 64.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.7,
+              "y": 86.1,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 27.5,
+              "y": 90,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 82,
+              "y": 115.7,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 15.7,
+              "y": 116.3,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 79,
+              "y": 122,
+              "v": 0.975
+            },
+            "rightHeel": {
+              "x": 16.6,
+              "y": 121.2,
+              "v": 0.942
+            },
+            "leftFootIndex": {
+              "x": 92.3,
+              "y": 123.6,
+              "v": 0.992
+            },
+            "rightFootIndex": {
+              "x": 10.5,
+              "y": 124.6,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.9,
+                "y": 10.3
+              },
+              "roll": -180,
+              "yaw": 1.029,
+              "pitch": 1.765
+            },
+            "torso": {
+              "center": {
+                "x": 52.3,
+                "y": 22.1
+              },
+              "angle": 89.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 111,
+                "y": 26.5
+              },
+              "angle": 8.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.2,
+                "y": 31
+              },
+              "angle": 16.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 79,
+                "y": 122
+              },
+              "angle": -6.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 16.6,
+                "y": 121.2
+              },
+              "angle": -150.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.992,
+          "keypoints": {
+            "nose": {
+              "x": 57.6,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.3,
+              "y": 9.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.5,
+              "y": 8.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57,
+              "y": 10.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.9,
+              "y": 9.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.9,
+              "y": 22.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.7,
+              "y": 23.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.2,
+              "y": 24.9,
+              "v": 0.995
+            },
+            "rightElbow": {
+              "x": 27.4,
+              "y": 42.1,
+              "v": 0.986
+            },
+            "leftWrist": {
+              "x": 103.6,
+              "y": 26.3,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 20.2,
+              "y": 28.9,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 109.3,
+              "y": 25.7,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 20.4,
+              "y": 23.4,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 59.9,
+              "y": 61.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.7,
+              "y": 61.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.2,
+              "y": 87.6,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 28.5,
+              "y": 82.9,
+              "v": 0.981
+            },
+            "leftAnkle": {
+              "x": 84.6,
+              "y": 115.4,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 27.5,
+              "y": 108.4,
+              "v": 0.99
+            },
+            "leftHeel": {
+              "x": 85.3,
+              "y": 119.1,
+              "v": 0.951
+            },
+            "rightHeel": {
+              "x": 30.1,
+              "y": 113,
+              "v": 0.943
+            },
+            "leftFootIndex": {
+              "x": 83,
+              "y": 124.6,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 16,
+              "y": 114.5,
+              "v": 0.982
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.4,
+                "y": 9.2
+              },
+              "roll": 172.5,
+              "yaw": 0.313,
+              "pitch": 0.77
+            },
+            "torso": {
+              "center": {
+                "x": 50.8,
+                "y": 23.1
+              },
+              "angle": 92.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.6,
+                "y": 26.3
+              },
+              "angle": 6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 20.2,
+                "y": 28.9
+              },
+              "angle": 87.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85.3,
+                "y": 119.1
+              },
+              "angle": -112.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.1,
+                "y": 113
+              },
+              "angle": -173.9
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.99,
+          "keypoints": {
+            "nose": {
+              "x": 58.2,
+              "y": 12,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.3,
+              "y": 9.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.4,
+              "y": 9.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.1,
+              "y": 10.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.7,
+              "y": 9.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66.8,
+              "y": 23,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.1,
+              "y": 24.6,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 27.6,
+              "y": 41.8,
+              "v": 0.986
+            },
+            "leftWrist": {
+              "x": 102.9,
+              "y": 24.7,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 21,
+              "y": 28.2,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 108.4,
+              "y": 25.1,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 21.1,
+              "y": 22.6,
+              "v": 0.993
+            },
+            "leftHip": {
+              "x": 59.8,
+              "y": 61.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.3,
+              "y": 62.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.4,
+              "y": 86.1,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 29.5,
+              "y": 82.1,
+              "v": 0.982
+            },
+            "leftAnkle": {
+              "x": 85.4,
+              "y": 116.3,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 28,
+              "y": 107.8,
+              "v": 0.986
+            },
+            "leftHeel": {
+              "x": 85.6,
+              "y": 119.7,
+              "v": 0.937
+            },
+            "rightHeel": {
+              "x": 30.5,
+              "y": 113.1,
+              "v": 0.941
+            },
+            "leftFootIndex": {
+              "x": 85.4,
+              "y": 125.9,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 16.2,
+              "y": 114.9,
+              "v": 0.974
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.9,
+                "y": 9.4
+              },
+              "roll": -178,
+              "yaw": 0.465,
+              "pitch": 0.913
+            },
+            "torso": {
+              "center": {
+                "x": 52.9,
+                "y": 23.9
+              },
+              "angle": 88.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 102.9,
+                "y": 24.7
+              },
+              "angle": -4.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 21,
+                "y": 28.2
+              },
+              "angle": 89
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85.6,
+                "y": 119.7
+              },
+              "angle": -91.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.5,
+                "y": 113.1
+              },
+              "angle": -172.8
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.992,
+          "keypoints": {
+            "nose": {
+              "x": 58.3,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.7,
+              "y": 9.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.6,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 56.8,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.6,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.8,
+              "y": 22.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37.8,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.1,
+              "y": 27.2,
+              "v": 0.987
+            },
+            "rightElbow": {
+              "x": 27.3,
+              "y": 42.3,
+              "v": 0.983
+            },
+            "leftWrist": {
+              "x": 102.7,
+              "y": 26.8,
+              "v": 0.989
+            },
+            "rightWrist": {
+              "x": 20,
+              "y": 29.1,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 108.3,
+              "y": 25.8,
+              "v": 0.987
+            },
+            "rightIndex": {
+              "x": 20.1,
+              "y": 23.4,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 60.1,
+              "y": 61.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45,
+              "y": 61.9,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 71.5,
+              "y": 88.2,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 28.7,
+              "y": 83.2,
+              "v": 0.979
+            },
+            "leftAnkle": {
+              "x": 84.7,
+              "y": 115.9,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 28.2,
+              "y": 108.3,
+              "v": 0.991
+            },
+            "leftHeel": {
+              "x": 85.7,
+              "y": 119.4,
+              "v": 0.964
+            },
+            "rightHeel": {
+              "x": 30.7,
+              "y": 113.5,
+              "v": 0.957
+            },
+            "leftFootIndex": {
+              "x": 83.8,
+              "y": 125,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 16.1,
+              "y": 114.5,
+              "v": 0.984
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.2,
+                "y": 9.7
+              },
+              "roll": 174.5,
+              "yaw": 0.369,
+              "pitch": 0.851
+            },
+            "torso": {
+              "center": {
+                "x": 50.8,
+                "y": 23.6
+              },
+              "angle": 92.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 102.7,
+                "y": 26.8
+              },
+              "angle": 10.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 20,
+                "y": 29.1
+              },
+              "angle": 89
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85.7,
+                "y": 119.4
+              },
+              "angle": -108.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.7,
+                "y": 113.5
+              },
+              "angle": -176.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 58.2,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.1,
+              "y": 9.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.1,
+              "y": 9.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.3,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66.4,
+              "y": 22.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.4,
+              "y": 24,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.4,
+              "y": 26.5,
+              "v": 0.997
+            },
+            "rightElbow": {
+              "x": 27.8,
+              "y": 41.8,
+              "v": 0.988
+            },
+            "leftWrist": {
+              "x": 102.4,
+              "y": 28.2,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 19.5,
+              "y": 28.9,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 108,
+              "y": 27.6,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 19.5,
+              "y": 22.8,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 59.4,
+              "y": 62.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.2,
+              "y": 61.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.7,
+              "y": 88.4,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 27.4,
+              "y": 83.5,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 85.7,
+              "y": 114.4,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 27.6,
+              "y": 107.7,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 86.5,
+              "y": 118.5,
+              "v": 0.956
+            },
+            "rightHeel": {
+              "x": 30.3,
+              "y": 112.6,
+              "v": 0.962
+            },
+            "leftFootIndex": {
+              "x": 85.6,
+              "y": 124.5,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 16.2,
+              "y": 114.4,
+              "v": 0.988
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.1,
+                "y": 9.8
+              },
+              "roll": 177.1,
+              "yaw": 0.275,
+              "pitch": 0.674
+            },
+            "torso": {
+              "center": {
+                "x": 52.4,
+                "y": 23.5
+              },
+              "angle": 89.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 102.4,
+                "y": 28.2
+              },
+              "angle": 6.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 19.5,
+                "y": 28.9
+              },
+              "angle": 90
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 86.5,
+                "y": 118.5
+              },
+              "angle": -98.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.3,
+                "y": 112.6
+              },
+              "angle": -172.7
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.989,
+          "keypoints": {
+            "nose": {
+              "x": 60.9,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.3,
+              "y": 9.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.1,
+              "y": 9.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.8,
+              "y": 10.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.8,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.9,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.6,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.4,
+              "y": 26.3,
+              "v": 0.993
+            },
+            "rightElbow": {
+              "x": 29.7,
+              "y": 42.1,
+              "v": 0.984
+            },
+            "leftWrist": {
+              "x": 101.8,
+              "y": 25.1,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 23.1,
+              "y": 29.5,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 107,
+              "y": 24.5,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 23,
+              "y": 23.7,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 61.5,
+              "y": 61.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.4,
+              "y": 61.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.7,
+              "y": 88.5,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 30.5,
+              "y": 83.4,
+              "v": 0.973
+            },
+            "leftAnkle": {
+              "x": 87.4,
+              "y": 115.1,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 29.9,
+              "y": 107.9,
+              "v": 0.981
+            },
+            "leftHeel": {
+              "x": 88.8,
+              "y": 119.3,
+              "v": 0.944
+            },
+            "rightHeel": {
+              "x": 33,
+              "y": 113.7,
+              "v": 0.936
+            },
+            "leftFootIndex": {
+              "x": 87,
+              "y": 125.1,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 18.2,
+              "y": 115,
+              "v": 0.97
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.7,
+                "y": 9.5
+              },
+              "roll": 176.4,
+              "yaw": 0.374,
+              "pitch": 0.842
+            },
+            "torso": {
+              "center": {
+                "x": 54.3,
+                "y": 23.8
+              },
+              "angle": 89.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 101.8,
+                "y": 25.1
+              },
+              "angle": 6.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 23.1,
+                "y": 29.5
+              },
+              "angle": 91
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 88.8,
+                "y": 119.3
+              },
+              "angle": -107.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 33,
+                "y": 113.7
+              },
+              "angle": -175
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 58.5,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.2,
+              "y": 9.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.8,
+              "y": 8.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57,
+              "y": 10,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.6,
+              "y": 9.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.9,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.5,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.9,
+              "y": 26,
+              "v": 0.995
+            },
+            "rightElbow": {
+              "x": 27.9,
+              "y": 41.6,
+              "v": 0.987
+            },
+            "leftWrist": {
+              "x": 101.9,
+              "y": 25.6,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 22.4,
+              "y": 28.9,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 108,
+              "y": 25,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 22.5,
+              "y": 23.3,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 59.4,
+              "y": 62.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.4,
+              "y": 62.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71,
+              "y": 87.3,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 28.9,
+              "y": 83.3,
+              "v": 0.989
+            },
+            "leftAnkle": {
+              "x": 83.5,
+              "y": 114.5,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 28.1,
+              "y": 108.4,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 83.8,
+              "y": 118.1,
+              "v": 0.961
+            },
+            "rightHeel": {
+              "x": 31.4,
+              "y": 113.4,
+              "v": 0.964
+            },
+            "leftFootIndex": {
+              "x": 84.4,
+              "y": 124.7,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 17.1,
+              "y": 115.4,
+              "v": 0.987
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.5,
+                "y": 9
+              },
+              "roll": 176.6,
+              "yaw": 0.294,
+              "pitch": 0.822
+            },
+            "torso": {
+              "center": {
+                "x": 52.2,
+                "y": 23.9
+              },
+              "angle": 89.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 101.9,
+                "y": 25.6
+              },
+              "angle": 5.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 22.4,
+                "y": 28.9
+              },
+              "angle": 89
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.8,
+                "y": 118.1
+              },
+              "angle": -84.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.4,
+                "y": 113.4
+              },
+              "angle": -172
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 58.1,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.7,
+              "y": 9.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.1,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.2,
+              "y": 10,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.9,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.5,
+              "y": 22.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.3,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.1,
+              "y": 27.4,
+              "v": 0.977
+            },
+            "rightElbow": {
+              "x": 27.4,
+              "y": 41.7,
+              "v": 0.986
+            },
+            "leftWrist": {
+              "x": 100.9,
+              "y": 26.9,
+              "v": 0.98
+            },
+            "rightWrist": {
+              "x": 20.9,
+              "y": 28.1,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 107.3,
+              "y": 25.7,
+              "v": 0.977
+            },
+            "rightIndex": {
+              "x": 20.8,
+              "y": 22.3,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 59.9,
+              "y": 61.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.7,
+              "y": 62,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.2,
+              "y": 88.8,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 28.6,
+              "y": 82.8,
+              "v": 0.993
+            },
+            "leftAnkle": {
+              "x": 85.1,
+              "y": 115,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 27.9,
+              "y": 107.9,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 85.5,
+              "y": 119,
+              "v": 0.971
+            },
+            "rightHeel": {
+              "x": 30.9,
+              "y": 113,
+              "v": 0.971
+            },
+            "leftFootIndex": {
+              "x": 85.8,
+              "y": 124.6,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 16.2,
+              "y": 114.8,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.9,
+                "y": 9.6
+              },
+              "roll": -180,
+              "yaw": 0.333,
+              "pitch": 0.833
+            },
+            "torso": {
+              "center": {
+                "x": 51.4,
+                "y": 23
+              },
+              "angle": 91.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.9,
+                "y": 26.9
+              },
+              "angle": 10.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 20.9,
+                "y": 28.1
+              },
+              "angle": 91
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85.5,
+                "y": 119
+              },
+              "angle": -86.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.9,
+                "y": 113
+              },
+              "angle": -173
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.924,
+          "keypoints": {
+            "nose": {
+              "x": 66.2,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.6,
+              "y": 9.8,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 63.5,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.9,
+              "y": 10.5,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 58.6,
+              "y": 10,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 71.5,
+              "y": 23.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.4,
+              "y": 24.4,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 84.5,
+              "y": 29.2,
+              "v": 0.587
+            },
+            "rightElbow": {
+              "x": 36.2,
+              "y": 42.3,
+              "v": 0.858
+            },
+            "leftWrist": {
+              "x": 93,
+              "y": 30.6,
+              "v": 0.545
+            },
+            "rightWrist": {
+              "x": 29.2,
+              "y": 29.8,
+              "v": 0.984
+            },
+            "leftIndex": {
+              "x": 94.8,
+              "y": 29.3,
+              "v": 0.607
+            },
+            "rightIndex": {
+              "x": 29.1,
+              "y": 23.8,
+              "v": 0.987
+            },
+            "leftHip": {
+              "x": 68,
+              "y": 61.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53,
+              "y": 62,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.3,
+              "y": 88.7,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 36.6,
+              "y": 82.5,
+              "v": 0.965
+            },
+            "leftAnkle": {
+              "x": 92.8,
+              "y": 115.3,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 35.8,
+              "y": 108.2,
+              "v": 0.984
+            },
+            "leftHeel": {
+              "x": 94.1,
+              "y": 119.9,
+              "v": 0.881
+            },
+            "rightHeel": {
+              "x": 38.6,
+              "y": 113.5,
+              "v": 0.92
+            },
+            "leftFootIndex": {
+              "x": 93.1,
+              "y": 124.9,
+              "v": 0.982
+            },
+            "rightFootIndex": {
+              "x": 24.3,
+              "y": 114.7,
+              "v": 0.965
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.1,
+                "y": 9.7
+              },
+              "roll": 176.3,
+              "yaw": 0.37,
+              "pitch": 0.869
+            },
+            "torso": {
+              "center": {
+                "x": 59,
+                "y": 23.9
+              },
+              "angle": 92.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93,
+                "y": 30.6
+              },
+              "angle": 35.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.2,
+                "y": 29.8
+              },
+              "angle": 91
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 94.1,
+                "y": 119.9
+              },
+              "angle": -101.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.6,
+                "y": 113.5
+              },
+              "angle": -175.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.958,
+          "keypoints": {
+            "nose": {
+              "x": 52.5,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 53.4,
+              "y": 10.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49.6,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 51.1,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 44.3,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 56.5,
+              "y": 24.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 30.9,
+              "y": 25.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.8,
+              "y": 31.3,
+              "v": 0.677
+            },
+            "rightElbow": {
+              "x": 21.5,
+              "y": 43.9,
+              "v": 0.95
+            },
+            "leftWrist": {
+              "x": 83.7,
+              "y": 32.7,
+              "v": 0.765
+            },
+            "rightWrist": {
+              "x": 12.9,
+              "y": 39.5,
+              "v": 0.975
+            },
+            "leftIndex": {
+              "x": 87.9,
+              "y": 31.4,
+              "v": 0.773
+            },
+            "rightIndex": {
+              "x": 11.4,
+              "y": 35.7,
+              "v": 0.975
+            },
+            "leftHip": {
+              "x": 55,
+              "y": 62.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 40.4,
+              "y": 66.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.6,
+              "y": 67.3,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 19.4,
+              "y": 89.4,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 107.2,
+              "y": 78.1,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 37,
+              "y": 113.2,
+              "v": 0.991
+            },
+            "leftHeel": {
+              "x": 110.7,
+              "y": 83.6,
+              "v": 0.996
+            },
+            "rightHeel": {
+              "x": 42.3,
+              "y": 116.3,
+              "v": 0.962
+            },
+            "leftFootIndex": {
+              "x": 115.3,
+              "y": 68.6,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 28.3,
+              "y": 123.7,
+              "v": 0.972
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.5,
+                "y": 10.8
+              },
+              "roll": 178.5,
+              "yaw": 0.263,
+              "pitch": 0.75
+            },
+            "torso": {
+              "center": {
+                "x": 43.7,
+                "y": 25
+              },
+              "angle": 95.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 83.7,
+                "y": 32.7
+              },
+              "angle": 17.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 12.9,
+                "y": 39.5
+              },
+              "angle": 111.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 110.7,
+                "y": 83.6
+              },
+              "angle": 73
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.3,
+                "y": 116.3
+              },
+              "angle": -152.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.921,
+          "keypoints": {
+            "nose": {
+              "x": 48.7,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 48.6,
+              "y": 10.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 46.2,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 45.5,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 41.2,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 50.3,
+              "y": 23,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 28.4,
+              "y": 22,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 54.1,
+              "y": 40.7,
+              "v": 0.254
+            },
+            "rightElbow": {
+              "x": 13.4,
+              "y": 37.1,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 59.3,
+              "y": 46.5,
+              "v": 0.413
+            },
+            "rightWrist": {
+              "x": 28.6,
+              "y": 36.9,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 61.2,
+              "y": 46,
+              "v": 0.577
+            },
+            "rightIndex": {
+              "x": 33.7,
+              "y": 34.8,
+              "v": 0.993
+            },
+            "leftHip": {
+              "x": 48.9,
+              "y": 57.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 38.1,
+              "y": 60.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.6,
+              "y": 60.5,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 49.6,
+              "y": 90.9,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 105.4,
+              "y": 68.6,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 30.7,
+              "y": 113.2,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 108.1,
+              "y": 72.5,
+              "v": 0.991
+            },
+            "rightHeel": {
+              "x": 26.2,
+              "y": 116.8,
+              "v": 0.973
+            },
+            "leftFootIndex": {
+              "x": 112.8,
+              "y": 63,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 35.1,
+              "y": 124.4,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 47.4,
+                "y": 10.3
+              },
+              "roll": 170.5,
+              "yaw": 0.534,
+              "pitch": 1.027
+            },
+            "torso": {
+              "center": {
+                "x": 39.3,
+                "y": 22.5
+              },
+              "angle": 96.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 59.3,
+                "y": 46.5
+              },
+              "angle": 14.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.6,
+                "y": 36.9
+              },
+              "angle": 22.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 108.1,
+                "y": 72.5
+              },
+              "angle": 63.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 26.2,
+                "y": 116.8
+              },
+              "angle": -40.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.931,
+          "keypoints": {
+            "nose": {
+              "x": 48.3,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 48.4,
+              "y": 9.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 45.9,
+              "y": 9.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 44.9,
+              "y": 9.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 40.9,
+              "y": 9.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 50.4,
+              "y": 22.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 28.2,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 51.9,
+              "y": 41.4,
+              "v": 0.354
+            },
+            "rightElbow": {
+              "x": 13.3,
+              "y": 35.3,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 61.3,
+              "y": 52.9,
+              "v": 0.546
+            },
+            "rightWrist": {
+              "x": 29,
+              "y": 35.7,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 64.2,
+              "y": 54.3,
+              "v": 0.666
+            },
+            "rightIndex": {
+              "x": 33.7,
+              "y": 33.4,
+              "v": 0.992
+            },
+            "leftHip": {
+              "x": 48.9,
+              "y": 56.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 39.1,
+              "y": 60,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.6,
+              "y": 59.1,
+              "v": 0.983
+            },
+            "rightKnee": {
+              "x": 51.1,
+              "y": 90.7,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 104.9,
+              "y": 66.6,
+              "v": 0.98
+            },
+            "rightAnkle": {
+              "x": 30.5,
+              "y": 113.4,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 107.1,
+              "y": 69.6,
+              "v": 0.975
+            },
+            "rightHeel": {
+              "x": 25.8,
+              "y": 117,
+              "v": 0.949
+            },
+            "leftFootIndex": {
+              "x": 114.1,
+              "y": 59.7,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 37.6,
+              "y": 123.4,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 47.2,
+                "y": 9.1
+              },
+              "roll": 177.7,
+              "yaw": 0.46,
+              "pitch": 1.019
+            },
+            "torso": {
+              "center": {
+                "x": 39.3,
+                "y": 21.6
+              },
+              "angle": 97.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 61.3,
+                "y": 52.9
+              },
+              "angle": -25.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29,
+                "y": 35.7
+              },
+              "angle": 26.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 107.1,
+                "y": 69.6
+              },
+              "angle": 54.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25.8,
+                "y": 117
+              },
+              "angle": -28.5
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.93,
+          "keypoints": {
+            "nose": {
+              "x": 65.8,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66,
+              "y": 9.7,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 63,
+              "y": 9.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.5,
+              "y": 10.7,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 58.2,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.9,
+              "y": 23.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.9,
+              "y": 24.7,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 83.2,
+              "y": 28.4,
+              "v": 0.644
+            },
+            "rightElbow": {
+              "x": 35.8,
+              "y": 42.3,
+              "v": 0.889
+            },
+            "leftWrist": {
+              "x": 92.8,
+              "y": 31.9,
+              "v": 0.586
+            },
+            "rightWrist": {
+              "x": 28.4,
+              "y": 29.7,
+              "v": 0.978
+            },
+            "leftIndex": {
+              "x": 95.5,
+              "y": 31.5,
+              "v": 0.607
+            },
+            "rightIndex": {
+              "x": 28.3,
+              "y": 24.1,
+              "v": 0.979
+            },
+            "leftHip": {
+              "x": 66.4,
+              "y": 61.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.2,
+              "y": 61.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.2,
+              "y": 87.3,
+              "v": 0.993
+            },
+            "rightKnee": {
+              "x": 28.2,
+              "y": 71.8,
+              "v": 0.984
+            },
+            "leftAnkle": {
+              "x": 91.9,
+              "y": 113.4,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 41.9,
+              "y": 95.7,
+              "v": 0.976
+            },
+            "leftHeel": {
+              "x": 92.4,
+              "y": 118.2,
+              "v": 0.92
+            },
+            "rightHeel": {
+              "x": 46.8,
+              "y": 98.1,
+              "v": 0.906
+            },
+            "leftFootIndex": {
+              "x": 91,
+              "y": 124.3,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 35.5,
+              "y": 108.2,
+              "v": 0.953
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.5,
+                "y": 9.7
+              },
+              "roll": -180,
+              "yaw": 0.433,
+              "pitch": 0.833
+            },
+            "torso": {
+              "center": {
+                "x": 58.4,
+                "y": 24
+              },
+              "angle": 90.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92.8,
+                "y": 31.9
+              },
+              "angle": 8.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.4,
+                "y": 29.7
+              },
+              "angle": 91
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 92.4,
+                "y": 118.2
+              },
+              "angle": -102.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 46.8,
+                "y": 98.1
+              },
+              "angle": -138.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.944,
+          "keypoints": {
+            "nose": {
+              "x": 59.8,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 60.1,
+              "y": 9.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.9,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.4,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.7,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66.6,
+              "y": 23.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.7,
+              "y": 24.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.3,
+              "y": 37.4,
+              "v": 0.726
+            },
+            "rightElbow": {
+              "x": 29.6,
+              "y": 42.7,
+              "v": 0.948
+            },
+            "leftWrist": {
+              "x": 93.6,
+              "y": 40.8,
+              "v": 0.685
+            },
+            "rightWrist": {
+              "x": 21.7,
+              "y": 29.1,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 97.1,
+              "y": 39.9,
+              "v": 0.728
+            },
+            "rightIndex": {
+              "x": 22.1,
+              "y": 23.1,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 62.8,
+              "y": 61,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47,
+              "y": 61.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.2,
+              "y": 88.1,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 30.6,
+              "y": 82.4,
+              "v": 0.956
+            },
+            "leftAnkle": {
+              "x": 85.8,
+              "y": 113.7,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 29,
+              "y": 108.5,
+              "v": 0.98
+            },
+            "leftHeel": {
+              "x": 86.7,
+              "y": 118.6,
+              "v": 0.872
+            },
+            "rightHeel": {
+              "x": 31.8,
+              "y": 113.4,
+              "v": 0.903
+            },
+            "leftFootIndex": {
+              "x": 85.5,
+              "y": 123.8,
+              "v": 0.982
+            },
+            "rightFootIndex": {
+              "x": 17.2,
+              "y": 114.7,
+              "v": 0.968
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58.5,
+                "y": 9.5
+              },
+              "roll": -178.2,
+              "yaw": 0.406,
+              "pitch": 0.765
+            },
+            "torso": {
+              "center": {
+                "x": 53.2,
+                "y": 24.2
+              },
+              "angle": 92.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.6,
+                "y": 40.8
+              },
+              "angle": 14.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 21.7,
+                "y": 29.1
+              },
+              "angle": 86.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 86.7,
+                "y": 118.6
+              },
+              "angle": -103
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.8,
+                "y": 113.4
+              },
+              "angle": -174.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.868,
+          "keypoints": {
+            "nose": {
+              "x": 47,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 47.3,
+              "y": 9.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 43.5,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 45.1,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 38.4,
+              "y": 11,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 54.1,
+              "y": 19.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 28.8,
+              "y": 26.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.3,
+              "y": 24,
+              "v": 0.17
+            },
+            "rightElbow": {
+              "x": 19.6,
+              "y": 46.8,
+              "v": 0.926
+            },
+            "leftWrist": {
+              "x": 67.2,
+              "y": 20.2,
+              "v": 0.288
+            },
+            "rightWrist": {
+              "x": 13.5,
+              "y": 33.3,
+              "v": 0.974
+            },
+            "leftIndex": {
+              "x": 60.9,
+              "y": 14.3,
+              "v": 0.384
+            },
+            "rightIndex": {
+              "x": 13.7,
+              "y": 27.2,
+              "v": 0.969
+            },
+            "leftHip": {
+              "x": 61.5,
+              "y": 53,
+              "v": 0.998
+            },
+            "rightHip": {
+              "x": 51.3,
+              "y": 62.5,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 80.5,
+              "y": 37,
+              "v": 0.948
+            },
+            "rightKnee": {
+              "x": 46.8,
+              "y": 88.9,
+              "v": 0.893
+            },
+            "leftAnkle": {
+              "x": 106.7,
+              "y": 23.7,
+              "v": 0.93
+            },
+            "rightAnkle": {
+              "x": 56,
+              "y": 116.6,
+              "v": 0.922
+            },
+            "leftHeel": {
+              "x": 111.4,
+              "y": 26.1,
+              "v": 0.916
+            },
+            "rightHeel": {
+              "x": 60,
+              "y": 121.6,
+              "v": 0.856
+            },
+            "leftFootIndex": {
+              "x": 108.5,
+              "y": 9.6,
+              "v": 0.961
+            },
+            "rightFootIndex": {
+              "x": 44.2,
+              "y": 124.1,
+              "v": 0.83
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 45.4,
+                "y": 9.7
+              },
+              "roll": -172.5,
+              "yaw": 0.417,
+              "pitch": 0.639
+            },
+            "torso": {
+              "center": {
+                "x": 41.5,
+                "y": 23.2
+              },
+              "angle": 113.4
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 13.5,
+                "y": 33.3
+              },
+              "angle": 88.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 111.4,
+                "y": 26.1
+              },
+              "angle": 100
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 60,
+                "y": 121.6
+              },
+              "angle": -171
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.884,
+          "keypoints": {
+            "nose": {
+              "x": 42.3,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 42.6,
+              "y": 8.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 38.6,
+              "y": 9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 41.3,
+              "y": 9.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 33.9,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 50.4,
+              "y": 19.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 25,
+              "y": 25.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 67.2,
+              "y": 24.8,
+              "v": 0.373
+            },
+            "rightElbow": {
+              "x": 16.2,
+              "y": 39.3,
+              "v": 0.945
+            },
+            "leftWrist": {
+              "x": 85.1,
+              "y": 31.5,
+              "v": 0.243
+            },
+            "rightWrist": {
+              "x": 19.4,
+              "y": 40.3,
+              "v": 0.913
+            },
+            "leftIndex": {
+              "x": 90.6,
+              "y": 31.3,
+              "v": 0.271
+            },
+            "rightIndex": {
+              "x": 22.1,
+              "y": 37.7,
+              "v": 0.89
+            },
+            "leftHip": {
+              "x": 55,
+              "y": 53,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.9,
+              "y": 61.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.9,
+              "y": 37,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 42.6,
+              "y": 89,
+              "v": 0.978
+            },
+            "leftAnkle": {
+              "x": 106.8,
+              "y": 23.6,
+              "v": 0.984
+            },
+            "rightAnkle": {
+              "x": 51,
+              "y": 115.3,
+              "v": 0.963
+            },
+            "leftHeel": {
+              "x": 110.5,
+              "y": 25.5,
+              "v": 0.975
+            },
+            "rightHeel": {
+              "x": 55.1,
+              "y": 120.4,
+              "v": 0.914
+            },
+            "leftFootIndex": {
+              "x": 112.4,
+              "y": 8.1,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 41.5,
+              "y": 123.7,
+              "v": 0.91
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 40.6,
+                "y": 9
+              },
+              "roll": -178.6,
+              "yaw": 0.425,
+              "pitch": 0.662
+            },
+            "torso": {
+              "center": {
+                "x": 37.7,
+                "y": 22.4
+              },
+              "angle": 108.7
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 19.4,
+                "y": 40.3
+              },
+              "angle": 43.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 110.5,
+                "y": 25.5
+              },
+              "angle": 83.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 55.1,
+                "y": 120.4
+              },
+              "angle": -166.4
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.972,
+          "keypoints": {
+            "nose": {
+              "x": 59,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.4,
+              "y": 9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.7,
+              "y": 8.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.1,
+              "y": 10.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.9,
+              "y": 10,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67,
+              "y": 23.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39,
+              "y": 24.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.6,
+              "y": 37.8,
+              "v": 0.783
+            },
+            "rightElbow": {
+              "x": 28.5,
+              "y": 42.6,
+              "v": 0.968
+            },
+            "leftWrist": {
+              "x": 88,
+              "y": 32.6,
+              "v": 0.871
+            },
+            "rightWrist": {
+              "x": 21,
+              "y": 29.4,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 92.1,
+              "y": 29,
+              "v": 0.889
+            },
+            "rightIndex": {
+              "x": 21.6,
+              "y": 23.6,
+              "v": 0.995
+            },
+            "leftHip": {
+              "x": 60.3,
+              "y": 61.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.3,
+              "y": 61.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.9,
+              "y": 88.3,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 29.5,
+              "y": 81.8,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 85.2,
+              "y": 113.7,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 28.3,
+              "y": 107.9,
+              "v": 0.99
+            },
+            "leftHeel": {
+              "x": 86.2,
+              "y": 118.4,
+              "v": 0.965
+            },
+            "rightHeel": {
+              "x": 31.2,
+              "y": 113,
+              "v": 0.946
+            },
+            "leftFootIndex": {
+              "x": 85.6,
+              "y": 122.5,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 17.3,
+              "y": 114.9,
+              "v": 0.982
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.6,
+                "y": 8.9
+              },
+              "roll": 176.9,
+              "yaw": 0.391,
+              "pitch": 0.783
+            },
+            "torso": {
+              "center": {
+                "x": 53,
+                "y": 24.3
+              },
+              "angle": 89.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88,
+                "y": 32.6
+              },
+              "angle": 41.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 21,
+                "y": 29.4
+              },
+              "angle": 84.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 86.2,
+                "y": 118.4
+              },
+              "angle": -98.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.2,
+                "y": 113
+              },
+              "angle": -172.2
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.853,
+          "keypoints": {
+            "nose": {
+              "x": 72.4,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.7,
+              "y": 9.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.4,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.7,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.1,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.5,
+              "y": 23,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.4,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 88.5,
+              "y": 27.9,
+              "v": 0.698
+            },
+            "rightElbow": {
+              "x": 46,
+              "y": 35.4,
+              "v": 0.557
+            },
+            "leftWrist": {
+              "x": 93.6,
+              "y": 29.7,
+              "v": 0.441
+            },
+            "rightWrist": {
+              "x": 37.3,
+              "y": 42.4,
+              "v": 0.344
+            },
+            "leftIndex": {
+              "x": 94.4,
+              "y": 29.3,
+              "v": 0.486
+            },
+            "rightIndex": {
+              "x": 34.8,
+              "y": 42.6,
+              "v": 0.362
+            },
+            "leftHip": {
+              "x": 74,
+              "y": 60.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.7,
+              "y": 61,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86,
+              "y": 87.7,
+              "v": 0.991
+            },
+            "rightKnee": {
+              "x": 43.7,
+              "y": 82,
+              "v": 0.979
+            },
+            "leftAnkle": {
+              "x": 99,
+              "y": 113.7,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 42.2,
+              "y": 108.2,
+              "v": 0.988
+            },
+            "leftHeel": {
+              "x": 100.4,
+              "y": 117.7,
+              "v": 0.889
+            },
+            "rightHeel": {
+              "x": 45,
+              "y": 113.3,
+              "v": 0.931
+            },
+            "leftFootIndex": {
+              "x": 98.1,
+              "y": 124.1,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 30.7,
+              "y": 114.6,
+              "v": 0.979
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.1,
+                "y": 9.5
+              },
+              "roll": -180,
+              "yaw": 0.409,
+              "pitch": 0.788
+            },
+            "torso": {
+              "center": {
+                "x": 66.5,
+                "y": 23.4
+              },
+              "angle": 90.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.6,
+                "y": 29.7
+              },
+              "angle": 26.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.3,
+                "y": 42.4
+              },
+              "angle": -175.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 100.4,
+                "y": 117.7
+              },
+              "angle": -109.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45,
+                "y": 113.3
+              },
+              "angle": -174.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.929,
+          "keypoints": {
+            "nose": {
+              "x": 70.6,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.1,
+              "y": 9.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.8,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.6,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.7,
+              "y": 23.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.5,
+              "y": 24.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 89.9,
+              "y": 32.6,
+              "v": 0.894
+            },
+            "rightElbow": {
+              "x": 42.2,
+              "y": 39.8,
+              "v": 0.731
+            },
+            "leftWrist": {
+              "x": 100.1,
+              "y": 33.7,
+              "v": 0.753
+            },
+            "rightWrist": {
+              "x": 34.7,
+              "y": 39.3,
+              "v": 0.622
+            },
+            "leftIndex": {
+              "x": 102.6,
+              "y": 30.3,
+              "v": 0.775
+            },
+            "rightIndex": {
+              "x": 31.8,
+              "y": 36.1,
+              "v": 0.69
+            },
+            "leftHip": {
+              "x": 72.7,
+              "y": 61.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.5,
+              "y": 62.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.7,
+              "y": 88.5,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 41.8,
+              "y": 82.9,
+              "v": 0.991
+            },
+            "leftAnkle": {
+              "x": 96.6,
+              "y": 114.4,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 41.3,
+              "y": 108.3,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 97.2,
+              "y": 119.1,
+              "v": 0.954
+            },
+            "rightHeel": {
+              "x": 43.6,
+              "y": 113.4,
+              "v": 0.969
+            },
+            "leftFootIndex": {
+              "x": 95.9,
+              "y": 123.8,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 29.6,
+              "y": 114.8,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.4,
+                "y": 9.8
+              },
+              "roll": -180,
+              "yaw": 0.348,
+              "pitch": 0.758
+            },
+            "torso": {
+              "center": {
+                "x": 64.6,
+                "y": 24.2
+              },
+              "angle": 90.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.1,
+                "y": 33.7
+              },
+              "angle": 53.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.7,
+                "y": 39.3
+              },
+              "angle": 132.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 97.2,
+                "y": 119.1
+              },
+              "angle": -105.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.6,
+                "y": 113.4
+              },
+              "angle": -174.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.969,
+          "keypoints": {
+            "nose": {
+              "x": 49.1,
+              "y": 17,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 49.6,
+              "y": 14.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 46.8,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 48.1,
+              "y": 14.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 42.3,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 54.4,
+              "y": 27.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 31.5,
+              "y": 27.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.2,
+              "y": 31.9,
+              "v": 0.987
+            },
+            "rightElbow": {
+              "x": 21.1,
+              "y": 41.1,
+              "v": 0.907
+            },
+            "leftWrist": {
+              "x": 85.7,
+              "y": 34.8,
+              "v": 0.965
+            },
+            "rightWrist": {
+              "x": 14.7,
+              "y": 38.7,
+              "v": 0.785
+            },
+            "leftIndex": {
+              "x": 91.9,
+              "y": 31.6,
+              "v": 0.949
+            },
+            "rightIndex": {
+              "x": 13.6,
+              "y": 36.8,
+              "v": 0.788
+            },
+            "leftHip": {
+              "x": 50.6,
+              "y": 61.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 37,
+              "y": 62.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 61.5,
+              "y": 85.8,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 21.8,
+              "y": 81.1,
+              "v": 0.991
+            },
+            "leftAnkle": {
+              "x": 73.3,
+              "y": 109.7,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 21.5,
+              "y": 103.8,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 73.7,
+              "y": 113.3,
+              "v": 0.962
+            },
+            "rightHeel": {
+              "x": 24.4,
+              "y": 108.8,
+              "v": 0.969
+            },
+            "leftFootIndex": {
+              "x": 73.1,
+              "y": 118.8,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 10.9,
+              "y": 110.1,
+              "v": 0.991
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 48.2,
+                "y": 14
+              },
+              "roll": 171.9,
+              "yaw": 0.318,
+              "pitch": 1.061
+            },
+            "torso": {
+              "center": {
+                "x": 43,
+                "y": 27.3
+              },
+              "angle": 91.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.7,
+                "y": 34.8
+              },
+              "angle": 27.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 14.7,
+                "y": 38.7
+              },
+              "angle": 120.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.7,
+                "y": 113.3
+              },
+              "angle": -96.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 24.4,
+                "y": 108.8
+              },
+              "angle": -174.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.956,
+          "keypoints": {
+            "nose": {
+              "x": 55,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.9,
+              "y": 10.1,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 52.8,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.4,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 47.5,
+              "y": 9.8,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 61.2,
+              "y": 22.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 35.6,
+              "y": 24,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.4,
+              "y": 28.9,
+              "v": 0.854
+            },
+            "rightElbow": {
+              "x": 25.3,
+              "y": 41.7,
+              "v": 0.765
+            },
+            "leftWrist": {
+              "x": 71.1,
+              "y": 36.4,
+              "v": 0.91
+            },
+            "rightWrist": {
+              "x": 18.2,
+              "y": 29.3,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 66.4,
+              "y": 35.1,
+              "v": 0.928
+            },
+            "rightIndex": {
+              "x": 18.2,
+              "y": 23.2,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 57.2,
+              "y": 61.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.1,
+              "y": 61.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.1,
+              "y": 88.4,
+              "v": 0.979
+            },
+            "rightKnee": {
+              "x": 26.4,
+              "y": 81.6,
+              "v": 0.943
+            },
+            "leftAnkle": {
+              "x": 81,
+              "y": 113.6,
+              "v": 0.984
+            },
+            "rightAnkle": {
+              "x": 25,
+              "y": 108.2,
+              "v": 0.979
+            },
+            "leftHeel": {
+              "x": 81.2,
+              "y": 118.5,
+              "v": 0.832
+            },
+            "rightHeel": {
+              "x": 27.2,
+              "y": 113.5,
+              "v": 0.904
+            },
+            "leftFootIndex": {
+              "x": 82.1,
+              "y": 123.6,
+              "v": 0.973
+            },
+            "rightFootIndex": {
+              "x": 13.4,
+              "y": 114.8,
+              "v": 0.957
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.4,
+                "y": 10
+              },
+              "roll": 174.5,
+              "yaw": 0.209,
+              "pitch": 0.915
+            },
+            "torso": {
+              "center": {
+                "x": 48.4,
+                "y": 23.3
+              },
+              "angle": 91.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 71.1,
+                "y": 36.4
+              },
+              "angle": 164.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 18.2,
+                "y": 29.3
+              },
+              "angle": 90
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 81.2,
+                "y": 118.5
+              },
+              "angle": -80
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27.2,
+                "y": 113.5
+              },
+              "angle": -174.6
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.963,
+          "keypoints": {
+            "nose": {
+              "x": 58.8,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.7,
+              "y": 9.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 55.5,
+              "y": 9.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 58.7,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.3,
+              "y": 10.3,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 65.7,
+              "y": 22.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.6,
+              "y": 25,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.2,
+              "y": 31.3,
+              "v": 0.916
+            },
+            "rightElbow": {
+              "x": 28.1,
+              "y": 42.5,
+              "v": 0.838
+            },
+            "leftWrist": {
+              "x": 67.3,
+              "y": 34.9,
+              "v": 0.91
+            },
+            "rightWrist": {
+              "x": 21.4,
+              "y": 28.9,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 61.4,
+              "y": 35.7,
+              "v": 0.924
+            },
+            "rightIndex": {
+              "x": 21.6,
+              "y": 22.9,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 60.9,
+              "y": 61.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.7,
+              "y": 62.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.5,
+              "y": 87,
+              "v": 0.989
+            },
+            "rightKnee": {
+              "x": 29.4,
+              "y": 82,
+              "v": 0.922
+            },
+            "leftAnkle": {
+              "x": 85.1,
+              "y": 113.3,
+              "v": 0.984
+            },
+            "rightAnkle": {
+              "x": 28,
+              "y": 108,
+              "v": 0.975
+            },
+            "leftHeel": {
+              "x": 86.1,
+              "y": 117.8,
+              "v": 0.866
+            },
+            "rightHeel": {
+              "x": 30.4,
+              "y": 113.3,
+              "v": 0.908
+            },
+            "leftFootIndex": {
+              "x": 84.2,
+              "y": 123.8,
+              "v": 0.976
+            },
+            "rightFootIndex": {
+              "x": 17.3,
+              "y": 114.5,
+              "v": 0.954
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.6,
+                "y": 9.5
+              },
+              "roll": 177.3,
+              "yaw": 0.285,
+              "pitch": 0.666
+            },
+            "torso": {
+              "center": {
+                "x": 52.7,
+                "y": 23.9
+              },
+              "angle": 91
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 67.3,
+                "y": 34.9
+              },
+              "angle": -172.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 21.4,
+                "y": 28.9
+              },
+              "angle": 88.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 86.1,
+                "y": 117.8
+              },
+              "angle": -107.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.4,
+                "y": 113.3
+              },
+              "angle": -174.8
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.905,
+          "keypoints": {
+            "nose": {
+              "x": 65.7,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.5,
+              "y": 10,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 63.2,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.4,
+              "y": 10.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 58.3,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.7,
+              "y": 23.4,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 46.6,
+              "y": 24.2,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 85.7,
+              "y": 34.2,
+              "v": 0.424
+            },
+            "rightElbow": {
+              "x": 35.8,
+              "y": 42.3,
+              "v": 0.886
+            },
+            "leftWrist": {
+              "x": 91.3,
+              "y": 34,
+              "v": 0.378
+            },
+            "rightWrist": {
+              "x": 29,
+              "y": 29.3,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 92.1,
+              "y": 31.9,
+              "v": 0.497
+            },
+            "rightIndex": {
+              "x": 29,
+              "y": 22.9,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 68.4,
+              "y": 61.1,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 53.2,
+              "y": 61.4,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 79.9,
+              "y": 87.7,
+              "v": 0.986
+            },
+            "rightKnee": {
+              "x": 36.9,
+              "y": 81.5,
+              "v": 0.954
+            },
+            "leftAnkle": {
+              "x": 92.6,
+              "y": 113.7,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 36.4,
+              "y": 107.9,
+              "v": 0.982
+            },
+            "leftHeel": {
+              "x": 93.9,
+              "y": 118.1,
+              "v": 0.875
+            },
+            "rightHeel": {
+              "x": 39.4,
+              "y": 113.9,
+              "v": 0.917
+            },
+            "leftFootIndex": {
+              "x": 93.4,
+              "y": 124.5,
+              "v": 0.98
+            },
+            "rightFootIndex": {
+              "x": 24.5,
+              "y": 114.7,
+              "v": 0.966
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.9,
+                "y": 10
+              },
+              "roll": 178.3,
+              "yaw": 0.257,
+              "pitch": 0.833
+            },
+            "torso": {
+              "center": {
+                "x": 59.7,
+                "y": 23.8
+              },
+              "angle": 91.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.3,
+                "y": 34
+              },
+              "angle": 69.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29,
+                "y": 29.3
+              },
+              "angle": 90
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.9,
+                "y": 118.1
+              },
+              "angle": -94.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.4,
+                "y": 113.9
+              },
+              "angle": -176.9
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.891,
+          "keypoints": {
+            "nose": {
+              "x": 66.3,
+              "y": 12.4,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 67,
+              "y": 9.8,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 63.4,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.5,
+              "y": 10.5,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 58.8,
+              "y": 10,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 71.5,
+              "y": 23,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 46.1,
+              "y": 24.2,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 82.4,
+              "y": 31,
+              "v": 0.359
+            },
+            "rightElbow": {
+              "x": 36,
+              "y": 42.2,
+              "v": 0.843
+            },
+            "leftWrist": {
+              "x": 87.9,
+              "y": 30.1,
+              "v": 0.309
+            },
+            "rightWrist": {
+              "x": 29.2,
+              "y": 29.1,
+              "v": 0.984
+            },
+            "leftIndex": {
+              "x": 88.7,
+              "y": 28.6,
+              "v": 0.42
+            },
+            "rightIndex": {
+              "x": 29,
+              "y": 23.5,
+              "v": 0.988
+            },
+            "leftHip": {
+              "x": 67.5,
+              "y": 61.4,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 52.1,
+              "y": 62,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 79.5,
+              "y": 86.9,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 36.4,
+              "y": 82.8,
+              "v": 0.941
+            },
+            "leftAnkle": {
+              "x": 92.7,
+              "y": 114.9,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 36.1,
+              "y": 108,
+              "v": 0.976
+            },
+            "leftHeel": {
+              "x": 93.5,
+              "y": 118.8,
+              "v": 0.886
+            },
+            "rightHeel": {
+              "x": 39.3,
+              "y": 113.3,
+              "v": 0.895
+            },
+            "leftFootIndex": {
+              "x": 93.2,
+              "y": 125.2,
+              "v": 0.982
+            },
+            "rightFootIndex": {
+              "x": 24.1,
+              "y": 115.3,
+              "v": 0.948
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.2,
+                "y": 9.7
+              },
+              "roll": 176.8,
+              "yaw": 0.305,
+              "pitch": 0.749
+            },
+            "torso": {
+              "center": {
+                "x": 58.8,
+                "y": 23.6
+              },
+              "angle": 91.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.9,
+                "y": 30.1
+              },
+              "angle": 61.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.2,
+                "y": 29.1
+              },
+              "angle": 92
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.5,
+                "y": 118.8
+              },
+              "angle": -92.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.3,
+                "y": 113.3
+              },
+              "angle": -172.5
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.908,
+          "keypoints": {
+            "nose": {
+              "x": 66.4,
+              "y": 13,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.9,
+              "y": 10.1,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 63.5,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 67.5,
+              "y": 10.7,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 59.4,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.2,
+              "y": 24,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 48,
+              "y": 24.5,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 86,
+              "y": 34.3,
+              "v": 0.428
+            },
+            "rightElbow": {
+              "x": 37.8,
+              "y": 44.3,
+              "v": 0.899
+            },
+            "leftWrist": {
+              "x": 93.2,
+              "y": 36.5,
+              "v": 0.381
+            },
+            "rightWrist": {
+              "x": 36.9,
+              "y": 31.1,
+              "v": 0.982
+            },
+            "leftIndex": {
+              "x": 94.7,
+              "y": 34.5,
+              "v": 0.479
+            },
+            "rightIndex": {
+              "x": 37.9,
+              "y": 26.4,
+              "v": 0.984
+            },
+            "leftHip": {
+              "x": 68.8,
+              "y": 61,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 53.2,
+              "y": 61.3,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 80,
+              "y": 87.5,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 37.7,
+              "y": 82.2,
+              "v": 0.972
+            },
+            "leftAnkle": {
+              "x": 93.1,
+              "y": 114.5,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 36.2,
+              "y": 107.9,
+              "v": 0.988
+            },
+            "leftHeel": {
+              "x": 94.1,
+              "y": 118.4,
+              "v": 0.91
+            },
+            "rightHeel": {
+              "x": 38.2,
+              "y": 113.4,
+              "v": 0.925
+            },
+            "leftFootIndex": {
+              "x": 91.5,
+              "y": 124.2,
+              "v": 0.987
+            },
+            "rightFootIndex": {
+              "x": 24.5,
+              "y": 114.7,
+              "v": 0.976
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.7,
+                "y": 10
+              },
+              "roll": 176.1,
+              "yaw": 0.159,
+              "pitch": 0.692
+            },
+            "torso": {
+              "center": {
+                "x": 61.1,
+                "y": 24.3
+              },
+              "angle": 89.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.2,
+                "y": 36.5
+              },
+              "angle": 53.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.9,
+                "y": 31.1
+              },
+              "angle": 78
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 94.1,
+                "y": 118.4
+              },
+              "angle": -114.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.2,
+                "y": 113.4
+              },
+              "angle": -174.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.972,
+          "keypoints": {
+            "nose": {
+              "x": 75,
+              "y": 14,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.3,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.4,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.6,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.8,
+              "y": 28.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.6,
+              "y": 19.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 91.4,
+              "y": 36.8,
+              "v": 0.995
+            },
+            "rightElbow": {
+              "x": 34.5,
+              "y": 23.3,
+              "v": 0.983
+            },
+            "leftWrist": {
+              "x": 112,
+              "y": 39.6,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 22.7,
+              "y": 35.2,
+              "v": 0.795
+            },
+            "leftIndex": {
+              "x": 119.1,
+              "y": 39.3,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 19.9,
+              "y": 36.6,
+              "v": 0.704
+            },
+            "leftHip": {
+              "x": 57.6,
+              "y": 64,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.6,
+              "y": 63.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.3,
+              "y": 80.4,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 30.8,
+              "y": 88.2,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 72.2,
+              "y": 107.9,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 8.7,
+              "y": 112.8,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 67.5,
+              "y": 112.7,
+              "v": 0.984
+            },
+            "rightHeel": {
+              "x": 5.6,
+              "y": 116.4,
+              "v": 0.954
+            },
+            "leftFootIndex": {
+              "x": 85.4,
+              "y": 115.4,
+              "v": 0.992
+            },
+            "rightFootIndex": {
+              "x": 8.8,
+              "y": 123.6,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.9,
+                "y": 10.9
+              },
+              "roll": 170.2,
+              "yaw": 0.391,
+              "pitch": 1.07
+            },
+            "torso": {
+              "center": {
+                "x": 62.2,
+                "y": 24.2
+              },
+              "angle": 73
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 112,
+                "y": 39.6
+              },
+              "angle": 2.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 22.7,
+                "y": 35.2
+              },
+              "angle": -153.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.5,
+                "y": 112.7
+              },
+              "angle": -8.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 5.6,
+                "y": 116.4
+              },
+              "angle": -66
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.948,
+          "keypoints": {
+            "nose": {
+              "x": 79.9,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 79.9,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 79,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.5,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 73.5,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 48.9,
+              "y": 18.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 74.7,
+              "y": 27.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 31.5,
+              "y": 31.1,
+              "v": 0.946
+            },
+            "rightElbow": {
+              "x": 77.3,
+              "y": 49.1,
+              "v": 0.947
+            },
+            "leftWrist": {
+              "x": 27.3,
+              "y": 50,
+              "v": 0.879
+            },
+            "rightWrist": {
+              "x": 82.1,
+              "y": 55.9,
+              "v": 0.645
+            },
+            "leftIndex": {
+              "x": 28.1,
+              "y": 54.4,
+              "v": 0.833
+            },
+            "rightIndex": {
+              "x": 85.7,
+              "y": 56.7,
+              "v": 0.609
+            },
+            "leftHip": {
+              "x": 46.1,
+              "y": 63.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.2,
+              "y": 65.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 37.3,
+              "y": 89.1,
+              "v": 0.98
+            },
+            "rightKnee": {
+              "x": 84.7,
+              "y": 86.9,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 19,
+              "y": 115.4,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 77.3,
+              "y": 117.2,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 15.4,
+              "y": 120.1,
+              "v": 0.995
+            },
+            "rightHeel": {
+              "x": 73.5,
+              "y": 123.5,
+              "v": 0.996
+            },
+            "leftFootIndex": {
+              "x": 25.4,
+              "y": 121.6,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 91.4,
+              "y": 122.6,
+              "v": 0.991
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 79.5,
+                "y": 12.4
+              },
+              "roll": -167.5,
+              "yaw": 0.488,
+              "pitch": 3.688
+            },
+            "torso": {
+              "center": {
+                "x": 61.8,
+                "y": 22.8
+              },
+              "angle": 78.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 27.3,
+                "y": 50
+              },
+              "angle": -79.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 82.1,
+                "y": 55.9
+              },
+              "angle": -12.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 15.4,
+                "y": 120.1
+              },
+              "angle": -8.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 73.5,
+                "y": 123.5
+              },
+              "angle": 2.9
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.945,
+          "keypoints": {
+            "nose": {
+              "x": 67,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.6,
+              "y": 10.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 64.4,
+              "y": 9.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 66,
+              "y": 11.4,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 59.2,
+              "y": 10,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 72,
+              "y": 23.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.4,
+              "y": 24.7,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 84.8,
+              "y": 28.7,
+              "v": 0.699
+            },
+            "rightElbow": {
+              "x": 36.5,
+              "y": 42,
+              "v": 0.926
+            },
+            "leftWrist": {
+              "x": 97.3,
+              "y": 30.6,
+              "v": 0.674
+            },
+            "rightWrist": {
+              "x": 28.8,
+              "y": 29.3,
+              "v": 0.992
+            },
+            "leftIndex": {
+              "x": 100.2,
+              "y": 30.3,
+              "v": 0.727
+            },
+            "rightIndex": {
+              "x": 28.7,
+              "y": 23.8,
+              "v": 0.994
+            },
+            "leftHip": {
+              "x": 67.6,
+              "y": 61.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.1,
+              "y": 61.8,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 79.5,
+              "y": 87.4,
+              "v": 0.991
+            },
+            "rightKnee": {
+              "x": 37,
+              "y": 82.3,
+              "v": 0.964
+            },
+            "leftAnkle": {
+              "x": 93.3,
+              "y": 115.8,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 36.3,
+              "y": 108.1,
+              "v": 0.985
+            },
+            "leftHeel": {
+              "x": 94.2,
+              "y": 119.3,
+              "v": 0.916
+            },
+            "rightHeel": {
+              "x": 39.2,
+              "y": 113,
+              "v": 0.932
+            },
+            "leftFootIndex": {
+              "x": 92.9,
+              "y": 125.7,
+              "v": 0.987
+            },
+            "rightFootIndex": {
+              "x": 24.4,
+              "y": 115.2,
+              "v": 0.969
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66,
+                "y": 10.1
+              },
+              "roll": 164.3,
+              "yaw": 0.301,
+              "pitch": 0.827
+            },
+            "torso": {
+              "center": {
+                "x": 59.2,
+                "y": 24
+              },
+              "angle": 91
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.3,
+                "y": 30.6
+              },
+              "angle": 5.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.8,
+                "y": 29.3
+              },
+              "angle": 91
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 94.2,
+                "y": 119.3
+              },
+              "angle": -101.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.2,
+                "y": 113
+              },
+              "angle": -171.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.958,
+          "keypoints": {
+            "nose": {
+              "x": 117.4,
+              "y": 21.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 120.3,
+              "y": 19.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 117,
+              "y": 17,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 118.1,
+              "y": 19.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 111.4,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 113.5,
+              "y": 39.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 91.2,
+              "y": 16.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 112.1,
+              "y": 64.2,
+              "v": 0.999
+            },
+            "rightElbow": {
+              "x": 72.6,
+              "y": 25.4,
+              "v": 0.759
+            },
+            "leftWrist": {
+              "x": 103.7,
+              "y": 85.1,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 59.4,
+              "y": 21,
+              "v": 0.706
+            },
+            "leftIndex": {
+              "x": 97.8,
+              "y": 90.3,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 56.6,
+              "y": 18.1,
+              "v": 0.719
+            },
+            "leftHip": {
+              "x": 73,
+              "y": 61.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.5,
+              "y": 48.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 53.7,
+              "y": 86.9,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 30.2,
+              "y": 43.3,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 39.4,
+              "y": 113.9,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 21.7,
+              "y": 72.9,
+              "v": 0.989
+            },
+            "leftHeel": {
+              "x": 38,
+              "y": 117.8,
+              "v": 0.937
+            },
+            "rightHeel": {
+              "x": 23.8,
+              "y": 80.1,
+              "v": 0.952
+            },
+            "leftFootIndex": {
+              "x": 26.9,
+              "y": 121.3,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 3.8,
+              "y": 76.5,
+              "v": 0.982
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 118.7,
+                "y": 18.4
+              },
+              "roll": 140.7,
+              "yaw": -0.293,
+              "pitch": 0.833
+            },
+            "torso": {
+              "center": {
+                "x": 102.4,
+                "y": 27.8
+              },
+              "angle": 38.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.7,
+                "y": 85.1
+              },
+              "angle": -138.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 59.4,
+                "y": 21
+              },
+              "angle": 134
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 38,
+                "y": 117.8
+              },
+              "angle": -162.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.8,
+                "y": 80.1
+              },
+              "angle": 169.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.85,
+          "keypoints": {
+            "nose": {
+              "x": 66.5,
+              "y": 12.4,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 67.1,
+              "y": 9.9,
+              "v": 0.994
+            },
+            "rightEye": {
+              "x": 63.8,
+              "y": 9.9,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 65.5,
+              "y": 10.8,
+              "v": 0.995
+            },
+            "rightEar": {
+              "x": 58.8,
+              "y": 10.4,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 71.7,
+              "y": 22.7,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 46.2,
+              "y": 24.7,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 83,
+              "y": 29,
+              "v": 0.185
+            },
+            "rightElbow": {
+              "x": 35.9,
+              "y": 42.9,
+              "v": 0.746
+            },
+            "leftWrist": {
+              "x": 88.4,
+              "y": 29.6,
+              "v": 0.123
+            },
+            "rightWrist": {
+              "x": 28.9,
+              "y": 29.7,
+              "v": 0.963
+            },
+            "leftIndex": {
+              "x": 89.3,
+              "y": 28.6,
+              "v": 0.156
+            },
+            "rightIndex": {
+              "x": 28.9,
+              "y": 23.8,
+              "v": 0.965
+            },
+            "leftHip": {
+              "x": 67.6,
+              "y": 62.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.7,
+              "y": 62.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.2,
+              "y": 88.8,
+              "v": 0.98
+            },
+            "rightKnee": {
+              "x": 35.8,
+              "y": 83.5,
+              "v": 0.932
+            },
+            "leftAnkle": {
+              "x": 92.6,
+              "y": 113.5,
+              "v": 0.986
+            },
+            "rightAnkle": {
+              "x": 35.4,
+              "y": 107.6,
+              "v": 0.977
+            },
+            "leftHeel": {
+              "x": 93.7,
+              "y": 117.1,
+              "v": 0.782
+            },
+            "rightHeel": {
+              "x": 38.2,
+              "y": 113.3,
+              "v": 0.865
+            },
+            "leftFootIndex": {
+              "x": 92.5,
+              "y": 124,
+              "v": 0.964
+            },
+            "rightFootIndex": {
+              "x": 24.7,
+              "y": 114.6,
+              "v": 0.944
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.4,
+                "y": 9.9
+              },
+              "roll": -180,
+              "yaw": 0.318,
+              "pitch": 0.758
+            },
+            "torso": {
+              "center": {
+                "x": 59,
+                "y": 23.7
+              },
+              "angle": 91.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 28.9,
+                "y": 29.7
+              },
+              "angle": 90
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.7,
+                "y": 117.1
+              },
+              "angle": -99.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.2,
+                "y": 113.3
+              },
+              "angle": -174.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.934,
+          "keypoints": {
+            "nose": {
+              "x": 30.3,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 32.3,
+              "y": 14.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 28.7,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 37.1,
+              "y": 13.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 30.3,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 51.3,
+              "y": 18.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 28.9,
+              "y": 32.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.6,
+              "y": 16.5,
+              "v": 0.75
+            },
+            "rightElbow": {
+              "x": 20,
+              "y": 51.7,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 71.6,
+              "y": 11,
+              "v": 0.482
+            },
+            "rightWrist": {
+              "x": 13.2,
+              "y": 70.7,
+              "v": 0.978
+            },
+            "leftIndex": {
+              "x": 73.9,
+              "y": 8.9,
+              "v": 0.429
+            },
+            "rightIndex": {
+              "x": 13.6,
+              "y": 77.4,
+              "v": 0.961
+            },
+            "leftHip": {
+              "x": 68.5,
+              "y": 52.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.2,
+              "y": 61.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95,
+              "y": 59.2,
+              "v": 0.985
+            },
+            "rightKnee": {
+              "x": 69.2,
+              "y": 85.7,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 101.3,
+              "y": 85.4,
+              "v": 0.984
+            },
+            "rightAnkle": {
+              "x": 78.4,
+              "y": 113.9,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 99.6,
+              "y": 91.6,
+              "v": 0.966
+            },
+            "rightHeel": {
+              "x": 78.7,
+              "y": 118,
+              "v": 0.968
+            },
+            "leftFootIndex": {
+              "x": 115.6,
+              "y": 88.7,
+              "v": 0.987
+            },
+            "rightFootIndex": {
+              "x": 86.1,
+              "y": 122,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 30.5,
+                "y": 15.5
+              },
+              "roll": -156,
+              "yaw": -0.051,
+              "pitch": 0.838
+            },
+            "torso": {
+              "center": {
+                "x": 40.1,
+                "y": 25.5
+              },
+              "angle": 125.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 71.6,
+                "y": 11
+              },
+              "angle": 42.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 13.2,
+                "y": 70.7
+              },
+              "angle": -86.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 99.6,
+                "y": 91.6
+              },
+              "angle": 10.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 78.7,
+                "y": 118
+              },
+              "angle": -28.4
+            }
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.937,
+          "keypoints": {
+            "nose": {
+              "x": 66.3,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.6,
+              "y": 10,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 63.7,
+              "y": 9.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.2,
+              "y": 10.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 58.8,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.8,
+              "y": 22,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.7,
+              "y": 24.3,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 85.5,
+              "y": 28.1,
+              "v": 0.632
+            },
+            "rightElbow": {
+              "x": 35.5,
+              "y": 41.4,
+              "v": 0.942
+            },
+            "leftWrist": {
+              "x": 93.4,
+              "y": 28.5,
+              "v": 0.597
+            },
+            "rightWrist": {
+              "x": 28.9,
+              "y": 28.2,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 96.1,
+              "y": 27.3,
+              "v": 0.656
+            },
+            "rightIndex": {
+              "x": 28.8,
+              "y": 22.6,
+              "v": 0.995
+            },
+            "leftHip": {
+              "x": 67.7,
+              "y": 60.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.1,
+              "y": 61.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.1,
+              "y": 88,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 36.3,
+              "y": 82.4,
+              "v": 0.969
+            },
+            "leftAnkle": {
+              "x": 92.8,
+              "y": 113.9,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 35.4,
+              "y": 107.4,
+              "v": 0.988
+            },
+            "leftHeel": {
+              "x": 93.5,
+              "y": 117.7,
+              "v": 0.902
+            },
+            "rightHeel": {
+              "x": 37.9,
+              "y": 113.1,
+              "v": 0.932
+            },
+            "leftFootIndex": {
+              "x": 92.5,
+              "y": 123.9,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 24.2,
+              "y": 114,
+              "v": 0.978
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.2,
+                "y": 9.9
+              },
+              "roll": 174.1,
+              "yaw": 0.394,
+              "pitch": 0.978
+            },
+            "torso": {
+              "center": {
+                "x": 59.3,
+                "y": 23.2
+              },
+              "angle": 91.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.4,
+                "y": 28.5
+              },
+              "angle": 24
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.9,
+                "y": 28.2
+              },
+              "angle": 91
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.5,
+                "y": 117.7
+              },
+              "angle": -99.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.9,
+                "y": 113.1
+              },
+              "angle": -176.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.966,
+          "keypoints": {
+            "nose": {
+              "x": 61.2,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.7,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.6,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60.3,
+              "y": 12.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 53.7,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.1,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42,
+              "y": 26.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.1,
+              "y": 30.7,
+              "v": 0.809
+            },
+            "rightElbow": {
+              "x": 31,
+              "y": 44.3,
+              "v": 0.972
+            },
+            "leftWrist": {
+              "x": 96.6,
+              "y": 30.4,
+              "v": 0.794
+            },
+            "rightWrist": {
+              "x": 24.3,
+              "y": 30.7,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 101.1,
+              "y": 26,
+              "v": 0.821
+            },
+            "rightIndex": {
+              "x": 23.9,
+              "y": 24.5,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 62.4,
+              "y": 63.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.6,
+              "y": 64.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.8,
+              "y": 89.1,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 31.9,
+              "y": 84.2,
+              "v": 0.983
+            },
+            "leftAnkle": {
+              "x": 86.3,
+              "y": 113.6,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 30.8,
+              "y": 108.3,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 87.1,
+              "y": 118.3,
+              "v": 0.939
+            },
+            "rightHeel": {
+              "x": 32.7,
+              "y": 112.9,
+              "v": 0.948
+            },
+            "leftFootIndex": {
+              "x": 86.8,
+              "y": 123.6,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 19.9,
+              "y": 114.5,
+              "v": 0.988
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.2,
+                "y": 12.1
+              },
+              "roll": -180,
+              "yaw": 0.339,
+              "pitch": 0.871
+            },
+            "torso": {
+              "center": {
+                "x": 55.1,
+                "y": 26
+              },
+              "angle": 89.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.6,
+                "y": 30.4
+              },
+              "angle": 44.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 24.3,
+                "y": 30.7
+              },
+              "angle": 93.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 87.1,
+                "y": 118.3
+              },
+              "angle": -93.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.7,
+                "y": 112.9
+              },
+              "angle": -172.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.897,
+          "keypoints": {
+            "nose": {
+              "x": 66.4,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.5,
+              "y": 9.2,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 63.5,
+              "y": 8.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.2,
+              "y": 10.4,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 58.9,
+              "y": 9.5,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 71.7,
+              "y": 22.2,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 47.1,
+              "y": 24.5,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 84,
+              "y": 31,
+              "v": 0.419
+            },
+            "rightElbow": {
+              "x": 36.2,
+              "y": 41.9,
+              "v": 0.866
+            },
+            "leftWrist": {
+              "x": 92,
+              "y": 31.3,
+              "v": 0.317
+            },
+            "rightWrist": {
+              "x": 29.3,
+              "y": 28.6,
+              "v": 0.986
+            },
+            "leftIndex": {
+              "x": 93.8,
+              "y": 30.3,
+              "v": 0.413
+            },
+            "rightIndex": {
+              "x": 29.2,
+              "y": 22.7,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 67.8,
+              "y": 61,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53,
+              "y": 61.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.6,
+              "y": 86.7,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 36.8,
+              "y": 82.1,
+              "v": 0.933
+            },
+            "leftAnkle": {
+              "x": 92.5,
+              "y": 114.5,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 35.9,
+              "y": 107.4,
+              "v": 0.981
+            },
+            "leftHeel": {
+              "x": 93.5,
+              "y": 118.9,
+              "v": 0.89
+            },
+            "rightHeel": {
+              "x": 39,
+              "y": 113.3,
+              "v": 0.911
+            },
+            "leftFootIndex": {
+              "x": 92.7,
+              "y": 124.8,
+              "v": 0.984
+            },
+            "rightFootIndex": {
+              "x": 24.1,
+              "y": 114.8,
+              "v": 0.961
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65,
+                "y": 9
+              },
+              "roll": 170.5,
+              "yaw": 0.46,
+              "pitch": 0.871
+            },
+            "torso": {
+              "center": {
+                "x": 59.4,
+                "y": 23.4
+              },
+              "angle": 91.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92,
+                "y": 31.3
+              },
+              "angle": 29.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.3,
+                "y": 28.6
+              },
+              "angle": 91
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93.5,
+                "y": 118.9
+              },
+              "angle": -97.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39,
+                "y": 113.3
+              },
+              "angle": -174.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.92,
+          "keypoints": {
+            "nose": {
+              "x": 63.8,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.5,
+              "y": 9.5,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 60.9,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.2,
+              "y": 10.4,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 56.2,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.3,
+              "y": 23.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.1,
+              "y": 24.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.7,
+              "y": 32.4,
+              "v": 0.52
+            },
+            "rightElbow": {
+              "x": 34.2,
+              "y": 42.6,
+              "v": 0.875
+            },
+            "leftWrist": {
+              "x": 92.8,
+              "y": 30.3,
+              "v": 0.499
+            },
+            "rightWrist": {
+              "x": 26.8,
+              "y": 29.7,
+              "v": 0.984
+            },
+            "leftIndex": {
+              "x": 94.5,
+              "y": 26.6,
+              "v": 0.629
+            },
+            "rightIndex": {
+              "x": 26.5,
+              "y": 23.6,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 65.4,
+              "y": 62,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.3,
+              "y": 62.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.7,
+              "y": 87.1,
+              "v": 0.992
+            },
+            "rightKnee": {
+              "x": 34.5,
+              "y": 83.7,
+              "v": 0.95
+            },
+            "leftAnkle": {
+              "x": 89.4,
+              "y": 113.2,
+              "v": 0.987
+            },
+            "rightAnkle": {
+              "x": 33.8,
+              "y": 108.3,
+              "v": 0.981
+            },
+            "leftHeel": {
+              "x": 90.2,
+              "y": 117.5,
+              "v": 0.887
+            },
+            "rightHeel": {
+              "x": 36.8,
+              "y": 113.4,
+              "v": 0.916
+            },
+            "leftFootIndex": {
+              "x": 89.4,
+              "y": 124.1,
+              "v": 0.98
+            },
+            "rightFootIndex": {
+              "x": 22,
+              "y": 114.8,
+              "v": 0.963
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.7,
+                "y": 9.5
+              },
+              "roll": -180,
+              "yaw": 0.306,
+              "pitch": 0.778
+            },
+            "torso": {
+              "center": {
+                "x": 58.2,
+                "y": 23.9
+              },
+              "angle": 89.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92.8,
+                "y": 30.3
+              },
+              "angle": 65.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 26.8,
+                "y": 29.7
+              },
+              "angle": 92.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 90.2,
+                "y": 117.5
+              },
+              "angle": -96.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.8,
+                "y": 113.4
+              },
+              "angle": -174.6
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.987,
+          "keypoints": {
+            "nose": {
+              "x": 79.7,
+              "y": 16,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 81.4,
+              "y": 13.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 78.5,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 78.6,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 73.4,
+              "y": 10,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.1,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.3,
+              "y": 17.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.5,
+              "y": 46.2,
+              "v": 0.986
+            },
+            "rightElbow": {
+              "x": 37.3,
+              "y": 39.2,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 85.9,
+              "y": 66.1,
+              "v": 0.99
+            },
+            "rightWrist": {
+              "x": 37.8,
+              "y": 62.1,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 84.9,
+              "y": 71.9,
+              "v": 0.978
+            },
+            "rightIndex": {
+              "x": 38.6,
+              "y": 68.4,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 62.9,
+              "y": 59.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49,
+              "y": 58.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.5,
+              "y": 82.9,
+              "v": 0.96
+            },
+            "rightKnee": {
+              "x": 43.3,
+              "y": 87.6,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 68.3,
+              "y": 110,
+              "v": 0.956
+            },
+            "rightAnkle": {
+              "x": 34.2,
+              "y": 116.5,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 63.6,
+              "y": 114.8,
+              "v": 0.932
+            },
+            "rightHeel": {
+              "x": 31.6,
+              "y": 120.6,
+              "v": 0.956
+            },
+            "leftFootIndex": {
+              "x": 79.2,
+              "y": 117.2,
+              "v": 0.967
+            },
+            "rightFootIndex": {
+              "x": 37.9,
+              "y": 126.3,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 80,
+                "y": 12.6
+              },
+              "roll": 154.2,
+              "yaw": -0.078,
+              "pitch": 1.056
+            },
+            "torso": {
+              "center": {
+                "x": 67.2,
+                "y": 21.5
+              },
+              "angle": 73.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.9,
+                "y": 66.1
+              },
+              "angle": -99.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.8,
+                "y": 62.1
+              },
+              "angle": -82.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 63.6,
+                "y": 114.8
+              },
+              "angle": -8.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.6,
+                "y": 120.6
+              },
+              "angle": -42.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.896,
+          "keypoints": {
+            "nose": {
+              "x": 40.5,
+              "y": 17.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 41.1,
+              "y": 13.1,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 38.2,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 45.6,
+              "y": 9.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 40.7,
+              "y": 13.6,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 62.3,
+              "y": 14.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.3,
+              "y": 21.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.5,
+              "y": 35.8,
+              "v": 0.99
+            },
+            "rightElbow": {
+              "x": 42.6,
+              "y": 40.5,
+              "v": 0.851
+            },
+            "leftWrist": {
+              "x": 82.4,
+              "y": 60.2,
+              "v": 0.957
+            },
+            "rightWrist": {
+              "x": 36.9,
+              "y": 58.2,
+              "v": 0.982
+            },
+            "leftIndex": {
+              "x": 79.8,
+              "y": 66.1,
+              "v": 0.921
+            },
+            "rightIndex": {
+              "x": 35.5,
+              "y": 64,
+              "v": 0.972
+            },
+            "leftHip": {
+              "x": 64.3,
+              "y": 54.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.3,
+              "y": 53.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 52.9,
+              "y": 81.3,
+              "v": 0.93
+            },
+            "rightKnee": {
+              "x": 39.8,
+              "y": 78.2,
+              "v": 0.865
+            },
+            "leftAnkle": {
+              "x": 51.5,
+              "y": 105.3,
+              "v": 0.766
+            },
+            "rightAnkle": {
+              "x": 45.1,
+              "y": 105.4,
+              "v": 0.749
+            },
+            "leftHeel": {
+              "x": 63.8,
+              "y": 108.5,
+              "v": 0.449
+            },
+            "rightHeel": {
+              "x": 48.7,
+              "y": 111.2,
+              "v": 0.672
+            },
+            "leftFootIndex": {
+              "x": 53.4,
+              "y": 115.9,
+              "v": 0.737
+            },
+            "rightFootIndex": {
+              "x": 33,
+              "y": 113.8,
+              "v": 0.761
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 39.7,
+                "y": 14.3
+              },
+              "roll": -141.6,
+              "yaw": 0.23,
+              "pitch": 0.824
+            },
+            "torso": {
+              "center": {
+                "x": 51.3,
+                "y": 17.9
+              },
+              "angle": 101.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.4,
+                "y": 60.2
+              },
+              "angle": -113.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.9,
+                "y": 58.2
+              },
+              "angle": -103.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 63.8,
+                "y": 108.5
+              },
+              "angle": -144.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.7,
+                "y": 111.2
+              },
+              "angle": -170.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 79.6,
+              "y": 15.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 80.4,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 78.1,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 77.8,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 73.2,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.1,
+              "y": 23.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.8,
+              "y": 19.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.4,
+              "y": 42.5,
+              "v": 0.874
+            },
+            "rightElbow": {
+              "x": 41.2,
+              "y": 38.3,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 82.8,
+              "y": 58.3,
+              "v": 0.965
+            },
+            "rightWrist": {
+              "x": 43.7,
+              "y": 59.9,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 84.6,
+              "y": 64.1,
+              "v": 0.956
+            },
+            "rightIndex": {
+              "x": 45.6,
+              "y": 65.8,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 69,
+              "y": 58.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56,
+              "y": 58.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.6,
+              "y": 81.4,
+              "v": 0.973
+            },
+            "rightKnee": {
+              "x": 48.5,
+              "y": 85.6,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 78.6,
+              "y": 108.4,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 39,
+              "y": 113.3,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 75.2,
+              "y": 113.1,
+              "v": 0.958
+            },
+            "rightHeel": {
+              "x": 36.1,
+              "y": 117.2,
+              "v": 0.916
+            },
+            "leftFootIndex": {
+              "x": 90.5,
+              "y": 114.7,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 41.4,
+              "y": 123.9,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 79.3,
+                "y": 12.1
+              },
+              "roll": 156.5,
+              "yaw": 0.14,
+              "pitch": 1.196
+            },
+            "torso": {
+              "center": {
+                "x": 67.4,
+                "y": 21.3
+              },
+              "angle": 82.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.8,
+                "y": 58.3
+              },
+              "angle": -72.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.7,
+                "y": 59.9
+              },
+              "angle": -72.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 75.2,
+                "y": 113.1
+              },
+              "angle": -6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.1,
+                "y": 117.2
+              },
+              "angle": -51.7
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.965,
+          "keypoints": {
+            "nose": {
+              "x": 66.6,
+              "y": 14.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.3,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.2,
+              "y": 12.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.7,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72,
+              "y": 27.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.5,
+              "y": 29.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.5,
+              "y": 38.8,
+              "v": 0.774
+            },
+            "rightElbow": {
+              "x": 32.2,
+              "y": 48.6,
+              "v": 0.911
+            },
+            "leftWrist": {
+              "x": 102.1,
+              "y": 39.1,
+              "v": 0.818
+            },
+            "rightWrist": {
+              "x": 23.1,
+              "y": 35.2,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 104.6,
+              "y": 39.2,
+              "v": 0.871
+            },
+            "rightIndex": {
+              "x": 22.4,
+              "y": 28.1,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 67.7,
+              "y": 69.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.3,
+              "y": 70.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.9,
+              "y": 98.1,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 29.2,
+              "y": 96.3,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 68.4,
+              "y": 103.1,
+              "v": 0.971
+            },
+            "rightAnkle": {
+              "x": 50.3,
+              "y": 107.8,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 63.8,
+              "y": 102.5,
+              "v": 0.947
+            },
+            "rightHeel": {
+              "x": 56.1,
+              "y": 105.8,
+              "v": 0.983
+            },
+            "leftFootIndex": {
+              "x": 67.1,
+              "y": 118.4,
+              "v": 0.953
+            },
+            "rightFootIndex": {
+              "x": 51.6,
+              "y": 123.6,
+              "v": 0.985
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.2,
+                "y": 11.7
+              },
+              "roll": 176.9,
+              "yaw": 0.391,
+              "pitch": 0.783
+            },
+            "torso": {
+              "center": {
+                "x": 57.8,
+                "y": 28.1
+              },
+              "angle": 92.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 102.1,
+                "y": 39.1
+              },
+              "angle": -2.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 23.1,
+                "y": 35.2
+              },
+              "angle": 95.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 63.8,
+                "y": 102.5
+              },
+              "angle": -78.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 56.1,
+                "y": 105.8
+              },
+              "angle": -104.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.885,
+          "keypoints": {
+            "nose": {
+              "x": 66.1,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.3,
+              "y": 9.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 63.4,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.1,
+              "y": 10.7,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 58.3,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.6,
+              "y": 23.2,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 46.2,
+              "y": 24.7,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 84.4,
+              "y": 33.3,
+              "v": 0.342
+            },
+            "rightElbow": {
+              "x": 35.1,
+              "y": 42.1,
+              "v": 0.927
+            },
+            "leftWrist": {
+              "x": 91.3,
+              "y": 37.3,
+              "v": 0.257
+            },
+            "rightWrist": {
+              "x": 28.6,
+              "y": 29.2,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 92.7,
+              "y": 37.3,
+              "v": 0.361
+            },
+            "rightIndex": {
+              "x": 28.4,
+              "y": 23,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 67.4,
+              "y": 60.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.6,
+              "y": 61.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.7,
+              "y": 88.7,
+              "v": 0.993
+            },
+            "rightKnee": {
+              "x": 35.9,
+              "y": 84.2,
+              "v": 0.972
+            },
+            "leftAnkle": {
+              "x": 92,
+              "y": 114.4,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 52.9,
+              "y": 95.7,
+              "v": 0.926
+            },
+            "leftHeel": {
+              "x": 93,
+              "y": 118.9,
+              "v": 0.945
+            },
+            "rightHeel": {
+              "x": 58.7,
+              "y": 94.8,
+              "v": 0.771
+            },
+            "leftFootIndex": {
+              "x": 91.9,
+              "y": 124.1,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 53,
+              "y": 108.7,
+              "v": 0.883
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.9,
+                "y": 9.7
+              },
+              "roll": -176.1,
+              "yaw": 0.43,
+              "pitch": 0.86
+            },
+            "torso": {
+              "center": {
+                "x": 58.9,
+                "y": 24
+              },
+              "angle": 91.7
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 28.6,
+                "y": 29.2
+              },
+              "angle": 91.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 93,
+                "y": 118.9
+              },
+              "angle": -101.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 58.7,
+                "y": 94.8
+              },
+              "angle": -112.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.925,
+          "keypoints": {
+            "nose": {
+              "x": 64,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.3,
+              "y": 8.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 61.1,
+              "y": 8.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.7,
+              "y": 9.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.9,
+              "y": 9.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.2,
+              "y": 21,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.8,
+              "y": 22.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.6,
+              "y": 33.8,
+              "v": 0.456
+            },
+            "rightElbow": {
+              "x": 37.1,
+              "y": 39.1,
+              "v": 0.873
+            },
+            "leftWrist": {
+              "x": 89.9,
+              "y": 42.4,
+              "v": 0.535
+            },
+            "rightWrist": {
+              "x": 29.7,
+              "y": 27.2,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 92.2,
+              "y": 43.8,
+              "v": 0.667
+            },
+            "rightIndex": {
+              "x": 29.8,
+              "y": 22.1,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 68.4,
+              "y": 55.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.3,
+              "y": 57.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 89.5,
+              "y": 61.6,
+              "v": 0.991
+            },
+            "rightKnee": {
+              "x": 50.8,
+              "y": 85.2,
+              "v": 0.993
+            },
+            "leftAnkle": {
+              "x": 72.1,
+              "y": 77.1,
+              "v": 0.947
+            },
+            "rightAnkle": {
+              "x": 50.6,
+              "y": 112.3,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 67.5,
+              "y": 75.1,
+              "v": 0.902
+            },
+            "rightHeel": {
+              "x": 52.5,
+              "y": 116.5,
+              "v": 0.978
+            },
+            "leftFootIndex": {
+              "x": 67.3,
+              "y": 88.2,
+              "v": 0.948
+            },
+            "rightFootIndex": {
+              "x": 49.7,
+              "y": 124.1,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.7,
+                "y": 8.6
+              },
+              "roll": -178.2,
+              "yaw": 0.406,
+              "pitch": 0.859
+            },
+            "torso": {
+              "center": {
+                "x": 59,
+                "y": 21.8
+              },
+              "angle": 94.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.9,
+                "y": 42.4
+              },
+              "angle": -31.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.7,
+                "y": 27.2
+              },
+              "angle": 88.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.5,
+                "y": 75.1
+              },
+              "angle": -90.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 52.5,
+                "y": 116.5
+              },
+              "angle": -110.2
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/peks/poses.json
+++ b/public/assets/fighters/peks/poses.json
@@ -1,0 +1,8252 @@
+{
+  "version": 1,
+  "fighter": "peks",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:40:39.450Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.756,
+          "keypoints": {
+            "nose": {
+              "x": 75.2,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.9,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.4,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.6,
+              "y": 13.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.9,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.1,
+              "y": 26.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.1,
+              "y": 44.6,
+              "v": 0.495
+            },
+            "rightElbow": {
+              "x": 57.2,
+              "y": 44,
+              "v": 0.972
+            },
+            "leftWrist": {
+              "x": 95.1,
+              "y": 35.7,
+              "v": 0.799
+            },
+            "rightWrist": {
+              "x": 72,
+              "y": 41.9,
+              "v": 0.982
+            },
+            "leftIndex": {
+              "x": 98.9,
+              "y": 32.1,
+              "v": 0.807
+            },
+            "rightIndex": {
+              "x": 76.1,
+              "y": 37.9,
+              "v": 0.966
+            },
+            "leftHip": {
+              "x": 77.6,
+              "y": 61,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.6,
+              "y": 62.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 85.3,
+              "y": 78,
+              "v": 0.441
+            },
+            "rightKnee": {
+              "x": 65.7,
+              "y": 86.5,
+              "v": 0.639
+            },
+            "leftAnkle": {
+              "x": 82.2,
+              "y": 102.3,
+              "v": 0.271
+            },
+            "rightAnkle": {
+              "x": 61.3,
+              "y": 112.8,
+              "v": 0.628
+            },
+            "leftHeel": {
+              "x": 79.8,
+              "y": 105.9,
+              "v": 0.298
+            },
+            "rightHeel": {
+              "x": 60.2,
+              "y": 117.3,
+              "v": 0.252
+            },
+            "leftFootIndex": {
+              "x": 87,
+              "y": 111.2,
+              "v": 0.344
+            },
+            "rightFootIndex": {
+              "x": 62.9,
+              "y": 124.9,
+              "v": 0.501
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.2,
+                "y": 11.5
+              },
+              "roll": 170.3,
+              "yaw": 0.296,
+              "pitch": 0.788
+            },
+            "torso": {
+              "center": {
+                "x": 70,
+                "y": 26.9
+              },
+              "angle": 92.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.1,
+                "y": 35.7
+              },
+              "angle": 43.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72,
+                "y": 41.9
+              },
+              "angle": 44.3
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 61.3,
+                "y": 112.8
+              },
+              "angle": -82.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.762,
+          "keypoints": {
+            "nose": {
+              "x": 75.3,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.5,
+              "y": 11,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.2,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.1,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.8,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.7,
+              "y": 27.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.5,
+              "y": 27,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85,
+              "y": 47.9,
+              "v": 0.546
+            },
+            "rightElbow": {
+              "x": 57.5,
+              "y": 47.7,
+              "v": 0.957
+            },
+            "leftWrist": {
+              "x": 94.1,
+              "y": 37.2,
+              "v": 0.814
+            },
+            "rightWrist": {
+              "x": 71.1,
+              "y": 42.4,
+              "v": 0.971
+            },
+            "leftIndex": {
+              "x": 98.5,
+              "y": 32.3,
+              "v": 0.82
+            },
+            "rightIndex": {
+              "x": 75.5,
+              "y": 38,
+              "v": 0.945
+            },
+            "leftHip": {
+              "x": 77.4,
+              "y": 61.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64.9,
+              "y": 62.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.5,
+              "y": 78.1,
+              "v": 0.744
+            },
+            "rightKnee": {
+              "x": 65.2,
+              "y": 82.3,
+              "v": 0.521
+            },
+            "leftAnkle": {
+              "x": 80.3,
+              "y": 102,
+              "v": 0.384
+            },
+            "rightAnkle": {
+              "x": 60,
+              "y": 105.3,
+              "v": 0.434
+            },
+            "leftHeel": {
+              "x": 78.3,
+              "y": 105,
+              "v": 0.352
+            },
+            "rightHeel": {
+              "x": 60,
+              "y": 108.9,
+              "v": 0.218
+            },
+            "leftFootIndex": {
+              "x": 82.7,
+              "y": 112.2,
+              "v": 0.452
+            },
+            "rightFootIndex": {
+              "x": 57.9,
+              "y": 114.1,
+              "v": 0.373
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.9,
+                "y": 10.8
+              },
+              "roll": 171.4,
+              "yaw": 0.434,
+              "pitch": 0.854
+            },
+            "torso": {
+              "center": {
+                "x": 69.6,
+                "y": 27.5
+              },
+              "angle": 92.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.1,
+                "y": 37.2
+              },
+              "angle": 48.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 71.1,
+                "y": 42.4
+              },
+              "angle": 45
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.3,
+                "y": 105
+              },
+              "angle": -58.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 60,
+                "y": 105.3
+              },
+              "angle": -103.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.723,
+          "keypoints": {
+            "nose": {
+              "x": 75,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.6,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.3,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.4,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.1,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.1,
+              "y": 26.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.9,
+              "y": 26,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.7,
+              "y": 43.1,
+              "v": 0.353
+            },
+            "rightElbow": {
+              "x": 57.9,
+              "y": 43.9,
+              "v": 0.951
+            },
+            "leftWrist": {
+              "x": 94.8,
+              "y": 36.1,
+              "v": 0.682
+            },
+            "rightWrist": {
+              "x": 72.7,
+              "y": 42.1,
+              "v": 0.974
+            },
+            "leftIndex": {
+              "x": 98.7,
+              "y": 32.3,
+              "v": 0.738
+            },
+            "rightIndex": {
+              "x": 76.7,
+              "y": 37.8,
+              "v": 0.959
+            },
+            "leftHip": {
+              "x": 76.6,
+              "y": 60.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.4,
+              "y": 61.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.8,
+              "y": 78.2,
+              "v": 0.265
+            },
+            "rightKnee": {
+              "x": 66.5,
+              "y": 85.5,
+              "v": 0.605
+            },
+            "leftAnkle": {
+              "x": 77.7,
+              "y": 102.4,
+              "v": 0.221
+            },
+            "rightAnkle": {
+              "x": 61.4,
+              "y": 113.8,
+              "v": 0.58
+            },
+            "leftHeel": {
+              "x": 75,
+              "y": 106.2,
+              "v": 0.298
+            },
+            "rightHeel": {
+              "x": 60.8,
+              "y": 118.1,
+              "v": 0.27
+            },
+            "leftFootIndex": {
+              "x": 82.6,
+              "y": 110.7,
+              "v": 0.284
+            },
+            "rightFootIndex": {
+              "x": 62.2,
+              "y": 124.2,
+              "v": 0.448
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.9,
+                "y": 11.3
+              },
+              "roll": 166.4,
+              "yaw": 0.309,
+              "pitch": 0.825
+            },
+            "torso": {
+              "center": {
+                "x": 69.5,
+                "y": 26.4
+              },
+              "angle": 92.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.8,
+                "y": 36.1
+              },
+              "angle": 44.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72.7,
+                "y": 42.1
+              },
+              "angle": 47.1
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 61.4,
+                "y": 113.8
+              },
+              "angle": -85.6
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.795,
+          "keypoints": {
+            "nose": {
+              "x": 75.4,
+              "y": 13.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 76.1,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.4,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75,
+              "y": 12.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.8,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.6,
+              "y": 27.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.2,
+              "y": 26.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.4,
+              "y": 43.2,
+              "v": 0.571
+            },
+            "rightElbow": {
+              "x": 58,
+              "y": 45.5,
+              "v": 0.98
+            },
+            "leftWrist": {
+              "x": 94.2,
+              "y": 35.5,
+              "v": 0.838
+            },
+            "rightWrist": {
+              "x": 72.3,
+              "y": 42.4,
+              "v": 0.985
+            },
+            "leftIndex": {
+              "x": 98.5,
+              "y": 32.1,
+              "v": 0.835
+            },
+            "rightIndex": {
+              "x": 76.6,
+              "y": 37.9,
+              "v": 0.968
+            },
+            "leftHip": {
+              "x": 77.8,
+              "y": 61.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.8,
+              "y": 62.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.5,
+              "y": 82.7,
+              "v": 0.442
+            },
+            "rightKnee": {
+              "x": 65.7,
+              "y": 87.3,
+              "v": 0.732
+            },
+            "leftAnkle": {
+              "x": 81.2,
+              "y": 103.7,
+              "v": 0.401
+            },
+            "rightAnkle": {
+              "x": 61.5,
+              "y": 113.5,
+              "v": 0.772
+            },
+            "leftHeel": {
+              "x": 79.3,
+              "y": 107,
+              "v": 0.364
+            },
+            "rightHeel": {
+              "x": 60.6,
+              "y": 116.8,
+              "v": 0.357
+            },
+            "leftFootIndex": {
+              "x": 86,
+              "y": 111.8,
+              "v": 0.425
+            },
+            "rightFootIndex": {
+              "x": 62.2,
+              "y": 122.1,
+              "v": 0.624
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.3,
+                "y": 11.1
+              },
+              "roll": 167.8,
+              "yaw": 0.304,
+              "pitch": 0.74
+            },
+            "torso": {
+              "center": {
+                "x": 69.9,
+                "y": 27
+              },
+              "angle": 93.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.2,
+                "y": 35.5
+              },
+              "angle": 38.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72.3,
+                "y": 42.4
+              },
+              "angle": 46.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 79.3,
+                "y": 107
+              },
+              "angle": -35.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 60.6,
+                "y": 116.8
+              },
+              "angle": -73.2
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.695,
+          "keypoints": {
+            "nose": {
+              "x": 75,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.6,
+              "y": 11.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 72.4,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.1,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.8,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.3,
+              "y": 27.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.1,
+              "y": 27.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85,
+              "y": 43.3,
+              "v": 0.318
+            },
+            "rightElbow": {
+              "x": 57,
+              "y": 44.5,
+              "v": 0.96
+            },
+            "leftWrist": {
+              "x": 94.4,
+              "y": 36.1,
+              "v": 0.702
+            },
+            "rightWrist": {
+              "x": 72,
+              "y": 42.2,
+              "v": 0.979
+            },
+            "leftIndex": {
+              "x": 98.2,
+              "y": 32,
+              "v": 0.747
+            },
+            "rightIndex": {
+              "x": 76.3,
+              "y": 37.8,
+              "v": 0.957
+            },
+            "leftHip": {
+              "x": 78.1,
+              "y": 61.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.4,
+              "y": 62.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.6,
+              "y": 83.1,
+              "v": 0.187
+            },
+            "rightKnee": {
+              "x": 65.2,
+              "y": 84,
+              "v": 0.429
+            },
+            "leftAnkle": {
+              "x": 81.3,
+              "y": 104.2,
+              "v": 0.243
+            },
+            "rightAnkle": {
+              "x": 58.6,
+              "y": 108.6,
+              "v": 0.465
+            },
+            "leftHeel": {
+              "x": 79.2,
+              "y": 107.2,
+              "v": 0.211
+            },
+            "rightHeel": {
+              "x": 58.4,
+              "y": 112.6,
+              "v": 0.172
+            },
+            "leftFootIndex": {
+              "x": 85.6,
+              "y": 112.6,
+              "v": 0.257
+            },
+            "rightFootIndex": {
+              "x": 56.3,
+              "y": 118.8,
+              "v": 0.352
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74,
+                "y": 11.4
+              },
+              "roll": 171.1,
+              "yaw": 0.309,
+              "pitch": 0.911
+            },
+            "torso": {
+              "center": {
+                "x": 69.7,
+                "y": 27.2
+              },
+              "angle": 94.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.4,
+                "y": 36.1
+              },
+              "angle": 47.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72,
+                "y": 42.2
+              },
+              "angle": 45.7
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 58.6,
+                "y": 108.6
+              },
+              "angle": -102.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.908,
+          "keypoints": {
+            "nose": {
+              "x": 74.8,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.5,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.8,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.4,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.8,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.7,
+              "y": 25.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59,
+              "y": 25.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.9,
+              "y": 41.2,
+              "v": 0.299
+            },
+            "rightElbow": {
+              "x": 58.2,
+              "y": 44.3,
+              "v": 0.985
+            },
+            "leftWrist": {
+              "x": 89.5,
+              "y": 42.1,
+              "v": 0.572
+            },
+            "rightWrist": {
+              "x": 73.1,
+              "y": 42.4,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 90.6,
+              "y": 40.1,
+              "v": 0.718
+            },
+            "rightIndex": {
+              "x": 76.6,
+              "y": 38.2,
+              "v": 0.995
+            },
+            "leftHip": {
+              "x": 70.1,
+              "y": 60.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.9,
+              "y": 61.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75,
+              "y": 79.4,
+              "v": 0.805
+            },
+            "rightKnee": {
+              "x": 76.6,
+              "y": 80.2,
+              "v": 0.992
+            },
+            "leftAnkle": {
+              "x": 72,
+              "y": 93.6,
+              "v": 0.886
+            },
+            "rightAnkle": {
+              "x": 60,
+              "y": 107.1,
+              "v": 0.992
+            },
+            "leftHeel": {
+              "x": 68.4,
+              "y": 94.6,
+              "v": 0.85
+            },
+            "rightHeel": {
+              "x": 58.5,
+              "y": 112.5,
+              "v": 0.895
+            },
+            "leftFootIndex": {
+              "x": 70.7,
+              "y": 105.6,
+              "v": 0.911
+            },
+            "rightFootIndex": {
+              "x": 62.2,
+              "y": 125,
+              "v": 0.983
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.7,
+                "y": 11.2
+              },
+              "roll": 164.9,
+              "yaw": 0.3,
+              "pitch": 0.835
+            },
+            "torso": {
+              "center": {
+                "x": 68.4,
+                "y": 25.6
+              },
+              "angle": 87.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.5,
+                "y": 42.1
+              },
+              "angle": 61.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 73.1,
+                "y": 42.4
+              },
+              "angle": 50.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.4,
+                "y": 94.6
+              },
+              "angle": -78.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 58.5,
+                "y": 112.5
+              },
+              "angle": -73.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.725,
+          "keypoints": {
+            "nose": {
+              "x": 74.8,
+              "y": 14.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.7,
+              "y": 12,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 72.1,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.5,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.7,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.2,
+              "y": 26.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59,
+              "y": 26.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.7,
+              "y": 44.1,
+              "v": 0.145
+            },
+            "rightElbow": {
+              "x": 57.9,
+              "y": 44.9,
+              "v": 0.902
+            },
+            "leftWrist": {
+              "x": 94.3,
+              "y": 37.4,
+              "v": 0.356
+            },
+            "rightWrist": {
+              "x": 73.1,
+              "y": 42.4,
+              "v": 0.94
+            },
+            "leftIndex": {
+              "x": 98.4,
+              "y": 33.1,
+              "v": 0.444
+            },
+            "rightIndex": {
+              "x": 76.9,
+              "y": 38.3,
+              "v": 0.913
+            },
+            "leftHip": {
+              "x": 74.5,
+              "y": 61.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66,
+              "y": 61.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.3,
+              "y": 82.3,
+              "v": 0.232
+            },
+            "rightKnee": {
+              "x": 79,
+              "y": 80.8,
+              "v": 0.817
+            },
+            "leftAnkle": {
+              "x": 76.1,
+              "y": 101.2,
+              "v": 0.383
+            },
+            "rightAnkle": {
+              "x": 67.1,
+              "y": 104.5,
+              "v": 0.726
+            },
+            "leftHeel": {
+              "x": 71.7,
+              "y": 104.2,
+              "v": 0.425
+            },
+            "rightHeel": {
+              "x": 59.9,
+              "y": 108,
+              "v": 0.31
+            },
+            "leftFootIndex": {
+              "x": 83.8,
+              "y": 112.9,
+              "v": 0.45
+            },
+            "rightFootIndex": {
+              "x": 68.8,
+              "y": 120,
+              "v": 0.641
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.9,
+                "y": 11.5
+              },
+              "roll": 164.5,
+              "yaw": 0.241,
+              "pitch": 0.83
+            },
+            "torso": {
+              "center": {
+                "x": 69.1,
+                "y": 26.4
+              },
+              "angle": 91.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.3,
+                "y": 37.4
+              },
+              "angle": 46.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 73.1,
+                "y": 42.4
+              },
+              "angle": 47.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.7,
+                "y": 104.2
+              },
+              "angle": -35.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 59.9,
+                "y": 108
+              },
+              "angle": -53.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.751,
+          "keypoints": {
+            "nose": {
+              "x": 75.3,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.9,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.7,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.1,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.8,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.6,
+              "y": 27.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.7,
+              "y": 27.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83,
+              "y": 44.4,
+              "v": 0.29
+            },
+            "rightElbow": {
+              "x": 57.6,
+              "y": 46.3,
+              "v": 0.95
+            },
+            "leftWrist": {
+              "x": 93.7,
+              "y": 37.3,
+              "v": 0.604
+            },
+            "rightWrist": {
+              "x": 72,
+              "y": 42.5,
+              "v": 0.971
+            },
+            "leftIndex": {
+              "x": 97.4,
+              "y": 33.1,
+              "v": 0.675
+            },
+            "rightIndex": {
+              "x": 76.3,
+              "y": 38.1,
+              "v": 0.947
+            },
+            "leftHip": {
+              "x": 76.6,
+              "y": 61.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64.9,
+              "y": 63.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.9,
+              "y": 79.6,
+              "v": 0.459
+            },
+            "rightKnee": {
+              "x": 64.5,
+              "y": 87.5,
+              "v": 0.748
+            },
+            "leftAnkle": {
+              "x": 84.4,
+              "y": 101.8,
+              "v": 0.317
+            },
+            "rightAnkle": {
+              "x": 61.1,
+              "y": 113.3,
+              "v": 0.737
+            },
+            "leftHeel": {
+              "x": 82.6,
+              "y": 104.9,
+              "v": 0.3
+            },
+            "rightHeel": {
+              "x": 60.3,
+              "y": 117.1,
+              "v": 0.328
+            },
+            "leftFootIndex": {
+              "x": 88.8,
+              "y": 111.1,
+              "v": 0.354
+            },
+            "rightFootIndex": {
+              "x": 61.7,
+              "y": 124.6,
+              "v": 0.59
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.3,
+                "y": 11.1
+              },
+              "roll": 176.4,
+              "yaw": 0.312,
+              "pitch": 0.967
+            },
+            "torso": {
+              "center": {
+                "x": 69.2,
+                "y": 27.3
+              },
+              "angle": 92.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.7,
+                "y": 37.3
+              },
+              "angle": 48.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72,
+                "y": 42.5
+              },
+              "angle": 45.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 82.6,
+                "y": 104.9
+              },
+              "angle": -45
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 60.3,
+                "y": 117.1
+              },
+              "angle": -79.4
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.706,
+          "keypoints": {
+            "nose": {
+              "x": 71.6,
+              "y": 15.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.3,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.8,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.8,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.1,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.9,
+              "y": 25.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.5,
+              "y": 27.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 88.2,
+              "y": 31.7,
+              "v": 0.91
+            },
+            "rightElbow": {
+              "x": 48.6,
+              "y": 45.5,
+              "v": 0.977
+            },
+            "leftWrist": {
+              "x": 105.9,
+              "y": 29.6,
+              "v": 0.961
+            },
+            "rightWrist": {
+              "x": 63,
+              "y": 45.2,
+              "v": 0.948
+            },
+            "leftIndex": {
+              "x": 111.7,
+              "y": 28.8,
+              "v": 0.945
+            },
+            "rightIndex": {
+              "x": 68.3,
+              "y": 40.9,
+              "v": 0.886
+            },
+            "leftHip": {
+              "x": 72.6,
+              "y": 60.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.9,
+              "y": 62.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82,
+              "y": 82.3,
+              "v": 0.132
+            },
+            "rightKnee": {
+              "x": 56.4,
+              "y": 84.1,
+              "v": 0.376
+            },
+            "leftAnkle": {
+              "x": 79.5,
+              "y": 104.8,
+              "v": 0.099
+            },
+            "rightAnkle": {
+              "x": 43.9,
+              "y": 110,
+              "v": 0.345
+            },
+            "leftHeel": {
+              "x": 77.6,
+              "y": 108.2,
+              "v": 0.143
+            },
+            "rightHeel": {
+              "x": 42.8,
+              "y": 114.9,
+              "v": 0.153
+            },
+            "leftFootIndex": {
+              "x": 83.9,
+              "y": 113.3,
+              "v": 0.115
+            },
+            "rightFootIndex": {
+              "x": 43.1,
+              "y": 122.5,
+              "v": 0.251
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.1,
+                "y": 12
+              },
+              "roll": 162.3,
+              "yaw": 0.591,
+              "pitch": 1.219
+            },
+            "torso": {
+              "center": {
+                "x": 63.7,
+                "y": 26.4
+              },
+              "angle": 94.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 105.9,
+                "y": 29.6
+              },
+              "angle": 7.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 63,
+                "y": 45.2
+              },
+              "angle": 39.1
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.748,
+          "keypoints": {
+            "nose": {
+              "x": 71,
+              "y": 13.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.3,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.2,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.1,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.2,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.6,
+              "y": 23.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.3,
+              "y": 25.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.5,
+              "y": 30.3,
+              "v": 0.901
+            },
+            "rightElbow": {
+              "x": 52.3,
+              "y": 44.1,
+              "v": 0.984
+            },
+            "leftWrist": {
+              "x": 103.5,
+              "y": 29.1,
+              "v": 0.985
+            },
+            "rightWrist": {
+              "x": 67.4,
+              "y": 41.8,
+              "v": 0.992
+            },
+            "leftIndex": {
+              "x": 109,
+              "y": 28.5,
+              "v": 0.981
+            },
+            "rightIndex": {
+              "x": 71.7,
+              "y": 37.1,
+              "v": 0.983
+            },
+            "leftHip": {
+              "x": 71.4,
+              "y": 58.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.2,
+              "y": 60.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.3,
+              "y": 79.9,
+              "v": 0.24
+            },
+            "rightKnee": {
+              "x": 64.9,
+              "y": 80.1,
+              "v": 0.526
+            },
+            "leftAnkle": {
+              "x": 71.6,
+              "y": 102.8,
+              "v": 0.17
+            },
+            "rightAnkle": {
+              "x": 56.7,
+              "y": 109.3,
+              "v": 0.429
+            },
+            "leftHeel": {
+              "x": 70,
+              "y": 105.9,
+              "v": 0.221
+            },
+            "rightHeel": {
+              "x": 54.8,
+              "y": 111.6,
+              "v": 0.2
+            },
+            "leftFootIndex": {
+              "x": 74.8,
+              "y": 111.4,
+              "v": 0.223
+            },
+            "rightFootIndex": {
+              "x": 57.3,
+              "y": 120.1,
+              "v": 0.361
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.8,
+                "y": 10.6
+              },
+              "roll": -180,
+              "yaw": 0.403,
+              "pitch": 0.903
+            },
+            "torso": {
+              "center": {
+                "x": 64,
+                "y": 24.8
+              },
+              "angle": 93.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.5,
+                "y": 29.1
+              },
+              "angle": 6.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 67.4,
+                "y": 41.8
+              },
+              "angle": 47.5
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 56.7,
+                "y": 109.3
+              },
+              "angle": -86.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.744,
+          "keypoints": {
+            "nose": {
+              "x": 71.1,
+              "y": 13.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.1,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.8,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.1,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.2,
+              "y": 24.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.5,
+              "y": 25.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.9,
+              "y": 30.3,
+              "v": 0.858
+            },
+            "rightElbow": {
+              "x": 54.6,
+              "y": 43.9,
+              "v": 0.968
+            },
+            "leftWrist": {
+              "x": 102.2,
+              "y": 28.6,
+              "v": 0.938
+            },
+            "rightWrist": {
+              "x": 69,
+              "y": 42.4,
+              "v": 0.927
+            },
+            "leftIndex": {
+              "x": 107.2,
+              "y": 28.6,
+              "v": 0.927
+            },
+            "rightIndex": {
+              "x": 72.1,
+              "y": 39.7,
+              "v": 0.865
+            },
+            "leftHip": {
+              "x": 71.8,
+              "y": 55.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.1,
+              "y": 56.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.4,
+              "y": 80.9,
+              "v": 0.26
+            },
+            "rightKnee": {
+              "x": 63.1,
+              "y": 76.4,
+              "v": 0.51
+            },
+            "leftAnkle": {
+              "x": 68.7,
+              "y": 101.1,
+              "v": 0.248
+            },
+            "rightAnkle": {
+              "x": 51,
+              "y": 99,
+              "v": 0.418
+            },
+            "leftHeel": {
+              "x": 66.6,
+              "y": 104.6,
+              "v": 0.357
+            },
+            "rightHeel": {
+              "x": 49,
+              "y": 102.5,
+              "v": 0.231
+            },
+            "leftFootIndex": {
+              "x": 73.5,
+              "y": 107,
+              "v": 0.272
+            },
+            "rightFootIndex": {
+              "x": 49.7,
+              "y": 107.2,
+              "v": 0.327
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.9,
+                "y": 10.5
+              },
+              "roll": 173.4,
+              "yaw": 0.266,
+              "pitch": 0.705
+            },
+            "torso": {
+              "center": {
+                "x": 64.9,
+                "y": 24.8
+              },
+              "angle": 93.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 102.2,
+                "y": 28.6
+              },
+              "angle": 0
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 69,
+                "y": 42.4
+              },
+              "angle": 41.1
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 51,
+                "y": 99
+              },
+              "angle": -99
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.702,
+          "keypoints": {
+            "nose": {
+              "x": 72,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.7,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.5,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.4,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.5,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.6,
+              "y": 24.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.3,
+              "y": 25.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.5,
+              "y": 31.4,
+              "v": 0.821
+            },
+            "rightElbow": {
+              "x": 54.5,
+              "y": 44,
+              "v": 0.956
+            },
+            "leftWrist": {
+              "x": 100.5,
+              "y": 28.6,
+              "v": 0.961
+            },
+            "rightWrist": {
+              "x": 69.5,
+              "y": 42.7,
+              "v": 0.912
+            },
+            "leftIndex": {
+              "x": 106.3,
+              "y": 28.1,
+              "v": 0.957
+            },
+            "rightIndex": {
+              "x": 73.6,
+              "y": 39.6,
+              "v": 0.855
+            },
+            "leftHip": {
+              "x": 74.1,
+              "y": 57,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.4,
+              "y": 58.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.2,
+              "y": 79.7,
+              "v": 0.118
+            },
+            "rightKnee": {
+              "x": 66.7,
+              "y": 75.3,
+              "v": 0.45
+            },
+            "leftAnkle": {
+              "x": 75.8,
+              "y": 100.8,
+              "v": 0.134
+            },
+            "rightAnkle": {
+              "x": 51.5,
+              "y": 97.5,
+              "v": 0.241
+            },
+            "leftHeel": {
+              "x": 73.9,
+              "y": 104.3,
+              "v": 0.221
+            },
+            "rightHeel": {
+              "x": 48.5,
+              "y": 100.3,
+              "v": 0.117
+            },
+            "leftFootIndex": {
+              "x": 81.5,
+              "y": 106.9,
+              "v": 0.182
+            },
+            "rightFootIndex": {
+              "x": 51.6,
+              "y": 107.1,
+              "v": 0.228
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.1,
+                "y": 11.1
+              },
+              "roll": 172.9,
+              "yaw": 0.279,
+              "pitch": 0.837
+            },
+            "torso": {
+              "center": {
+                "x": 65.9,
+                "y": 25.4
+              },
+              "angle": 95
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.5,
+                "y": 28.6
+              },
+              "angle": 4.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 69.5,
+                "y": 42.7
+              },
+              "angle": 37.1
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.698,
+          "keypoints": {
+            "nose": {
+              "x": 76.1,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 76.6,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.6,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.3,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68,
+              "y": 12,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.3,
+              "y": 28.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.9,
+              "y": 28,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.2,
+              "y": 42.9,
+              "v": 0.728
+            },
+            "rightElbow": {
+              "x": 46.7,
+              "y": 42.2,
+              "v": 0.942
+            },
+            "leftWrist": {
+              "x": 92.6,
+              "y": 29.1,
+              "v": 0.899
+            },
+            "rightWrist": {
+              "x": 58.8,
+              "y": 44.8,
+              "v": 0.956
+            },
+            "leftIndex": {
+              "x": 93.9,
+              "y": 22.6,
+              "v": 0.863
+            },
+            "rightIndex": {
+              "x": 64.2,
+              "y": 42,
+              "v": 0.9
+            },
+            "leftHip": {
+              "x": 77.2,
+              "y": 61.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.3,
+              "y": 62.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.9,
+              "y": 83.8,
+              "v": 0.113
+            },
+            "rightKnee": {
+              "x": 61.6,
+              "y": 85.7,
+              "v": 0.399
+            },
+            "leftAnkle": {
+              "x": 83.6,
+              "y": 103.5,
+              "v": 0.093
+            },
+            "rightAnkle": {
+              "x": 56,
+              "y": 113,
+              "v": 0.451
+            },
+            "leftHeel": {
+              "x": 81.9,
+              "y": 106.7,
+              "v": 0.103
+            },
+            "rightHeel": {
+              "x": 54.7,
+              "y": 115,
+              "v": 0.153
+            },
+            "leftFootIndex": {
+              "x": 86.7,
+              "y": 109.6,
+              "v": 0.119
+            },
+            "rightFootIndex": {
+              "x": 57.4,
+              "y": 124.1,
+              "v": 0.329
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.6,
+                "y": 10.9
+              },
+              "roll": 171.5,
+              "yaw": 0.371,
+              "pitch": 0.841
+            },
+            "torso": {
+              "center": {
+                "x": 69.1,
+                "y": 28.5
+              },
+              "angle": 93.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92.6,
+                "y": 29.1
+              },
+              "angle": 78.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 58.8,
+                "y": 44.8
+              },
+              "angle": 27.4
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 56,
+                "y": 113
+              },
+              "angle": -82.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.775,
+          "keypoints": {
+            "nose": {
+              "x": 70.6,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.2,
+              "y": 11,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.8,
+              "y": 12,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.8,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.8,
+              "y": 27,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 89.5,
+              "y": 28.2,
+              "v": 0.924
+            },
+            "rightElbow": {
+              "x": 52.6,
+              "y": 44.7,
+              "v": 0.979
+            },
+            "leftWrist": {
+              "x": 103.7,
+              "y": 26.6,
+              "v": 0.975
+            },
+            "rightWrist": {
+              "x": 67.3,
+              "y": 42.9,
+              "v": 0.984
+            },
+            "leftIndex": {
+              "x": 107.9,
+              "y": 25.8,
+              "v": 0.97
+            },
+            "rightIndex": {
+              "x": 71.4,
+              "y": 38.5,
+              "v": 0.971
+            },
+            "leftHip": {
+              "x": 71.5,
+              "y": 58,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.1,
+              "y": 59.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.5,
+              "y": 79.8,
+              "v": 0.291
+            },
+            "rightKnee": {
+              "x": 67.1,
+              "y": 74.6,
+              "v": 0.725
+            },
+            "leftAnkle": {
+              "x": 76.7,
+              "y": 99.1,
+              "v": 0.234
+            },
+            "rightAnkle": {
+              "x": 60.2,
+              "y": 99.8,
+              "v": 0.512
+            },
+            "leftHeel": {
+              "x": 75.1,
+              "y": 102.2,
+              "v": 0.27
+            },
+            "rightHeel": {
+              "x": 59,
+              "y": 103.1,
+              "v": 0.3
+            },
+            "leftFootIndex": {
+              "x": 81.6,
+              "y": 106,
+              "v": 0.255
+            },
+            "rightFootIndex": {
+              "x": 60.6,
+              "y": 109.5,
+              "v": 0.441
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.1,
+                "y": 11
+              },
+              "roll": 178.6,
+              "yaw": 0.357,
+              "pitch": 0.774
+            },
+            "torso": {
+              "center": {
+                "x": 64.4,
+                "y": 26.2
+              },
+              "angle": 93.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.7,
+                "y": 26.6
+              },
+              "angle": 10.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 67.3,
+                "y": 42.9
+              },
+              "angle": 47
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 59,
+                "y": 103.1
+              },
+              "angle": -76
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.733,
+          "keypoints": {
+            "nose": {
+              "x": 68.2,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.1,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.1,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.1,
+              "y": 25.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.3,
+              "y": 26.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87,
+              "y": 30.4,
+              "v": 0.927
+            },
+            "rightElbow": {
+              "x": 51.1,
+              "y": 43.8,
+              "v": 0.976
+            },
+            "leftWrist": {
+              "x": 103.6,
+              "y": 27.6,
+              "v": 0.935
+            },
+            "rightWrist": {
+              "x": 64.9,
+              "y": 42.5,
+              "v": 0.952
+            },
+            "leftIndex": {
+              "x": 109.9,
+              "y": 27,
+              "v": 0.919
+            },
+            "rightIndex": {
+              "x": 69.2,
+              "y": 38.6,
+              "v": 0.908
+            },
+            "leftHip": {
+              "x": 71,
+              "y": 57.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.9,
+              "y": 58.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.4,
+              "y": 80.8,
+              "v": 0.28
+            },
+            "rightKnee": {
+              "x": 62.1,
+              "y": 78.7,
+              "v": 0.452
+            },
+            "leftAnkle": {
+              "x": 73.2,
+              "y": 102,
+              "v": 0.196
+            },
+            "rightAnkle": {
+              "x": 57.2,
+              "y": 102.7,
+              "v": 0.358
+            },
+            "leftHeel": {
+              "x": 71.5,
+              "y": 105.7,
+              "v": 0.289
+            },
+            "rightHeel": {
+              "x": 56.5,
+              "y": 106.3,
+              "v": 0.196
+            },
+            "leftFootIndex": {
+              "x": 78.5,
+              "y": 108.3,
+              "v": 0.212
+            },
+            "rightFootIndex": {
+              "x": 57.5,
+              "y": 111,
+              "v": 0.259
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.1,
+                "y": 11
+              },
+              "roll": 173,
+              "yaw": 0.278,
+              "pitch": 0.666
+            },
+            "torso": {
+              "center": {
+                "x": 62.7,
+                "y": 26.2
+              },
+              "angle": 95
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.6,
+                "y": 27.6
+              },
+              "angle": 5.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 64.9,
+                "y": 42.5
+              },
+              "angle": 42.2
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.732,
+          "keypoints": {
+            "nose": {
+              "x": 69.9,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.3,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.3,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.5,
+              "y": 12.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.6,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.8,
+              "y": 27,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.7,
+              "y": 27.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.8,
+              "y": 31.1,
+              "v": 0.908
+            },
+            "rightElbow": {
+              "x": 51.3,
+              "y": 44.8,
+              "v": 0.986
+            },
+            "leftWrist": {
+              "x": 104.5,
+              "y": 29.7,
+              "v": 0.956
+            },
+            "rightWrist": {
+              "x": 66.6,
+              "y": 42.3,
+              "v": 0.98
+            },
+            "leftIndex": {
+              "x": 109.3,
+              "y": 29.2,
+              "v": 0.945
+            },
+            "rightIndex": {
+              "x": 70.7,
+              "y": 38.1,
+              "v": 0.956
+            },
+            "leftHip": {
+              "x": 72.4,
+              "y": 60.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.1,
+              "y": 62.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.2,
+              "y": 82.6,
+              "v": 0.231
+            },
+            "rightKnee": {
+              "x": 60.5,
+              "y": 85.9,
+              "v": 0.465
+            },
+            "leftAnkle": {
+              "x": 79.2,
+              "y": 104,
+              "v": 0.168
+            },
+            "rightAnkle": {
+              "x": 55.9,
+              "y": 110.7,
+              "v": 0.401
+            },
+            "leftHeel": {
+              "x": 77.7,
+              "y": 107.6,
+              "v": 0.207
+            },
+            "rightHeel": {
+              "x": 55.2,
+              "y": 114.6,
+              "v": 0.169
+            },
+            "leftFootIndex": {
+              "x": 84.1,
+              "y": 110.2,
+              "v": 0.19
+            },
+            "rightFootIndex": {
+              "x": 56.3,
+              "y": 118.2,
+              "v": 0.281
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.8,
+                "y": 11.5
+              },
+              "roll": 163.3,
+              "yaw": 0.351,
+              "pitch": 0.878
+            },
+            "torso": {
+              "center": {
+                "x": 63.3,
+                "y": 27.1
+              },
+              "angle": 95.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 104.5,
+                "y": 29.7
+              },
+              "angle": 5.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 66.6,
+                "y": 42.3
+              },
+              "angle": 45.7
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.714,
+          "keypoints": {
+            "nose": {
+              "x": 73.2,
+              "y": 15.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.8,
+              "y": 12,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.2,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.3,
+              "y": 12.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 58.9,
+              "y": 27.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 72.9,
+              "y": 27.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 68,
+              "y": 39.8,
+              "v": 0.04
+            },
+            "rightElbow": {
+              "x": 93.7,
+              "y": 27.5,
+              "v": 0.937
+            },
+            "leftWrist": {
+              "x": 77.4,
+              "y": 45.3,
+              "v": 0.021
+            },
+            "rightWrist": {
+              "x": 112.9,
+              "y": 26.2,
+              "v": 0.988
+            },
+            "leftIndex": {
+              "x": 79.6,
+              "y": 45.3,
+              "v": 0.038
+            },
+            "rightIndex": {
+              "x": 117.8,
+              "y": 26.3,
+              "v": 0.979
+            },
+            "leftHip": {
+              "x": 60.1,
+              "y": 62.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 67.8,
+              "y": 62.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 51,
+              "y": 86.9,
+              "v": 0.475
+            },
+            "rightKnee": {
+              "x": 76.7,
+              "y": 85.9,
+              "v": 0.687
+            },
+            "leftAnkle": {
+              "x": 32.1,
+              "y": 106.1,
+              "v": 0.588
+            },
+            "rightAnkle": {
+              "x": 69.7,
+              "y": 112.3,
+              "v": 0.603
+            },
+            "leftHeel": {
+              "x": 28.5,
+              "y": 108.3,
+              "v": 0.685
+            },
+            "rightHeel": {
+              "x": 67.1,
+              "y": 116.8,
+              "v": 0.538
+            },
+            "leftFootIndex": {
+              "x": 24.1,
+              "y": 111.6,
+              "v": 0.456
+            },
+            "rightFootIndex": {
+              "x": 73.2,
+              "y": 118.4,
+              "v": 0.383
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72,
+                "y": 12.1
+              },
+              "roll": -172.9,
+              "yaw": 0.744,
+              "pitch": 2.047
+            },
+            "torso": {
+              "center": {
+                "x": 65.9,
+                "y": 27.4
+              },
+              "angle": 86.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 112.9,
+                "y": 26.2
+              },
+              "angle": -1.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 28.5,
+                "y": 108.3
+              },
+              "angle": -143.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 67.1,
+                "y": 116.8
+              },
+              "angle": -14.7
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.882,
+          "keypoints": {
+            "nose": {
+              "x": 74.4,
+              "y": 13.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.9,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.4,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.2,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.9,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.9,
+              "y": 26.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.4,
+              "y": 26.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.3,
+              "y": 43.9,
+              "v": 0.705
+            },
+            "rightElbow": {
+              "x": 53.6,
+              "y": 45.1,
+              "v": 0.983
+            },
+            "leftWrist": {
+              "x": 94.4,
+              "y": 36.3,
+              "v": 0.947
+            },
+            "rightWrist": {
+              "x": 68.7,
+              "y": 43.3,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 99.3,
+              "y": 31.8,
+              "v": 0.951
+            },
+            "rightIndex": {
+              "x": 73.1,
+              "y": 39.3,
+              "v": 0.988
+            },
+            "leftHip": {
+              "x": 75.6,
+              "y": 59.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.5,
+              "y": 60.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95.7,
+              "y": 71.5,
+              "v": 0.894
+            },
+            "rightKnee": {
+              "x": 62.4,
+              "y": 85.2,
+              "v": 0.899
+            },
+            "leftAnkle": {
+              "x": 79.6,
+              "y": 92.4,
+              "v": 0.496
+            },
+            "rightAnkle": {
+              "x": 55.3,
+              "y": 111.1,
+              "v": 0.924
+            },
+            "leftHeel": {
+              "x": 74.9,
+              "y": 92.9,
+              "v": 0.524
+            },
+            "rightHeel": {
+              "x": 54.3,
+              "y": 113.3,
+              "v": 0.582
+            },
+            "leftFootIndex": {
+              "x": 78.5,
+              "y": 104.8,
+              "v": 0.555
+            },
+            "rightFootIndex": {
+              "x": 56.5,
+              "y": 124.4,
+              "v": 0.84
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.7,
+                "y": 11.1
+              },
+              "roll": 177.7,
+              "yaw": 0.699,
+              "pitch": 1.139
+            },
+            "torso": {
+              "center": {
+                "x": 67.7,
+                "y": 26.6
+              },
+              "angle": 93.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.4,
+                "y": 36.3
+              },
+              "angle": 42.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 68.7,
+                "y": 43.3
+              },
+              "angle": 42.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.9,
+                "y": 92.9
+              },
+              "angle": -73.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 54.3,
+                "y": 113.3
+              },
+              "angle": -78.8
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.938,
+          "keypoints": {
+            "nose": {
+              "x": 75.8,
+              "y": 13.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 76.9,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.6,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 76.1,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.9,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80,
+              "y": 27.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.2,
+              "y": 25.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.3,
+              "y": 44.8,
+              "v": 0.263
+            },
+            "rightElbow": {
+              "x": 58.8,
+              "y": 43.9,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 95.9,
+              "y": 37.1,
+              "v": 0.726
+            },
+            "rightWrist": {
+              "x": 73.1,
+              "y": 42.7,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 100.7,
+              "y": 32.4,
+              "v": 0.836
+            },
+            "rightIndex": {
+              "x": 77.8,
+              "y": 39.4,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 72.8,
+              "y": 62.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.4,
+              "y": 61.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.2,
+              "y": 89.8,
+              "v": 0.889
+            },
+            "rightKnee": {
+              "x": 97.5,
+              "y": 65.3,
+              "v": 0.989
+            },
+            "leftAnkle": {
+              "x": 61.2,
+              "y": 114.1,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 74.5,
+              "y": 87.5,
+              "v": 0.988
+            },
+            "leftHeel": {
+              "x": 58.4,
+              "y": 115.8,
+              "v": 0.983
+            },
+            "rightHeel": {
+              "x": 70.2,
+              "y": 88,
+              "v": 0.948
+            },
+            "leftFootIndex": {
+              "x": 62.6,
+              "y": 124.9,
+              "v": 0.99
+            },
+            "rightFootIndex": {
+              "x": 76.3,
+              "y": 99.6,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.8,
+                "y": 11.1
+              },
+              "roll": 165.7,
+              "yaw": 0.237,
+              "pitch": 0.642
+            },
+            "torso": {
+              "center": {
+                "x": 70.1,
+                "y": 26.6
+              },
+              "angle": 89.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.9,
+                "y": 37.1
+              },
+              "angle": 44.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 73.1,
+                "y": 42.7
+              },
+              "angle": 35.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 58.4,
+                "y": 115.8
+              },
+              "angle": -65.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 70.2,
+                "y": 88
+              },
+              "angle": -62.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.762,
+          "keypoints": {
+            "nose": {
+              "x": 72.4,
+              "y": 14.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.8,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.8,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.7,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.1,
+              "y": 25.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.4,
+              "y": 26.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.4,
+              "y": 44.1,
+              "v": 0.22
+            },
+            "rightElbow": {
+              "x": 53.2,
+              "y": 45.9,
+              "v": 0.95
+            },
+            "leftWrist": {
+              "x": 88.9,
+              "y": 38.2,
+              "v": 0.513
+            },
+            "rightWrist": {
+              "x": 67.9,
+              "y": 43.3,
+              "v": 0.975
+            },
+            "leftIndex": {
+              "x": 94.7,
+              "y": 32.8,
+              "v": 0.635
+            },
+            "rightIndex": {
+              "x": 72,
+              "y": 38.8,
+              "v": 0.964
+            },
+            "leftHip": {
+              "x": 68.2,
+              "y": 57.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.2,
+              "y": 59,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.7,
+              "y": 75.6,
+              "v": 0.374
+            },
+            "rightKnee": {
+              "x": 81.9,
+              "y": 69.8,
+              "v": 0.8
+            },
+            "leftAnkle": {
+              "x": 76.4,
+              "y": 96,
+              "v": 0.33
+            },
+            "rightAnkle": {
+              "x": 66.3,
+              "y": 95.6,
+              "v": 0.784
+            },
+            "leftHeel": {
+              "x": 73.5,
+              "y": 98.4,
+              "v": 0.39
+            },
+            "rightHeel": {
+              "x": 61.3,
+              "y": 102.4,
+              "v": 0.443
+            },
+            "leftFootIndex": {
+              "x": 78.7,
+              "y": 104.8,
+              "v": 0.418
+            },
+            "rightFootIndex": {
+              "x": 71.5,
+              "y": 107.5,
+              "v": 0.733
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.4,
+                "y": 11.7
+              },
+              "roll": 173.9,
+              "yaw": 0.355,
+              "pitch": 1.048
+            },
+            "torso": {
+              "center": {
+                "x": 64.3,
+                "y": 26.1
+              },
+              "angle": 89.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.9,
+                "y": 38.2
+              },
+              "angle": 43
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 67.9,
+                "y": 43.3
+              },
+              "angle": 47.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.5,
+                "y": 98.4
+              },
+              "angle": -50.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 61.3,
+                "y": 102.4
+              },
+              "angle": -26.6
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.789,
+          "keypoints": {
+            "nose": {
+              "x": 71.5,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.6,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.7,
+              "y": 11.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.2,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.4,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.3,
+              "y": 25.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.8,
+              "y": 26.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.9,
+              "y": 42.6,
+              "v": 0.413
+            },
+            "rightElbow": {
+              "x": 54.2,
+              "y": 44.8,
+              "v": 0.915
+            },
+            "leftWrist": {
+              "x": 91.8,
+              "y": 34,
+              "v": 0.794
+            },
+            "rightWrist": {
+              "x": 68.6,
+              "y": 42.5,
+              "v": 0.948
+            },
+            "leftIndex": {
+              "x": 96.3,
+              "y": 30.2,
+              "v": 0.833
+            },
+            "rightIndex": {
+              "x": 72.3,
+              "y": 38.1,
+              "v": 0.935
+            },
+            "leftHip": {
+              "x": 70.7,
+              "y": 56.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.5,
+              "y": 57.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90.2,
+              "y": 66.3,
+              "v": 0.317
+            },
+            "rightKnee": {
+              "x": 78.5,
+              "y": 71.5,
+              "v": 0.9
+            },
+            "leftAnkle": {
+              "x": 69.4,
+              "y": 79.3,
+              "v": 0.232
+            },
+            "rightAnkle": {
+              "x": 60.2,
+              "y": 93.6,
+              "v": 0.811
+            },
+            "leftHeel": {
+              "x": 65,
+              "y": 79.8,
+              "v": 0.369
+            },
+            "rightHeel": {
+              "x": 55.9,
+              "y": 95.7,
+              "v": 0.573
+            },
+            "leftFootIndex": {
+              "x": 69.9,
+              "y": 85.7,
+              "v": 0.346
+            },
+            "rightFootIndex": {
+              "x": 62.8,
+              "y": 104.5,
+              "v": 0.764
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.2,
+                "y": 11.6
+              },
+              "roll": 172.1,
+              "yaw": 0.461,
+              "pitch": 1.059
+            },
+            "torso": {
+              "center": {
+                "x": 64.6,
+                "y": 26
+              },
+              "angle": 92.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.8,
+                "y": 34
+              },
+              "angle": 40.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 68.6,
+                "y": 42.5
+              },
+              "angle": 49.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 65,
+                "y": 79.8
+              },
+              "angle": -50.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 55.9,
+                "y": 95.7
+              },
+              "angle": -51.9
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.725,
+          "keypoints": {
+            "nose": {
+              "x": 52.2,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 53,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49.3,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 51.7,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 45.3,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 55.2,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 36.8,
+              "y": 24.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 62.6,
+              "y": 40.5,
+              "v": 0.67
+            },
+            "rightElbow": {
+              "x": 36.6,
+              "y": 42.3,
+              "v": 0.954
+            },
+            "leftWrist": {
+              "x": 74,
+              "y": 34.3,
+              "v": 0.796
+            },
+            "rightWrist": {
+              "x": 50.5,
+              "y": 41,
+              "v": 0.981
+            },
+            "leftIndex": {
+              "x": 78.7,
+              "y": 30.6,
+              "v": 0.81
+            },
+            "rightIndex": {
+              "x": 54,
+              "y": 37.4,
+              "v": 0.969
+            },
+            "leftHip": {
+              "x": 50.2,
+              "y": 52.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 39.3,
+              "y": 55.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 64.1,
+              "y": 55.7,
+              "v": 0.365
+            },
+            "rightKnee": {
+              "x": 52.3,
+              "y": 68.7,
+              "v": 0.592
+            },
+            "leftAnkle": {
+              "x": 59.9,
+              "y": 72.8,
+              "v": 0.09
+            },
+            "rightAnkle": {
+              "x": 49,
+              "y": 95.2,
+              "v": 0.465
+            },
+            "leftHeel": {
+              "x": 57.7,
+              "y": 75.8,
+              "v": 0.165
+            },
+            "rightHeel": {
+              "x": 48.2,
+              "y": 99.8,
+              "v": 0.263
+            },
+            "leftFootIndex": {
+              "x": 63.1,
+              "y": 77.4,
+              "v": 0.167
+            },
+            "rightFootIndex": {
+              "x": 50.3,
+              "y": 101.3,
+              "v": 0.384
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.2,
+                "y": 11.3
+              },
+              "roll": 166.3,
+              "yaw": 0.276,
+              "pitch": 0.748
+            },
+            "torso": {
+              "center": {
+                "x": 46,
+                "y": 25.2
+              },
+              "angle": 87.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 74,
+                "y": 34.3
+              },
+              "angle": 38.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.5,
+                "y": 41
+              },
+              "angle": 45.8
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 49,
+                "y": 95.2
+              },
+              "angle": -78
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.737,
+          "keypoints": {
+            "nose": {
+              "x": 53.3,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 53.5,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 50.9,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 51.6,
+              "y": 12,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46.9,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 55.8,
+              "y": 25.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 37,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.2,
+              "y": 40.6,
+              "v": 0.254
+            },
+            "rightElbow": {
+              "x": 38.4,
+              "y": 42.9,
+              "v": 0.929
+            },
+            "leftWrist": {
+              "x": 74.3,
+              "y": 33.3,
+              "v": 0.518
+            },
+            "rightWrist": {
+              "x": 52.4,
+              "y": 40.5,
+              "v": 0.978
+            },
+            "leftIndex": {
+              "x": 79,
+              "y": 29.4,
+              "v": 0.619
+            },
+            "rightIndex": {
+              "x": 55.3,
+              "y": 37,
+              "v": 0.964
+            },
+            "leftHip": {
+              "x": 52.2,
+              "y": 54.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.7,
+              "y": 55.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 57.7,
+              "y": 67.7,
+              "v": 0.397
+            },
+            "rightKnee": {
+              "x": 50.8,
+              "y": 75.3,
+              "v": 0.816
+            },
+            "leftAnkle": {
+              "x": 40,
+              "y": 74,
+              "v": 0.146
+            },
+            "rightAnkle": {
+              "x": 46.3,
+              "y": 101.3,
+              "v": 0.779
+            },
+            "leftHeel": {
+              "x": 36.3,
+              "y": 74.3,
+              "v": 0.294
+            },
+            "rightHeel": {
+              "x": 45.5,
+              "y": 105,
+              "v": 0.473
+            },
+            "leftFootIndex": {
+              "x": 39.8,
+              "y": 79.5,
+              "v": 0.201
+            },
+            "rightFootIndex": {
+              "x": 47.6,
+              "y": 111.1,
+              "v": 0.583
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 52.2,
+                "y": 11
+              },
+              "roll": 155.2,
+              "yaw": 0.384,
+              "pitch": 0.943
+            },
+            "torso": {
+              "center": {
+                "x": 46.4,
+                "y": 24.9
+              },
+              "angle": 92
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 74.3,
+                "y": 33.3
+              },
+              "angle": 39.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52.4,
+                "y": 40.5
+              },
+              "angle": 50.4
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 45.5,
+                "y": 105
+              },
+              "angle": -71
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.771,
+          "keypoints": {
+            "nose": {
+              "x": 50.3,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 50.8,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 46.5,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 49.7,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 42.5,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 54,
+              "y": 25.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 34.2,
+              "y": 25.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 63.3,
+              "y": 38.1,
+              "v": 0.78
+            },
+            "rightElbow": {
+              "x": 33,
+              "y": 44.3,
+              "v": 0.967
+            },
+            "leftWrist": {
+              "x": 72.7,
+              "y": 29.3,
+              "v": 0.935
+            },
+            "rightWrist": {
+              "x": 48.1,
+              "y": 41.9,
+              "v": 0.989
+            },
+            "leftIndex": {
+              "x": 76,
+              "y": 24.6,
+              "v": 0.935
+            },
+            "rightIndex": {
+              "x": 52.2,
+              "y": 38.1,
+              "v": 0.98
+            },
+            "leftHip": {
+              "x": 50.1,
+              "y": 55.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 40.8,
+              "y": 56.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 52.2,
+              "y": 69.6,
+              "v": 0.322
+            },
+            "rightKnee": {
+              "x": 54.5,
+              "y": 67.6,
+              "v": 0.584
+            },
+            "leftAnkle": {
+              "x": 39.3,
+              "y": 91.9,
+              "v": 0.338
+            },
+            "rightAnkle": {
+              "x": 50.9,
+              "y": 94.3,
+              "v": 0.419
+            },
+            "leftHeel": {
+              "x": 36.3,
+              "y": 94.5,
+              "v": 0.35
+            },
+            "rightHeel": {
+              "x": 49.3,
+              "y": 97.9,
+              "v": 0.295
+            },
+            "leftFootIndex": {
+              "x": 39,
+              "y": 101.4,
+              "v": 0.42
+            },
+            "rightFootIndex": {
+              "x": 55.6,
+              "y": 104.5,
+              "v": 0.415
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 48.7,
+                "y": 10.6
+              },
+              "roll": 170.8,
+              "yaw": 0.379,
+              "pitch": 0.7
+            },
+            "torso": {
+              "center": {
+                "x": 44.1,
+                "y": 25.5
+              },
+              "angle": 92.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 72.7,
+                "y": 29.3
+              },
+              "angle": 54.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48.1,
+                "y": 41.9
+              },
+              "angle": 42.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 36.3,
+                "y": 94.5
+              },
+              "angle": -68.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 50.9,
+                "y": 94.3
+              },
+              "angle": -65.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.966,
+          "keypoints": {
+            "nose": {
+              "x": 61.4,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.3,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.3,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.5,
+              "y": 13,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 54.3,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.8,
+              "y": 27.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46,
+              "y": 28.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73,
+              "y": 40.7,
+              "v": 0.817
+            },
+            "rightElbow": {
+              "x": 35.2,
+              "y": 42.6,
+              "v": 0.969
+            },
+            "leftWrist": {
+              "x": 79.5,
+              "y": 29.5,
+              "v": 0.937
+            },
+            "rightWrist": {
+              "x": 51.3,
+              "y": 42.8,
+              "v": 0.971
+            },
+            "leftIndex": {
+              "x": 81,
+              "y": 24.1,
+              "v": 0.932
+            },
+            "rightIndex": {
+              "x": 55.2,
+              "y": 38.2,
+              "v": 0.954
+            },
+            "leftHip": {
+              "x": 60.3,
+              "y": 63.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.3,
+              "y": 61.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60.7,
+              "y": 86.6,
+              "v": 0.884
+            },
+            "rightKnee": {
+              "x": 78.3,
+              "y": 42.1,
+              "v": 0.931
+            },
+            "leftAnkle": {
+              "x": 56.7,
+              "y": 112.4,
+              "v": 0.954
+            },
+            "rightAnkle": {
+              "x": 106.5,
+              "y": 30.7,
+              "v": 0.989
+            },
+            "leftHeel": {
+              "x": 54,
+              "y": 112.7,
+              "v": 0.963
+            },
+            "rightHeel": {
+              "x": 111.5,
+              "y": 32.1,
+              "v": 0.986
+            },
+            "leftFootIndex": {
+              "x": 56.4,
+              "y": 122.8,
+              "v": 0.937
+            },
+            "rightFootIndex": {
+              "x": 116.9,
+              "y": 19.8,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.3,
+                "y": 11.5
+              },
+              "roll": 171.5,
+              "yaw": 0.272,
+              "pitch": 0.692
+            },
+            "torso": {
+              "center": {
+                "x": 55.4,
+                "y": 27.7
+              },
+              "angle": 92.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 79.5,
+                "y": 29.5
+              },
+              "angle": 74.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 51.3,
+                "y": 42.8
+              },
+              "angle": 49.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 54,
+                "y": 112.7
+              },
+              "angle": -76.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 111.5,
+                "y": 32.1
+              },
+              "angle": 66.3
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.981,
+          "keypoints": {
+            "nose": {
+              "x": 59.6,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.3,
+              "y": 11,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.4,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.9,
+              "y": 12,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.7,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.9,
+              "y": 25.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.7,
+              "y": 27.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.2,
+              "y": 37.8,
+              "v": 0.848
+            },
+            "rightElbow": {
+              "x": 44,
+              "y": 45.2,
+              "v": 0.991
+            },
+            "leftWrist": {
+              "x": 80.1,
+              "y": 29.6,
+              "v": 0.889
+            },
+            "rightWrist": {
+              "x": 56.4,
+              "y": 43.3,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 81.2,
+              "y": 24.3,
+              "v": 0.921
+            },
+            "rightIndex": {
+              "x": 60.9,
+              "y": 39.1,
+              "v": 0.995
+            },
+            "leftHip": {
+              "x": 62.8,
+              "y": 61.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.2,
+              "y": 60.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60.4,
+              "y": 87,
+              "v": 0.984
+            },
+            "rightKnee": {
+              "x": 78.9,
+              "y": 43.6,
+              "v": 0.966
+            },
+            "leftAnkle": {
+              "x": 54,
+              "y": 113.5,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 104,
+              "y": 31.1,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 51.2,
+              "y": 115,
+              "v": 0.997
+            },
+            "rightHeel": {
+              "x": 108.9,
+              "y": 32.3,
+              "v": 0.991
+            },
+            "leftFootIndex": {
+              "x": 46.9,
+              "y": 126.3,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 113.9,
+              "y": 21.3,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.9,
+                "y": 10.9
+              },
+              "roll": 176.1,
+              "yaw": 0.602,
+              "pitch": 1.101
+            },
+            "torso": {
+              "center": {
+                "x": 53.8,
+                "y": 26.1
+              },
+              "angle": 99.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.1,
+                "y": 29.6
+              },
+              "angle": 78.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 56.4,
+                "y": 43.3
+              },
+              "angle": 43
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 51.2,
+                "y": 115
+              },
+              "angle": -110.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 108.9,
+                "y": 32.3
+              },
+              "angle": 65.6
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.767,
+          "keypoints": {
+            "nose": {
+              "x": 74.7,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.1,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.3,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.7,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.3,
+              "y": 26.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.9,
+              "y": 26.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.1,
+              "y": 43.9,
+              "v": 0.543
+            },
+            "rightElbow": {
+              "x": 56.3,
+              "y": 44.5,
+              "v": 0.978
+            },
+            "leftWrist": {
+              "x": 93.8,
+              "y": 36,
+              "v": 0.84
+            },
+            "rightWrist": {
+              "x": 71.6,
+              "y": 41.6,
+              "v": 0.989
+            },
+            "leftIndex": {
+              "x": 98.3,
+              "y": 31.5,
+              "v": 0.835
+            },
+            "rightIndex": {
+              "x": 75.8,
+              "y": 37.4,
+              "v": 0.975
+            },
+            "leftHip": {
+              "x": 78.1,
+              "y": 59.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.1,
+              "y": 60.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86,
+              "y": 81.3,
+              "v": 0.294
+            },
+            "rightKnee": {
+              "x": 65.5,
+              "y": 83.5,
+              "v": 0.749
+            },
+            "leftAnkle": {
+              "x": 85.8,
+              "y": 101.5,
+              "v": 0.281
+            },
+            "rightAnkle": {
+              "x": 61.7,
+              "y": 113.2,
+              "v": 0.734
+            },
+            "leftHeel": {
+              "x": 84.1,
+              "y": 104.4,
+              "v": 0.249
+            },
+            "rightHeel": {
+              "x": 61,
+              "y": 115.4,
+              "v": 0.291
+            },
+            "leftFootIndex": {
+              "x": 90.2,
+              "y": 109.9,
+              "v": 0.301
+            },
+            "rightFootIndex": {
+              "x": 62.8,
+              "y": 123.6,
+              "v": 0.594
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.2,
+                "y": 11.1
+              },
+              "roll": 178.5,
+              "yaw": 0.395,
+              "pitch": 0.802
+            },
+            "torso": {
+              "center": {
+                "x": 69.1,
+                "y": 26.3
+              },
+              "angle": 95.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.8,
+                "y": 36
+              },
+              "angle": 45
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 71.6,
+                "y": 41.6
+              },
+              "angle": 45
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 61.7,
+                "y": 113.2
+              },
+              "angle": -84
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.807,
+          "keypoints": {
+            "nose": {
+              "x": 61.5,
+              "y": 13.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.5,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.3,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.6,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 54.7,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66.7,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.7,
+              "y": 25.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.7,
+              "y": 31.6,
+              "v": 0.925
+            },
+            "rightElbow": {
+              "x": 39.6,
+              "y": 38,
+              "v": 0.975
+            },
+            "leftWrist": {
+              "x": 88.3,
+              "y": 29.5,
+              "v": 0.939
+            },
+            "rightWrist": {
+              "x": 31.3,
+              "y": 44.1,
+              "v": 0.982
+            },
+            "leftIndex": {
+              "x": 93.6,
+              "y": 27.2,
+              "v": 0.927
+            },
+            "rightIndex": {
+              "x": 26,
+              "y": 44,
+              "v": 0.972
+            },
+            "leftHip": {
+              "x": 63.1,
+              "y": 57,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.6,
+              "y": 57.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.7,
+              "y": 80.6,
+              "v": 0.728
+            },
+            "rightKnee": {
+              "x": 47.6,
+              "y": 79.7,
+              "v": 0.733
+            },
+            "leftAnkle": {
+              "x": 75.2,
+              "y": 100.7,
+              "v": 0.338
+            },
+            "rightAnkle": {
+              "x": 39.1,
+              "y": 103.2,
+              "v": 0.572
+            },
+            "leftHeel": {
+              "x": 74.5,
+              "y": 103.9,
+              "v": 0.252
+            },
+            "rightHeel": {
+              "x": 38.7,
+              "y": 107.2,
+              "v": 0.284
+            },
+            "leftFootIndex": {
+              "x": 78.9,
+              "y": 107.3,
+              "v": 0.427
+            },
+            "rightFootIndex": {
+              "x": 35.8,
+              "y": 109.2,
+              "v": 0.517
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.4,
+                "y": 11.2
+              },
+              "roll": 173.2,
+              "yaw": 0.26,
+              "pitch": 0.65
+            },
+            "torso": {
+              "center": {
+                "x": 56.2,
+                "y": 24.8
+              },
+              "angle": 92
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 88.3,
+                "y": 29.5
+              },
+              "angle": 23.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31.3,
+                "y": 44.1
+              },
+              "angle": 178.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 75.2,
+                "y": 100.7
+              },
+              "angle": -60.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.1,
+                "y": 103.2
+              },
+              "angle": -118.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.835,
+          "keypoints": {
+            "nose": {
+              "x": 53.9,
+              "y": 17.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.4,
+              "y": 14.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51.2,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 53.2,
+              "y": 15.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 47.1,
+              "y": 15.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 55.9,
+              "y": 29.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.2,
+              "y": 29.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 62.9,
+              "y": 41.4,
+              "v": 0.406
+            },
+            "rightElbow": {
+              "x": 38.4,
+              "y": 46,
+              "v": 0.961
+            },
+            "leftWrist": {
+              "x": 72.5,
+              "y": 37.9,
+              "v": 0.711
+            },
+            "rightWrist": {
+              "x": 51.7,
+              "y": 42.5,
+              "v": 0.973
+            },
+            "leftIndex": {
+              "x": 74.8,
+              "y": 36.4,
+              "v": 0.759
+            },
+            "rightIndex": {
+              "x": 55.4,
+              "y": 37.5,
+              "v": 0.956
+            },
+            "leftHip": {
+              "x": 51.3,
+              "y": 62.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.9,
+              "y": 63.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 56.6,
+              "y": 83.7,
+              "v": 0.565
+            },
+            "rightKnee": {
+              "x": 47.5,
+              "y": 84.8,
+              "v": 0.87
+            },
+            "leftAnkle": {
+              "x": 57,
+              "y": 99.6,
+              "v": 0.56
+            },
+            "rightAnkle": {
+              "x": 41.2,
+              "y": 108.7,
+              "v": 0.885
+            },
+            "leftHeel": {
+              "x": 55.5,
+              "y": 101.7,
+              "v": 0.565
+            },
+            "rightHeel": {
+              "x": 40.4,
+              "y": 110.4,
+              "v": 0.572
+            },
+            "leftFootIndex": {
+              "x": 61.8,
+              "y": 107.5,
+              "v": 0.621
+            },
+            "rightFootIndex": {
+              "x": 42.8,
+              "y": 118.4,
+              "v": 0.802
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 52.8,
+                "y": 14.5
+              },
+              "roll": 172.9,
+              "yaw": 0.341,
+              "pitch": 0.837
+            },
+            "torso": {
+              "center": {
+                "x": 48.1,
+                "y": 29.6
+              },
+              "angle": 88.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 72.5,
+                "y": 37.9
+              },
+              "angle": 33.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 51.7,
+                "y": 42.5
+              },
+              "angle": 53.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 55.5,
+                "y": 101.7
+              },
+              "angle": -42.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.4,
+                "y": 110.4
+              },
+              "angle": -73.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.721,
+          "keypoints": {
+            "nose": {
+              "x": 58.3,
+              "y": 15.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 58.6,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 55.4,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 56.8,
+              "y": 14,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.3,
+              "y": 13.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 60.7,
+              "y": 28.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.3,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.9,
+              "y": 30.2,
+              "v": 0.879
+            },
+            "rightElbow": {
+              "x": 41.1,
+              "y": 44.4,
+              "v": 0.94
+            },
+            "leftWrist": {
+              "x": 91.9,
+              "y": 29.9,
+              "v": 0.97
+            },
+            "rightWrist": {
+              "x": 52.7,
+              "y": 42.4,
+              "v": 0.932
+            },
+            "leftIndex": {
+              "x": 97.2,
+              "y": 27.5,
+              "v": 0.962
+            },
+            "rightIndex": {
+              "x": 56.9,
+              "y": 38,
+              "v": 0.882
+            },
+            "leftHip": {
+              "x": 60,
+              "y": 59.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.1,
+              "y": 61.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.8,
+              "y": 81.1,
+              "v": 0.123
+            },
+            "rightKnee": {
+              "x": 48.7,
+              "y": 83.9,
+              "v": 0.366
+            },
+            "leftAnkle": {
+              "x": 67.1,
+              "y": 101.5,
+              "v": 0.168
+            },
+            "rightAnkle": {
+              "x": 42.5,
+              "y": 106.4,
+              "v": 0.43
+            },
+            "leftHeel": {
+              "x": 66.3,
+              "y": 104.9,
+              "v": 0.198
+            },
+            "rightHeel": {
+              "x": 41.5,
+              "y": 110,
+              "v": 0.195
+            },
+            "leftFootIndex": {
+              "x": 70.6,
+              "y": 108.1,
+              "v": 0.202
+            },
+            "rightFootIndex": {
+              "x": 43.3,
+              "y": 114.7,
+              "v": 0.332
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57,
+                "y": 12.7
+              },
+              "roll": 172.9,
+              "yaw": 0.403,
+              "pitch": 0.961
+            },
+            "torso": {
+              "center": {
+                "x": 52,
+                "y": 28.2
+              },
+              "angle": 94.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.9,
+                "y": 29.9
+              },
+              "angle": 24.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52.7,
+                "y": 42.4
+              },
+              "angle": 46.3
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 42.5,
+                "y": 106.4
+              },
+              "angle": -84.5
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.642,
+          "keypoints": {
+            "nose": {
+              "x": 67.4,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.8,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.6,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 66.2,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.9,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.8,
+              "y": 26.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.6,
+              "y": 26.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.2,
+              "y": 36.2,
+              "v": 0.625
+            },
+            "rightElbow": {
+              "x": 48.4,
+              "y": 44.4,
+              "v": 0.923
+            },
+            "leftWrist": {
+              "x": 103.3,
+              "y": 34.4,
+              "v": 0.675
+            },
+            "rightWrist": {
+              "x": 63.5,
+              "y": 42.4,
+              "v": 0.872
+            },
+            "leftIndex": {
+              "x": 109,
+              "y": 33.4,
+              "v": 0.676
+            },
+            "rightIndex": {
+              "x": 68.1,
+              "y": 39,
+              "v": 0.786
+            },
+            "leftHip": {
+              "x": 69.8,
+              "y": 59.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.9,
+              "y": 60.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.7,
+              "y": 82.8,
+              "v": 0.129
+            },
+            "rightKnee": {
+              "x": 58.3,
+              "y": 82.9,
+              "v": 0.234
+            },
+            "leftAnkle": {
+              "x": 75.3,
+              "y": 104,
+              "v": 0.099
+            },
+            "rightAnkle": {
+              "x": 53.7,
+              "y": 108.8,
+              "v": 0.23
+            },
+            "leftHeel": {
+              "x": 73.7,
+              "y": 107,
+              "v": 0.131
+            },
+            "rightHeel": {
+              "x": 53.4,
+              "y": 112.4,
+              "v": 0.108
+            },
+            "leftFootIndex": {
+              "x": 79.7,
+              "y": 112.1,
+              "v": 0.122
+            },
+            "rightFootIndex": {
+              "x": 53.8,
+              "y": 118.1,
+              "v": 0.163
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.2,
+                "y": 11.3
+              },
+              "roll": 171.1,
+              "yaw": 0.371,
+              "pitch": 0.942
+            },
+            "torso": {
+              "center": {
+                "x": 61.2,
+                "y": 26.3
+              },
+              "angle": 94.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.3,
+                "y": 34.4
+              },
+              "angle": 10
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 63.5,
+                "y": 42.4
+              },
+              "angle": 36.5
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.664,
+          "keypoints": {
+            "nose": {
+              "x": 75.7,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 76.1,
+              "y": 11.8,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 72.5,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.7,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.7,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.6,
+              "y": 23.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.6,
+              "y": 28,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.2,
+              "y": 39.8,
+              "v": 0.326
+            },
+            "rightElbow": {
+              "x": 70.1,
+              "y": 44.4,
+              "v": 0.902
+            },
+            "leftWrist": {
+              "x": 93.6,
+              "y": 32.9,
+              "v": 0.345
+            },
+            "rightWrist": {
+              "x": 86.5,
+              "y": 35.4,
+              "v": 0.907
+            },
+            "leftIndex": {
+              "x": 95.2,
+              "y": 29.1,
+              "v": 0.398
+            },
+            "rightIndex": {
+              "x": 90.4,
+              "y": 31,
+              "v": 0.837
+            },
+            "leftHip": {
+              "x": 79.5,
+              "y": 61.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 67.9,
+              "y": 62.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.9,
+              "y": 87,
+              "v": 0.204
+            },
+            "rightKnee": {
+              "x": 66.3,
+              "y": 88.9,
+              "v": 0.644
+            },
+            "leftAnkle": {
+              "x": 82.6,
+              "y": 106,
+              "v": 0.123
+            },
+            "rightAnkle": {
+              "x": 62.2,
+              "y": 116.1,
+              "v": 0.613
+            },
+            "leftHeel": {
+              "x": 80.9,
+              "y": 108.5,
+              "v": 0.145
+            },
+            "rightHeel": {
+              "x": 61.1,
+              "y": 119.1,
+              "v": 0.222
+            },
+            "leftFootIndex": {
+              "x": 85.6,
+              "y": 113.9,
+              "v": 0.152
+            },
+            "rightFootIndex": {
+              "x": 64,
+              "y": 123.6,
+              "v": 0.457
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.3,
+                "y": 11.3
+              },
+              "roll": 164.5,
+              "yaw": 0.375,
+              "pitch": 0.83
+            },
+            "torso": {
+              "center": {
+                "x": 70.1,
+                "y": 25.9
+              },
+              "angle": 95.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.6,
+                "y": 32.9
+              },
+              "angle": 67.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 86.5,
+                "y": 35.4
+              },
+              "angle": 48.4
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 62.2,
+                "y": 116.1
+              },
+              "angle": -76.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.65,
+          "keypoints": {
+            "nose": {
+              "x": 77.2,
+              "y": 14.3,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 77.2,
+              "y": 11.8,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 74.2,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.2,
+              "y": 12.5,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 69.3,
+              "y": 11.4,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 79.3,
+              "y": 25.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.6,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 88.3,
+              "y": 41.5,
+              "v": 0.171
+            },
+            "rightElbow": {
+              "x": 69.4,
+              "y": 44.8,
+              "v": 0.925
+            },
+            "leftWrist": {
+              "x": 93.5,
+              "y": 35.2,
+              "v": 0.24
+            },
+            "rightWrist": {
+              "x": 85.7,
+              "y": 36.6,
+              "v": 0.941
+            },
+            "leftIndex": {
+              "x": 96.1,
+              "y": 33,
+              "v": 0.31
+            },
+            "rightIndex": {
+              "x": 89.3,
+              "y": 31.6,
+              "v": 0.887
+            },
+            "leftHip": {
+              "x": 78.7,
+              "y": 62.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 67.6,
+              "y": 63,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.3,
+              "y": 88,
+              "v": 0.115
+            },
+            "rightKnee": {
+              "x": 66.3,
+              "y": 87.5,
+              "v": 0.601
+            },
+            "leftAnkle": {
+              "x": 79.2,
+              "y": 107,
+              "v": 0.137
+            },
+            "rightAnkle": {
+              "x": 62.2,
+              "y": 115.5,
+              "v": 0.615
+            },
+            "leftHeel": {
+              "x": 77.3,
+              "y": 109.7,
+              "v": 0.17
+            },
+            "rightHeel": {
+              "x": 60.9,
+              "y": 117.5,
+              "v": 0.219
+            },
+            "leftFootIndex": {
+              "x": 82.8,
+              "y": 114.9,
+              "v": 0.169
+            },
+            "rightFootIndex": {
+              "x": 64.2,
+              "y": 125.7,
+              "v": 0.445
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 75.7,
+                "y": 11.3
+              },
+              "roll": 161.6,
+              "yaw": 0.474,
+              "pitch": 0.949
+            },
+            "torso": {
+              "center": {
+                "x": 70,
+                "y": 26.8
+              },
+              "angle": 95.1
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 85.7,
+                "y": 36.6
+              },
+              "angle": 54.2
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 62.2,
+                "y": 115.5
+              },
+              "angle": -78.9
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.695,
+          "keypoints": {
+            "nose": {
+              "x": 66.3,
+              "y": 15,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.9,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.6,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65,
+              "y": 12.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.1,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.3,
+              "y": 25.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.4,
+              "y": 27.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.5,
+              "y": 30.9,
+              "v": 0.903
+            },
+            "rightElbow": {
+              "x": 48.2,
+              "y": 45.4,
+              "v": 0.726
+            },
+            "leftWrist": {
+              "x": 80.7,
+              "y": 12.8,
+              "v": 0.97
+            },
+            "rightWrist": {
+              "x": 60,
+              "y": 46.6,
+              "v": 0.446
+            },
+            "leftIndex": {
+              "x": 79.5,
+              "y": 6.6,
+              "v": 0.949
+            },
+            "rightIndex": {
+              "x": 64.5,
+              "y": 44.6,
+              "v": 0.372
+            },
+            "leftHip": {
+              "x": 66.3,
+              "y": 60.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.1,
+              "y": 61.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.1,
+              "y": 81.9,
+              "v": 0.272
+            },
+            "rightKnee": {
+              "x": 65.8,
+              "y": 82,
+              "v": 0.537
+            },
+            "leftAnkle": {
+              "x": 78.3,
+              "y": 102.9,
+              "v": 0.188
+            },
+            "rightAnkle": {
+              "x": 53.5,
+              "y": 107.6,
+              "v": 0.525
+            },
+            "leftHeel": {
+              "x": 76.5,
+              "y": 106.7,
+              "v": 0.223
+            },
+            "rightHeel": {
+              "x": 50.7,
+              "y": 111.6,
+              "v": 0.234
+            },
+            "leftFootIndex": {
+              "x": 84.2,
+              "y": 108.8,
+              "v": 0.223
+            },
+            "rightFootIndex": {
+              "x": 55.2,
+              "y": 116.5,
+              "v": 0.412
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.3,
+                "y": 12.2
+              },
+              "roll": 171.4,
+              "yaw": 0.315,
+              "pitch": 0.854
+            },
+            "torso": {
+              "center": {
+                "x": 58.9,
+                "y": 26.6
+              },
+              "angle": 93.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.7,
+                "y": 12.8
+              },
+              "angle": 101
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 60,
+                "y": 46.6
+              },
+              "angle": 24
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 53.5,
+                "y": 107.6
+              },
+              "angle": -79.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.631,
+          "keypoints": {
+            "nose": {
+              "x": 73.9,
+              "y": 13.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.9,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 77.2,
+              "y": 13.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 69.3,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 81.1,
+              "y": 25.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63,
+              "y": 27.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 89.6,
+              "y": 21.2,
+              "v": 0.934
+            },
+            "rightElbow": {
+              "x": 54.9,
+              "y": 42.1,
+              "v": 0.912
+            },
+            "leftWrist": {
+              "x": 78.2,
+              "y": 20.6,
+              "v": 0.799
+            },
+            "rightWrist": {
+              "x": 48.5,
+              "y": 58.1,
+              "v": 0.945
+            },
+            "leftIndex": {
+              "x": 72.9,
+              "y": 20,
+              "v": 0.6
+            },
+            "rightIndex": {
+              "x": 44.8,
+              "y": 63.3,
+              "v": 0.893
+            },
+            "leftHip": {
+              "x": 77.5,
+              "y": 58,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 67.4,
+              "y": 58.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.7,
+              "y": 82.8,
+              "v": 0.055
+            },
+            "rightKnee": {
+              "x": 65.1,
+              "y": 77,
+              "v": 0.068
+            },
+            "leftAnkle": {
+              "x": 75,
+              "y": 102.2,
+              "v": 0.034
+            },
+            "rightAnkle": {
+              "x": 53.8,
+              "y": 97.9,
+              "v": 0.065
+            },
+            "leftHeel": {
+              "x": 73.5,
+              "y": 104.9,
+              "v": 0.05
+            },
+            "rightHeel": {
+              "x": 52.4,
+              "y": 101.1,
+              "v": 0.034
+            },
+            "leftFootIndex": {
+              "x": 78.3,
+              "y": 109.9,
+              "v": 0.059
+            },
+            "rightFootIndex": {
+              "x": 51.9,
+              "y": 105.9,
+              "v": 0.062
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74,
+                "y": 11.7
+              },
+              "roll": 165.6,
+              "yaw": -0.012,
+              "pitch": 0.546
+            },
+            "torso": {
+              "center": {
+                "x": 72.1,
+                "y": 26.5
+              },
+              "angle": 90.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 78.2,
+                "y": 20.6
+              },
+              "angle": 173.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48.5,
+                "y": 58.1
+              },
+              "angle": -125.4
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.757,
+          "keypoints": {
+            "nose": {
+              "x": 75,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.4,
+              "y": 10.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.2,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.7,
+              "y": 11,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.3,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.2,
+              "y": 26.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.9,
+              "y": 27,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.2,
+              "y": 41.9,
+              "v": 0.536
+            },
+            "rightElbow": {
+              "x": 58.6,
+              "y": 45.9,
+              "v": 0.943
+            },
+            "leftWrist": {
+              "x": 95.5,
+              "y": 34.2,
+              "v": 0.81
+            },
+            "rightWrist": {
+              "x": 73.1,
+              "y": 42.4,
+              "v": 0.972
+            },
+            "leftIndex": {
+              "x": 99.3,
+              "y": 30.3,
+              "v": 0.833
+            },
+            "rightIndex": {
+              "x": 76.6,
+              "y": 37.8,
+              "v": 0.954
+            },
+            "leftHip": {
+              "x": 77.6,
+              "y": 61.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.7,
+              "y": 62.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.9,
+              "y": 81.3,
+              "v": 0.388
+            },
+            "rightKnee": {
+              "x": 66.4,
+              "y": 87.1,
+              "v": 0.682
+            },
+            "leftAnkle": {
+              "x": 82.7,
+              "y": 103,
+              "v": 0.28
+            },
+            "rightAnkle": {
+              "x": 63.5,
+              "y": 112.7,
+              "v": 0.666
+            },
+            "leftHeel": {
+              "x": 80.7,
+              "y": 105.6,
+              "v": 0.238
+            },
+            "rightHeel": {
+              "x": 61.7,
+              "y": 115.8,
+              "v": 0.271
+            },
+            "leftFootIndex": {
+              "x": 86.4,
+              "y": 113.1,
+              "v": 0.312
+            },
+            "rightFootIndex": {
+              "x": 65,
+              "y": 123.8,
+              "v": 0.519
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.8,
+                "y": 10.3
+              },
+              "roll": -178.2,
+              "yaw": 0.375,
+              "pitch": 0.921
+            },
+            "torso": {
+              "center": {
+                "x": 70.1,
+                "y": 26.7
+              },
+              "angle": 93.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.5,
+                "y": 34.2
+              },
+              "angle": 45.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 73.1,
+                "y": 42.4
+              },
+              "angle": 52.7
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 63.5,
+                "y": 112.7
+              },
+              "angle": -82.3
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.787,
+          "keypoints": {
+            "nose": {
+              "x": 85.2,
+              "y": 16.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 85.8,
+              "y": 13.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 82.9,
+              "y": 12.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 83.7,
+              "y": 13.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 79.1,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 82.3,
+              "y": 26.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 69.7,
+              "y": 25.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85,
+              "y": 39.8,
+              "v": 0.094
+            },
+            "rightElbow": {
+              "x": 73.8,
+              "y": 42.4,
+              "v": 0.989
+            },
+            "leftWrist": {
+              "x": 96.9,
+              "y": 36.1,
+              "v": 0.313
+            },
+            "rightWrist": {
+              "x": 91.9,
+              "y": 38.3,
+              "v": 0.978
+            },
+            "leftIndex": {
+              "x": 100.1,
+              "y": 33.9,
+              "v": 0.485
+            },
+            "rightIndex": {
+              "x": 96.3,
+              "y": 35.5,
+              "v": 0.953
+            },
+            "leftHip": {
+              "x": 72.4,
+              "y": 57.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.6,
+              "y": 56.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63.7,
+              "y": 78,
+              "v": 0.132
+            },
+            "rightKnee": {
+              "x": 64.8,
+              "y": 79.9,
+              "v": 0.982
+            },
+            "leftAnkle": {
+              "x": 46.9,
+              "y": 92.9,
+              "v": 0.431
+            },
+            "rightAnkle": {
+              "x": 44.1,
+              "y": 95.9,
+              "v": 0.945
+            },
+            "leftHeel": {
+              "x": 43.6,
+              "y": 94.4,
+              "v": 0.601
+            },
+            "rightHeel": {
+              "x": 40.5,
+              "y": 96.7,
+              "v": 0.734
+            },
+            "leftFootIndex": {
+              "x": 46.8,
+              "y": 100.2,
+              "v": 0.553
+            },
+            "rightFootIndex": {
+              "x": 42.9,
+              "y": 106.6,
+              "v": 0.914
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 84.4,
+                "y": 13
+              },
+              "roll": 161,
+              "yaw": 0.277,
+              "pitch": 1.011
+            },
+            "torso": {
+              "center": {
+                "x": 76,
+                "y": 26.2
+              },
+              "angle": 78.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.9,
+                "y": 36.1
+              },
+              "angle": 34.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 91.9,
+                "y": 38.3
+              },
+              "angle": 32.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 43.6,
+                "y": 94.4
+              },
+              "angle": -61.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.5,
+                "y": 96.7
+              },
+              "angle": -76.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.777,
+          "keypoints": {
+            "nose": {
+              "x": 79.8,
+              "y": 15.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 80.9,
+              "y": 13.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 77.5,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 79.2,
+              "y": 14,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 72.7,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 81.5,
+              "y": 28.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63,
+              "y": 25.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.4,
+              "y": 46.8,
+              "v": 0.759
+            },
+            "rightElbow": {
+              "x": 52.8,
+              "y": 42,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 98.8,
+              "y": 55.4,
+              "v": 0.917
+            },
+            "rightWrist": {
+              "x": 40.1,
+              "y": 54.3,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 105.1,
+              "y": 58.7,
+              "v": 0.907
+            },
+            "rightIndex": {
+              "x": 35.6,
+              "y": 59.2,
+              "v": 0.995
+            },
+            "leftHip": {
+              "x": 75.8,
+              "y": 63,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.2,
+              "y": 62,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.1,
+              "y": 88.9,
+              "v": 0.221
+            },
+            "rightKnee": {
+              "x": 61.1,
+              "y": 86.7,
+              "v": 0.74
+            },
+            "leftAnkle": {
+              "x": 68.7,
+              "y": 111.6,
+              "v": 0.209
+            },
+            "rightAnkle": {
+              "x": 47.8,
+              "y": 113.8,
+              "v": 0.644
+            },
+            "leftHeel": {
+              "x": 66.8,
+              "y": 114.9,
+              "v": 0.229
+            },
+            "rightHeel": {
+              "x": 45.9,
+              "y": 115.6,
+              "v": 0.262
+            },
+            "leftFootIndex": {
+              "x": 70.6,
+              "y": 120.4,
+              "v": 0.371
+            },
+            "rightFootIndex": {
+              "x": 48.6,
+              "y": 125,
+              "v": 0.633
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 79.2,
+                "y": 13
+              },
+              "roll": 170,
+              "yaw": 0.174,
+              "pitch": 0.782
+            },
+            "torso": {
+              "center": {
+                "x": 72.3,
+                "y": 27.3
+              },
+              "angle": 87.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.8,
+                "y": 55.4
+              },
+              "angle": -27.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 40.1,
+                "y": 54.3
+              },
+              "angle": -132.6
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 47.8,
+                "y": 113.8
+              },
+              "angle": -85.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.762,
+          "keypoints": {
+            "nose": {
+              "x": 71.5,
+              "y": 14,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.7,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.4,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.2,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.1,
+              "y": 11.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77,
+              "y": 25.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.8,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.4,
+              "y": 40.7,
+              "v": 0.891
+            },
+            "rightElbow": {
+              "x": 47.7,
+              "y": 42.5,
+              "v": 0.994
+            },
+            "leftWrist": {
+              "x": 95.6,
+              "y": 41.6,
+              "v": 0.934
+            },
+            "rightWrist": {
+              "x": 35.6,
+              "y": 53.6,
+              "v": 0.992
+            },
+            "leftIndex": {
+              "x": 101.3,
+              "y": 37.9,
+              "v": 0.921
+            },
+            "rightIndex": {
+              "x": 30.6,
+              "y": 58.1,
+              "v": 0.983
+            },
+            "leftHip": {
+              "x": 74.8,
+              "y": 58.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.7,
+              "y": 59.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.9,
+              "y": 83.6,
+              "v": 0.384
+            },
+            "rightKnee": {
+              "x": 60,
+              "y": 82.4,
+              "v": 0.532
+            },
+            "leftAnkle": {
+              "x": 76,
+              "y": 106.7,
+              "v": 0.255
+            },
+            "rightAnkle": {
+              "x": 56.2,
+              "y": 108.3,
+              "v": 0.427
+            },
+            "leftHeel": {
+              "x": 75,
+              "y": 110.1,
+              "v": 0.203
+            },
+            "rightHeel": {
+              "x": 56.7,
+              "y": 112.4,
+              "v": 0.202
+            },
+            "leftFootIndex": {
+              "x": 77.4,
+              "y": 114.4,
+              "v": 0.375
+            },
+            "rightFootIndex": {
+              "x": 53.4,
+              "y": 115.4,
+              "v": 0.432
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.1,
+                "y": 11.1
+              },
+              "roll": 169.7,
+              "yaw": 0.432,
+              "pitch": 0.865
+            },
+            "torso": {
+              "center": {
+                "x": 66.4,
+                "y": 26.9
+              },
+              "angle": 94.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.6,
+                "y": 41.6
+              },
+              "angle": 33
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.6,
+                "y": 53.6
+              },
+              "angle": -138
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 56.2,
+                "y": 108.3
+              },
+              "angle": -111.5
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.695,
+          "keypoints": {
+            "nose": {
+              "x": 69.3,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.3,
+              "y": 12,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 66.5,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.5,
+              "y": 13.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.8,
+              "y": 28.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.2,
+              "y": 26.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.2,
+              "y": 45.5,
+              "v": 0.756
+            },
+            "rightElbow": {
+              "x": 48.3,
+              "y": 42.2,
+              "v": 0.987
+            },
+            "leftWrist": {
+              "x": 96.9,
+              "y": 53,
+              "v": 0.926
+            },
+            "rightWrist": {
+              "x": 39.5,
+              "y": 59.1,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 102.3,
+              "y": 55.3,
+              "v": 0.911
+            },
+            "rightIndex": {
+              "x": 36.6,
+              "y": 63.9,
+              "v": 0.987
+            },
+            "leftHip": {
+              "x": 73.2,
+              "y": 61,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.8,
+              "y": 61.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.5,
+              "y": 86.5,
+              "v": 0.135
+            },
+            "rightKnee": {
+              "x": 57.9,
+              "y": 85.7,
+              "v": 0.353
+            },
+            "leftAnkle": {
+              "x": 73.6,
+              "y": 108.1,
+              "v": 0.082
+            },
+            "rightAnkle": {
+              "x": 55.2,
+              "y": 113.1,
+              "v": 0.276
+            },
+            "leftHeel": {
+              "x": 72.3,
+              "y": 110.8,
+              "v": 0.081
+            },
+            "rightHeel": {
+              "x": 55.1,
+              "y": 116.2,
+              "v": 0.1
+            },
+            "leftFootIndex": {
+              "x": 73,
+              "y": 114.5,
+              "v": 0.15
+            },
+            "rightFootIndex": {
+              "x": 58,
+              "y": 124.2,
+              "v": 0.255
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 68.4,
+                "y": 11.6
+              },
+              "roll": 166.7,
+              "yaw": 0.23,
+              "pitch": 0.653
+            },
+            "torso": {
+              "center": {
+                "x": 64.5,
+                "y": 27.4
+              },
+              "angle": 94.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.9,
+                "y": 53
+              },
+              "angle": -23.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.5,
+                "y": 59.1
+              },
+              "angle": -121.1
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.766,
+          "keypoints": {
+            "nose": {
+              "x": 74.6,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.6,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.9,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.6,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.5,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.3,
+              "y": 26.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.8,
+              "y": 26.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.9,
+              "y": 45,
+              "v": 0.478
+            },
+            "rightElbow": {
+              "x": 57,
+              "y": 44.4,
+              "v": 0.965
+            },
+            "leftWrist": {
+              "x": 95.2,
+              "y": 35.5,
+              "v": 0.704
+            },
+            "rightWrist": {
+              "x": 73.2,
+              "y": 42.2,
+              "v": 0.94
+            },
+            "leftIndex": {
+              "x": 100.1,
+              "y": 31.9,
+              "v": 0.714
+            },
+            "rightIndex": {
+              "x": 76.9,
+              "y": 37.9,
+              "v": 0.877
+            },
+            "leftHip": {
+              "x": 76.4,
+              "y": 60.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.2,
+              "y": 61.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.5,
+              "y": 79.7,
+              "v": 0.379
+            },
+            "rightKnee": {
+              "x": 67.5,
+              "y": 85.5,
+              "v": 0.797
+            },
+            "leftAnkle": {
+              "x": 82.3,
+              "y": 102.6,
+              "v": 0.345
+            },
+            "rightAnkle": {
+              "x": 60.5,
+              "y": 111.8,
+              "v": 0.722
+            },
+            "leftHeel": {
+              "x": 80.2,
+              "y": 106.3,
+              "v": 0.371
+            },
+            "rightHeel": {
+              "x": 59.6,
+              "y": 115.5,
+              "v": 0.329
+            },
+            "leftFootIndex": {
+              "x": 87.9,
+              "y": 110.7,
+              "v": 0.409
+            },
+            "rightFootIndex": {
+              "x": 62.5,
+              "y": 121.9,
+              "v": 0.595
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.8,
+                "y": 11.1
+              },
+              "roll": 163.4,
+              "yaw": 0.22,
+              "pitch": 0.764
+            },
+            "torso": {
+              "center": {
+                "x": 69.1,
+                "y": 26.3
+              },
+              "angle": 92.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.2,
+                "y": 35.5
+              },
+              "angle": 36.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 73.2,
+                "y": 42.2
+              },
+              "angle": 49.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80.2,
+                "y": 106.3
+              },
+              "angle": -29.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 59.6,
+                "y": 115.5
+              },
+              "angle": -65.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.717,
+          "keypoints": {
+            "nose": {
+              "x": 74.9,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.7,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.8,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.7,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.4,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 81.1,
+              "y": 27.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.1,
+              "y": 26.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.2,
+              "y": 45.2,
+              "v": 0.38
+            },
+            "rightElbow": {
+              "x": 57.5,
+              "y": 45.4,
+              "v": 0.887
+            },
+            "leftWrist": {
+              "x": 94.3,
+              "y": 36.7,
+              "v": 0.656
+            },
+            "rightWrist": {
+              "x": 72.5,
+              "y": 42.7,
+              "v": 0.923
+            },
+            "leftIndex": {
+              "x": 98.1,
+              "y": 32.5,
+              "v": 0.668
+            },
+            "rightIndex": {
+              "x": 76.3,
+              "y": 38.7,
+              "v": 0.87
+            },
+            "leftHip": {
+              "x": 77.2,
+              "y": 61.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.8,
+              "y": 62.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.1,
+              "y": 83.1,
+              "v": 0.33
+            },
+            "rightKnee": {
+              "x": 65.8,
+              "y": 86.1,
+              "v": 0.59
+            },
+            "leftAnkle": {
+              "x": 84.7,
+              "y": 103.2,
+              "v": 0.287
+            },
+            "rightAnkle": {
+              "x": 61.2,
+              "y": 111.9,
+              "v": 0.603
+            },
+            "leftHeel": {
+              "x": 83.2,
+              "y": 106.3,
+              "v": 0.256
+            },
+            "rightHeel": {
+              "x": 60.5,
+              "y": 116.2,
+              "v": 0.274
+            },
+            "leftFootIndex": {
+              "x": 89.7,
+              "y": 111.5,
+              "v": 0.311
+            },
+            "rightFootIndex": {
+              "x": 60.9,
+              "y": 122.2,
+              "v": 0.466
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.8,
+                "y": 11.4
+              },
+              "roll": 172.7,
+              "yaw": 0.292,
+              "pitch": 0.776
+            },
+            "torso": {
+              "center": {
+                "x": 70.1,
+                "y": 27.2
+              },
+              "angle": 92.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.3,
+                "y": 36.7
+              },
+              "angle": 47.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72.5,
+                "y": 42.7
+              },
+              "angle": 46.5
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 61.2,
+                "y": 111.9
+              },
+              "angle": -91.7
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.688,
+          "keypoints": {
+            "nose": {
+              "x": 75.1,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.6,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.5,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.1,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.1,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.1,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.9,
+              "y": 26.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.7,
+              "y": 44,
+              "v": 0.453
+            },
+            "rightElbow": {
+              "x": 57.6,
+              "y": 45.4,
+              "v": 0.935
+            },
+            "leftWrist": {
+              "x": 94.3,
+              "y": 36.6,
+              "v": 0.783
+            },
+            "rightWrist": {
+              "x": 71.4,
+              "y": 42.3,
+              "v": 0.952
+            },
+            "leftIndex": {
+              "x": 98.1,
+              "y": 32.4,
+              "v": 0.803
+            },
+            "rightIndex": {
+              "x": 75.8,
+              "y": 37.9,
+              "v": 0.911
+            },
+            "leftHip": {
+              "x": 77.8,
+              "y": 61.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.7,
+              "y": 62.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.7,
+              "y": 83.4,
+              "v": 0.165
+            },
+            "rightKnee": {
+              "x": 66,
+              "y": 85.9,
+              "v": 0.421
+            },
+            "leftAnkle": {
+              "x": 82.7,
+              "y": 105.3,
+              "v": 0.172
+            },
+            "rightAnkle": {
+              "x": 60.6,
+              "y": 112.3,
+              "v": 0.419
+            },
+            "leftHeel": {
+              "x": 80.5,
+              "y": 108.8,
+              "v": 0.168
+            },
+            "rightHeel": {
+              "x": 59.3,
+              "y": 116.6,
+              "v": 0.142
+            },
+            "leftFootIndex": {
+              "x": 85.8,
+              "y": 110.9,
+              "v": 0.199
+            },
+            "rightFootIndex": {
+              "x": 62.2,
+              "y": 122.4,
+              "v": 0.308
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.1,
+                "y": 11.7
+              },
+              "roll": 162.1,
+              "yaw": 0.322,
+              "pitch": 0.921
+            },
+            "torso": {
+              "center": {
+                "x": 69.5,
+                "y": 26.8
+              },
+              "angle": 93.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.3,
+                "y": 36.6
+              },
+              "angle": 47.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 71.4,
+                "y": 42.3
+              },
+              "angle": 45
+            },
+            "leftFoot": null,
+            "rightFoot": {
+              "anchor": {
+                "x": 60.6,
+                "y": 112.3
+              },
+              "angle": -81
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.75,
+          "keypoints": {
+            "nose": {
+              "x": 75,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.3,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.7,
+              "y": 12,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.5,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.4,
+              "y": 27,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.7,
+              "y": 26.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.9,
+              "y": 44.7,
+              "v": 0.381
+            },
+            "rightElbow": {
+              "x": 58.3,
+              "y": 45.2,
+              "v": 0.968
+            },
+            "leftWrist": {
+              "x": 94.8,
+              "y": 36.3,
+              "v": 0.719
+            },
+            "rightWrist": {
+              "x": 72.3,
+              "y": 42.4,
+              "v": 0.984
+            },
+            "leftIndex": {
+              "x": 98.8,
+              "y": 32.2,
+              "v": 0.759
+            },
+            "rightIndex": {
+              "x": 76.4,
+              "y": 38.2,
+              "v": 0.972
+            },
+            "leftHip": {
+              "x": 77.3,
+              "y": 60.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.9,
+              "y": 61.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.8,
+              "y": 79.9,
+              "v": 0.467
+            },
+            "rightKnee": {
+              "x": 67.1,
+              "y": 84.8,
+              "v": 0.619
+            },
+            "leftAnkle": {
+              "x": 80.4,
+              "y": 103.2,
+              "v": 0.324
+            },
+            "rightAnkle": {
+              "x": 62.9,
+              "y": 111.9,
+              "v": 0.572
+            },
+            "leftHeel": {
+              "x": 78.9,
+              "y": 106.6,
+              "v": 0.324
+            },
+            "rightHeel": {
+              "x": 61.3,
+              "y": 115.9,
+              "v": 0.266
+            },
+            "leftFootIndex": {
+              "x": 84.4,
+              "y": 111.6,
+              "v": 0.408
+            },
+            "rightFootIndex": {
+              "x": 62.7,
+              "y": 122.3,
+              "v": 0.485
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.7,
+                "y": 11.1
+              },
+              "roll": 173.1,
+              "yaw": 0.406,
+              "pitch": 0.902
+            },
+            "torso": {
+              "center": {
+                "x": 69.6,
+                "y": 26.7
+              },
+              "angle": 93.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.8,
+                "y": 36.3
+              },
+              "angle": 45.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72.3,
+                "y": 42.4
+              },
+              "angle": 45.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.9,
+                "y": 106.6
+              },
+              "angle": -42.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 62.9,
+                "y": 111.9
+              },
+              "angle": -91.1
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.864,
+          "keypoints": {
+            "nose": {
+              "x": 90.3,
+              "y": 17.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 91.9,
+              "y": 15.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 89,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 90.5,
+              "y": 15.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 84.9,
+              "y": 12.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 88.5,
+              "y": 29.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 70.9,
+              "y": 22.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.1,
+              "y": 47.1,
+              "v": 0.489
+            },
+            "rightElbow": {
+              "x": 59.7,
+              "y": 38.3,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 93.2,
+              "y": 58,
+              "v": 0.891
+            },
+            "rightWrist": {
+              "x": 52.9,
+              "y": 56.8,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 98.8,
+              "y": 59.7,
+              "v": 0.902
+            },
+            "rightIndex": {
+              "x": 53,
+              "y": 62.4,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 74.6,
+              "y": 59.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64.1,
+              "y": 56.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.8,
+              "y": 85,
+              "v": 0.679
+            },
+            "rightKnee": {
+              "x": 60,
+              "y": 78.7,
+              "v": 0.854
+            },
+            "leftAnkle": {
+              "x": 67.9,
+              "y": 107.4,
+              "v": 0.758
+            },
+            "rightAnkle": {
+              "x": 44.6,
+              "y": 96.8,
+              "v": 0.775
+            },
+            "leftHeel": {
+              "x": 64.1,
+              "y": 108.4,
+              "v": 0.631
+            },
+            "rightHeel": {
+              "x": 42.2,
+              "y": 97.6,
+              "v": 0.367
+            },
+            "leftFootIndex": {
+              "x": 68,
+              "y": 117.3,
+              "v": 0.788
+            },
+            "rightFootIndex": {
+              "x": 42.6,
+              "y": 110.6,
+              "v": 0.744
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 90.5,
+                "y": 14.7
+              },
+              "roll": 157.5,
+              "yaw": -0.048,
+              "pitch": 0.988
+            },
+            "torso": {
+              "center": {
+                "x": 79.7,
+                "y": 26.2
+              },
+              "angle": 72
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.2,
+                "y": 58
+              },
+              "angle": -16.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52.9,
+                "y": 56.8
+              },
+              "angle": -89
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 64.1,
+                "y": 108.4
+              },
+              "angle": -66.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.2,
+                "y": 97.6
+              },
+              "angle": -88.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.693,
+          "keypoints": {
+            "nose": {
+              "x": 80.1,
+              "y": 18.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 82,
+              "y": 16.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 78.3,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 79.9,
+              "y": 16.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 73.6,
+              "y": 13,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 81,
+              "y": 30.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60,
+              "y": 26.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.3,
+              "y": 46.8,
+              "v": 0.637
+            },
+            "rightElbow": {
+              "x": 57,
+              "y": 46.2,
+              "v": 0.967
+            },
+            "leftWrist": {
+              "x": 96.2,
+              "y": 36.2,
+              "v": 0.893
+            },
+            "rightWrist": {
+              "x": 72,
+              "y": 42.7,
+              "v": 0.978
+            },
+            "leftIndex": {
+              "x": 100.2,
+              "y": 31.9,
+              "v": 0.863
+            },
+            "rightIndex": {
+              "x": 76.4,
+              "y": 38.5,
+              "v": 0.945
+            },
+            "leftHip": {
+              "x": 76,
+              "y": 64.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64,
+              "y": 65,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.9,
+              "y": 89.2,
+              "v": 0.222
+            },
+            "rightKnee": {
+              "x": 61.5,
+              "y": 88.9,
+              "v": 0.333
+            },
+            "leftAnkle": {
+              "x": 75.6,
+              "y": 110.4,
+              "v": 0.149
+            },
+            "rightAnkle": {
+              "x": 56.2,
+              "y": 114.3,
+              "v": 0.295
+            },
+            "leftHeel": {
+              "x": 73.4,
+              "y": 113.5,
+              "v": 0.149
+            },
+            "rightHeel": {
+              "x": 57.3,
+              "y": 117.9,
+              "v": 0.107
+            },
+            "leftFootIndex": {
+              "x": 78.7,
+              "y": 118.5,
+              "v": 0.19
+            },
+            "rightFootIndex": {
+              "x": 59.8,
+              "y": 123.7,
+              "v": 0.208
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 80.2,
+                "y": 15.6
+              },
+              "roll": 157.9,
+              "yaw": -0.013,
+              "pitch": 0.764
+            },
+            "torso": {
+              "center": {
+                "x": 70.5,
+                "y": 28.7
+              },
+              "angle": 89.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.2,
+                "y": 36.2
+              },
+              "angle": 47.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72,
+                "y": 42.7
+              },
+              "angle": 43.7
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.705,
+          "keypoints": {
+            "nose": {
+              "x": 88.6,
+              "y": 17.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 90.1,
+              "y": 15,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 87,
+              "y": 14.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 88.6,
+              "y": 15.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 82.6,
+              "y": 13,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 87.4,
+              "y": 29.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 69.9,
+              "y": 26,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.3,
+              "y": 46.8,
+              "v": 0.282
+            },
+            "rightElbow": {
+              "x": 63,
+              "y": 43.7,
+              "v": 0.982
+            },
+            "leftWrist": {
+              "x": 90.3,
+              "y": 57.7,
+              "v": 0.423
+            },
+            "rightWrist": {
+              "x": 77.4,
+              "y": 52.9,
+              "v": 0.987
+            },
+            "leftIndex": {
+              "x": 90.8,
+              "y": 62.2,
+              "v": 0.491
+            },
+            "rightIndex": {
+              "x": 82.4,
+              "y": 53.9,
+              "v": 0.975
+            },
+            "leftHip": {
+              "x": 78.2,
+              "y": 62.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 68.3,
+              "y": 62.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.9,
+              "y": 88.3,
+              "v": 0.237
+            },
+            "rightKnee": {
+              "x": 71,
+              "y": 86,
+              "v": 0.655
+            },
+            "leftAnkle": {
+              "x": 69.8,
+              "y": 109.1,
+              "v": 0.259
+            },
+            "rightAnkle": {
+              "x": 61.9,
+              "y": 112.4,
+              "v": 0.57
+            },
+            "leftHeel": {
+              "x": 67.3,
+              "y": 111.8,
+              "v": 0.3
+            },
+            "rightHeel": {
+              "x": 58.6,
+              "y": 114.3,
+              "v": 0.257
+            },
+            "leftFootIndex": {
+              "x": 72.5,
+              "y": 118.3,
+              "v": 0.324
+            },
+            "rightFootIndex": {
+              "x": 63.8,
+              "y": 123.6,
+              "v": 0.463
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 88.6,
+                "y": 14.6
+              },
+              "roll": 163.8,
+              "yaw": 0.015,
+              "pitch": 0.914
+            },
+            "torso": {
+              "center": {
+                "x": 78.7,
+                "y": 27.9
+              },
+              "angle": 81.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.3,
+                "y": 57.7
+              },
+              "angle": -83.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 77.4,
+                "y": 52.9
+              },
+              "angle": -11.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.3,
+                "y": 111.8
+              },
+              "angle": -51.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 61.9,
+                "y": 112.4
+              },
+              "angle": -80.4
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.767,
+          "keypoints": {
+            "nose": {
+              "x": 74.8,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.5,
+              "y": 12,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.7,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.2,
+              "y": 12.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.8,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.2,
+              "y": 26.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.2,
+              "y": 27.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.5,
+              "y": 43.4,
+              "v": 0.483
+            },
+            "rightElbow": {
+              "x": 57.9,
+              "y": 45.6,
+              "v": 0.958
+            },
+            "leftWrist": {
+              "x": 94.3,
+              "y": 36,
+              "v": 0.777
+            },
+            "rightWrist": {
+              "x": 71.9,
+              "y": 42.4,
+              "v": 0.98
+            },
+            "leftIndex": {
+              "x": 99,
+              "y": 32.5,
+              "v": 0.783
+            },
+            "rightIndex": {
+              "x": 76,
+              "y": 38.5,
+              "v": 0.965
+            },
+            "leftHip": {
+              "x": 77.4,
+              "y": 61.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.2,
+              "y": 62.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.9,
+              "y": 85.8,
+              "v": 0.347
+            },
+            "rightKnee": {
+              "x": 66.2,
+              "y": 87.2,
+              "v": 0.732
+            },
+            "leftAnkle": {
+              "x": 74.4,
+              "y": 106.9,
+              "v": 0.303
+            },
+            "rightAnkle": {
+              "x": 61.2,
+              "y": 112.7,
+              "v": 0.746
+            },
+            "leftHeel": {
+              "x": 72.3,
+              "y": 109.6,
+              "v": 0.3
+            },
+            "rightHeel": {
+              "x": 60.2,
+              "y": 115.2,
+              "v": 0.308
+            },
+            "leftFootIndex": {
+              "x": 78,
+              "y": 116.5,
+              "v": 0.347
+            },
+            "rightFootIndex": {
+              "x": 63.2,
+              "y": 122.8,
+              "v": 0.604
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.6,
+                "y": 11.6
+              },
+              "roll": 168.1,
+              "yaw": 0.309,
+              "pitch": 0.824
+            },
+            "torso": {
+              "center": {
+                "x": 69.7,
+                "y": 27
+              },
+              "angle": 93.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.3,
+                "y": 36
+              },
+              "angle": 36.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 71.9,
+                "y": 42.4
+              },
+              "angle": 43.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.3,
+                "y": 109.6
+              },
+              "angle": -50.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 60.2,
+                "y": 115.2
+              },
+              "angle": -68.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.841,
+          "keypoints": {
+            "nose": {
+              "x": 74.7,
+              "y": 13.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.6,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.2,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.6,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.3,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.4,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.1,
+              "y": 26.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.4,
+              "y": 44.7,
+              "v": 0.521
+            },
+            "rightElbow": {
+              "x": 58.6,
+              "y": 44.8,
+              "v": 0.97
+            },
+            "leftWrist": {
+              "x": 94.9,
+              "y": 36.4,
+              "v": 0.752
+            },
+            "rightWrist": {
+              "x": 73,
+              "y": 42.3,
+              "v": 0.979
+            },
+            "leftIndex": {
+              "x": 99.7,
+              "y": 32.3,
+              "v": 0.767
+            },
+            "rightIndex": {
+              "x": 76.4,
+              "y": 38.4,
+              "v": 0.957
+            },
+            "leftHip": {
+              "x": 77.1,
+              "y": 61.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.5,
+              "y": 62.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.9,
+              "y": 85.2,
+              "v": 0.609
+            },
+            "rightKnee": {
+              "x": 66.6,
+              "y": 86.5,
+              "v": 0.856
+            },
+            "leftAnkle": {
+              "x": 77.8,
+              "y": 106.4,
+              "v": 0.634
+            },
+            "rightAnkle": {
+              "x": 61.2,
+              "y": 112.9,
+              "v": 0.874
+            },
+            "leftHeel": {
+              "x": 75.9,
+              "y": 109.6,
+              "v": 0.529
+            },
+            "rightHeel": {
+              "x": 60.7,
+              "y": 115,
+              "v": 0.491
+            },
+            "leftFootIndex": {
+              "x": 81.9,
+              "y": 114.5,
+              "v": 0.645
+            },
+            "rightFootIndex": {
+              "x": 63.1,
+              "y": 122.4,
+              "v": 0.769
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.9,
+                "y": 11.3
+              },
+              "roll": 165.2,
+              "yaw": 0.227,
+              "pitch": 0.753
+            },
+            "torso": {
+              "center": {
+                "x": 69.8,
+                "y": 26.9
+              },
+              "angle": 92.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.9,
+                "y": 36.4
+              },
+              "angle": 40.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 73,
+                "y": 42.3
+              },
+              "angle": 48.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 75.9,
+                "y": 109.6
+              },
+              "angle": -39.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 60.7,
+                "y": 115
+              },
+              "angle": -72
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.784,
+          "keypoints": {
+            "nose": {
+              "x": 75,
+              "y": 14.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.6,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.5,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74,
+              "y": 12.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.2,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.4,
+              "y": 26.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.9,
+              "y": 26.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.6,
+              "y": 42.8,
+              "v": 0.521
+            },
+            "rightElbow": {
+              "x": 57.6,
+              "y": 45,
+              "v": 0.966
+            },
+            "leftWrist": {
+              "x": 94.7,
+              "y": 36.2,
+              "v": 0.813
+            },
+            "rightWrist": {
+              "x": 72.4,
+              "y": 42.1,
+              "v": 0.974
+            },
+            "leftIndex": {
+              "x": 98.6,
+              "y": 32.4,
+              "v": 0.829
+            },
+            "rightIndex": {
+              "x": 76.5,
+              "y": 37.9,
+              "v": 0.954
+            },
+            "leftHip": {
+              "x": 77.3,
+              "y": 60.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.9,
+              "y": 62.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86,
+              "y": 79.7,
+              "v": 0.408
+            },
+            "rightKnee": {
+              "x": 65.9,
+              "y": 86.5,
+              "v": 0.769
+            },
+            "leftAnkle": {
+              "x": 86.1,
+              "y": 101.6,
+              "v": 0.332
+            },
+            "rightAnkle": {
+              "x": 60.4,
+              "y": 113.2,
+              "v": 0.761
+            },
+            "leftHeel": {
+              "x": 84.3,
+              "y": 105,
+              "v": 0.323
+            },
+            "rightHeel": {
+              "x": 59.8,
+              "y": 116.8,
+              "v": 0.361
+            },
+            "leftFootIndex": {
+              "x": 91.5,
+              "y": 109.8,
+              "v": 0.382
+            },
+            "rightFootIndex": {
+              "x": 61.7,
+              "y": 124.5,
+              "v": 0.63
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.1,
+                "y": 11.4
+              },
+              "roll": 169,
+              "yaw": 0.301,
+              "pitch": 0.982
+            },
+            "torso": {
+              "center": {
+                "x": 69.2,
+                "y": 26.9
+              },
+              "angle": 94
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.7,
+                "y": 36.2
+              },
+              "angle": 44.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 72.4,
+                "y": 42.1
+              },
+              "angle": 45.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 84.3,
+                "y": 105
+              },
+              "angle": -33.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 59.8,
+                "y": 116.8
+              },
+              "angle": -76.1
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/richi/poses.json
+++ b/public/assets/fighters/richi/poses.json
@@ -1,0 +1,3983 @@
+{
+  "version": 1,
+  "fighter": "richi",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:41:31.523Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.834,
+          "keypoints": {
+            "nose": {
+              "x": 62.5,
+              "y": 27.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66,
+              "y": 25.5,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 61.4,
+              "y": 26.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.8,
+              "y": 26.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.7,
+              "y": 27.3,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 75.7,
+              "y": 38.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.7,
+              "y": 39.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.3,
+              "y": 52.6,
+              "v": 0.331
+            },
+            "rightElbow": {
+              "x": 54.2,
+              "y": 55.5,
+              "v": 0.523
+            },
+            "leftWrist": {
+              "x": 80,
+              "y": 54.7,
+              "v": 0.321
+            },
+            "rightWrist": {
+              "x": 58.9,
+              "y": 50.7,
+              "v": 0.44
+            },
+            "leftIndex": {
+              "x": 79.9,
+              "y": 53.3,
+              "v": 0.404
+            },
+            "rightIndex": {
+              "x": 60.4,
+              "y": 46.9,
+              "v": 0.555
+            },
+            "leftHip": {
+              "x": 71.6,
+              "y": 71.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.9,
+              "y": 70.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.4,
+              "y": 83.7,
+              "v": 0.928
+            },
+            "rightKnee": {
+              "x": 56.9,
+              "y": 86.4,
+              "v": 0.989
+            },
+            "leftAnkle": {
+              "x": 84,
+              "y": 109.7,
+              "v": 0.956
+            },
+            "rightAnkle": {
+              "x": 47.5,
+              "y": 114.1,
+              "v": 0.987
+            },
+            "leftHeel": {
+              "x": 81.1,
+              "y": 115,
+              "v": 0.943
+            },
+            "rightHeel": {
+              "x": 45.9,
+              "y": 118.3,
+              "v": 0.878
+            },
+            "leftFootIndex": {
+              "x": 92.7,
+              "y": 116.6,
+              "v": 0.956
+            },
+            "rightFootIndex": {
+              "x": 49.5,
+              "y": 123.8,
+              "v": 0.978
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.7,
+                "y": 25.9
+              },
+              "roll": -171.3,
+              "yaw": -0.258,
+              "pitch": 0.355
+            },
+            "torso": {
+              "center": {
+                "x": 65.7,
+                "y": 38.8
+              },
+              "angle": 89.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80,
+                "y": 54.7
+              },
+              "angle": 94.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 58.9,
+                "y": 50.7
+              },
+              "angle": 68.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 81.1,
+                "y": 115
+              },
+              "angle": -7.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45.9,
+                "y": 118.3
+              },
+              "angle": -56.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.585,
+          "keypoints": {
+            "nose": {
+              "x": 75.4,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 77.4,
+              "y": 21.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.5,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 78.5,
+              "y": 23.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 70.8,
+              "y": 21.8,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 81.5,
+              "y": 33.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63.6,
+              "y": 33.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.7,
+              "y": 45.5,
+              "v": 0.369
+            },
+            "rightElbow": {
+              "x": 63.1,
+              "y": 47.5,
+              "v": 0.267
+            },
+            "leftWrist": {
+              "x": 84.3,
+              "y": 51.6,
+              "v": 0.469
+            },
+            "rightWrist": {
+              "x": 68,
+              "y": 44.9,
+              "v": 0.334
+            },
+            "leftIndex": {
+              "x": 83.8,
+              "y": 52.6,
+              "v": 0.508
+            },
+            "rightIndex": {
+              "x": 69.5,
+              "y": 42.5,
+              "v": 0.384
+            },
+            "leftHip": {
+              "x": 77.5,
+              "y": 60.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 66.6,
+              "y": 60.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 81.7,
+              "y": 78,
+              "v": 0.304
+            },
+            "rightKnee": {
+              "x": 67.1,
+              "y": 80.8,
+              "v": 0.174
+            },
+            "leftAnkle": {
+              "x": 81.4,
+              "y": 100,
+              "v": 0.441
+            },
+            "rightAnkle": {
+              "x": 69.6,
+              "y": 100.2,
+              "v": 0.221
+            },
+            "leftHeel": {
+              "x": 79.8,
+              "y": 103.7,
+              "v": 0.307
+            },
+            "rightHeel": {
+              "x": 70.5,
+              "y": 103.1,
+              "v": 0.096
+            },
+            "leftFootIndex": {
+              "x": 84.7,
+              "y": 106.6,
+              "v": 0.414
+            },
+            "rightFootIndex": {
+              "x": 70,
+              "y": 107,
+              "v": 0.181
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 75.5,
+                "y": 21.5
+              },
+              "roll": 169.8,
+              "yaw": -0.013,
+              "pitch": 0.467
+            },
+            "torso": {
+              "center": {
+                "x": 72.6,
+                "y": 33.5
+              },
+              "angle": 88.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 84.3,
+                "y": 51.6
+              },
+              "angle": -116.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 68,
+                "y": 44.9
+              },
+              "angle": 58
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 79.8,
+                "y": 103.7
+              },
+              "angle": -30.6
+            },
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.63,
+          "keypoints": {
+            "nose": {
+              "x": 63.5,
+              "y": 28.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.6,
+              "y": 25.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.3,
+              "y": 27,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.8,
+              "y": 26.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.2,
+              "y": 28.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.8,
+              "y": 38.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.9,
+              "y": 38.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79,
+              "y": 51.1,
+              "v": 0.276
+            },
+            "rightElbow": {
+              "x": 53.6,
+              "y": 49.5,
+              "v": 0.345
+            },
+            "leftWrist": {
+              "x": 76,
+              "y": 53.3,
+              "v": 0.33
+            },
+            "rightWrist": {
+              "x": 52.8,
+              "y": 49.2,
+              "v": 0.598
+            },
+            "leftIndex": {
+              "x": 75,
+              "y": 52.3,
+              "v": 0.435
+            },
+            "rightIndex": {
+              "x": 53.1,
+              "y": 47.7,
+              "v": 0.704
+            },
+            "leftHip": {
+              "x": 73.1,
+              "y": 67.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.1,
+              "y": 67,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.1,
+              "y": 80.7,
+              "v": 0.48
+            },
+            "rightKnee": {
+              "x": 55.5,
+              "y": 83.8,
+              "v": 0.29
+            },
+            "leftAnkle": {
+              "x": 81.2,
+              "y": 104.2,
+              "v": 0.503
+            },
+            "rightAnkle": {
+              "x": 58.7,
+              "y": 103.7,
+              "v": 0.273
+            },
+            "leftHeel": {
+              "x": 79.9,
+              "y": 108,
+              "v": 0.356
+            },
+            "rightHeel": {
+              "x": 60.8,
+              "y": 106.9,
+              "v": 0.142
+            },
+            "leftFootIndex": {
+              "x": 84.5,
+              "y": 111.4,
+              "v": 0.517
+            },
+            "rightFootIndex": {
+              "x": 56.5,
+              "y": 110.2,
+              "v": 0.242
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.5,
+                "y": 26.5
+              },
+              "roll": -165.7,
+              "yaw": 0.011,
+              "pitch": 0.462
+            },
+            "torso": {
+              "center": {
+                "x": 67.4,
+                "y": 38.6
+              },
+              "angle": 89.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76,
+                "y": 53.3
+              },
+              "angle": 135
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 52.8,
+                "y": 49.2
+              },
+              "angle": 78.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 79.9,
+                "y": 108
+              },
+              "angle": -36.5
+            },
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.551,
+          "keypoints": {
+            "nose": {
+              "x": 67.3,
+              "y": 28.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.1,
+              "y": 26.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.4,
+              "y": 26.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.9,
+              "y": 27.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.6,
+              "y": 28,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 76.2,
+              "y": 39.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.8,
+              "y": 39,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.5,
+              "y": 52.8,
+              "v": 0.321
+            },
+            "rightElbow": {
+              "x": 58.2,
+              "y": 52.4,
+              "v": 0.15
+            },
+            "leftWrist": {
+              "x": 82.6,
+              "y": 56.1,
+              "v": 0.42
+            },
+            "rightWrist": {
+              "x": 59.8,
+              "y": 51.5,
+              "v": 0.315
+            },
+            "leftIndex": {
+              "x": 83.1,
+              "y": 55.6,
+              "v": 0.51
+            },
+            "rightIndex": {
+              "x": 60.5,
+              "y": 49.5,
+              "v": 0.441
+            },
+            "leftHip": {
+              "x": 71.5,
+              "y": 67.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.9,
+              "y": 67.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.4,
+              "y": 80,
+              "v": 0.193
+            },
+            "rightKnee": {
+              "x": 61.8,
+              "y": 83.6,
+              "v": 0.147
+            },
+            "leftAnkle": {
+              "x": 74.9,
+              "y": 103.6,
+              "v": 0.262
+            },
+            "rightAnkle": {
+              "x": 62.8,
+              "y": 106,
+              "v": 0.195
+            },
+            "leftHeel": {
+              "x": 73.4,
+              "y": 107.3,
+              "v": 0.183
+            },
+            "rightHeel": {
+              "x": 63.2,
+              "y": 109.6,
+              "v": 0.081
+            },
+            "leftFootIndex": {
+              "x": 76.4,
+              "y": 110.4,
+              "v": 0.295
+            },
+            "rightFootIndex": {
+              "x": 64.3,
+              "y": 112.4,
+              "v": 0.173
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.3,
+                "y": 26.8
+              },
+              "roll": -175.4,
+              "yaw": 0.013,
+              "pitch": 0.525
+            },
+            "torso": {
+              "center": {
+                "x": 67.5,
+                "y": 39.3
+              },
+              "angle": 87.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.6,
+                "y": 56.1
+              },
+              "angle": 45
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 59.8,
+                "y": 51.5
+              },
+              "angle": 70.7
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.762,
+          "keypoints": {
+            "nose": {
+              "x": 65.2,
+              "y": 29.1,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 66.5,
+              "y": 26.1,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 63.1,
+              "y": 27.4,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 68.6,
+              "y": 25.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 61.9,
+              "y": 28,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 75.9,
+              "y": 35.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.3,
+              "y": 36.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.8,
+              "y": 50.9,
+              "v": 0.372
+            },
+            "rightElbow": {
+              "x": 61.6,
+              "y": 48.8,
+              "v": 0.541
+            },
+            "leftWrist": {
+              "x": 73.7,
+              "y": 55.8,
+              "v": 0.4
+            },
+            "rightWrist": {
+              "x": 66.4,
+              "y": 51,
+              "v": 0.611
+            },
+            "leftIndex": {
+              "x": 71.9,
+              "y": 55.5,
+              "v": 0.483
+            },
+            "rightIndex": {
+              "x": 68.2,
+              "y": 50.4,
+              "v": 0.699
+            },
+            "leftHip": {
+              "x": 73.8,
+              "y": 66.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64.4,
+              "y": 66.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.4,
+              "y": 79.3,
+              "v": 0.577
+            },
+            "rightKnee": {
+              "x": 69.6,
+              "y": 81.7,
+              "v": 0.698
+            },
+            "leftAnkle": {
+              "x": 84.5,
+              "y": 105.8,
+              "v": 0.797
+            },
+            "rightAnkle": {
+              "x": 66.1,
+              "y": 107.9,
+              "v": 0.775
+            },
+            "leftHeel": {
+              "x": 82.6,
+              "y": 110.4,
+              "v": 0.634
+            },
+            "rightHeel": {
+              "x": 65.4,
+              "y": 111.8,
+              "v": 0.388
+            },
+            "leftFootIndex": {
+              "x": 89.6,
+              "y": 112.3,
+              "v": 0.816
+            },
+            "rightFootIndex": {
+              "x": 68,
+              "y": 116.2,
+              "v": 0.751
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64.8,
+                "y": 26.8
+              },
+              "roll": -159.1,
+              "yaw": 0.11,
+              "pitch": 0.646
+            },
+            "torso": {
+              "center": {
+                "x": 68.1,
+                "y": 36.3
+              },
+              "angle": 91.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.7,
+                "y": 55.8
+              },
+              "angle": 170.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 66.4,
+                "y": 51
+              },
+              "angle": 18.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 82.6,
+                "y": 110.4
+              },
+              "angle": -15.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 65.4,
+                "y": 111.8
+              },
+              "angle": -59.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.541,
+          "keypoints": {
+            "nose": {
+              "x": 65.5,
+              "y": 32,
+              "v": 0.987
+            },
+            "leftEye": {
+              "x": 67.3,
+              "y": 29.5,
+              "v": 0.977
+            },
+            "rightEye": {
+              "x": 64.2,
+              "y": 29.9,
+              "v": 0.985
+            },
+            "leftEar": {
+              "x": 69.6,
+              "y": 29.9,
+              "v": 0.986
+            },
+            "rightEar": {
+              "x": 63.5,
+              "y": 30.4,
+              "v": 0.967
+            },
+            "leftShoulder": {
+              "x": 72.9,
+              "y": 41.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 62.1,
+              "y": 37.8,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 62.6,
+              "y": 55.4,
+              "v": 0.161
+            },
+            "rightElbow": {
+              "x": 65.9,
+              "y": 48.4,
+              "v": 0.056
+            },
+            "leftWrist": {
+              "x": 53.5,
+              "y": 52.6,
+              "v": 0.187
+            },
+            "rightWrist": {
+              "x": 67.6,
+              "y": 45.7,
+              "v": 0.199
+            },
+            "leftIndex": {
+              "x": 52.2,
+              "y": 50,
+              "v": 0.258
+            },
+            "rightIndex": {
+              "x": 67.7,
+              "y": 43.8,
+              "v": 0.323
+            },
+            "leftHip": {
+              "x": 67.3,
+              "y": 70,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.4,
+              "y": 68.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.7,
+              "y": 79.9,
+              "v": 0.197
+            },
+            "rightKnee": {
+              "x": 60.3,
+              "y": 74.2,
+              "v": 0.295
+            },
+            "leftAnkle": {
+              "x": 72.7,
+              "y": 102.4,
+              "v": 0.353
+            },
+            "rightAnkle": {
+              "x": 55.3,
+              "y": 98.4,
+              "v": 0.352
+            },
+            "leftHeel": {
+              "x": 71.2,
+              "y": 105.7,
+              "v": 0.278
+            },
+            "rightHeel": {
+              "x": 54.6,
+              "y": 101.9,
+              "v": 0.174
+            },
+            "leftFootIndex": {
+              "x": 73.3,
+              "y": 110.3,
+              "v": 0.365
+            },
+            "rightFootIndex": {
+              "x": 55.8,
+              "y": 107.4,
+              "v": 0.338
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.8,
+                "y": 29.7
+              },
+              "roll": -172.6,
+              "yaw": -0.08,
+              "pitch": 0.736
+            },
+            "torso": {
+              "center": {
+                "x": 67.5,
+                "y": 39.5
+              },
+              "angle": 82
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 72.7,
+                "y": 102.4
+              },
+              "angle": -85.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 55.3,
+                "y": 98.4
+              },
+              "angle": -86.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.637,
+          "keypoints": {
+            "nose": {
+              "x": 62.4,
+              "y": 40.6,
+              "v": 0.997
+            },
+            "leftEye": {
+              "x": 64.3,
+              "y": 37.6,
+              "v": 0.995
+            },
+            "rightEye": {
+              "x": 61,
+              "y": 38.8,
+              "v": 0.997
+            },
+            "leftEar": {
+              "x": 67.3,
+              "y": 35.3,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 60.6,
+              "y": 37.3,
+              "v": 0.994
+            },
+            "leftShoulder": {
+              "x": 74.9,
+              "y": 39.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.2,
+              "y": 41.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 76.3,
+              "y": 54.5,
+              "v": 0.232
+            },
+            "rightElbow": {
+              "x": 60.3,
+              "y": 56.8,
+              "v": 0.115
+            },
+            "leftWrist": {
+              "x": 70.7,
+              "y": 59.6,
+              "v": 0.409
+            },
+            "rightWrist": {
+              "x": 60,
+              "y": 57.1,
+              "v": 0.457
+            },
+            "leftIndex": {
+              "x": 69.1,
+              "y": 58.7,
+              "v": 0.513
+            },
+            "rightIndex": {
+              "x": 59.6,
+              "y": 54.9,
+              "v": 0.582
+            },
+            "leftHip": {
+              "x": 70.9,
+              "y": 70.4,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 62,
+              "y": 69.8,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 72.3,
+              "y": 76.5,
+              "v": 0.525
+            },
+            "rightKnee": {
+              "x": 57.3,
+              "y": 70.1,
+              "v": 0.256
+            },
+            "leftAnkle": {
+              "x": 71.7,
+              "y": 102.3,
+              "v": 0.602
+            },
+            "rightAnkle": {
+              "x": 58.4,
+              "y": 93.5,
+              "v": 0.281
+            },
+            "leftHeel": {
+              "x": 71.2,
+              "y": 106.6,
+              "v": 0.475
+            },
+            "rightHeel": {
+              "x": 59.9,
+              "y": 98.4,
+              "v": 0.25
+            },
+            "leftFootIndex": {
+              "x": 70,
+              "y": 108,
+              "v": 0.627
+            },
+            "rightFootIndex": {
+              "x": 55.5,
+              "y": 97,
+              "v": 0.352
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.7,
+                "y": 38.2
+              },
+              "roll": -160,
+              "yaw": -0.071,
+              "pitch": 0.683
+            },
+            "torso": {
+              "center": {
+                "x": 67.1,
+                "y": 40.6
+              },
+              "angle": 88.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 70.7,
+                "y": 59.6
+              },
+              "angle": 150.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 60,
+                "y": 57.1
+              },
+              "angle": 100.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.2,
+                "y": 106.6
+              },
+              "angle": -130.6
+            },
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.511,
+          "keypoints": {
+            "nose": {
+              "x": 66.7,
+              "y": 29.9,
+              "v": 0.997
+            },
+            "leftEye": {
+              "x": 69.2,
+              "y": 27.2,
+              "v": 0.994
+            },
+            "rightEye": {
+              "x": 65.1,
+              "y": 28.1,
+              "v": 0.997
+            },
+            "leftEar": {
+              "x": 72.9,
+              "y": 27.9,
+              "v": 0.996
+            },
+            "rightEar": {
+              "x": 64.7,
+              "y": 29.3,
+              "v": 0.991
+            },
+            "leftShoulder": {
+              "x": 81.9,
+              "y": 39.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 62.5,
+              "y": 41.1,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 85.1,
+              "y": 53.7,
+              "v": 0.169
+            },
+            "rightElbow": {
+              "x": 65,
+              "y": 55.7,
+              "v": 0.1
+            },
+            "leftWrist": {
+              "x": 83.2,
+              "y": 58.4,
+              "v": 0.207
+            },
+            "rightWrist": {
+              "x": 68.5,
+              "y": 52,
+              "v": 0.245
+            },
+            "leftIndex": {
+              "x": 81.9,
+              "y": 58.6,
+              "v": 0.321
+            },
+            "rightIndex": {
+              "x": 69.7,
+              "y": 49.1,
+              "v": 0.35
+            },
+            "leftHip": {
+              "x": 78.9,
+              "y": 68.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 67.7,
+              "y": 69.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.8,
+              "y": 85.3,
+              "v": 0.117
+            },
+            "rightKnee": {
+              "x": 66.9,
+              "y": 88.4,
+              "v": 0.08
+            },
+            "leftAnkle": {
+              "x": 82.2,
+              "y": 105.4,
+              "v": 0.32
+            },
+            "rightAnkle": {
+              "x": 71.4,
+              "y": 105.4,
+              "v": 0.14
+            },
+            "leftHeel": {
+              "x": 81.4,
+              "y": 108.7,
+              "v": 0.213
+            },
+            "rightHeel": {
+              "x": 73.2,
+              "y": 107.9,
+              "v": 0.077
+            },
+            "leftFootIndex": {
+              "x": 84,
+              "y": 112.4,
+              "v": 0.326
+            },
+            "rightFootIndex": {
+              "x": 71.2,
+              "y": 112.4,
+              "v": 0.126
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.2,
+                "y": 27.7
+              },
+              "roll": -167.6,
+              "yaw": -0.107,
+              "pitch": 0.536
+            },
+            "torso": {
+              "center": {
+                "x": 72.2,
+                "y": 40.2
+              },
+              "angle": 92.2
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 82.2,
+                "y": 105.4
+              },
+              "angle": -75.6
+            },
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 4,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.698,
+          "keypoints": {
+            "nose": {
+              "x": 54.5,
+              "y": 29.2,
+              "v": 0.952
+            },
+            "leftEye": {
+              "x": 54.5,
+              "y": 27.2,
+              "v": 0.96
+            },
+            "rightEye": {
+              "x": 52.4,
+              "y": 28.5,
+              "v": 0.976
+            },
+            "leftEar": {
+              "x": 55.4,
+              "y": 27.5,
+              "v": 0.984
+            },
+            "rightEar": {
+              "x": 51.3,
+              "y": 29.9,
+              "v": 0.931
+            },
+            "leftShoulder": {
+              "x": 60.7,
+              "y": 38.5,
+              "v": 0.998
+            },
+            "rightShoulder": {
+              "x": 50.5,
+              "y": 40,
+              "v": 0.995
+            },
+            "leftElbow": {
+              "x": 65.5,
+              "y": 52.5,
+              "v": 0.036
+            },
+            "rightElbow": {
+              "x": 58.3,
+              "y": 52.6,
+              "v": 0.108
+            },
+            "leftWrist": {
+              "x": 62.6,
+              "y": 52,
+              "v": 0.047
+            },
+            "rightWrist": {
+              "x": 66,
+              "y": 51.8,
+              "v": 0.124
+            },
+            "leftIndex": {
+              "x": 61.3,
+              "y": 49.9,
+              "v": 0.102
+            },
+            "rightIndex": {
+              "x": 68,
+              "y": 49.8,
+              "v": 0.207
+            },
+            "leftHip": {
+              "x": 59,
+              "y": 71.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55,
+              "y": 71.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 61,
+              "y": 94.4,
+              "v": 0.573
+            },
+            "rightKnee": {
+              "x": 72.1,
+              "y": 74.3,
+              "v": 0.857
+            },
+            "leftAnkle": {
+              "x": 48.1,
+              "y": 115.9,
+              "v": 0.837
+            },
+            "rightAnkle": {
+              "x": 92.6,
+              "y": 87.4,
+              "v": 0.93
+            },
+            "leftHeel": {
+              "x": 44.5,
+              "y": 118.1,
+              "v": 0.829
+            },
+            "rightHeel": {
+              "x": 93.6,
+              "y": 91,
+              "v": 0.901
+            },
+            "leftFootIndex": {
+              "x": 53.1,
+              "y": 122.6,
+              "v": 0.792
+            },
+            "rightFootIndex": {
+              "x": 105.8,
+              "y": 87.2,
+              "v": 0.92
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.5,
+                "y": 27.9
+              },
+              "roll": -148.2,
+              "yaw": 0.425,
+              "pitch": 0.547
+            },
+            "torso": {
+              "center": {
+                "x": 55.6,
+                "y": 39.3
+              },
+              "angle": 92.5
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 44.5,
+                "y": 118.1
+              },
+              "angle": -27.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 93.6,
+                "y": 91
+              },
+              "angle": 17.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.822,
+          "keypoints": {
+            "nose": {
+              "x": 49.1,
+              "y": 27.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 51.6,
+              "y": 25.8,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 47.1,
+              "y": 25.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.1,
+              "y": 25.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46,
+              "y": 25.9,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 64.8,
+              "y": 36.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.4,
+              "y": 36,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.4,
+              "y": 51.9,
+              "v": 0.705
+            },
+            "rightElbow": {
+              "x": 37.7,
+              "y": 50.1,
+              "v": 0.523
+            },
+            "leftWrist": {
+              "x": 71.8,
+              "y": 57.1,
+              "v": 0.881
+            },
+            "rightWrist": {
+              "x": 32.6,
+              "y": 52.9,
+              "v": 0.754
+            },
+            "leftIndex": {
+              "x": 71.2,
+              "y": 56.3,
+              "v": 0.901
+            },
+            "rightIndex": {
+              "x": 31.1,
+              "y": 52.3,
+              "v": 0.806
+            },
+            "leftHip": {
+              "x": 60.8,
+              "y": 67.8,
+              "v": 0.999
+            },
+            "rightHip": {
+              "x": 48.9,
+              "y": 65.3,
+              "v": 0.999
+            },
+            "leftKnee": {
+              "x": 51.1,
+              "y": 80.7,
+              "v": 0.757
+            },
+            "rightKnee": {
+              "x": 39.2,
+              "y": 72.8,
+              "v": 0.549
+            },
+            "leftAnkle": {
+              "x": 37.3,
+              "y": 107,
+              "v": 0.863
+            },
+            "rightAnkle": {
+              "x": 37.9,
+              "y": 100.1,
+              "v": 0.567
+            },
+            "leftHeel": {
+              "x": 35.1,
+              "y": 110.6,
+              "v": 0.76
+            },
+            "rightHeel": {
+              "x": 39.2,
+              "y": 104.1,
+              "v": 0.425
+            },
+            "leftFootIndex": {
+              "x": 32.7,
+              "y": 115.2,
+              "v": 0.858
+            },
+            "rightFootIndex": {
+              "x": 34.6,
+              "y": 108.9,
+              "v": 0.569
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 49.4,
+                "y": 25.7
+              },
+              "roll": 177.5,
+              "yaw": -0.056,
+              "pitch": 0.466
+            },
+            "torso": {
+              "center": {
+                "x": 54.1,
+                "y": 36.1
+              },
+              "angle": 91.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 71.8,
+                "y": 57.1
+              },
+              "angle": 126.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.6,
+                "y": 52.9
+              },
+              "angle": 158.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 35.1,
+                "y": 110.6
+              },
+              "angle": -117.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.2,
+                "y": 104.1
+              },
+              "angle": -133.8
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.554,
+          "keypoints": {
+            "nose": {
+              "x": 63.2,
+              "y": 27.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.6,
+              "y": 24.4,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 61.2,
+              "y": 25.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.6,
+              "y": 24.4,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 61,
+              "y": 26.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.9,
+              "y": 34.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 62.4,
+              "y": 37.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.1,
+              "y": 48.3,
+              "v": 0.071
+            },
+            "rightElbow": {
+              "x": 66.7,
+              "y": 52.6,
+              "v": 0.392
+            },
+            "leftWrist": {
+              "x": 79.7,
+              "y": 48.8,
+              "v": 0.183
+            },
+            "rightWrist": {
+              "x": 78.7,
+              "y": 52.8,
+              "v": 0.745
+            },
+            "leftIndex": {
+              "x": 79.4,
+              "y": 47,
+              "v": 0.303
+            },
+            "rightIndex": {
+              "x": 83.1,
+              "y": 51.2,
+              "v": 0.746
+            },
+            "leftHip": {
+              "x": 76.5,
+              "y": 63.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 67.5,
+              "y": 64.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79,
+              "y": 72.6,
+              "v": 0.068
+            },
+            "rightKnee": {
+              "x": 65.3,
+              "y": 77.4,
+              "v": 0.101
+            },
+            "leftAnkle": {
+              "x": 72.8,
+              "y": 93.1,
+              "v": 0.175
+            },
+            "rightAnkle": {
+              "x": 66.1,
+              "y": 95.4,
+              "v": 0.172
+            },
+            "leftHeel": {
+              "x": 71.5,
+              "y": 96,
+              "v": 0.193
+            },
+            "rightHeel": {
+              "x": 67.5,
+              "y": 98.6,
+              "v": 0.169
+            },
+            "leftFootIndex": {
+              "x": 70.8,
+              "y": 101.1,
+              "v": 0.214
+            },
+            "rightFootIndex": {
+              "x": 64.5,
+              "y": 101.9,
+              "v": 0.203
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.4,
+                "y": 25
+              },
+              "roll": -163.5,
+              "yaw": -0.044,
+              "pitch": 0.512
+            },
+            "torso": {
+              "center": {
+                "x": 70.2,
+                "y": 36
+              },
+              "angle": 93.8
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 78.7,
+                "y": 52.8
+              },
+              "angle": 20
+            },
+            "leftFoot": null,
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.767,
+          "keypoints": {
+            "nose": {
+              "x": 51.2,
+              "y": 28.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 52,
+              "y": 26.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49.4,
+              "y": 27,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52.7,
+              "y": 27.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48,
+              "y": 28.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 47.7,
+              "y": 38.5,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 54.9,
+              "y": 37.5,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 45,
+              "y": 50.6,
+              "v": 0.025
+            },
+            "rightElbow": {
+              "x": 62.6,
+              "y": 47,
+              "v": 0.332
+            },
+            "leftWrist": {
+              "x": 43.1,
+              "y": 49.5,
+              "v": 0.082
+            },
+            "rightWrist": {
+              "x": 72.2,
+              "y": 40.7,
+              "v": 0.632
+            },
+            "leftIndex": {
+              "x": 42.8,
+              "y": 46.9,
+              "v": 0.154
+            },
+            "rightIndex": {
+              "x": 74.9,
+              "y": 37.8,
+              "v": 0.617
+            },
+            "leftHip": {
+              "x": 49.4,
+              "y": 70,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.4,
+              "y": 68.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 50,
+              "y": 91.5,
+              "v": 0.63
+            },
+            "rightKnee": {
+              "x": 52.3,
+              "y": 91,
+              "v": 0.85
+            },
+            "leftAnkle": {
+              "x": 48,
+              "y": 110.9,
+              "v": 0.929
+            },
+            "rightAnkle": {
+              "x": 48.5,
+              "y": 111.6,
+              "v": 0.933
+            },
+            "leftHeel": {
+              "x": 46.3,
+              "y": 113.4,
+              "v": 0.903
+            },
+            "rightHeel": {
+              "x": 48,
+              "y": 115.2,
+              "v": 0.821
+            },
+            "leftFootIndex": {
+              "x": 45.9,
+              "y": 113.2,
+              "v": 0.868
+            },
+            "rightFootIndex": {
+              "x": 48.6,
+              "y": 117.9,
+              "v": 0.864
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 50.7,
+                "y": 26.6
+              },
+              "roll": -162.9,
+              "yaw": 0.184,
+              "pitch": 0.735
+            },
+            "torso": {
+              "center": {
+                "x": 51.3,
+                "y": 38
+              },
+              "angle": 89.3
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 72.2,
+                "y": 40.7
+              },
+              "angle": 47
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 46.3,
+                "y": 113.4
+              },
+              "angle": 153.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48,
+                "y": 115.2
+              },
+              "angle": -77.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.817,
+          "keypoints": {
+            "nose": {
+              "x": 41.2,
+              "y": 36,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 42.4,
+              "y": 33.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 38.7,
+              "y": 35,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 44.9,
+              "y": 32.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 37.6,
+              "y": 36.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 51.7,
+              "y": 40.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.5,
+              "y": 43.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 52.7,
+              "y": 49.8,
+              "v": 0.244
+            },
+            "rightElbow": {
+              "x": 40,
+              "y": 50.1,
+              "v": 0.539
+            },
+            "leftWrist": {
+              "x": 51.7,
+              "y": 46.5,
+              "v": 0.411
+            },
+            "rightWrist": {
+              "x": 32.7,
+              "y": 47.4,
+              "v": 0.91
+            },
+            "leftIndex": {
+              "x": 51.7,
+              "y": 44.1,
+              "v": 0.512
+            },
+            "rightIndex": {
+              "x": 29.5,
+              "y": 46.2,
+              "v": 0.927
+            },
+            "leftHip": {
+              "x": 54.3,
+              "y": 66.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.9,
+              "y": 67.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 57.6,
+              "y": 76.4,
+              "v": 0.729
+            },
+            "rightKnee": {
+              "x": 45.9,
+              "y": 86.5,
+              "v": 0.864
+            },
+            "leftAnkle": {
+              "x": 58.3,
+              "y": 91.7,
+              "v": 0.721
+            },
+            "rightAnkle": {
+              "x": 47.1,
+              "y": 107.3,
+              "v": 0.945
+            },
+            "leftHeel": {
+              "x": 57.8,
+              "y": 94.2,
+              "v": 0.565
+            },
+            "rightHeel": {
+              "x": 49.2,
+              "y": 110.7,
+              "v": 0.786
+            },
+            "leftFootIndex": {
+              "x": 59,
+              "y": 97.6,
+              "v": 0.729
+            },
+            "rightFootIndex": {
+              "x": 42.7,
+              "y": 114.6,
+              "v": 0.911
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 40.6,
+                "y": 34.1
+              },
+              "roll": -154.1,
+              "yaw": 0.158,
+              "pitch": 0.462
+            },
+            "torso": {
+              "center": {
+                "x": 45.1,
+                "y": 42.3
+              },
+              "angle": 101.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 51.7,
+                "y": 46.5
+              },
+              "angle": 90
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.7,
+                "y": 47.4
+              },
+              "angle": 159.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 57.8,
+                "y": 94.2
+              },
+              "angle": -70.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 49.2,
+                "y": 110.7
+              },
+              "angle": -149
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.666,
+          "keypoints": {
+            "nose": {
+              "x": 46.6,
+              "y": 37.2,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 47.5,
+              "y": 34.7,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 44.2,
+              "y": 35.6,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 48.7,
+              "y": 34.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 42.2,
+              "y": 36.3,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 51.9,
+              "y": 41.6,
+              "v": 0.999
+            },
+            "rightShoulder": {
+              "x": 41.4,
+              "y": 43.5,
+              "v": 0.997
+            },
+            "leftElbow": {
+              "x": 48.3,
+              "y": 48.6,
+              "v": 0.208
+            },
+            "rightElbow": {
+              "x": 42.6,
+              "y": 47.3,
+              "v": 0.171
+            },
+            "leftWrist": {
+              "x": 41.7,
+              "y": 49.4,
+              "v": 0.308
+            },
+            "rightWrist": {
+              "x": 40.1,
+              "y": 46.2,
+              "v": 0.263
+            },
+            "leftIndex": {
+              "x": 39.8,
+              "y": 48.4,
+              "v": 0.45
+            },
+            "rightIndex": {
+              "x": 38.9,
+              "y": 45.7,
+              "v": 0.391
+            },
+            "leftHip": {
+              "x": 55.7,
+              "y": 69.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.2,
+              "y": 70,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 49.9,
+              "y": 89.3,
+              "v": 0.322
+            },
+            "rightKnee": {
+              "x": 44.2,
+              "y": 89.8,
+              "v": 0.384
+            },
+            "leftAnkle": {
+              "x": 42.4,
+              "y": 109.6,
+              "v": 0.667
+            },
+            "rightAnkle": {
+              "x": 42.2,
+              "y": 110.9,
+              "v": 0.725
+            },
+            "leftHeel": {
+              "x": 43.6,
+              "y": 111.6,
+              "v": 0.516
+            },
+            "rightHeel": {
+              "x": 46.8,
+              "y": 114.7,
+              "v": 0.575
+            },
+            "leftFootIndex": {
+              "x": 41.2,
+              "y": 115.1,
+              "v": 0.656
+            },
+            "rightFootIndex": {
+              "x": 39.8,
+              "y": 117.8,
+              "v": 0.684
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 45.9,
+                "y": 35.2
+              },
+              "roll": -164.7,
+              "yaw": 0.219,
+              "pitch": 0.599
+            },
+            "torso": {
+              "center": {
+                "x": 46.7,
+                "y": 42.6
+              },
+              "angle": 102
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 41.7,
+                "y": 49.4
+              },
+              "angle": 152.2
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 43.6,
+                "y": 111.6
+              },
+              "angle": -124.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 46.8,
+                "y": 114.7
+              },
+              "angle": -156.1
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.582,
+          "keypoints": {
+            "nose": {
+              "x": 68.3,
+              "y": 29.1,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 70.1,
+              "y": 26.5,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 65.5,
+              "y": 27.4,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 72.4,
+              "y": 27.2,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 63.2,
+              "y": 28.7,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 78.6,
+              "y": 39.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59.1,
+              "y": 39.8,
+              "v": 0.999
+            },
+            "leftElbow": {
+              "x": 79.7,
+              "y": 54.1,
+              "v": 0.206
+            },
+            "rightElbow": {
+              "x": 58.3,
+              "y": 52.4,
+              "v": 0.31
+            },
+            "leftWrist": {
+              "x": 77.8,
+              "y": 51.8,
+              "v": 0.278
+            },
+            "rightWrist": {
+              "x": 64.7,
+              "y": 48,
+              "v": 0.506
+            },
+            "leftIndex": {
+              "x": 77.6,
+              "y": 49.1,
+              "v": 0.357
+            },
+            "rightIndex": {
+              "x": 66.9,
+              "y": 44.8,
+              "v": 0.554
+            },
+            "leftHip": {
+              "x": 75.7,
+              "y": 69.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.3,
+              "y": 70.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.8,
+              "y": 80.4,
+              "v": 0.257
+            },
+            "rightKnee": {
+              "x": 60,
+              "y": 83.6,
+              "v": 0.357
+            },
+            "leftAnkle": {
+              "x": 81.5,
+              "y": 103.4,
+              "v": 0.349
+            },
+            "rightAnkle": {
+              "x": 66.4,
+              "y": 105.3,
+              "v": 0.276
+            },
+            "leftHeel": {
+              "x": 79.6,
+              "y": 107.2,
+              "v": 0.245
+            },
+            "rightHeel": {
+              "x": 68,
+              "y": 108.3,
+              "v": 0.14
+            },
+            "leftFootIndex": {
+              "x": 83.4,
+              "y": 110.4,
+              "v": 0.336
+            },
+            "rightFootIndex": {
+              "x": 68.5,
+              "y": 113,
+              "v": 0.231
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.8,
+                "y": 27
+              },
+              "roll": -168.9,
+              "yaw": 0.107,
+              "pitch": 0.459
+            },
+            "torso": {
+              "center": {
+                "x": 68.9,
+                "y": 39.7
+              },
+              "angle": 91.2
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 64.7,
+                "y": 48
+              },
+              "angle": 55.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 81.5,
+                "y": 103.4
+              },
+              "angle": -74.8
+            },
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.69,
+          "keypoints": {
+            "nose": {
+              "x": 49.3,
+              "y": 28.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 53.2,
+              "y": 26.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49,
+              "y": 27.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.9,
+              "y": 27.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 47.5,
+              "y": 29.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 64.4,
+              "y": 40.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 44.2,
+              "y": 41,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.3,
+              "y": 53.3,
+              "v": 0.33
+            },
+            "rightElbow": {
+              "x": 36.6,
+              "y": 53.9,
+              "v": 0.396
+            },
+            "leftWrist": {
+              "x": 70.9,
+              "y": 56.7,
+              "v": 0.366
+            },
+            "rightWrist": {
+              "x": 28.5,
+              "y": 54.1,
+              "v": 0.556
+            },
+            "leftIndex": {
+              "x": 70.4,
+              "y": 55.8,
+              "v": 0.449
+            },
+            "rightIndex": {
+              "x": 26,
+              "y": 52.9,
+              "v": 0.65
+            },
+            "leftHip": {
+              "x": 58.9,
+              "y": 73.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.1,
+              "y": 72,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 57.5,
+              "y": 90.8,
+              "v": 0.189
+            },
+            "rightKnee": {
+              "x": 42.1,
+              "y": 90.1,
+              "v": 0.733
+            },
+            "leftAnkle": {
+              "x": 51.6,
+              "y": 110.5,
+              "v": 0.383
+            },
+            "rightAnkle": {
+              "x": 33.7,
+              "y": 112.2,
+              "v": 0.789
+            },
+            "leftHeel": {
+              "x": 50,
+              "y": 114,
+              "v": 0.316
+            },
+            "rightHeel": {
+              "x": 32.8,
+              "y": 116.2,
+              "v": 0.437
+            },
+            "leftFootIndex": {
+              "x": 52.5,
+              "y": 116.1,
+              "v": 0.503
+            },
+            "rightFootIndex": {
+              "x": 33.7,
+              "y": 118,
+              "v": 0.773
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.1,
+                "y": 27.2
+              },
+              "roll": -165.3,
+              "yaw": -0.415,
+              "pitch": 0.242
+            },
+            "torso": {
+              "center": {
+                "x": 54.3,
+                "y": 41
+              },
+              "angle": 87.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 70.9,
+                "y": 56.7
+              },
+              "angle": 119.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.5,
+                "y": 54.1
+              },
+              "angle": 154.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 50,
+                "y": 114
+              },
+              "angle": -40
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.8,
+                "y": 116.2
+              },
+              "angle": -63.4
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.914,
+          "keypoints": {
+            "nose": {
+              "x": 54.4,
+              "y": 27.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56.9,
+              "y": 25.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51.8,
+              "y": 26.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.6,
+              "y": 26.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 50.3,
+              "y": 28.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 69,
+              "y": 41.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.1,
+              "y": 41.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.5,
+              "y": 54,
+              "v": 0.767
+            },
+            "rightElbow": {
+              "x": 35.4,
+              "y": 52.5,
+              "v": 0.902
+            },
+            "leftWrist": {
+              "x": 79.2,
+              "y": 55.2,
+              "v": 0.863
+            },
+            "rightWrist": {
+              "x": 33.2,
+              "y": 58.7,
+              "v": 0.925
+            },
+            "leftIndex": {
+              "x": 79.4,
+              "y": 55.2,
+              "v": 0.879
+            },
+            "rightIndex": {
+              "x": 34.1,
+              "y": 59.7,
+              "v": 0.923
+            },
+            "leftHip": {
+              "x": 64.3,
+              "y": 75,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.6,
+              "y": 72.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.2,
+              "y": 86.1,
+              "v": 0.725
+            },
+            "rightKnee": {
+              "x": 44.9,
+              "y": 90,
+              "v": 0.968
+            },
+            "leftAnkle": {
+              "x": 64.8,
+              "y": 106,
+              "v": 0.832
+            },
+            "rightAnkle": {
+              "x": 35.4,
+              "y": 113.4,
+              "v": 0.959
+            },
+            "leftHeel": {
+              "x": 60.7,
+              "y": 111.5,
+              "v": 0.78
+            },
+            "rightHeel": {
+              "x": 32.5,
+              "y": 119.4,
+              "v": 0.703
+            },
+            "leftFootIndex": {
+              "x": 68.6,
+              "y": 117.8,
+              "v": 0.853
+            },
+            "rightFootIndex": {
+              "x": 36.9,
+              "y": 127.9,
+              "v": 0.934
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.4,
+                "y": 26.1
+              },
+              "roll": -172.2,
+              "yaw": 0.01,
+              "pitch": 0.301
+            },
+            "torso": {
+              "center": {
+                "x": 58.1,
+                "y": 41.7
+              },
+              "angle": 88.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 79.2,
+                "y": 55.2
+              },
+              "angle": 0
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.2,
+                "y": 58.7
+              },
+              "angle": -48
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.7,
+                "y": 111.5
+              },
+              "angle": -38.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.5,
+                "y": 119.4
+              },
+              "angle": -62.6
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.565,
+          "keypoints": {
+            "nose": {
+              "x": 69.5,
+              "y": 29.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.7,
+              "y": 26.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 67.1,
+              "y": 27.2,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 74.1,
+              "y": 27.1,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 65.1,
+              "y": 28,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 81,
+              "y": 39.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61.3,
+              "y": 39,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.9,
+              "y": 52.7,
+              "v": 0.214
+            },
+            "rightElbow": {
+              "x": 60.9,
+              "y": 54.7,
+              "v": 0.169
+            },
+            "leftWrist": {
+              "x": 77.8,
+              "y": 56.8,
+              "v": 0.254
+            },
+            "rightWrist": {
+              "x": 65.3,
+              "y": 51.7,
+              "v": 0.32
+            },
+            "leftIndex": {
+              "x": 75.8,
+              "y": 56.5,
+              "v": 0.358
+            },
+            "rightIndex": {
+              "x": 66.9,
+              "y": 48.8,
+              "v": 0.426
+            },
+            "leftHip": {
+              "x": 74.3,
+              "y": 68.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.6,
+              "y": 67.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.3,
+              "y": 85.2,
+              "v": 0.161
+            },
+            "rightKnee": {
+              "x": 62.4,
+              "y": 86.5,
+              "v": 0.159
+            },
+            "leftAnkle": {
+              "x": 72.5,
+              "y": 104.4,
+              "v": 0.436
+            },
+            "rightAnkle": {
+              "x": 59.3,
+              "y": 103.7,
+              "v": 0.265
+            },
+            "leftHeel": {
+              "x": 71.4,
+              "y": 107.8,
+              "v": 0.346
+            },
+            "rightHeel": {
+              "x": 59.7,
+              "y": 106.8,
+              "v": 0.15
+            },
+            "leftFootIndex": {
+              "x": 73.5,
+              "y": 110.5,
+              "v": 0.478
+            },
+            "rightFootIndex": {
+              "x": 57.8,
+              "y": 110,
+              "v": 0.266
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.4,
+                "y": 26.9
+              },
+              "roll": -172.6,
+              "yaw": 0.022,
+              "pitch": 0.517
+            },
+            "torso": {
+              "center": {
+                "x": 71.2,
+                "y": 39.1
+              },
+              "angle": 85.7
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 65.3,
+                "y": 51.7
+              },
+              "angle": 61.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.4,
+                "y": 107.8
+              },
+              "angle": -52.1
+            },
+            "rightFoot": null
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.76,
+          "keypoints": {
+            "nose": {
+              "x": 60.3,
+              "y": 27.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63,
+              "y": 26,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 59.3,
+              "y": 25.6,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 66.4,
+              "y": 26.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 59.1,
+              "y": 27.5,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 75.7,
+              "y": 38.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56.2,
+              "y": 39.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.8,
+              "y": 53.2,
+              "v": 0.404
+            },
+            "rightElbow": {
+              "x": 52.7,
+              "y": 52.7,
+              "v": 0.383
+            },
+            "leftWrist": {
+              "x": 81.1,
+              "y": 58.1,
+              "v": 0.412
+            },
+            "rightWrist": {
+              "x": 54.9,
+              "y": 51.7,
+              "v": 0.357
+            },
+            "leftIndex": {
+              "x": 79.8,
+              "y": 57.8,
+              "v": 0.499
+            },
+            "rightIndex": {
+              "x": 56.2,
+              "y": 49.8,
+              "v": 0.457
+            },
+            "leftHip": {
+              "x": 72.7,
+              "y": 72,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.2,
+              "y": 71.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.9,
+              "y": 88.6,
+              "v": 0.397
+            },
+            "rightKnee": {
+              "x": 56.5,
+              "y": 88.8,
+              "v": 0.925
+            },
+            "leftAnkle": {
+              "x": 82.6,
+              "y": 112.2,
+              "v": 0.754
+            },
+            "rightAnkle": {
+              "x": 45.5,
+              "y": 114.4,
+              "v": 0.934
+            },
+            "leftHeel": {
+              "x": 80.5,
+              "y": 115.4,
+              "v": 0.619
+            },
+            "rightHeel": {
+              "x": 43.5,
+              "y": 117.7,
+              "v": 0.612
+            },
+            "leftFootIndex": {
+              "x": 88,
+              "y": 118.6,
+              "v": 0.8
+            },
+            "rightFootIndex": {
+              "x": 45.3,
+              "y": 123,
+              "v": 0.923
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 61.2,
+                "y": 25.8
+              },
+              "roll": 173.8,
+              "yaw": -0.228,
+              "pitch": 0.403
+            },
+            "torso": {
+              "center": {
+                "x": 66,
+                "y": 38.8
+              },
+              "angle": 90.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 81.1,
+                "y": 58.1
+              },
+              "angle": 167
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 54.9,
+                "y": 51.7
+              },
+              "angle": 55.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80.5,
+                "y": 115.4
+              },
+              "angle": -23.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.5,
+                "y": 117.7
+              },
+              "angle": -71.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.623,
+          "keypoints": {
+            "nose": {
+              "x": 67.5,
+              "y": 29.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.9,
+              "y": 27.6,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 66.1,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.7,
+              "y": 27.6,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 65.2,
+              "y": 28.4,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 74.6,
+              "y": 37.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 64.2,
+              "y": 35.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.1,
+              "y": 51.4,
+              "v": 0.163
+            },
+            "rightElbow": {
+              "x": 67,
+              "y": 44.7,
+              "v": 0.15
+            },
+            "leftWrist": {
+              "x": 68.4,
+              "y": 53.4,
+              "v": 0.141
+            },
+            "rightWrist": {
+              "x": 68.8,
+              "y": 47.8,
+              "v": 0.392
+            },
+            "leftIndex": {
+              "x": 66.9,
+              "y": 52.1,
+              "v": 0.207
+            },
+            "rightIndex": {
+              "x": 69.1,
+              "y": 48.3,
+              "v": 0.491
+            },
+            "leftHip": {
+              "x": 69.8,
+              "y": 62.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.7,
+              "y": 61.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.8,
+              "y": 72.3,
+              "v": 0.486
+            },
+            "rightKnee": {
+              "x": 70.7,
+              "y": 65.2,
+              "v": 0.272
+            },
+            "leftAnkle": {
+              "x": 74.5,
+              "y": 95.4,
+              "v": 0.706
+            },
+            "rightAnkle": {
+              "x": 72.3,
+              "y": 90.9,
+              "v": 0.45
+            },
+            "leftHeel": {
+              "x": 73.9,
+              "y": 99.1,
+              "v": 0.467
+            },
+            "rightHeel": {
+              "x": 72.6,
+              "y": 95.1,
+              "v": 0.239
+            },
+            "leftFootIndex": {
+              "x": 73.7,
+              "y": 101.3,
+              "v": 0.697
+            },
+            "rightFootIndex": {
+              "x": 73.4,
+              "y": 97.1,
+              "v": 0.466
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.5,
+                "y": 27.9
+              },
+              "roll": -169.9,
+              "yaw": 0,
+              "pitch": 0.721
+            },
+            "torso": {
+              "center": {
+                "x": 69.4,
+                "y": 36.4
+              },
+              "angle": 84.1
+            },
+            "leftHand": null,
+            "rightHand": {
+              "anchor": {
+                "x": 68.8,
+                "y": 47.8
+              },
+              "angle": -59
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.9,
+                "y": 99.1
+              },
+              "angle": -95.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 72.3,
+                "y": 90.9
+              },
+              "angle": -79.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 3,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.853,
+          "keypoints": {
+            "nose": {
+              "x": 69.8,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.1,
+              "y": 25.1,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 68.7,
+              "y": 25.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.3,
+              "y": 24.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.4,
+              "y": 25.7,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 85.3,
+              "y": 35.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 62.3,
+              "y": 33.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 89.7,
+              "y": 50.9,
+              "v": 0.766
+            },
+            "rightElbow": {
+              "x": 51.1,
+              "y": 45.7,
+              "v": 0.692
+            },
+            "leftWrist": {
+              "x": 87.9,
+              "y": 57.1,
+              "v": 0.855
+            },
+            "rightWrist": {
+              "x": 47.2,
+              "y": 52.6,
+              "v": 0.826
+            },
+            "leftIndex": {
+              "x": 86.7,
+              "y": 59.1,
+              "v": 0.853
+            },
+            "rightIndex": {
+              "x": 47.4,
+              "y": 54,
+              "v": 0.857
+            },
+            "leftHip": {
+              "x": 74.8,
+              "y": 67.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.4,
+              "y": 64.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 82.8,
+              "y": 82.3,
+              "v": 0.541
+            },
+            "rightKnee": {
+              "x": 58.7,
+              "y": 74.5,
+              "v": 0.915
+            },
+            "leftAnkle": {
+              "x": 74.9,
+              "y": 104.1,
+              "v": 0.626
+            },
+            "rightAnkle": {
+              "x": 48.5,
+              "y": 104.9,
+              "v": 0.919
+            },
+            "leftHeel": {
+              "x": 72,
+              "y": 107.2,
+              "v": 0.515
+            },
+            "rightHeel": {
+              "x": 47.4,
+              "y": 109.6,
+              "v": 0.667
+            },
+            "leftFootIndex": {
+              "x": 76.5,
+              "y": 112.1,
+              "v": 0.681
+            },
+            "rightFootIndex": {
+              "x": 47.5,
+              "y": 114.6,
+              "v": 0.909
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.4,
+                "y": 25.4
+              },
+              "roll": -170,
+              "yaw": -0.174,
+              "pitch": 0.724
+            },
+            "torso": {
+              "center": {
+                "x": 73.8,
+                "y": 34.8
+              },
+              "angle": 79.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.9,
+                "y": 57.1
+              },
+              "angle": -121
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.2,
+                "y": 52.6
+              },
+              "angle": -81.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72,
+                "y": 107.2
+              },
+              "angle": -47.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.4,
+                "y": 109.6
+              },
+              "angle": -88.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": false,
+          "avgVisibility": 0,
+          "keypoints": null,
+          "derived": null
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.658,
+          "keypoints": {
+            "nose": {
+              "x": 72.4,
+              "y": 32.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.4,
+              "y": 29.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.6,
+              "y": 30.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 76.2,
+              "y": 29.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.5,
+              "y": 31.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 81.4,
+              "y": 39.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61,
+              "y": 40,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.9,
+              "y": 53.1,
+              "v": 0.394
+            },
+            "rightElbow": {
+              "x": 60.1,
+              "y": 50.8,
+              "v": 0.499
+            },
+            "leftWrist": {
+              "x": 82.4,
+              "y": 57.9,
+              "v": 0.53
+            },
+            "rightWrist": {
+              "x": 67.7,
+              "y": 50.4,
+              "v": 0.62
+            },
+            "leftIndex": {
+              "x": 81.2,
+              "y": 57.8,
+              "v": 0.593
+            },
+            "rightIndex": {
+              "x": 70.6,
+              "y": 49,
+              "v": 0.635
+            },
+            "leftHip": {
+              "x": 73.8,
+              "y": 67.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62,
+              "y": 66.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.9,
+              "y": 79.3,
+              "v": 0.342
+            },
+            "rightKnee": {
+              "x": 63.1,
+              "y": 76.1,
+              "v": 0.422
+            },
+            "leftAnkle": {
+              "x": 77.9,
+              "y": 96.7,
+              "v": 0.443
+            },
+            "rightAnkle": {
+              "x": 68,
+              "y": 95.2,
+              "v": 0.368
+            },
+            "leftHeel": {
+              "x": 76.4,
+              "y": 99.6,
+              "v": 0.305
+            },
+            "rightHeel": {
+              "x": 69.1,
+              "y": 98.3,
+              "v": 0.206
+            },
+            "leftFootIndex": {
+              "x": 79.5,
+              "y": 102.8,
+              "v": 0.435
+            },
+            "rightFootIndex": {
+              "x": 70.3,
+              "y": 101.8,
+              "v": 0.336
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.5,
+                "y": 30.2
+              },
+              "roll": -167.4,
+              "yaw": 0.151,
+              "pitch": 0.412
+            },
+            "torso": {
+              "center": {
+                "x": 71.2,
+                "y": 39.6
+              },
+              "angle": 83.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.4,
+                "y": 57.9
+              },
+              "angle": 175.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 67.7,
+                "y": 50.4
+              },
+              "angle": 25.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.4,
+                "y": 99.6
+              },
+              "angle": -45.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 68,
+                "y": 95.2
+              },
+              "angle": -70.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.59,
+          "keypoints": {
+            "nose": {
+              "x": 65.1,
+              "y": 28.3,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 67.3,
+              "y": 25.9,
+              "v": 0.997
+            },
+            "rightEye": {
+              "x": 63.3,
+              "y": 26.7,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 70.3,
+              "y": 26.7,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 62.5,
+              "y": 28.1,
+              "v": 0.997
+            },
+            "leftShoulder": {
+              "x": 77.9,
+              "y": 39.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 59,
+              "y": 39.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.3,
+              "y": 54,
+              "v": 0.208
+            },
+            "rightElbow": {
+              "x": 57.4,
+              "y": 51.6,
+              "v": 0.164
+            },
+            "leftWrist": {
+              "x": 78.1,
+              "y": 56,
+              "v": 0.289
+            },
+            "rightWrist": {
+              "x": 62.2,
+              "y": 48.8,
+              "v": 0.291
+            },
+            "leftIndex": {
+              "x": 78.4,
+              "y": 54.7,
+              "v": 0.412
+            },
+            "rightIndex": {
+              "x": 64.1,
+              "y": 46.1,
+              "v": 0.409
+            },
+            "leftHip": {
+              "x": 74.6,
+              "y": 70.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.8,
+              "y": 70.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.6,
+              "y": 79.4,
+              "v": 0.384
+            },
+            "rightKnee": {
+              "x": 54.5,
+              "y": 78.9,
+              "v": 0.5
+            },
+            "leftAnkle": {
+              "x": 82.4,
+              "y": 103.8,
+              "v": 0.414
+            },
+            "rightAnkle": {
+              "x": 57,
+              "y": 104.3,
+              "v": 0.328
+            },
+            "leftHeel": {
+              "x": 80.3,
+              "y": 107.7,
+              "v": 0.298
+            },
+            "rightHeel": {
+              "x": 58.8,
+              "y": 108,
+              "v": 0.183
+            },
+            "leftFootIndex": {
+              "x": 84.7,
+              "y": 111.2,
+              "v": 0.401
+            },
+            "rightFootIndex": {
+              "x": 55.8,
+              "y": 112.6,
+              "v": 0.301
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.3,
+                "y": 26.3
+              },
+              "roll": -168.7,
+              "yaw": -0.049,
+              "pitch": 0.49
+            },
+            "torso": {
+              "center": {
+                "x": 68.5,
+                "y": 39.5
+              },
+              "angle": 89.5
+            },
+            "leftHand": null,
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 82.4,
+                "y": 103.8
+              },
+              "angle": -72.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 57,
+                "y": 104.3
+              },
+              "angle": -98.2
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/simon/poses.json
+++ b/public/assets/fighters/simon/poses.json
@@ -1,0 +1,8462 @@
+{
+  "version": 1,
+  "fighter": "simon",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T16:11:53.778Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 75.1,
+              "y": 24.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.3,
+              "y": 21.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.9,
+              "y": 21.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.6,
+              "y": 22.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.1,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.7,
+              "y": 36.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54,
+              "y": 35.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.3,
+              "y": 50.6,
+              "v": 0.979
+            },
+            "rightElbow": {
+              "x": 43.2,
+              "y": 49.9,
+              "v": 0.988
+            },
+            "leftWrist": {
+              "x": 94.8,
+              "y": 39.3,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 34,
+              "y": 39.3,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 96.2,
+              "y": 32.3,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 32.4,
+              "y": 33.3,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 73.4,
+              "y": 70,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.6,
+              "y": 71,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 89.6,
+              "y": 90.7,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 45.6,
+              "y": 94.4,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 88.5,
+              "y": 114.4,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 36.5,
+              "y": 116.4,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 85.2,
+              "y": 118.5,
+              "v": 0.985
+            },
+            "rightHeel": {
+              "x": 37.4,
+              "y": 119.8,
+              "v": 0.967
+            },
+            "leftFootIndex": {
+              "x": 98.6,
+              "y": 120.7,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 31.2,
+              "y": 124.7,
+              "v": 0.994
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.6,
+                "y": 21.6
+              },
+              "roll": 164.1,
+              "yaw": 1.03,
+              "pitch": 1.854
+            },
+            "torso": {
+              "center": {
+                "x": 65.9,
+                "y": 35.9
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.8,
+                "y": 39.3
+              },
+              "angle": 78.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34,
+                "y": 39.3
+              },
+              "angle": 104.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85.2,
+                "y": 118.5
+              },
+              "angle": -9.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.4,
+                "y": 119.8
+              },
+              "angle": -141.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 66.1,
+              "y": 15.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 66.5,
+              "y": 13.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.9,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.1,
+              "y": 13.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 69.4,
+              "y": 27.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.6,
+              "y": 26.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.5,
+              "y": 40.4,
+              "v": 0.926
+            },
+            "rightElbow": {
+              "x": 34.7,
+              "y": 43.9,
+              "v": 0.991
+            },
+            "leftWrist": {
+              "x": 87.5,
+              "y": 28,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 50.7,
+              "y": 33.5,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 87.8,
+              "y": 21.7,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 55,
+              "y": 27.1,
+              "v": 0.994
+            },
+            "leftHip": {
+              "x": 65.3,
+              "y": 59.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.9,
+              "y": 63.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 92.4,
+              "y": 58.9,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 45.7,
+              "y": 91.5,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 81.3,
+              "y": 83.2,
+              "v": 0.988
+            },
+            "rightAnkle": {
+              "x": 37.5,
+              "y": 118.6,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 76.2,
+              "y": 84.1,
+              "v": 0.977
+            },
+            "rightHeel": {
+              "x": 36.4,
+              "y": 121.5,
+              "v": 0.985
+            },
+            "leftFootIndex": {
+              "x": 83.3,
+              "y": 96.2,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 37.1,
+              "y": 125.3,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.2,
+                "y": 12.9
+              },
+              "roll": 160.9,
+              "yaw": 0.327,
+              "pitch": 1
+            },
+            "torso": {
+              "center": {
+                "x": 57.5,
+                "y": 27.1
+              },
+              "angle": 91.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.5,
+                "y": 28
+              },
+              "angle": 87.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 50.7,
+                "y": 33.5
+              },
+              "angle": 56.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.2,
+                "y": 84.1
+              },
+              "angle": -59.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.4,
+                "y": 121.5
+              },
+              "angle": -79.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 71.5,
+              "y": 19.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 71.5,
+              "y": 17.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.6,
+              "y": 16.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.4,
+              "y": 18.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 63.7,
+              "y": 17.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.2,
+              "y": 31.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.3,
+              "y": 31.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 84.3,
+              "y": 46.6,
+              "v": 0.931
+            },
+            "rightElbow": {
+              "x": 41.4,
+              "y": 46.7,
+              "v": 0.981
+            },
+            "leftWrist": {
+              "x": 91.7,
+              "y": 33.3,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 32.4,
+              "y": 36.2,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 92.1,
+              "y": 26.9,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 30.6,
+              "y": 30,
+              "v": 0.992
+            },
+            "leftHip": {
+              "x": 70.2,
+              "y": 64.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57,
+              "y": 67.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 96.7,
+              "y": 65.9,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 47.4,
+              "y": 94.4,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 87.6,
+              "y": 90,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 36.9,
+              "y": 118.1,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 83.2,
+              "y": 92.7,
+              "v": 0.995
+            },
+            "rightHeel": {
+              "x": 36.3,
+              "y": 120.3,
+              "v": 0.991
+            },
+            "leftFootIndex": {
+              "x": 90.9,
+              "y": 102.1,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 33.8,
+              "y": 125.4,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.1,
+                "y": 17.3
+              },
+              "roll": 164.6,
+              "yaw": 0.482,
+              "pitch": 0.798
+            },
+            "torso": {
+              "center": {
+                "x": 63.8,
+                "y": 31.6
+              },
+              "angle": 89.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.7,
+                "y": 33.3
+              },
+              "angle": 86.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.4,
+                "y": 36.2
+              },
+              "angle": 106.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 83.2,
+                "y": 92.7
+              },
+              "angle": -50.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.3,
+                "y": 120.3
+              },
+              "angle": -116.1
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.989,
+          "keypoints": {
+            "nose": {
+              "x": 74.6,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.8,
+              "y": 21.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.9,
+              "y": 20.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.3,
+              "y": 21.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.6,
+              "y": 20.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.3,
+              "y": 35.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.5,
+              "y": 34.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.4,
+              "y": 50.1,
+              "v": 0.949
+            },
+            "rightElbow": {
+              "x": 42.2,
+              "y": 50.5,
+              "v": 0.987
+            },
+            "leftWrist": {
+              "x": 94.3,
+              "y": 37.9,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 33.8,
+              "y": 39.8,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 94.6,
+              "y": 31.6,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 32.4,
+              "y": 33.4,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 72.9,
+              "y": 70.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.1,
+              "y": 71.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 89.4,
+              "y": 89.9,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 45.1,
+              "y": 95.1,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 87.7,
+              "y": 112.5,
+              "v": 0.986
+            },
+            "rightAnkle": {
+              "x": 36.3,
+              "y": 115.7,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 84.4,
+              "y": 116.4,
+              "v": 0.96
+            },
+            "rightHeel": {
+              "x": 36.3,
+              "y": 118.8,
+              "v": 0.926
+            },
+            "leftFootIndex": {
+              "x": 96.4,
+              "y": 120.5,
+              "v": 0.984
+            },
+            "rightFootIndex": {
+              "x": 32.3,
+              "y": 125,
+              "v": 0.985
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.4,
+                "y": 21
+              },
+              "roll": 164.6,
+              "yaw": 0.416,
+              "pitch": 1.03
+            },
+            "torso": {
+              "center": {
+                "x": 65.4,
+                "y": 35.2
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.3,
+                "y": 37.9
+              },
+              "angle": 87.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.8,
+                "y": 39.8
+              },
+              "angle": 102.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 84.4,
+                "y": 116.4
+              },
+              "angle": -18.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.3,
+                "y": 118.8
+              },
+              "angle": -122.8
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 74.7,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.7,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.5,
+              "y": 21,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.4,
+              "y": 22,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.6,
+              "y": 20.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.2,
+              "y": 35.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.4,
+              "y": 35,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.2,
+              "y": 49.4,
+              "v": 0.977
+            },
+            "rightElbow": {
+              "x": 42.1,
+              "y": 49.4,
+              "v": 0.989
+            },
+            "leftWrist": {
+              "x": 93.5,
+              "y": 40.1,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 34.3,
+              "y": 39.4,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 95.6,
+              "y": 32.4,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 32.3,
+              "y": 33.1,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 72.6,
+              "y": 69.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.7,
+              "y": 69.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90.3,
+              "y": 90.1,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 45.2,
+              "y": 94.9,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 88.3,
+              "y": 114.4,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 35.1,
+              "y": 118,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 85.1,
+              "y": 118.1,
+              "v": 0.979
+            },
+            "rightHeel": {
+              "x": 35.8,
+              "y": 121.7,
+              "v": 0.967
+            },
+            "leftFootIndex": {
+              "x": 98.3,
+              "y": 121,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 29.6,
+              "y": 124.7,
+              "v": 0.994
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.6,
+                "y": 21.4
+              },
+              "roll": 162.3,
+              "yaw": 0.476,
+              "pitch": 1.191
+            },
+            "torso": {
+              "center": {
+                "x": 65.3,
+                "y": 35.2
+              },
+              "angle": 89.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.5,
+                "y": 40.1
+              },
+              "angle": 74.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.3,
+                "y": 39.4
+              },
+              "angle": 107.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 85.1,
+                "y": 118.1
+              },
+              "angle": -12.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.8,
+                "y": 121.7
+              },
+              "angle": -154.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 74.2,
+              "y": 24.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.9,
+              "y": 21.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.2,
+              "y": 20.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.3,
+              "y": 21.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.8,
+              "y": 21.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.6,
+              "y": 36.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.8,
+              "y": 35.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.3,
+              "y": 49.8,
+              "v": 0.966
+            },
+            "rightElbow": {
+              "x": 42.7,
+              "y": 50.2,
+              "v": 0.987
+            },
+            "leftWrist": {
+              "x": 94.1,
+              "y": 38.2,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 33.7,
+              "y": 39.7,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 95.2,
+              "y": 31.6,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 31.9,
+              "y": 33.5,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 71.9,
+              "y": 69.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.2,
+              "y": 70.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 89,
+              "y": 90.1,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 44.1,
+              "y": 95,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 87.9,
+              "y": 113.7,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 36.1,
+              "y": 116.9,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 84.9,
+              "y": 117.5,
+              "v": 0.977
+            },
+            "rightHeel": {
+              "x": 37,
+              "y": 120.8,
+              "v": 0.966
+            },
+            "leftFootIndex": {
+              "x": 95.2,
+              "y": 120.8,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 30.8,
+              "y": 124.9,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.6,
+                "y": 21
+              },
+              "roll": 173.7,
+              "yaw": 0.607,
+              "pitch": 1.123
+            },
+            "torso": {
+              "center": {
+                "x": 65.2,
+                "y": 35.7
+              },
+              "angle": 88.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.1,
+                "y": 38.2
+              },
+              "angle": 80.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.7,
+                "y": 39.7
+              },
+              "angle": 106.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 84.9,
+                "y": 117.5
+              },
+              "angle": -17.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37,
+                "y": 120.8
+              },
+              "angle": -146.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.989,
+          "keypoints": {
+            "nose": {
+              "x": 74.3,
+              "y": 20.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.6,
+              "y": 18.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.2,
+              "y": 17.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.6,
+              "y": 18.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.3,
+              "y": 18.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.6,
+              "y": 32.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.6,
+              "y": 31.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86,
+              "y": 46,
+              "v": 0.923
+            },
+            "rightElbow": {
+              "x": 42.7,
+              "y": 46.8,
+              "v": 0.994
+            },
+            "leftWrist": {
+              "x": 94.1,
+              "y": 34.1,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 34.7,
+              "y": 36.9,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 95.1,
+              "y": 27.9,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 32.5,
+              "y": 29.6,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 69.7,
+              "y": 65.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.5,
+              "y": 67.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60.6,
+              "y": 94.6,
+              "v": 0.966
+            },
+            "rightKnee": {
+              "x": 75.2,
+              "y": 86.4,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 54.9,
+              "y": 110.8,
+              "v": 0.981
+            },
+            "rightAnkle": {
+              "x": 58.7,
+              "y": 109.4,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 51.9,
+              "y": 113.1,
+              "v": 0.973
+            },
+            "rightHeel": {
+              "x": 54.3,
+              "y": 111,
+              "v": 0.949
+            },
+            "leftFootIndex": {
+              "x": 56.7,
+              "y": 118.1,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 63,
+              "y": 121.5,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.9,
+                "y": 17.9
+              },
+              "roll": 165.2,
+              "yaw": 0.398,
+              "pitch": 0.725
+            },
+            "torso": {
+              "center": {
+                "x": 65.6,
+                "y": 31.8
+              },
+              "angle": 90
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.1,
+                "y": 34.1
+              },
+              "angle": 80.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.7,
+                "y": 36.9
+              },
+              "angle": 106.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 51.9,
+                "y": 113.1
+              },
+              "angle": -46.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 54.3,
+                "y": 111
+              },
+              "angle": -50.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 75.1,
+              "y": 19.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.7,
+              "y": 17.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.2,
+              "y": 17,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.4,
+              "y": 18.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.4,
+              "y": 17.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.4,
+              "y": 31.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.3,
+              "y": 31.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.3,
+              "y": 46,
+              "v": 0.946
+            },
+            "rightElbow": {
+              "x": 43.7,
+              "y": 46.1,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 94.6,
+              "y": 33.3,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 35.1,
+              "y": 36.6,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 94.9,
+              "y": 27,
+              "v": 1
+            },
+            "rightIndex": {
+              "x": 32.6,
+              "y": 29.6,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 70.9,
+              "y": 64.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.2,
+              "y": 67.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 94.9,
+              "y": 66.6,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 58.5,
+              "y": 95.4,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 85.3,
+              "y": 88.7,
+              "v": 1
+            },
+            "rightAnkle": {
+              "x": 51.3,
+              "y": 116.8,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 80,
+              "y": 91.4,
+              "v": 0.999
+            },
+            "rightHeel": {
+              "x": 48.2,
+              "y": 118.6,
+              "v": 0.998
+            },
+            "leftFootIndex": {
+              "x": 90.1,
+              "y": 99.6,
+              "v": 1
+            },
+            "rightFootIndex": {
+              "x": 55.9,
+              "y": 124.7,
+              "v": 1
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.5,
+                "y": 17.3
+              },
+              "roll": 166.5,
+              "yaw": 0.642,
+              "pitch": 1.011
+            },
+            "torso": {
+              "center": {
+                "x": 65.4,
+                "y": 31.7
+              },
+              "angle": 91.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.6,
+                "y": 33.3
+              },
+              "angle": 87.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.1,
+                "y": 36.6
+              },
+              "angle": 109.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80,
+                "y": 91.4
+              },
+              "angle": -39.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 48.2,
+                "y": 118.6
+              },
+              "angle": -38.4
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 67.1,
+              "y": 24.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.7,
+              "y": 21.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.8,
+              "y": 20.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.5,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 59.9,
+              "y": 21,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 69.6,
+              "y": 33.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.8,
+              "y": 34.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.7,
+              "y": 33.3,
+              "v": 0.986
+            },
+            "rightElbow": {
+              "x": 33.4,
+              "y": 48.5,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 101.3,
+              "y": 33.1,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 24.5,
+              "y": 38.3,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 104.9,
+              "y": 32.5,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 24.2,
+              "y": 32.5,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 62.1,
+              "y": 66.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.2,
+              "y": 69.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.7,
+              "y": 70.6,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 36.6,
+              "y": 94.7,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 75.5,
+              "y": 93,
+              "v": 0.988
+            },
+            "rightAnkle": {
+              "x": 27.7,
+              "y": 116.2,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 69.7,
+              "y": 95.8,
+              "v": 0.968
+            },
+            "rightHeel": {
+              "x": 27.2,
+              "y": 119.8,
+              "v": 0.96
+            },
+            "leftFootIndex": {
+              "x": 81.6,
+              "y": 103.9,
+              "v": 0.986
+            },
+            "rightFootIndex": {
+              "x": 23.7,
+              "y": 125.4,
+              "v": 0.994
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.3,
+                "y": 21.1
+              },
+              "roll": 168.3,
+              "yaw": 0.287,
+              "pitch": 1.114
+            },
+            "torso": {
+              "center": {
+                "x": 57.7,
+                "y": 34.2
+              },
+              "angle": 86.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 101.3,
+                "y": 33.1
+              },
+              "angle": 9.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 24.5,
+                "y": 38.3
+              },
+              "angle": 93
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.7,
+                "y": 95.8
+              },
+              "angle": -34.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27.2,
+                "y": 119.8
+              },
+              "angle": -122
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 64.2,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.5,
+              "y": 18.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.9,
+              "y": 17.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 62.4,
+              "y": 19,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.2,
+              "y": 18,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.6,
+              "y": 31.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43,
+              "y": 32.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.9,
+              "y": 30.7,
+              "v": 0.986
+            },
+            "rightElbow": {
+              "x": 32.7,
+              "y": 47,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 103.2,
+              "y": 31.3,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 24.8,
+              "y": 36.2,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 107.6,
+              "y": 29.7,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 23.4,
+              "y": 30.1,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 62,
+              "y": 66.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.4,
+              "y": 68.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 85.4,
+              "y": 70.6,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 35.3,
+              "y": 94,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 74,
+              "y": 92.6,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 25.4,
+              "y": 116.5,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 68.3,
+              "y": 94.4,
+              "v": 0.976
+            },
+            "rightHeel": {
+              "x": 25.7,
+              "y": 119.9,
+              "v": 0.981
+            },
+            "leftFootIndex": {
+              "x": 78.3,
+              "y": 105.6,
+              "v": 0.985
+            },
+            "rightFootIndex": {
+              "x": 20.3,
+              "y": 124.4,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.2,
+                "y": 18.2
+              },
+              "roll": 164.9,
+              "yaw": 0.371,
+              "pitch": 1.133
+            },
+            "torso": {
+              "center": {
+                "x": 55.8,
+                "y": 31.9
+              },
+              "angle": 89
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 103.2,
+                "y": 31.3
+              },
+              "angle": 20
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 24.8,
+                "y": 36.2
+              },
+              "angle": 102.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.3,
+                "y": 94.4
+              },
+              "angle": -48.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 25.7,
+                "y": 119.9
+              },
+              "angle": -140.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 64.2,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63.4,
+              "y": 20.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.7,
+              "y": 20.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 59.9,
+              "y": 21.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.4,
+              "y": 21.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.9,
+              "y": 33.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42.3,
+              "y": 34.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.6,
+              "y": 32.3,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 30.6,
+              "y": 50.2,
+              "v": 0.994
+            },
+            "leftWrist": {
+              "x": 104,
+              "y": 32.6,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 22.1,
+              "y": 38.6,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 108.2,
+              "y": 31,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 21.3,
+              "y": 32.4,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 62.2,
+              "y": 69.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.3,
+              "y": 71,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 85.2,
+              "y": 78.7,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 33.9,
+              "y": 95.9,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 75.6,
+              "y": 99.7,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 24,
+              "y": 116.3,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 70.7,
+              "y": 101.2,
+              "v": 0.983
+            },
+            "rightHeel": {
+              "x": 24.7,
+              "y": 119.7,
+              "v": 0.98
+            },
+            "leftFootIndex": {
+              "x": 81.6,
+              "y": 111.5,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 18.8,
+              "y": 124.9,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.6,
+                "y": 20.5
+              },
+              "roll": -180,
+              "yaw": 0.971,
+              "pitch": 1.824
+            },
+            "torso": {
+              "center": {
+                "x": 55.1,
+                "y": 34.1
+              },
+              "angle": 89.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 104,
+                "y": 32.6
+              },
+              "angle": 20.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 22.1,
+                "y": 38.6
+              },
+              "angle": 97.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.7,
+                "y": 101.2
+              },
+              "angle": -43.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 24.7,
+                "y": 119.7
+              },
+              "angle": -138.6
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 64.7,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.6,
+              "y": 19.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62.5,
+              "y": 19,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.5,
+              "y": 19.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.2,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.7,
+              "y": 31.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42.9,
+              "y": 33.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.3,
+              "y": 31,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 30.2,
+              "y": 48.4,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 104.9,
+              "y": 30.7,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 23.3,
+              "y": 36.7,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 109.8,
+              "y": 29.7,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 22.1,
+              "y": 30.3,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 61.5,
+              "y": 66.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.7,
+              "y": 69,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86.3,
+              "y": 72.2,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 33.3,
+              "y": 94.4,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 77.4,
+              "y": 93.2,
+              "v": 0.982
+            },
+            "rightAnkle": {
+              "x": 23,
+              "y": 117.4,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 72.8,
+              "y": 94.9,
+              "v": 0.955
+            },
+            "rightHeel": {
+              "x": 23.3,
+              "y": 121.3,
+              "v": 0.983
+            },
+            "leftFootIndex": {
+              "x": 81.6,
+              "y": 105.7,
+              "v": 0.978
+            },
+            "rightFootIndex": {
+              "x": 18.2,
+              "y": 124.1,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.6,
+                "y": 19.2
+              },
+              "roll": 171.9,
+              "yaw": 0.542,
+              "pitch": 1.438
+            },
+            "torso": {
+              "center": {
+                "x": 55.3,
+                "y": 32.8
+              },
+              "angle": 88.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 104.9,
+                "y": 30.7
+              },
+              "angle": 11.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 23.3,
+                "y": 36.7
+              },
+              "angle": 100.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.8,
+                "y": 94.9
+              },
+              "angle": -50.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 23.3,
+                "y": 121.3
+              },
+              "angle": -151.2
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 75.5,
+              "y": 23.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.6,
+              "y": 21.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.3,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.1,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.3,
+              "y": 21.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.2,
+              "y": 36.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.3,
+              "y": 35.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.4,
+              "y": 50.3,
+              "v": 0.988
+            },
+            "rightElbow": {
+              "x": 42.5,
+              "y": 50.2,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 94.8,
+              "y": 37.7,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 34.1,
+              "y": 39.7,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 94.9,
+              "y": 31.3,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 32.6,
+              "y": 33.4,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 72.6,
+              "y": 69.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.8,
+              "y": 70.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 89.5,
+              "y": 90.6,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 45.1,
+              "y": 95,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 88,
+              "y": 114.3,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 35.2,
+              "y": 117.7,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 84.9,
+              "y": 118.5,
+              "v": 0.993
+            },
+            "rightHeel": {
+              "x": 35.8,
+              "y": 121,
+              "v": 0.982
+            },
+            "leftFootIndex": {
+              "x": 97.9,
+              "y": 120.4,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 30.1,
+              "y": 124.1,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.9,
+                "y": 21.3
+              },
+              "roll": 175.6,
+              "yaw": 1.189,
+              "pitch": 2.032
+            },
+            "torso": {
+              "center": {
+                "x": 65.3,
+                "y": 36.2
+              },
+              "angle": 89.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.8,
+                "y": 37.7
+              },
+              "angle": 89.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.1,
+                "y": 39.7
+              },
+              "angle": 103.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 84.9,
+                "y": 118.5
+              },
+              "angle": -8.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.8,
+                "y": 121
+              },
+              "angle": -151.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.998,
+          "keypoints": {
+            "nose": {
+              "x": 54.2,
+              "y": 18.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 53.5,
+              "y": 15.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51.3,
+              "y": 15.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 50.4,
+              "y": 16.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 45.8,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 58.4,
+              "y": 28.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 31,
+              "y": 30.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.3,
+              "y": 28.8,
+              "v": 0.997
+            },
+            "rightElbow": {
+              "x": 18.5,
+              "y": 45,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 98.1,
+              "y": 27.8,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 12.6,
+              "y": 32.4,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 103.7,
+              "y": 26.5,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 11.3,
+              "y": 26.1,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 49.5,
+              "y": 62.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 34.9,
+              "y": 65.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.4,
+              "y": 65.9,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 23.9,
+              "y": 91.7,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 62.9,
+              "y": 87.5,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 15.6,
+              "y": 114.1,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 58.2,
+              "y": 88.5,
+              "v": 0.987
+            },
+            "rightHeel": {
+              "x": 15.8,
+              "y": 117.1,
+              "v": 0.993
+            },
+            "leftFootIndex": {
+              "x": 65.2,
+              "y": 101,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 11.6,
+              "y": 125,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 52.4,
+                "y": 15.7
+              },
+              "roll": 177.4,
+              "yaw": 0.817,
+              "pitch": 1.476
+            },
+            "torso": {
+              "center": {
+                "x": 44.7,
+                "y": 29.5
+              },
+              "angle": 85.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.1,
+                "y": 27.8
+              },
+              "angle": 13.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 12.6,
+                "y": 32.4
+              },
+              "angle": 101.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 58.2,
+                "y": 88.5
+              },
+              "angle": -60.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 15.8,
+                "y": 117.1
+              },
+              "angle": -118
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 55.5,
+              "y": 22.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.1,
+              "y": 20.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53,
+              "y": 19.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 51.8,
+              "y": 20.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 47.8,
+              "y": 19.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.5,
+              "y": 32.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 33.5,
+              "y": 33.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.9,
+              "y": 32.6,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 21.9,
+              "y": 48.3,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 96.2,
+              "y": 32.6,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 13.9,
+              "y": 37.7,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 102.1,
+              "y": 31.5,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 12.9,
+              "y": 31.1,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 52.4,
+              "y": 68.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 37.7,
+              "y": 70.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.1,
+              "y": 73.2,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 24.5,
+              "y": 94.2,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 67.3,
+              "y": 95.6,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 14.9,
+              "y": 115.4,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 62.8,
+              "y": 97.3,
+              "v": 0.965
+            },
+            "rightHeel": {
+              "x": 15.5,
+              "y": 119.2,
+              "v": 0.975
+            },
+            "leftFootIndex": {
+              "x": 70,
+              "y": 108.5,
+              "v": 0.984
+            },
+            "rightFootIndex": {
+              "x": 10.5,
+              "y": 125.1,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.1,
+                "y": 19.9
+              },
+              "roll": 166.6,
+              "yaw": 0.672,
+              "pitch": 1.228
+            },
+            "torso": {
+              "center": {
+                "x": 46.5,
+                "y": 33.2
+              },
+              "angle": 87.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.2,
+                "y": 32.6
+              },
+              "angle": 10.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 13.9,
+                "y": 37.7
+              },
+              "angle": 98.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 62.8,
+                "y": 97.3
+              },
+              "angle": -57.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 15.5,
+                "y": 119.2
+              },
+              "angle": -130.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 55.8,
+              "y": 23.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56,
+              "y": 20.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.4,
+              "y": 20.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.1,
+              "y": 21.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.5,
+              "y": 20.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.9,
+              "y": 33.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 34.7,
+              "y": 34.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.7,
+              "y": 33.9,
+              "v": 0.994
+            },
+            "rightElbow": {
+              "x": 23.4,
+              "y": 50.7,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 96.1,
+              "y": 34,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 15.5,
+              "y": 39.7,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 101.7,
+              "y": 32.9,
+              "v": 0.993
+            },
+            "rightIndex": {
+              "x": 13.7,
+              "y": 33.6,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 53.8,
+              "y": 68.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 40.1,
+              "y": 70.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 77.5,
+              "y": 72.2,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 26.9,
+              "y": 94.8,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 70.5,
+              "y": 94.7,
+              "v": 0.986
+            },
+            "rightAnkle": {
+              "x": 18,
+              "y": 117.9,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 65.8,
+              "y": 96.7,
+              "v": 0.967
+            },
+            "rightHeel": {
+              "x": 18.4,
+              "y": 121.8,
+              "v": 0.982
+            },
+            "leftFootIndex": {
+              "x": 75.3,
+              "y": 106.6,
+              "v": 0.981
+            },
+            "rightFootIndex": {
+              "x": 12.8,
+              "y": 124.5,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.7,
+                "y": 20.5
+              },
+              "roll": 169.1,
+              "yaw": 0.415,
+              "pitch": 1.076
+            },
+            "torso": {
+              "center": {
+                "x": 47.3,
+                "y": 34.3
+              },
+              "angle": 89.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.1,
+                "y": 34
+              },
+              "angle": 11.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 15.5,
+                "y": 39.7
+              },
+              "angle": 106.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 65.8,
+                "y": 96.7
+              },
+              "angle": -46.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 18.4,
+                "y": 121.8
+              },
+              "angle": -154.3
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.977,
+          "keypoints": {
+            "nose": {
+              "x": 60.1,
+              "y": 21.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 59.6,
+              "y": 18.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.8,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.8,
+              "y": 18.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.5,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.9,
+              "y": 28.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 38.7,
+              "y": 30.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.6,
+              "y": 28.9,
+              "v": 0.97
+            },
+            "rightElbow": {
+              "x": 26.2,
+              "y": 47,
+              "v": 0.982
+            },
+            "leftWrist": {
+              "x": 98.7,
+              "y": 27.9,
+              "v": 0.984
+            },
+            "rightWrist": {
+              "x": 35.6,
+              "y": 39.7,
+              "v": 0.942
+            },
+            "leftIndex": {
+              "x": 103.4,
+              "y": 26.8,
+              "v": 0.976
+            },
+            "rightIndex": {
+              "x": 40.4,
+              "y": 34.8,
+              "v": 0.91
+            },
+            "leftHip": {
+              "x": 54.8,
+              "y": 63.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 42.5,
+              "y": 66.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 78.2,
+              "y": 65.1,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 33.8,
+              "y": 93.3,
+              "v": 0.994
+            },
+            "leftAnkle": {
+              "x": 68.7,
+              "y": 87.8,
+              "v": 0.961
+            },
+            "rightAnkle": {
+              "x": 25.7,
+              "y": 117.2,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 63.8,
+              "y": 89.1,
+              "v": 0.89
+            },
+            "rightHeel": {
+              "x": 26,
+              "y": 120,
+              "v": 0.928
+            },
+            "leftFootIndex": {
+              "x": 69.5,
+              "y": 99.6,
+              "v": 0.95
+            },
+            "rightFootIndex": {
+              "x": 22.4,
+              "y": 126.1,
+              "v": 0.986
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58.7,
+                "y": 18.3
+              },
+              "roll": -180,
+              "yaw": 0.778,
+              "pitch": 1.556
+            },
+            "torso": {
+              "center": {
+                "x": 50.8,
+                "y": 29.4
+              },
+              "angle": 86.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 98.7,
+                "y": 27.9
+              },
+              "angle": 13.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.6,
+                "y": 39.7
+              },
+              "angle": 45.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 63.8,
+                "y": 89.1
+              },
+              "angle": -61.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 26,
+                "y": 120
+              },
+              "angle": -120.5
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 74.9,
+              "y": 24.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.6,
+              "y": 21.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.5,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72,
+              "y": 22.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.5,
+              "y": 21.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.1,
+              "y": 36.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.2,
+              "y": 35.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.2,
+              "y": 50.6,
+              "v": 0.974
+            },
+            "rightElbow": {
+              "x": 42.1,
+              "y": 50.8,
+              "v": 0.987
+            },
+            "leftWrist": {
+              "x": 94.5,
+              "y": 38.7,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 33.4,
+              "y": 40.3,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 95.1,
+              "y": 31.9,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 31.9,
+              "y": 33.9,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 72.6,
+              "y": 70.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.3,
+              "y": 71.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 89.7,
+              "y": 90.2,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 44,
+              "y": 96.2,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 87.8,
+              "y": 114,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 35.7,
+              "y": 116,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 84.6,
+              "y": 118.2,
+              "v": 0.984
+            },
+            "rightHeel": {
+              "x": 36.1,
+              "y": 119.4,
+              "v": 0.954
+            },
+            "leftFootIndex": {
+              "x": 96.8,
+              "y": 120.7,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 30,
+              "y": 124.9,
+              "v": 0.991
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.6,
+                "y": 21.7
+              },
+              "roll": 169.2,
+              "yaw": 0.632,
+              "pitch": 1.497
+            },
+            "torso": {
+              "center": {
+                "x": 65.2,
+                "y": 36
+              },
+              "angle": 89.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.5,
+                "y": 38.7
+              },
+              "angle": 85
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.4,
+                "y": 40.3
+              },
+              "angle": 103.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 84.6,
+                "y": 118.2
+              },
+              "angle": -11.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.1,
+                "y": 119.4
+              },
+              "angle": -138
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.992,
+          "keypoints": {
+            "nose": {
+              "x": 73.4,
+              "y": 21.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.3,
+              "y": 18.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.2,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.2,
+              "y": 19.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.9,
+              "y": 18.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77,
+              "y": 33.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53,
+              "y": 32.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.6,
+              "y": 47.1,
+              "v": 0.957
+            },
+            "rightElbow": {
+              "x": 42.4,
+              "y": 48.1,
+              "v": 0.981
+            },
+            "leftWrist": {
+              "x": 94,
+              "y": 37,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 33.4,
+              "y": 36.7,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 94.6,
+              "y": 29.9,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 32,
+              "y": 31,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 72.7,
+              "y": 67.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.6,
+              "y": 68.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 89.1,
+              "y": 89.4,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 45.3,
+              "y": 94.1,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 87.7,
+              "y": 114.8,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 35.5,
+              "y": 116.4,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 84.6,
+              "y": 119.3,
+              "v": 0.976
+            },
+            "rightHeel": {
+              "x": 36.4,
+              "y": 120.2,
+              "v": 0.946
+            },
+            "leftFootIndex": {
+              "x": 98.1,
+              "y": 120.6,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 30.3,
+              "y": 124.7,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.8,
+                "y": 18.6
+              },
+              "roll": 169,
+              "yaw": 0.523,
+              "pitch": 0.982
+            },
+            "torso": {
+              "center": {
+                "x": 65,
+                "y": 33
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94,
+                "y": 37
+              },
+              "angle": 85.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.4,
+                "y": 36.7
+              },
+              "angle": 103.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 84.6,
+                "y": 119.3
+              },
+              "angle": -5.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.4,
+                "y": 120.2
+              },
+              "angle": -143.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 56.4,
+              "y": 21.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 55.8,
+              "y": 19.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.7,
+              "y": 18.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52.9,
+              "y": 19.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.1,
+              "y": 19.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 58.7,
+              "y": 34.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 35.3,
+              "y": 33.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 68.3,
+              "y": 48.1,
+              "v": 0.976
+            },
+            "rightElbow": {
+              "x": 23.4,
+              "y": 47.4,
+              "v": 0.99
+            },
+            "leftWrist": {
+              "x": 76.2,
+              "y": 36.3,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 14.1,
+              "y": 37.6,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 77.3,
+              "y": 29.9,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 11.9,
+              "y": 30.9,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 55.4,
+              "y": 67.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 40.3,
+              "y": 70.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.3,
+              "y": 66.7,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 25.2,
+              "y": 94.2,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 105.7,
+              "y": 66.7,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 14.6,
+              "y": 115.5,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 106.1,
+              "y": 70.5,
+              "v": 0.988
+            },
+            "rightHeel": {
+              "x": 15.1,
+              "y": 118.6,
+              "v": 0.977
+            },
+            "leftFootIndex": {
+              "x": 112.2,
+              "y": 63,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 9.2,
+              "y": 124.1,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 54.8,
+                "y": 19.1
+              },
+              "roll": 169.2,
+              "yaw": 0.772,
+              "pitch": 1.31
+            },
+            "torso": {
+              "center": {
+                "x": 47,
+                "y": 33.8
+              },
+              "angle": 91.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 76.2,
+                "y": 36.3
+              },
+              "angle": 80.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 14.1,
+                "y": 37.6
+              },
+              "angle": 108.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 106.1,
+                "y": 70.5
+              },
+              "angle": 50.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 15.1,
+                "y": 118.6
+              },
+              "angle": -137
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 75.6,
+              "y": 22,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.9,
+              "y": 19,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73,
+              "y": 18.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.1,
+              "y": 19.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.5,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.9,
+              "y": 33.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.5,
+              "y": 32.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 87.3,
+              "y": 47.8,
+              "v": 0.983
+            },
+            "rightElbow": {
+              "x": 42.2,
+              "y": 48.6,
+              "v": 0.99
+            },
+            "leftWrist": {
+              "x": 95.5,
+              "y": 35.4,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 32.8,
+              "y": 36.7,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 96.5,
+              "y": 28.6,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 30.9,
+              "y": 30.8,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 72.7,
+              "y": 67.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.2,
+              "y": 68,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90.5,
+              "y": 89.2,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 45,
+              "y": 94.3,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 89,
+              "y": 114.3,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 35.4,
+              "y": 116.3,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 86,
+              "y": 118.9,
+              "v": 0.993
+            },
+            "rightHeel": {
+              "x": 35.7,
+              "y": 119.7,
+              "v": 0.976
+            },
+            "leftFootIndex": {
+              "x": 99.9,
+              "y": 120.2,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 30.9,
+              "y": 124.5,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74,
+                "y": 18.8
+              },
+              "roll": 168.1,
+              "yaw": 0.85,
+              "pitch": 1.648
+            },
+            "torso": {
+              "center": {
+                "x": 65.7,
+                "y": 32.8
+              },
+              "angle": 88.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.5,
+                "y": 35.4
+              },
+              "angle": 81.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.8,
+                "y": 36.7
+              },
+              "angle": 107.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 86,
+                "y": 118.9
+              },
+              "angle": -5.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.7,
+                "y": 119.7
+              },
+              "angle": -135
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 73.4,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.1,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.9,
+              "y": 22.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.6,
+              "y": 20.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.4,
+              "y": 34.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.3,
+              "y": 32.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.1,
+              "y": 46.7,
+              "v": 0.915
+            },
+            "rightElbow": {
+              "x": 42.7,
+              "y": 47.9,
+              "v": 0.986
+            },
+            "leftWrist": {
+              "x": 91.4,
+              "y": 35.6,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 35.5,
+              "y": 37.4,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 92.9,
+              "y": 29.3,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 34.1,
+              "y": 31.4,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 68.8,
+              "y": 65.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.6,
+              "y": 69.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 94.1,
+              "y": 62.8,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 52.5,
+              "y": 96.3,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 81.9,
+              "y": 86.4,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 42.6,
+              "y": 116.2,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 76.6,
+              "y": 87.2,
+              "v": 0.986
+            },
+            "rightHeel": {
+              "x": 40.9,
+              "y": 117.7,
+              "v": 0.977
+            },
+            "leftFootIndex": {
+              "x": 82.3,
+              "y": 99.5,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 41.7,
+              "y": 124.7,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.6,
+                "y": 20.9
+              },
+              "roll": 152.7,
+              "yaw": 0.244,
+              "pitch": 0.831
+            },
+            "torso": {
+              "center": {
+                "x": 63.9,
+                "y": 33.6
+              },
+              "angle": 88.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.4,
+                "y": 35.6
+              },
+              "angle": 76.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.5,
+                "y": 37.4
+              },
+              "angle": 103.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.6,
+                "y": 87.2
+              },
+              "angle": -65.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.9,
+                "y": 117.7
+              },
+              "angle": -83.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.991,
+          "keypoints": {
+            "nose": {
+              "x": 53.1,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 53.4,
+              "y": 18.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 50,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 51.6,
+              "y": 19.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 45,
+              "y": 18.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 56.6,
+              "y": 32,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 32.5,
+              "y": 32.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 66.4,
+              "y": 45.2,
+              "v": 0.94
+            },
+            "rightElbow": {
+              "x": 22,
+              "y": 48.3,
+              "v": 0.981
+            },
+            "leftWrist": {
+              "x": 72.1,
+              "y": 34,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 14.4,
+              "y": 37,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 72.8,
+              "y": 27.3,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 12.7,
+              "y": 30.8,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 55.7,
+              "y": 62.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43,
+              "y": 68.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 83.5,
+              "y": 56.7,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 33.9,
+              "y": 94.5,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 107.4,
+              "y": 55.3,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 32.9,
+              "y": 117.5,
+              "v": 0.991
+            },
+            "leftHeel": {
+              "x": 109.8,
+              "y": 59.7,
+              "v": 0.988
+            },
+            "rightHeel": {
+              "x": 34.8,
+              "y": 120.5,
+              "v": 0.958
+            },
+            "leftFootIndex": {
+              "x": 116.1,
+              "y": 47.5,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 27,
+              "y": 124.8,
+              "v": 0.978
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.7,
+                "y": 18.6
+              },
+              "roll": 170,
+              "yaw": 0.405,
+              "pitch": 0.753
+            },
+            "torso": {
+              "center": {
+                "x": 44.6,
+                "y": 32.3
+              },
+              "angle": 98.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 72.1,
+                "y": 34
+              },
+              "angle": 84
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 14.4,
+                "y": 37
+              },
+              "angle": 105.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 109.8,
+                "y": 59.7
+              },
+              "angle": 62.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 34.8,
+                "y": 120.5
+              },
+              "angle": -151.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.99,
+          "keypoints": {
+            "nose": {
+              "x": 46.8,
+              "y": 23.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 46.4,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 43.8,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 43.7,
+              "y": 22.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 38.9,
+              "y": 21.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 52.8,
+              "y": 30.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 28.3,
+              "y": 38.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 68.5,
+              "y": 38.8,
+              "v": 0.966
+            },
+            "rightElbow": {
+              "x": 18.4,
+              "y": 53.3,
+              "v": 0.99
+            },
+            "leftWrist": {
+              "x": 72.7,
+              "y": 25.5,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 8.7,
+              "y": 43.3,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 71.5,
+              "y": 19.6,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 7.7,
+              "y": 37.1,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 61.9,
+              "y": 60.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.7,
+              "y": 69.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86.3,
+              "y": 46.7,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 38.3,
+              "y": 94.4,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 109.1,
+              "y": 40.2,
+              "v": 0.988
+            },
+            "rightAnkle": {
+              "x": 41.4,
+              "y": 117.5,
+              "v": 0.987
+            },
+            "leftHeel": {
+              "x": 112.1,
+              "y": 43,
+              "v": 0.961
+            },
+            "rightHeel": {
+              "x": 44.6,
+              "y": 122.4,
+              "v": 0.946
+            },
+            "leftFootIndex": {
+              "x": 112.8,
+              "y": 36.7,
+              "v": 0.987
+            },
+            "rightFootIndex": {
+              "x": 31.4,
+              "y": 124.4,
+              "v": 0.961
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 45.1,
+                "y": 21.5
+              },
+              "roll": 169.1,
+              "yaw": 0.642,
+              "pitch": 0.925
+            },
+            "torso": {
+              "center": {
+                "x": 40.6,
+                "y": 34.3
+              },
+              "angle": 116.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 72.7,
+                "y": 25.5
+              },
+              "angle": 101.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 8.7,
+                "y": 43.3
+              },
+              "angle": 99.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 112.1,
+                "y": 43
+              },
+              "angle": 83.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.6,
+                "y": 122.4
+              },
+              "angle": -171.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 49.9,
+              "y": 19.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 49.4,
+              "y": 16.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 46.9,
+              "y": 16.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 47,
+              "y": 17.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 41.5,
+              "y": 17.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 55.8,
+              "y": 29.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 28.3,
+              "y": 31.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.3,
+              "y": 39.6,
+              "v": 0.975
+            },
+            "rightElbow": {
+              "x": 17.5,
+              "y": 45.3,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 79.4,
+              "y": 30,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 8.1,
+              "y": 35.5,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 81.1,
+              "y": 23.7,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 7.4,
+              "y": 29,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 57.5,
+              "y": 61.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43.1,
+              "y": 68.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 86.5,
+              "y": 53.3,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 30.2,
+              "y": 91.8,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 111.5,
+              "y": 50.7,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 28.6,
+              "y": 115.9,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 114.4,
+              "y": 53.7,
+              "v": 0.992
+            },
+            "rightHeel": {
+              "x": 30.9,
+              "y": 119.7,
+              "v": 0.974
+            },
+            "leftFootIndex": {
+              "x": 118.6,
+              "y": 47.3,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 21.7,
+              "y": 123,
+              "v": 0.99
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 48.2,
+                "y": 16.9
+              },
+              "roll": -177.7,
+              "yaw": 0.699,
+              "pitch": 1.059
+            },
+            "torso": {
+              "center": {
+                "x": 42.1,
+                "y": 30.7
+              },
+              "angle": 103.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 79.4,
+                "y": 30
+              },
+              "angle": 74.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 8.1,
+                "y": 35.5
+              },
+              "angle": 96.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 114.4,
+                "y": 53.7
+              },
+              "angle": 56.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.9,
+                "y": 119.7
+              },
+              "angle": -160.3
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 43.5,
+              "y": 18.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 41.9,
+              "y": 16.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 40.7,
+              "y": 16.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 38.3,
+              "y": 17.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 35.6,
+              "y": 17.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 49.3,
+              "y": 27.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 23.8,
+              "y": 32.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 65,
+              "y": 35.8,
+              "v": 0.987
+            },
+            "rightElbow": {
+              "x": 12.2,
+              "y": 47.1,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 73,
+              "y": 25.8,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 13.9,
+              "y": 44.6,
+              "v": 0.992
+            },
+            "leftIndex": {
+              "x": 74.4,
+              "y": 19,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 15.3,
+              "y": 45.4,
+              "v": 0.986
+            },
+            "leftHip": {
+              "x": 55.9,
+              "y": 57.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 43,
+              "y": 66.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 79.1,
+              "y": 48.5,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 34,
+              "y": 92.1,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 103.9,
+              "y": 44.4,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 35,
+              "y": 116.4,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 107.1,
+              "y": 47.9,
+              "v": 0.99
+            },
+            "rightHeel": {
+              "x": 37.6,
+              "y": 120.2,
+              "v": 0.977
+            },
+            "leftFootIndex": {
+              "x": 112.9,
+              "y": 40,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 29,
+              "y": 124.7,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 41.3,
+                "y": 16.5
+              },
+              "roll": -175.2,
+              "yaw": 1.827,
+              "pitch": 1.37
+            },
+            "torso": {
+              "center": {
+                "x": 36.6,
+                "y": 30.4
+              },
+              "angle": 112.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73,
+                "y": 25.8
+              },
+              "angle": 78.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 13.9,
+                "y": 44.6
+              },
+              "angle": -29.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 107.1,
+                "y": 47.9
+              },
+              "angle": 53.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.6,
+                "y": 120.2
+              },
+              "angle": -152.4
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 74.2,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.7,
+              "y": 20.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.5,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.1,
+              "y": 21.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77,
+              "y": 34.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.8,
+              "y": 34,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.5,
+              "y": 49.2,
+              "v": 0.98
+            },
+            "rightElbow": {
+              "x": 41.1,
+              "y": 49.2,
+              "v": 0.98
+            },
+            "leftWrist": {
+              "x": 93.8,
+              "y": 38.9,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 33.9,
+              "y": 38.8,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 94.7,
+              "y": 32.4,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 32,
+              "y": 32.6,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 71.9,
+              "y": 69,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.8,
+              "y": 69.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 89.8,
+              "y": 91.1,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 44.2,
+              "y": 95.4,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 87.8,
+              "y": 114.9,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 35,
+              "y": 117.5,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 84.6,
+              "y": 118.6,
+              "v": 0.977
+            },
+            "rightHeel": {
+              "x": 35.6,
+              "y": 120.9,
+              "v": 0.964
+            },
+            "leftFootIndex": {
+              "x": 97.1,
+              "y": 120.9,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 30,
+              "y": 124.8,
+              "v": 0.994
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.6,
+                "y": 20.4
+              },
+              "roll": 164.7,
+              "yaw": 0.702,
+              "pitch": 1.359
+            },
+            "torso": {
+              "center": {
+                "x": 64.9,
+                "y": 34.5
+              },
+              "angle": 89.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.8,
+                "y": 38.9
+              },
+              "angle": 82.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.9,
+                "y": 38.8
+              },
+              "angle": 107
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 84.6,
+                "y": 118.6
+              },
+              "angle": -10.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.6,
+                "y": 120.9
+              },
+              "angle": -145.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 72.8,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.6,
+              "y": 20,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.9,
+              "y": 19.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.9,
+              "y": 20.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.1,
+              "y": 19.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.1,
+              "y": 34.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.2,
+              "y": 33.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.5,
+              "y": 48.1,
+              "v": 0.938
+            },
+            "rightElbow": {
+              "x": 41.1,
+              "y": 48.7,
+              "v": 0.984
+            },
+            "leftWrist": {
+              "x": 90.5,
+              "y": 39.5,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 33.3,
+              "y": 39.8,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 92.7,
+              "y": 32.3,
+              "v": 0.993
+            },
+            "rightIndex": {
+              "x": 30.8,
+              "y": 32.7,
+              "v": 0.995
+            },
+            "leftHip": {
+              "x": 70.5,
+              "y": 67,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57,
+              "y": 68.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 94.9,
+              "y": 69.8,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 45.7,
+              "y": 95.1,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 85.9,
+              "y": 92.2,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 36.2,
+              "y": 117.2,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 81.6,
+              "y": 94.7,
+              "v": 0.991
+            },
+            "rightHeel": {
+              "x": 35.6,
+              "y": 120,
+              "v": 0.983
+            },
+            "leftFootIndex": {
+              "x": 91.3,
+              "y": 103.2,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 32.6,
+              "y": 124.4,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.3,
+                "y": 19.7
+              },
+              "roll": 165.5,
+              "yaw": 0.556,
+              "pitch": 0.914
+            },
+            "torso": {
+              "center": {
+                "x": 63.7,
+                "y": 34.1
+              },
+              "angle": 90.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.5,
+                "y": 39.5
+              },
+              "angle": 73
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.3,
+                "y": 39.8
+              },
+              "angle": 109.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 81.6,
+                "y": 94.7
+              },
+              "angle": -41.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.6,
+                "y": 120
+              },
+              "angle": -124.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 72.7,
+              "y": 22.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.4,
+              "y": 20,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.7,
+              "y": 20,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.3,
+              "y": 20.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.1,
+              "y": 20.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 75.6,
+              "y": 34.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.9,
+              "y": 34,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.1,
+              "y": 48,
+              "v": 0.945
+            },
+            "rightElbow": {
+              "x": 41.1,
+              "y": 48.1,
+              "v": 0.982
+            },
+            "leftWrist": {
+              "x": 93.3,
+              "y": 36.6,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 32.8,
+              "y": 39.8,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 93.6,
+              "y": 30.6,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 30,
+              "y": 32.7,
+              "v": 0.994
+            },
+            "leftHip": {
+              "x": 71.5,
+              "y": 67.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.4,
+              "y": 68.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95.2,
+              "y": 71.1,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 44.8,
+              "y": 93.6,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 85.9,
+              "y": 94,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 35,
+              "y": 116,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 81.9,
+              "y": 96.6,
+              "v": 0.988
+            },
+            "rightHeel": {
+              "x": 35,
+              "y": 119.9,
+              "v": 0.987
+            },
+            "leftFootIndex": {
+              "x": 91.5,
+              "y": 105,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 30,
+              "y": 125.2,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.1,
+                "y": 20
+              },
+              "roll": -180,
+              "yaw": 0.611,
+              "pitch": 1
+            },
+            "torso": {
+              "center": {
+                "x": 64.3,
+                "y": 34.3
+              },
+              "angle": 90.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.3,
+                "y": 36.6
+              },
+              "angle": 87.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.8,
+                "y": 39.8
+              },
+              "angle": 111.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 81.9,
+                "y": 96.6
+              },
+              "angle": -41.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35,
+                "y": 119.9
+              },
+              "angle": -133.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 74.5,
+              "y": 22,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.1,
+              "y": 20.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.2,
+              "y": 19.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.4,
+              "y": 20.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.2,
+              "y": 19.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.8,
+              "y": 35.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.1,
+              "y": 34.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.1,
+              "y": 49.6,
+              "v": 0.942
+            },
+            "rightElbow": {
+              "x": 41.4,
+              "y": 49.4,
+              "v": 0.971
+            },
+            "leftWrist": {
+              "x": 95,
+              "y": 36.6,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 33,
+              "y": 39.8,
+              "v": 0.991
+            },
+            "leftIndex": {
+              "x": 95.3,
+              "y": 30.4,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 31.1,
+              "y": 32.9,
+              "v": 0.99
+            },
+            "leftHip": {
+              "x": 71.2,
+              "y": 68,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.4,
+              "y": 69.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 94.2,
+              "y": 68.5,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 43.9,
+              "y": 95.1,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 82.7,
+              "y": 91.1,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 34.5,
+              "y": 117,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 76.5,
+              "y": 93.9,
+              "v": 0.994
+            },
+            "rightHeel": {
+              "x": 34.3,
+              "y": 120.3,
+              "v": 0.987
+            },
+            "leftFootIndex": {
+              "x": 86.3,
+              "y": 102.8,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 30.4,
+              "y": 123.3,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.7,
+                "y": 19.6
+              },
+              "roll": 161,
+              "yaw": 0.603,
+              "pitch": 0.782
+            },
+            "torso": {
+              "center": {
+                "x": 65,
+                "y": 34.8
+              },
+              "angle": 88.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95,
+                "y": 36.6
+              },
+              "angle": 87.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33,
+                "y": 39.8
+              },
+              "angle": 105.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.5,
+                "y": 93.9
+              },
+              "angle": -42.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 34.3,
+                "y": 120.3
+              },
+              "angle": -142.4
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.992,
+          "keypoints": {
+            "nose": {
+              "x": 74.4,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.4,
+              "y": 20.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.8,
+              "y": 19.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.7,
+              "y": 21.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.8,
+              "y": 20,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77,
+              "y": 34.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.4,
+              "y": 33.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86,
+              "y": 48.4,
+              "v": 0.936
+            },
+            "rightElbow": {
+              "x": 42.6,
+              "y": 48.8,
+              "v": 0.964
+            },
+            "leftWrist": {
+              "x": 92.4,
+              "y": 38.5,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 35.1,
+              "y": 38.9,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 94.6,
+              "y": 31.2,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 32.9,
+              "y": 32.5,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 72.2,
+              "y": 67.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.8,
+              "y": 68.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 94,
+              "y": 68.4,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 45.7,
+              "y": 92.3,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 83.7,
+              "y": 90.5,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 36.6,
+              "y": 114.5,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 78,
+              "y": 92.1,
+              "v": 0.983
+            },
+            "rightHeel": {
+              "x": 37.4,
+              "y": 118.5,
+              "v": 0.985
+            },
+            "leftFootIndex": {
+              "x": 85.9,
+              "y": 102.6,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 29.8,
+              "y": 120.6,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.1,
+                "y": 20
+              },
+              "roll": 159,
+              "yaw": 0.467,
+              "pitch": 1.041
+            },
+            "torso": {
+              "center": {
+                "x": 65.2,
+                "y": 34.3
+              },
+              "angle": 90.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92.4,
+                "y": 38.5
+              },
+              "angle": 73.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.1,
+                "y": 38.9
+              },
+              "angle": 109
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78,
+                "y": 92.1
+              },
+              "angle": -53
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.4,
+                "y": 118.5
+              },
+              "angle": -164.6
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.991,
+          "keypoints": {
+            "nose": {
+              "x": 74.4,
+              "y": 22,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.6,
+              "y": 20.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.9,
+              "y": 19.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.5,
+              "y": 21.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.5,
+              "y": 20.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.5,
+              "y": 35.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54,
+              "y": 34.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.6,
+              "y": 48.1,
+              "v": 0.865
+            },
+            "rightElbow": {
+              "x": 42,
+              "y": 49.2,
+              "v": 0.986
+            },
+            "leftWrist": {
+              "x": 93,
+              "y": 36,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 34.5,
+              "y": 38.8,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 93.4,
+              "y": 29.7,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 32.7,
+              "y": 32.2,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 72.1,
+              "y": 67.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.8,
+              "y": 69.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 93.6,
+              "y": 68.4,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 46.9,
+              "y": 94,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 82.8,
+              "y": 90.2,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 36.7,
+              "y": 115.9,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 77.8,
+              "y": 93.1,
+              "v": 0.991
+            },
+            "rightHeel": {
+              "x": 36.5,
+              "y": 118.4,
+              "v": 0.987
+            },
+            "leftFootIndex": {
+              "x": 87,
+              "y": 101.3,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 31.2,
+              "y": 124.2,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.3,
+                "y": 19.9
+              },
+              "roll": 161.6,
+              "yaw": 0.755,
+              "pitch": 0.755
+            },
+            "torso": {
+              "center": {
+                "x": 65.3,
+                "y": 35
+              },
+              "angle": 90.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93,
+                "y": 36
+              },
+              "angle": 86.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.5,
+                "y": 38.8
+              },
+              "angle": 105.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 77.8,
+                "y": 93.1
+              },
+              "angle": -41.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.5,
+                "y": 118.4
+              },
+              "angle": -132.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.989,
+          "keypoints": {
+            "nose": {
+              "x": 75.4,
+              "y": 23.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.8,
+              "y": 21.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.1,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.2,
+              "y": 22,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.2,
+              "y": 20.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.7,
+              "y": 36.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.8,
+              "y": 35.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.9,
+              "y": 50.2,
+              "v": 0.896
+            },
+            "rightElbow": {
+              "x": 42.8,
+              "y": 49.9,
+              "v": 0.943
+            },
+            "leftWrist": {
+              "x": 94.5,
+              "y": 38.4,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 34.5,
+              "y": 40,
+              "v": 0.992
+            },
+            "leftIndex": {
+              "x": 95.1,
+              "y": 31.4,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 32.7,
+              "y": 33.5,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 71.2,
+              "y": 69.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.9,
+              "y": 70.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 94.4,
+              "y": 76.1,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 45.5,
+              "y": 94.5,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 84.2,
+              "y": 96.2,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 35.5,
+              "y": 116.6,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 78.9,
+              "y": 98.5,
+              "v": 0.987
+            },
+            "rightHeel": {
+              "x": 35.7,
+              "y": 120.3,
+              "v": 0.974
+            },
+            "leftFootIndex": {
+              "x": 89.2,
+              "y": 107.1,
+              "v": 0.992
+            },
+            "rightFootIndex": {
+              "x": 31.6,
+              "y": 124.1,
+              "v": 0.994
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.4,
+                "y": 20.8
+              },
+              "roll": 159.7,
+              "yaw": 0.677,
+              "pitch": 0.834
+            },
+            "torso": {
+              "center": {
+                "x": 65.3,
+                "y": 35.9
+              },
+              "angle": 88.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.5,
+                "y": 38.4
+              },
+              "angle": 85.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.5,
+                "y": 40
+              },
+              "angle": 105.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.9,
+                "y": 98.5
+              },
+              "angle": -39.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.7,
+                "y": 120.3
+              },
+              "angle": -137.2
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.974,
+          "keypoints": {
+            "nose": {
+              "x": 74.4,
+              "y": 29.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 76.4,
+              "y": 27,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.1,
+              "y": 25.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.8,
+              "y": 25.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 69.4,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74,
+              "y": 33.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.1,
+              "y": 31.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 89.1,
+              "y": 37.8,
+              "v": 0.849
+            },
+            "rightElbow": {
+              "x": 37.8,
+              "y": 44.5,
+              "v": 0.976
+            },
+            "leftWrist": {
+              "x": 96.1,
+              "y": 25.2,
+              "v": 0.983
+            },
+            "rightWrist": {
+              "x": 34.8,
+              "y": 52.8,
+              "v": 0.933
+            },
+            "leftIndex": {
+              "x": 96.2,
+              "y": 19.6,
+              "v": 0.979
+            },
+            "rightIndex": {
+              "x": 35.1,
+              "y": 51.8,
+              "v": 0.915
+            },
+            "leftHip": {
+              "x": 67.5,
+              "y": 65,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.9,
+              "y": 69.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 93.7,
+              "y": 62.7,
+              "v": 0.985
+            },
+            "rightKnee": {
+              "x": 47.9,
+              "y": 96.4,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 85.1,
+              "y": 86,
+              "v": 0.955
+            },
+            "rightAnkle": {
+              "x": 34.2,
+              "y": 114.1,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 80.6,
+              "y": 88.9,
+              "v": 0.946
+            },
+            "rightHeel": {
+              "x": 31.9,
+              "y": 114.6,
+              "v": 0.937
+            },
+            "leftFootIndex": {
+              "x": 92.7,
+              "y": 94.9,
+              "v": 0.962
+            },
+            "rightFootIndex": {
+              "x": 31.9,
+              "y": 125.3,
+              "v": 0.985
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.8,
+                "y": 26.5
+              },
+              "roll": 161.6,
+              "yaw": -0.101,
+              "pitch": 0.877
+            },
+            "torso": {
+              "center": {
+                "x": 63.6,
+                "y": 32.6
+              },
+              "angle": 87.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.1,
+                "y": 25.2
+              },
+              "angle": 89
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34.8,
+                "y": 52.8
+              },
+              "angle": 73.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 80.6,
+                "y": 88.9
+              },
+              "angle": -26.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.9,
+                "y": 114.6
+              },
+              "angle": -90
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.987,
+          "keypoints": {
+            "nose": {
+              "x": 78.8,
+              "y": 27.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 79,
+              "y": 24.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 76.3,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.6,
+              "y": 24.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 71,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.7,
+              "y": 36.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.4,
+              "y": 32.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 89.4,
+              "y": 47.3,
+              "v": 0.914
+            },
+            "rightElbow": {
+              "x": 36.1,
+              "y": 48.2,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 97.9,
+              "y": 34.1,
+              "v": 0.974
+            },
+            "rightWrist": {
+              "x": 47.7,
+              "y": 36.7,
+              "v": 0.991
+            },
+            "leftIndex": {
+              "x": 98.2,
+              "y": 27.6,
+              "v": 0.948
+            },
+            "rightIndex": {
+              "x": 54.8,
+              "y": 31,
+              "v": 0.975
+            },
+            "leftHip": {
+              "x": 68.7,
+              "y": 70.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.4,
+              "y": 73.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95.1,
+              "y": 66.8,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 43.5,
+              "y": 98.3,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 87.5,
+              "y": 91.6,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 29.6,
+              "y": 114.2,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 82.2,
+              "y": 95.4,
+              "v": 0.978
+            },
+            "rightHeel": {
+              "x": 27.4,
+              "y": 115.9,
+              "v": 0.96
+            },
+            "leftFootIndex": {
+              "x": 93.3,
+              "y": 103.9,
+              "v": 0.99
+            },
+            "rightFootIndex": {
+              "x": 26.9,
+              "y": 126.1,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 77.7,
+                "y": 24
+              },
+              "roll": 167.5,
+              "yaw": 0.416,
+              "pitch": 1.302
+            },
+            "torso": {
+              "center": {
+                "x": 65.1,
+                "y": 34.4
+              },
+              "angle": 86.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.9,
+                "y": 34.1
+              },
+              "angle": 87.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 47.7,
+                "y": 36.7
+              },
+              "angle": 38.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 82.2,
+                "y": 95.4
+              },
+              "angle": -37.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 27.4,
+                "y": 115.9
+              },
+              "angle": -92.8
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 75.6,
+              "y": 26.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 78.1,
+              "y": 23.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.3,
+              "y": 21.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 77.5,
+              "y": 23.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 69.1,
+              "y": 21,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78.4,
+              "y": 37,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.8,
+              "y": 30.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.2,
+              "y": 53.6,
+              "v": 0.991
+            },
+            "rightElbow": {
+              "x": 38.7,
+              "y": 43.6,
+              "v": 0.994
+            },
+            "leftWrist": {
+              "x": 94.7,
+              "y": 52.3,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 33,
+              "y": 56.2,
+              "v": 0.982
+            },
+            "leftIndex": {
+              "x": 99.4,
+              "y": 48.2,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 30.7,
+              "y": 59.9,
+              "v": 0.974
+            },
+            "leftHip": {
+              "x": 67.9,
+              "y": 69.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52,
+              "y": 69.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.8,
+              "y": 89.9,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 38.6,
+              "y": 94.9,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 83.4,
+              "y": 113.6,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 29.9,
+              "y": 116.4,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 79.8,
+              "y": 118.2,
+              "v": 0.991
+            },
+            "rightHeel": {
+              "x": 31.1,
+              "y": 119.8,
+              "v": 0.982
+            },
+            "leftFootIndex": {
+              "x": 91.5,
+              "y": 120.9,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 24.6,
+              "y": 125.4,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 75.7,
+                "y": 22.8
+              },
+              "roll": 160.5,
+              "yaw": -0.02,
+              "pitch": 0.678
+            },
+            "torso": {
+              "center": {
+                "x": 66.1,
+                "y": 34
+              },
+              "angle": 80.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 94.7,
+                "y": 52.3
+              },
+              "angle": 41.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33,
+                "y": 56.2
+              },
+              "angle": -121.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 79.8,
+                "y": 118.2
+              },
+              "angle": -13
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.1,
+                "y": 119.8
+              },
+              "angle": -139.3
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.96,
+          "keypoints": {
+            "nose": {
+              "x": 55.2,
+              "y": 19.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.2,
+              "y": 16.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 52.5,
+              "y": 16.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 49.9,
+              "y": 17.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 47.3,
+              "y": 17.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 55.2,
+              "y": 32.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 35.2,
+              "y": 34.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 69.5,
+              "y": 47.5,
+              "v": 0.668
+            },
+            "rightElbow": {
+              "x": 30.2,
+              "y": 57.4,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 83.8,
+              "y": 37.2,
+              "v": 0.86
+            },
+            "rightWrist": {
+              "x": 32.5,
+              "y": 78.2,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 86.2,
+              "y": 31.2,
+              "v": 0.878
+            },
+            "rightIndex": {
+              "x": 35.8,
+              "y": 84.8,
+              "v": 0.99
+            },
+            "leftHip": {
+              "x": 62.2,
+              "y": 67.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.8,
+              "y": 68.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.1,
+              "y": 97.4,
+              "v": 0.863
+            },
+            "rightKnee": {
+              "x": 96.1,
+              "y": 75.7,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 46.6,
+              "y": 111.7,
+              "v": 0.935
+            },
+            "rightAnkle": {
+              "x": 82.7,
+              "y": 106.3,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 41.5,
+              "y": 113.1,
+              "v": 0.953
+            },
+            "rightHeel": {
+              "x": 77.2,
+              "y": 108.2,
+              "v": 0.988
+            },
+            "leftFootIndex": {
+              "x": 51.3,
+              "y": 124.8,
+              "v": 0.965
+            },
+            "rightFootIndex": {
+              "x": 88.6,
+              "y": 121.4,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.4,
+                "y": 16.8
+              },
+              "roll": -176.6,
+              "yaw": 1.086,
+              "pitch": 1.732
+            },
+            "torso": {
+              "center": {
+                "x": 45.2,
+                "y": 33.7
+              },
+              "angle": 113.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 83.8,
+                "y": 37.2
+              },
+              "angle": 68.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.5,
+                "y": 78.2
+              },
+              "angle": -63.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 41.5,
+                "y": 113.1
+              },
+              "angle": -50.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 77.2,
+                "y": 108.2
+              },
+              "angle": -49.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.99,
+          "keypoints": {
+            "nose": {
+              "x": 59.9,
+              "y": 24.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.2,
+              "y": 21.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 56.8,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 60.6,
+              "y": 21.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 52.7,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.9,
+              "y": 33.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 42.6,
+              "y": 33.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 72.7,
+              "y": 46.9,
+              "v": 0.84
+            },
+            "rightElbow": {
+              "x": 33.2,
+              "y": 53.2,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 83.7,
+              "y": 37.3,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 32.5,
+              "y": 72.8,
+              "v": 0.995
+            },
+            "leftIndex": {
+              "x": 85.6,
+              "y": 32,
+              "v": 0.993
+            },
+            "rightIndex": {
+              "x": 33.9,
+              "y": 79.5,
+              "v": 0.991
+            },
+            "leftHip": {
+              "x": 70,
+              "y": 63.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.8,
+              "y": 66.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 98.6,
+              "y": 75.4,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 68.4,
+              "y": 96.6,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 84.5,
+              "y": 99.8,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 46.7,
+              "y": 112.3,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 79.8,
+              "y": 99.9,
+              "v": 0.987
+            },
+            "rightHeel": {
+              "x": 41.6,
+              "y": 112.5,
+              "v": 0.997
+            },
+            "leftFootIndex": {
+              "x": 87.3,
+              "y": 113.7,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 49.8,
+              "y": 125.6,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59,
+                "y": 20.8
+              },
+              "roll": 168.4,
+              "yaw": 0.2,
+              "pitch": 0.79
+            },
+            "torso": {
+              "center": {
+                "x": 52.8,
+                "y": 33.4
+              },
+              "angle": 112
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 83.7,
+                "y": 37.3
+              },
+              "angle": 70.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.5,
+                "y": 72.8
+              },
+              "angle": -78.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 79.8,
+                "y": 99.9
+              },
+              "angle": -61.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.6,
+                "y": 112.5
+              },
+              "angle": -58
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 82.7,
+              "y": 29.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 84.7,
+              "y": 26.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 81.8,
+              "y": 25.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 82,
+              "y": 24.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 76.9,
+              "y": 23.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 80.8,
+              "y": 34.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 56,
+              "y": 28.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 88.4,
+              "y": 51.9,
+              "v": 0.976
+            },
+            "rightElbow": {
+              "x": 36.2,
+              "y": 36.3,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 100.4,
+              "y": 62.1,
+              "v": 0.986
+            },
+            "rightWrist": {
+              "x": 25.3,
+              "y": 51.1,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 107.1,
+              "y": 66,
+              "v": 0.982
+            },
+            "rightIndex": {
+              "x": 23.7,
+              "y": 57.3,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 63.1,
+              "y": 62.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.5,
+              "y": 65.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 90.7,
+              "y": 73.7,
+              "v": 0.984
+            },
+            "rightKnee": {
+              "x": 66.6,
+              "y": 88.2,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 83.2,
+              "y": 100.5,
+              "v": 0.969
+            },
+            "rightAnkle": {
+              "x": 56.9,
+              "y": 110.6,
+              "v": 0.975
+            },
+            "leftHeel": {
+              "x": 78.7,
+              "y": 103.6,
+              "v": 0.944
+            },
+            "rightHeel": {
+              "x": 53.3,
+              "y": 111.7,
+              "v": 0.851
+            },
+            "leftFootIndex": {
+              "x": 91.1,
+              "y": 112.5,
+              "v": 0.975
+            },
+            "rightFootIndex": {
+              "x": 59.4,
+              "y": 124.2,
+              "v": 0.967
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 83.3,
+                "y": 26.3
+              },
+              "roll": 161,
+              "yaw": -0.179,
+              "pitch": 1.108
+            },
+            "torso": {
+              "center": {
+                "x": 68.4,
+                "y": 31.5
+              },
+              "angle": 69.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 100.4,
+                "y": 62.1
+              },
+              "angle": -30.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 25.3,
+                "y": 51.1
+              },
+              "angle": -104.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.7,
+                "y": 103.6
+              },
+              "angle": -35.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 53.3,
+                "y": 111.7
+              },
+              "angle": -64
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 53.9,
+              "y": 16,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 51.7,
+              "y": 15.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49.6,
+              "y": 16.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 51,
+              "y": 18,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 47.5,
+              "y": 20.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.7,
+              "y": 31.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 46.4,
+              "y": 35.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.9,
+              "y": 45.6,
+              "v": 0.956
+            },
+            "rightElbow": {
+              "x": 39.2,
+              "y": 53.2,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 95.9,
+              "y": 39.6,
+              "v": 0.984
+            },
+            "rightWrist": {
+              "x": 35.4,
+              "y": 51.6,
+              "v": 0.989
+            },
+            "leftIndex": {
+              "x": 99.4,
+              "y": 35,
+              "v": 0.986
+            },
+            "rightIndex": {
+              "x": 34.4,
+              "y": 49.4,
+              "v": 0.988
+            },
+            "leftHip": {
+              "x": 76.4,
+              "y": 58.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 65.2,
+              "y": 63.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 103.1,
+              "y": 66.9,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 78.7,
+              "y": 87.1,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 93.6,
+              "y": 91.8,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 69.1,
+              "y": 108.1,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 88.9,
+              "y": 94.1,
+              "v": 0.997
+            },
+            "rightHeel": {
+              "x": 65.2,
+              "y": 109.7,
+              "v": 0.998
+            },
+            "leftFootIndex": {
+              "x": 98.5,
+              "y": 104.5,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 72.2,
+              "y": 123,
+              "v": 1
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 50.7,
+                "y": 15.8
+              },
+              "roll": -150.3,
+              "yaw": 1.344,
+              "pitch": 0.083
+            },
+            "torso": {
+              "center": {
+                "x": 56.1,
+                "y": 33.8
+              },
+              "angle": 118.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.9,
+                "y": 39.6
+              },
+              "angle": 52.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.4,
+                "y": 51.6
+              },
+              "angle": 114.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 88.9,
+                "y": 94.1
+              },
+              "angle": -47.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 65.2,
+                "y": 109.7
+              },
+              "angle": -62.2
+            }
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 73.2,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72.4,
+              "y": 16.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.9,
+              "y": 16.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.8,
+              "y": 17.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.3,
+              "y": 17.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.9,
+              "y": 31.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.8,
+              "y": 30.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.1,
+              "y": 43.4,
+              "v": 0.924
+            },
+            "rightElbow": {
+              "x": 43.8,
+              "y": 45.7,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 91.6,
+              "y": 30.6,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 35.7,
+              "y": 35.5,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 92.3,
+              "y": 24.3,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 34.2,
+              "y": 28.6,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 72.2,
+              "y": 63.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.1,
+              "y": 66.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95.5,
+              "y": 62.4,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 54.9,
+              "y": 93.3,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 86.2,
+              "y": 85.3,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 45.6,
+              "y": 118.1,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 81.4,
+              "y": 86.9,
+              "v": 0.993
+            },
+            "rightHeel": {
+              "x": 42.4,
+              "y": 121.2,
+              "v": 0.991
+            },
+            "leftFootIndex": {
+              "x": 89,
+              "y": 97.3,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 46,
+              "y": 125,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.2,
+                "y": 16.3
+              },
+              "roll": 177.7,
+              "yaw": 0.819,
+              "pitch": 0.819
+            },
+            "torso": {
+              "center": {
+                "x": 64.4,
+                "y": 31
+              },
+              "angle": 93.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.6,
+                "y": 30.6
+              },
+              "angle": 83.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.7,
+                "y": 35.5
+              },
+              "angle": 102.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 81.4,
+                "y": 86.9
+              },
+              "angle": -53.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 42.4,
+                "y": 121.2
+              },
+              "angle": -46.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 72.8,
+              "y": 20.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73,
+              "y": 17.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.5,
+              "y": 17,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.3,
+              "y": 17.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66,
+              "y": 17.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.6,
+              "y": 31,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.8,
+              "y": 30.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.6,
+              "y": 42.8,
+              "v": 0.882
+            },
+            "rightElbow": {
+              "x": 44.1,
+              "y": 44.8,
+              "v": 0.993
+            },
+            "leftWrist": {
+              "x": 90.9,
+              "y": 29.8,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 36.3,
+              "y": 34.8,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 91.6,
+              "y": 24.1,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 34.2,
+              "y": 28.5,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 72.3,
+              "y": 63,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.5,
+              "y": 66.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 94.9,
+              "y": 62,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 55,
+              "y": 92.6,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 86.4,
+              "y": 83.8,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 46.5,
+              "y": 115.7,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 81.5,
+              "y": 86.4,
+              "v": 0.991
+            },
+            "rightHeel": {
+              "x": 44.1,
+              "y": 118,
+              "v": 0.989
+            },
+            "leftFootIndex": {
+              "x": 89.2,
+              "y": 95.6,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 46.7,
+              "y": 124.5,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.8,
+                "y": 17.3
+              },
+              "roll": 166.5,
+              "yaw": 0.408,
+              "pitch": 1.089
+            },
+            "torso": {
+              "center": {
+                "x": 64.2,
+                "y": 30.9
+              },
+              "angle": 93.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.9,
+                "y": 29.8
+              },
+              "angle": 83
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.3,
+                "y": 34.8
+              },
+              "angle": 108.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 81.5,
+                "y": 86.4
+              },
+              "angle": -50.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.1,
+                "y": 118
+              },
+              "angle": -68.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.987,
+          "keypoints": {
+            "nose": {
+              "x": 74.6,
+              "y": 22.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.9,
+              "y": 19.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 72.7,
+              "y": 19.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.8,
+              "y": 19.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.8,
+              "y": 19.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76,
+              "y": 33.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.6,
+              "y": 32.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.2,
+              "y": 46.6,
+              "v": 0.888
+            },
+            "rightElbow": {
+              "x": 42.3,
+              "y": 47.6,
+              "v": 0.957
+            },
+            "leftWrist": {
+              "x": 93.8,
+              "y": 35.1,
+              "v": 0.988
+            },
+            "rightWrist": {
+              "x": 33.3,
+              "y": 36.9,
+              "v": 0.981
+            },
+            "leftIndex": {
+              "x": 94.4,
+              "y": 29.3,
+              "v": 0.982
+            },
+            "rightIndex": {
+              "x": 31.4,
+              "y": 30.7,
+              "v": 0.976
+            },
+            "leftHip": {
+              "x": 71.7,
+              "y": 67.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.2,
+              "y": 69.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 96.1,
+              "y": 68.2,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 48.5,
+              "y": 95.6,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 86.7,
+              "y": 90.9,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 40.5,
+              "y": 116.8,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 82.4,
+              "y": 92.6,
+              "v": 0.984
+            },
+            "rightHeel": {
+              "x": 40.1,
+              "y": 119.5,
+              "v": 0.968
+            },
+            "leftFootIndex": {
+              "x": 89.4,
+              "y": 102.8,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 36.8,
+              "y": 124.9,
+              "v": 0.994
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.3,
+                "y": 19.5
+              },
+              "roll": 166,
+              "yaw": 1.051,
+              "pitch": 2.142
+            },
+            "torso": {
+              "center": {
+                "x": 64.8,
+                "y": 33
+              },
+              "angle": 91.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.8,
+                "y": 35.1
+              },
+              "angle": 84.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.3,
+                "y": 36.9
+              },
+              "angle": 107
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 82.4,
+                "y": 92.6
+              },
+              "angle": -55.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.1,
+                "y": 119.5
+              },
+              "angle": -121.4
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.991,
+          "keypoints": {
+            "nose": {
+              "x": 73.4,
+              "y": 21.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.3,
+              "y": 19.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.6,
+              "y": 18.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 73.4,
+              "y": 20.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 65.8,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.9,
+              "y": 34.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54,
+              "y": 33.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 86.7,
+              "y": 47.5,
+              "v": 0.953
+            },
+            "rightElbow": {
+              "x": 42,
+              "y": 48.4,
+              "v": 0.97
+            },
+            "leftWrist": {
+              "x": 95.5,
+              "y": 35.5,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 33.6,
+              "y": 38.4,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 95.7,
+              "y": 29.4,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 31.5,
+              "y": 31.5,
+              "v": 0.992
+            },
+            "leftHip": {
+              "x": 71.4,
+              "y": 67.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.8,
+              "y": 68.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95.7,
+              "y": 73.8,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 44.9,
+              "y": 93.9,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 84.5,
+              "y": 94.3,
+              "v": 0.982
+            },
+            "rightAnkle": {
+              "x": 35.1,
+              "y": 118.4,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 79.2,
+              "y": 95.1,
+              "v": 0.964
+            },
+            "rightHeel": {
+              "x": 35.5,
+              "y": 121.8,
+              "v": 0.984
+            },
+            "leftFootIndex": {
+              "x": 84.8,
+              "y": 106.9,
+              "v": 0.978
+            },
+            "rightFootIndex": {
+              "x": 29.2,
+              "y": 123.9,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.4,
+                "y": 19
+              },
+              "roll": 160.6,
+              "yaw": 0.242,
+              "pitch": 0.676
+            },
+            "torso": {
+              "center": {
+                "x": 65.5,
+                "y": 33.8
+              },
+              "angle": 88.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.5,
+                "y": 35.5
+              },
+              "angle": 88.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.6,
+                "y": 38.4
+              },
+              "angle": 106.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 79.2,
+                "y": 95.1
+              },
+              "angle": -64.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.5,
+                "y": 121.8
+              },
+              "angle": -161.6
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 80.5,
+              "y": 25.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 81.9,
+              "y": 22.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 78.1,
+              "y": 21,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 80.5,
+              "y": 22.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 73.7,
+              "y": 20.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 79.1,
+              "y": 36.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.6,
+              "y": 30.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.2,
+              "y": 52.3,
+              "v": 0.97
+            },
+            "rightElbow": {
+              "x": 39.5,
+              "y": 45.1,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 96.5,
+              "y": 52.7,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 31,
+              "y": 61.5,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 101.4,
+              "y": 49,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 30.5,
+              "y": 67.7,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 63.9,
+              "y": 66.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.8,
+              "y": 67.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 84.5,
+              "y": 86.7,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 38.2,
+              "y": 93.7,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74.1,
+              "y": 108.3,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 28,
+              "y": 114.7,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 69.6,
+              "y": 112.1,
+              "v": 0.992
+            },
+            "rightHeel": {
+              "x": 26.6,
+              "y": 117.6,
+              "v": 0.973
+            },
+            "leftFootIndex": {
+              "x": 85.5,
+              "y": 115.7,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 25,
+              "y": 124.9,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 80,
+                "y": 21.6
+              },
+              "roll": 163.9,
+              "yaw": 0.126,
+              "pitch": 1.024
+            },
+            "torso": {
+              "center": {
+                "x": 67.4,
+                "y": 33.2
+              },
+              "angle": 72.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.5,
+                "y": 52.7
+              },
+              "angle": 37.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31,
+                "y": 61.5
+              },
+              "angle": -94.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 69.6,
+                "y": 112.1
+              },
+              "angle": -12.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 26.6,
+                "y": 117.6
+              },
+              "angle": -102.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 93.4,
+              "y": 32.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 94.9,
+              "y": 28.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 93.3,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 91.6,
+              "y": 26.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 87.6,
+              "y": 25.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 85.5,
+              "y": 38.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 65.8,
+              "y": 28.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82,
+              "y": 54.7,
+              "v": 0.929
+            },
+            "rightElbow": {
+              "x": 45.1,
+              "y": 38.8,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 97.1,
+              "y": 60.9,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 32.6,
+              "y": 55.4,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 103.9,
+              "y": 60.2,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 30.7,
+              "y": 61.3,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 63,
+              "y": 65.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.4,
+              "y": 64.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 88.2,
+              "y": 84.3,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 41,
+              "y": 92.8,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 75.1,
+              "y": 108.6,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 24.6,
+              "y": 113.5,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 70.3,
+              "y": 112.6,
+              "v": 0.996
+            },
+            "rightHeel": {
+              "x": 20.6,
+              "y": 115.8,
+              "v": 0.988
+            },
+            "leftFootIndex": {
+              "x": 88,
+              "y": 114.9,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 24.2,
+              "y": 125.7,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 94.1,
+                "y": 28.3
+              },
+              "roll": 166,
+              "yaw": -0.424,
+              "pitch": 2.425
+            },
+            "torso": {
+              "center": {
+                "x": 75.7,
+                "y": 33.2
+              },
+              "angle": 59.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.1,
+                "y": 60.9
+              },
+              "angle": 5.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.6,
+                "y": 55.4
+              },
+              "angle": -107.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 70.3,
+                "y": 112.6
+              },
+              "angle": -7.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 20.6,
+                "y": 115.8
+              },
+              "angle": -70
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.582,
+          "keypoints": {
+            "nose": {
+              "x": 71.9,
+              "y": 40.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.7,
+              "y": 39.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.8,
+              "y": 37.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 76,
+              "y": 40,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.2,
+              "y": 35.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76,
+              "y": 47.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60,
+              "y": 41,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.6,
+              "y": 55.1,
+              "v": 0.619
+            },
+            "rightElbow": {
+              "x": 53.8,
+              "y": 49,
+              "v": 0.165
+            },
+            "leftWrist": {
+              "x": 93.5,
+              "y": 57.3,
+              "v": 0.518
+            },
+            "rightWrist": {
+              "x": 47,
+              "y": 46,
+              "v": 0.175
+            },
+            "leftIndex": {
+              "x": 96.2,
+              "y": 56.6,
+              "v": 0.557
+            },
+            "rightIndex": {
+              "x": 44.4,
+              "y": 43.7,
+              "v": 0.199
+            },
+            "leftHip": {
+              "x": 61.3,
+              "y": 67.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.7,
+              "y": 62.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 50.4,
+              "y": 83.3,
+              "v": 0.142
+            },
+            "rightKnee": {
+              "x": 44.4,
+              "y": 72.9,
+              "v": 0.126
+            },
+            "leftAnkle": {
+              "x": 38.5,
+              "y": 93.1,
+              "v": 0.326
+            },
+            "rightAnkle": {
+              "x": 37.6,
+              "y": 90.3,
+              "v": 0.29
+            },
+            "leftHeel": {
+              "x": 36.4,
+              "y": 94,
+              "v": 0.31
+            },
+            "rightHeel": {
+              "x": 37.6,
+              "y": 93.5,
+              "v": 0.3
+            },
+            "leftFootIndex": {
+              "x": 34.7,
+              "y": 97.7,
+              "v": 0.373
+            },
+            "rightFootIndex": {
+              "x": 32.5,
+              "y": 95,
+              "v": 0.296
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.8,
+                "y": 38.3
+              },
+              "roll": 151.7,
+              "yaw": -0.192,
+              "pitch": 0.508
+            },
+            "torso": {
+              "center": {
+                "x": 68,
+                "y": 44.1
+              },
+              "angle": 63.3
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.5,
+                "y": 57.3
+              },
+              "angle": 14.5
+            },
+            "rightHand": null,
+            "leftFoot": {
+              "anchor": {
+                "x": 36.4,
+                "y": 94
+              },
+              "angle": -114.7
+            },
+            "rightFoot": null
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.975,
+          "keypoints": {
+            "nose": {
+              "x": 76.4,
+              "y": 23.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.3,
+              "y": 20.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 73.9,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.1,
+              "y": 21,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.8,
+              "y": 20.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.6,
+              "y": 34.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54,
+              "y": 34.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.5,
+              "y": 49.7,
+              "v": 0.833
+            },
+            "rightElbow": {
+              "x": 42.3,
+              "y": 50.2,
+              "v": 0.973
+            },
+            "leftWrist": {
+              "x": 92.9,
+              "y": 36.5,
+              "v": 0.978
+            },
+            "rightWrist": {
+              "x": 32.7,
+              "y": 38.9,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 92.8,
+              "y": 30.5,
+              "v": 0.978
+            },
+            "rightIndex": {
+              "x": 31.2,
+              "y": 32.5,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 72.6,
+              "y": 68.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.9,
+              "y": 70.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 96,
+              "y": 64.3,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 46.9,
+              "y": 95.6,
+              "v": 0.993
+            },
+            "leftAnkle": {
+              "x": 81.2,
+              "y": 83.4,
+              "v": 0.928
+            },
+            "rightAnkle": {
+              "x": 35.8,
+              "y": 119.4,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 76.1,
+              "y": 83.7,
+              "v": 0.898
+            },
+            "rightHeel": {
+              "x": 35,
+              "y": 122.3,
+              "v": 0.935
+            },
+            "leftFootIndex": {
+              "x": 80.3,
+              "y": 95.9,
+              "v": 0.936
+            },
+            "rightFootIndex": {
+              "x": 32.2,
+              "y": 126,
+              "v": 0.981
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 74.6,
+                "y": 20.5
+              },
+              "roll": 164.1,
+              "yaw": 1.236,
+              "pitch": 1.923
+            },
+            "torso": {
+              "center": {
+                "x": 65.8,
+                "y": 34.6
+              },
+              "angle": 89.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92.9,
+                "y": 36.5
+              },
+              "angle": 91
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 32.7,
+                "y": 38.9
+              },
+              "angle": 103.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.1,
+                "y": 83.7
+              },
+              "angle": -71
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35,
+                "y": 122.3
+              },
+              "angle": -127.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 74.4,
+              "y": 21.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 74.4,
+              "y": 18.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.1,
+              "y": 17.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.8,
+              "y": 19.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.4,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.2,
+              "y": 33.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.3,
+              "y": 32.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 85.7,
+              "y": 48.1,
+              "v": 0.883
+            },
+            "rightElbow": {
+              "x": 43,
+              "y": 46.7,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 93.1,
+              "y": 34.9,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 35.5,
+              "y": 36.4,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 93.8,
+              "y": 28.9,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 33.6,
+              "y": 30.5,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 72.3,
+              "y": 65.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.1,
+              "y": 67.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95.4,
+              "y": 64.4,
+              "v": 1
+            },
+            "rightKnee": {
+              "x": 46.2,
+              "y": 93.2,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 80.4,
+              "y": 83,
+              "v": 0.996
+            },
+            "rightAnkle": {
+              "x": 36.3,
+              "y": 116.2,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 75.5,
+              "y": 84.2,
+              "v": 0.991
+            },
+            "rightHeel": {
+              "x": 36.5,
+              "y": 118.6,
+              "v": 0.996
+            },
+            "leftFootIndex": {
+              "x": 79.9,
+              "y": 95.1,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 31.1,
+              "y": 119.6,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.8,
+                "y": 18.2
+              },
+              "roll": 160,
+              "yaw": 0.47,
+              "pitch": 0.883
+            },
+            "torso": {
+              "center": {
+                "x": 65.8,
+                "y": 33.1
+              },
+              "angle": 89.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 93.1,
+                "y": 34.9
+              },
+              "angle": 83.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 35.5,
+                "y": 36.4
+              },
+              "angle": 107.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 75.5,
+                "y": 84.2
+              },
+              "angle": -68
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.5,
+                "y": 118.6
+              },
+              "angle": -169.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 74.1,
+              "y": 22,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.7,
+              "y": 19.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.9,
+              "y": 18.8,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 71.4,
+              "y": 19.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 67.4,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.3,
+              "y": 32.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.4,
+              "y": 31,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.8,
+              "y": 45.2,
+              "v": 0.97
+            },
+            "rightElbow": {
+              "x": 43.3,
+              "y": 44.4,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 89.7,
+              "y": 33.1,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 36.8,
+              "y": 34.1,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 90.2,
+              "y": 27.9,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 35.7,
+              "y": 28,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 65.7,
+              "y": 65.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.6,
+              "y": 64.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 58.1,
+              "y": 91.5,
+              "v": 0.996
+            },
+            "rightKnee": {
+              "x": 89.6,
+              "y": 59.6,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 46.7,
+              "y": 113.6,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 81,
+              "y": 80.3,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 44.3,
+              "y": 112.5,
+              "v": 0.999
+            },
+            "rightHeel": {
+              "x": 75.5,
+              "y": 81.6,
+              "v": 0.982
+            },
+            "leftFootIndex": {
+              "x": 48.6,
+              "y": 123.4,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 82,
+              "y": 92.6,
+              "v": 0.991
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72.8,
+                "y": 19.1
+              },
+              "roll": 164.5,
+              "yaw": 0.696,
+              "pitch": 1.579
+            },
+            "torso": {
+              "center": {
+                "x": 63.9,
+                "y": 31.8
+              },
+              "angle": 90.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.7,
+                "y": 33.1
+              },
+              "angle": 84.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.8,
+                "y": 34.1
+              },
+              "angle": 100.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 44.3,
+                "y": 112.5
+              },
+              "angle": -68.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 75.5,
+                "y": 81.6
+              },
+              "angle": -59.4
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/public/assets/fighters/sun/poses.json
+++ b/public/assets/fighters/sun/poses.json
@@ -1,0 +1,8474 @@
+{
+  "version": 1,
+  "fighter": "sun",
+  "frameSize": 128,
+  "model": "mediapipe-pose-blazepose-ghum-heavy",
+  "generatedAt": "2026-04-16T20:41:10.870Z",
+  "animations": {
+    "idle": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 66.6,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.6,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64,
+              "y": 10,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.8,
+              "y": 11.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.2,
+              "y": 24.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.3,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.9,
+              "y": 40.6,
+              "v": 0.984
+            },
+            "rightElbow": {
+              "x": 46.8,
+              "y": 38.2,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 86.9,
+              "y": 51.1,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 43.5,
+              "y": 51.2,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 88.8,
+              "y": 54.2,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 43.6,
+              "y": 56.9,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 72.5,
+              "y": 57.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.8,
+              "y": 57.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.8,
+              "y": 84,
+              "v": 0.982
+            },
+            "rightKnee": {
+              "x": 52.9,
+              "y": 85.1,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74.8,
+              "y": 107.8,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 45.8,
+              "y": 112.7,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 71.9,
+              "y": 113.8,
+              "v": 0.974
+            },
+            "rightHeel": {
+              "x": 45,
+              "y": 116.1,
+              "v": 0.979
+            },
+            "leftFootIndex": {
+              "x": 84.2,
+              "y": 113.8,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 46.6,
+              "y": 124.1,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.3,
+                "y": 10.6
+              },
+              "roll": 166.6,
+              "yaw": 0.063,
+              "pitch": 0.539
+            },
+            "torso": {
+              "center": {
+                "x": 64.3,
+                "y": 24.1
+              },
+              "angle": 93.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.9,
+                "y": 51.1
+              },
+              "angle": -58.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.5,
+                "y": 51.2
+              },
+              "angle": -89
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.9,
+                "y": 113.8
+              },
+              "angle": 0
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 45,
+                "y": 116.1
+              },
+              "angle": -78.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 65.1,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 67.7,
+              "y": 9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.2,
+              "y": 8.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.2,
+              "y": 10.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.5,
+              "y": 9.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.9,
+              "y": 23.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.2,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.7,
+              "y": 39.8,
+              "v": 0.991
+            },
+            "rightElbow": {
+              "x": 45.8,
+              "y": 39.1,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 86.9,
+              "y": 50.9,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 43.4,
+              "y": 53.4,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 88.8,
+              "y": 54.7,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 44.1,
+              "y": 58.5,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 72.3,
+              "y": 57.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.5,
+              "y": 57.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.2,
+              "y": 83.8,
+              "v": 0.974
+            },
+            "rightKnee": {
+              "x": 52.7,
+              "y": 85.1,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 74.5,
+              "y": 108.3,
+              "v": 0.991
+            },
+            "rightAnkle": {
+              "x": 44.7,
+              "y": 114.2,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 71.9,
+              "y": 113.7,
+              "v": 0.954
+            },
+            "rightHeel": {
+              "x": 43.5,
+              "y": 118.4,
+              "v": 0.969
+            },
+            "leftFootIndex": {
+              "x": 84.1,
+              "y": 114.1,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 46.5,
+              "y": 123.3,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.5,
+                "y": 8.6
+              },
+              "roll": 169.9,
+              "yaw": -0.077,
+              "pitch": 0.438
+            },
+            "torso": {
+              "center": {
+                "x": 64.1,
+                "y": 23.5
+              },
+              "angle": 93.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.9,
+                "y": 50.9
+              },
+              "angle": -63.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.4,
+                "y": 53.4
+              },
+              "angle": -82.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.9,
+                "y": 113.7
+              },
+              "angle": -1.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.5,
+                "y": 118.4
+              },
+              "angle": -58.5
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.989,
+          "keypoints": {
+            "nose": {
+              "x": 65.3,
+              "y": 11.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.1,
+              "y": 10.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.5,
+              "y": 9.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.2,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.9,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.7,
+              "y": 24,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.6,
+              "y": 23.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80,
+              "y": 39.9,
+              "v": 0.972
+            },
+            "rightElbow": {
+              "x": 46.5,
+              "y": 38.6,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 87.2,
+              "y": 50.8,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 43.3,
+              "y": 53.3,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 89.5,
+              "y": 54.5,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 44.3,
+              "y": 57.9,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 73,
+              "y": 58.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.1,
+              "y": 58.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74,
+              "y": 83.6,
+              "v": 0.944
+            },
+            "rightKnee": {
+              "x": 53.4,
+              "y": 85.5,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 74.3,
+              "y": 108,
+              "v": 0.985
+            },
+            "rightAnkle": {
+              "x": 45.6,
+              "y": 112.9,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 71.7,
+              "y": 113.3,
+              "v": 0.933
+            },
+            "rightHeel": {
+              "x": 44.4,
+              "y": 117,
+              "v": 0.95
+            },
+            "leftFootIndex": {
+              "x": 84.4,
+              "y": 114.3,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 46.7,
+              "y": 122.9,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.8,
+                "y": 9.6
+              },
+              "roll": 167.7,
+              "yaw": -0.106,
+              "pitch": 0.467
+            },
+            "torso": {
+              "center": {
+                "x": 64.7,
+                "y": 23.6
+              },
+              "angle": 93.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.2,
+                "y": 50.8
+              },
+              "angle": -58.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.3,
+                "y": 53.3
+              },
+              "angle": -77.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.7,
+                "y": 113.3
+              },
+              "angle": -4.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.4,
+                "y": 117
+              },
+              "angle": -68.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 67,
+              "y": 13,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.3,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.3,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.5,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.1,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.8,
+              "y": 24.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.9,
+              "y": 24.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.1,
+              "y": 40.7,
+              "v": 0.994
+            },
+            "rightElbow": {
+              "x": 46.1,
+              "y": 40,
+              "v": 0.994
+            },
+            "leftWrist": {
+              "x": 87.5,
+              "y": 52,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 43.8,
+              "y": 53.6,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 89.6,
+              "y": 55.4,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 44.6,
+              "y": 57.8,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 72.8,
+              "y": 58.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.1,
+              "y": 57.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.2,
+              "y": 84.1,
+              "v": 0.977
+            },
+            "rightKnee": {
+              "x": 53.6,
+              "y": 84.9,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74.5,
+              "y": 107.7,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 45.3,
+              "y": 113.1,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 71.8,
+              "y": 112.5,
+              "v": 0.949
+            },
+            "rightHeel": {
+              "x": 44.1,
+              "y": 117.6,
+              "v": 0.975
+            },
+            "leftFootIndex": {
+              "x": 83,
+              "y": 114.6,
+              "v": 0.992
+            },
+            "rightFootIndex": {
+              "x": 47.2,
+              "y": 122.5,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.8,
+                "y": 10.4
+              },
+              "roll": 168.7,
+              "yaw": 0.039,
+              "pitch": 0.51
+            },
+            "torso": {
+              "center": {
+                "x": 64.9,
+                "y": 24.4
+              },
+              "angle": 92.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.5,
+                "y": 52
+              },
+              "angle": -58.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.8,
+                "y": 53.6
+              },
+              "angle": -79.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.8,
+                "y": 112.5
+              },
+              "angle": -10.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.1,
+                "y": 117.6
+              },
+              "angle": -57.7
+            }
+          }
+        }
+      ]
+    },
+    "walk": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 67.5,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.1,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.9,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.3,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.6,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.4,
+              "y": 24.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.5,
+              "y": 24,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.7,
+              "y": 40.3,
+              "v": 0.995
+            },
+            "rightElbow": {
+              "x": 46.8,
+              "y": 38.4,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 87.5,
+              "y": 51.1,
+              "v": 1
+            },
+            "rightWrist": {
+              "x": 44.3,
+              "y": 52.2,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 89,
+              "y": 55.1,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 44.6,
+              "y": 57.1,
+              "v": 0.995
+            },
+            "leftHip": {
+              "x": 72.4,
+              "y": 57.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.9,
+              "y": 58,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.9,
+              "y": 83.8,
+              "v": 0.982
+            },
+            "rightKnee": {
+              "x": 53.4,
+              "y": 84.9,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74.7,
+              "y": 107.9,
+              "v": 0.992
+            },
+            "rightAnkle": {
+              "x": 45.2,
+              "y": 112.7,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 71.7,
+              "y": 113.2,
+              "v": 0.963
+            },
+            "rightHeel": {
+              "x": 44.1,
+              "y": 117.1,
+              "v": 0.976
+            },
+            "leftFootIndex": {
+              "x": 84.2,
+              "y": 114,
+              "v": 0.994
+            },
+            "rightFootIndex": {
+              "x": 47.4,
+              "y": 122.5,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67,
+                "y": 10.4
+              },
+              "roll": 173.2,
+              "yaw": 0.118,
+              "pitch": 0.674
+            },
+            "torso": {
+              "center": {
+                "x": 64.5,
+                "y": 24.3
+              },
+              "angle": 92.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.5,
+                "y": 51.1
+              },
+              "angle": -69.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.3,
+                "y": 52.2
+              },
+              "angle": -86.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.7,
+                "y": 113.2
+              },
+              "angle": -3.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.1,
+                "y": 117.1
+              },
+              "angle": -58.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 68.1,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.8,
+              "y": 11,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 65.3,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.1,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.4,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.4,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 53.9,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.5,
+              "y": 39.8,
+              "v": 0.99
+            },
+            "rightElbow": {
+              "x": 45.2,
+              "y": 39.7,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 85.9,
+              "y": 50.8,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 43.2,
+              "y": 54.4,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 88.2,
+              "y": 54.7,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 43.7,
+              "y": 58.3,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 71.8,
+              "y": 57.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.2,
+              "y": 57.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.1,
+              "y": 83.9,
+              "v": 0.983
+            },
+            "rightKnee": {
+              "x": 52.5,
+              "y": 85,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74.5,
+              "y": 108.3,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 44.3,
+              "y": 113,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 71.9,
+              "y": 113.6,
+              "v": 0.97
+            },
+            "rightHeel": {
+              "x": 43.3,
+              "y": 117.3,
+              "v": 0.98
+            },
+            "leftFootIndex": {
+              "x": 84,
+              "y": 114,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 45.8,
+              "y": 122.9,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.1,
+                "y": 10.7
+              },
+              "roll": 168.7,
+              "yaw": 0.294,
+              "pitch": 0.855
+            },
+            "torso": {
+              "center": {
+                "x": 63.7,
+                "y": 23.8
+              },
+              "angle": 93.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.9,
+                "y": 50.8
+              },
+              "angle": -59.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.2,
+                "y": 54.4
+              },
+              "angle": -82.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.9,
+                "y": 113.6
+              },
+              "angle": -1.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.3,
+                "y": 117.3
+              },
+              "angle": -65.9
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 67.4,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.6,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.7,
+              "y": 9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.7,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.6,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.8,
+              "y": 24.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.9,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80,
+              "y": 39.7,
+              "v": 0.991
+            },
+            "rightElbow": {
+              "x": 47,
+              "y": 38.8,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 87.6,
+              "y": 51.2,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 44.4,
+              "y": 53.7,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 89.3,
+              "y": 55.1,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 44.9,
+              "y": 58.1,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 73.4,
+              "y": 57.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.8,
+              "y": 57.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.4,
+              "y": 84.2,
+              "v": 0.971
+            },
+            "rightKnee": {
+              "x": 53.8,
+              "y": 84.8,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 75.8,
+              "y": 108.9,
+              "v": 0.989
+            },
+            "rightAnkle": {
+              "x": 45.4,
+              "y": 113.1,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 73.3,
+              "y": 114,
+              "v": 0.957
+            },
+            "rightHeel": {
+              "x": 44,
+              "y": 118,
+              "v": 0.967
+            },
+            "leftFootIndex": {
+              "x": 85.1,
+              "y": 114.4,
+              "v": 0.993
+            },
+            "rightFootIndex": {
+              "x": 47.2,
+              "y": 123.4,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 67.2,
+                "y": 9.7
+              },
+              "roll": 165.1,
+              "yaw": 0.049,
+              "pitch": 0.444
+            },
+            "torso": {
+              "center": {
+                "x": 64.9,
+                "y": 23.9
+              },
+              "angle": 93.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.6,
+                "y": 51.2
+              },
+              "angle": -66.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.4,
+                "y": 53.7
+              },
+              "angle": -83.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.3,
+                "y": 114
+              },
+              "angle": -1.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44,
+                "y": 118
+              },
+              "angle": -59.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.992,
+          "keypoints": {
+            "nose": {
+              "x": 66.8,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.4,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.2,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.1,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.1,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74,
+              "y": 24.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.2,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.4,
+              "y": 40.4,
+              "v": 0.989
+            },
+            "rightElbow": {
+              "x": 45.8,
+              "y": 38.7,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 87.3,
+              "y": 51.7,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 43.3,
+              "y": 53,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 89,
+              "y": 55.1,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 43.9,
+              "y": 57.8,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 72.7,
+              "y": 57.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.7,
+              "y": 57.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.5,
+              "y": 83.8,
+              "v": 0.955
+            },
+            "rightKnee": {
+              "x": 53.2,
+              "y": 84.7,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 74.7,
+              "y": 107.7,
+              "v": 0.985
+            },
+            "rightAnkle": {
+              "x": 45.1,
+              "y": 113,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 71.9,
+              "y": 113.3,
+              "v": 0.94
+            },
+            "rightHeel": {
+              "x": 43.6,
+              "y": 117.2,
+              "v": 0.962
+            },
+            "leftFootIndex": {
+              "x": 83.9,
+              "y": 113.5,
+              "v": 0.99
+            },
+            "rightFootIndex": {
+              "x": 47.5,
+              "y": 123.5,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.3,
+                "y": 10.9
+              },
+              "roll": 171.9,
+              "yaw": 0.118,
+              "pitch": 0.66
+            },
+            "torso": {
+              "center": {
+                "x": 64.1,
+                "y": 24.1
+              },
+              "angle": 93.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.3,
+                "y": 51.7
+              },
+              "angle": -63.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.3,
+                "y": 53
+              },
+              "angle": -82.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.9,
+                "y": 113.3
+              },
+              "angle": -1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 43.6,
+                "y": 117.2
+              },
+              "angle": -58.2
+            }
+          }
+        }
+      ]
+    },
+    "light_punch": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.974,
+          "keypoints": {
+            "nose": {
+              "x": 53.6,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 56,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51.6,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.2,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 63.3,
+              "y": 23.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 41.9,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.7,
+              "y": 26.7,
+              "v": 0.98
+            },
+            "rightElbow": {
+              "x": 33,
+              "y": 39.7,
+              "v": 0.993
+            },
+            "leftWrist": {
+              "x": 91.1,
+              "y": 27.4,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 31,
+              "y": 54.7,
+              "v": 0.994
+            },
+            "leftIndex": {
+              "x": 94,
+              "y": 27.6,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 31.9,
+              "y": 58.7,
+              "v": 0.989
+            },
+            "leftHip": {
+              "x": 60.6,
+              "y": 58.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 47.5,
+              "y": 58.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60.7,
+              "y": 84.6,
+              "v": 0.816
+            },
+            "rightKnee": {
+              "x": 40.1,
+              "y": 84.8,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 62.2,
+              "y": 107.8,
+              "v": 0.937
+            },
+            "rightAnkle": {
+              "x": 32.5,
+              "y": 113.1,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 59.8,
+              "y": 113,
+              "v": 0.835
+            },
+            "rightHeel": {
+              "x": 31.5,
+              "y": 117.4,
+              "v": 0.927
+            },
+            "leftFootIndex": {
+              "x": 71.2,
+              "y": 114.3,
+              "v": 0.95
+            },
+            "rightFootIndex": {
+              "x": 34.5,
+              "y": 122.9,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.8,
+                "y": 10.8
+              },
+              "roll": 163.5,
+              "yaw": -0.044,
+              "pitch": 0.665
+            },
+            "torso": {
+              "center": {
+                "x": 52.6,
+                "y": 23.9
+              },
+              "angle": 92.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.1,
+                "y": 27.4
+              },
+              "angle": -3.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31,
+                "y": 54.7
+              },
+              "angle": -77.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 59.8,
+                "y": 113
+              },
+              "angle": -6.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 31.5,
+                "y": 117.4
+              },
+              "angle": -61.4
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 51.4,
+              "y": 14.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 52.8,
+              "y": 11.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52.9,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 45.4,
+              "y": 10.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 57.4,
+              "y": 22.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 36.1,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.1,
+              "y": 24.5,
+              "v": 0.998
+            },
+            "rightElbow": {
+              "x": 26,
+              "y": 37.9,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 91.4,
+              "y": 24.4,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 22.2,
+              "y": 53.1,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 96.5,
+              "y": 24.1,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 22.9,
+              "y": 57.4,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 52.8,
+              "y": 58,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 39.6,
+              "y": 58.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.1,
+              "y": 83.3,
+              "v": 0.977
+            },
+            "rightKnee": {
+              "x": 30.3,
+              "y": 86.8,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 68.6,
+              "y": 109.3,
+              "v": 0.961
+            },
+            "rightAnkle": {
+              "x": 18.5,
+              "y": 113.6,
+              "v": 0.99
+            },
+            "leftHeel": {
+              "x": 65.8,
+              "y": 114.6,
+              "v": 0.897
+            },
+            "rightHeel": {
+              "x": 16.9,
+              "y": 117.7,
+              "v": 0.848
+            },
+            "leftFootIndex": {
+              "x": 79.9,
+              "y": 116.7,
+              "v": 0.968
+            },
+            "rightFootIndex": {
+              "x": 19.6,
+              "y": 123.3,
+              "v": 0.984
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 50.9,
+                "y": 11.3
+              },
+              "roll": 174,
+              "yaw": 0.131,
+              "pitch": 0.785
+            },
+            "torso": {
+              "center": {
+                "x": 46.8,
+                "y": 22.9
+              },
+              "angle": 89.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 91.4,
+                "y": 24.4
+              },
+              "angle": 3.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 22.2,
+                "y": 53.1
+              },
+              "angle": -80.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 65.8,
+                "y": 114.6
+              },
+              "angle": -8.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 16.9,
+                "y": 117.7
+              },
+              "angle": -64.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.991,
+          "keypoints": {
+            "nose": {
+              "x": 53.6,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.9,
+              "y": 9.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 51.4,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55,
+              "y": 10.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 48.1,
+              "y": 9.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 61.6,
+              "y": 22.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.9,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.3,
+              "y": 24.6,
+              "v": 0.997
+            },
+            "rightElbow": {
+              "x": 33.1,
+              "y": 37.8,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 92.3,
+              "y": 24.1,
+              "v": 1
+            },
+            "rightWrist": {
+              "x": 30.1,
+              "y": 53,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 97.5,
+              "y": 23.7,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 30.4,
+              "y": 57.8,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 58.7,
+              "y": 57.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 46.1,
+              "y": 57.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 60.3,
+              "y": 83.1,
+              "v": 0.972
+            },
+            "rightKnee": {
+              "x": 39.1,
+              "y": 84.6,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 59.8,
+              "y": 107.3,
+              "v": 0.98
+            },
+            "rightAnkle": {
+              "x": 31.3,
+              "y": 112.8,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 57,
+              "y": 112.4,
+              "v": 0.93
+            },
+            "rightHeel": {
+              "x": 30.1,
+              "y": 117.1,
+              "v": 0.942
+            },
+            "leftFootIndex": {
+              "x": 69.1,
+              "y": 114.3,
+              "v": 0.984
+            },
+            "rightFootIndex": {
+              "x": 33.3,
+              "y": 122.6,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 53.2,
+                "y": 9.8
+              },
+              "roll": 175.1,
+              "yaw": 0.128,
+              "pitch": 0.754
+            },
+            "torso": {
+              "center": {
+                "x": 51.3,
+                "y": 23
+              },
+              "angle": 91.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 92.3,
+                "y": 24.1
+              },
+              "angle": 4.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 30.1,
+                "y": 53
+              },
+              "angle": -86.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 57,
+                "y": 112.4
+              },
+              "angle": -8.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30.1,
+                "y": 117.1
+              },
+              "angle": -59.8
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 51.3,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 53.6,
+              "y": 9.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49.5,
+              "y": 9.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.3,
+              "y": 10.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 47.2,
+              "y": 9.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 60.3,
+              "y": 22.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39.5,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.6,
+              "y": 24.6,
+              "v": 0.996
+            },
+            "rightElbow": {
+              "x": 31.3,
+              "y": 38.6,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 90.8,
+              "y": 24.3,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 29.4,
+              "y": 52.7,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 95.7,
+              "y": 23.6,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 29.8,
+              "y": 57.4,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 57.3,
+              "y": 57.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 44.8,
+              "y": 57.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 58.7,
+              "y": 83.4,
+              "v": 0.971
+            },
+            "rightKnee": {
+              "x": 38,
+              "y": 84.8,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 59.2,
+              "y": 106.8,
+              "v": 0.984
+            },
+            "rightAnkle": {
+              "x": 30,
+              "y": 112.6,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 56.4,
+              "y": 111.9,
+              "v": 0.947
+            },
+            "rightHeel": {
+              "x": 28.3,
+              "y": 117.4,
+              "v": 0.962
+            },
+            "leftFootIndex": {
+              "x": 68.6,
+              "y": 113.9,
+              "v": 0.988
+            },
+            "rightFootIndex": {
+              "x": 33.1,
+              "y": 122.2,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.6,
+                "y": 9.7
+              },
+              "roll": 173,
+              "yaw": -0.061,
+              "pitch": 0.666
+            },
+            "torso": {
+              "center": {
+                "x": 49.9,
+                "y": 23.2
+              },
+              "angle": 91.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.8,
+                "y": 24.3
+              },
+              "angle": 8.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.4,
+                "y": 52.7
+              },
+              "angle": -85.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 56.4,
+                "y": 111.9
+              },
+              "angle": -9.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 28.3,
+                "y": 117.4
+              },
+              "angle": -45
+            }
+          }
+        }
+      ]
+    },
+    "heavy_punch": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.998,
+          "keypoints": {
+            "nose": {
+              "x": 55.6,
+              "y": 13.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 57.5,
+              "y": 11,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 53.2,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.8,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 49.9,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 62.7,
+              "y": 23.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 43.4,
+              "y": 22.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.4,
+              "y": 25.9,
+              "v": 0.999
+            },
+            "rightElbow": {
+              "x": 34.5,
+              "y": 39.3,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 95,
+              "y": 25.8,
+              "v": 1
+            },
+            "rightWrist": {
+              "x": 31.9,
+              "y": 53.2,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 99.4,
+              "y": 25.6,
+              "v": 1
+            },
+            "rightIndex": {
+              "x": 32.1,
+              "y": 56.7,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 61.1,
+              "y": 58.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 48.6,
+              "y": 58.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 62,
+              "y": 83.6,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 41.5,
+              "y": 84.4,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 63.2,
+              "y": 107.4,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 33.8,
+              "y": 113.4,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 60.4,
+              "y": 113,
+              "v": 0.984
+            },
+            "rightHeel": {
+              "x": 32.4,
+              "y": 118.3,
+              "v": 0.995
+            },
+            "leftFootIndex": {
+              "x": 73.6,
+              "y": 114.6,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 36.2,
+              "y": 123.1,
+              "v": 1
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 55.4,
+                "y": 10.6
+              },
+              "roll": 168.2,
+              "yaw": 0.057,
+              "pitch": 0.649
+            },
+            "torso": {
+              "center": {
+                "x": 53.1,
+                "y": 23
+              },
+              "angle": 92.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95,
+                "y": 25.8
+              },
+              "angle": 2.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 31.9,
+                "y": 53.2
+              },
+              "angle": -86.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 60.4,
+                "y": 113
+              },
+              "angle": -6.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.4,
+                "y": 118.3
+              },
+              "angle": -51.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.998,
+          "keypoints": {
+            "nose": {
+              "x": 60,
+              "y": 13.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 61.7,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.3,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 61.9,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 54.3,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 66.5,
+              "y": 22.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 47.7,
+              "y": 23,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.5,
+              "y": 25.8,
+              "v": 0.999
+            },
+            "rightElbow": {
+              "x": 39.5,
+              "y": 38.4,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 96.8,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightWrist": {
+              "x": 36.1,
+              "y": 51.6,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 102.1,
+              "y": 25.1,
+              "v": 1
+            },
+            "rightIndex": {
+              "x": 35.5,
+              "y": 55.3,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 65,
+              "y": 57.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53,
+              "y": 57.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 66.7,
+              "y": 83.2,
+              "v": 0.991
+            },
+            "rightKnee": {
+              "x": 45.9,
+              "y": 84.7,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 67.5,
+              "y": 107.9,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 38.1,
+              "y": 112.3,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 64.7,
+              "y": 113.4,
+              "v": 0.984
+            },
+            "rightHeel": {
+              "x": 36.3,
+              "y": 117,
+              "v": 0.992
+            },
+            "leftFootIndex": {
+              "x": 77.4,
+              "y": 113.8,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 41.7,
+              "y": 122.4,
+              "v": 1
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 59.5,
+                "y": 10.3
+              },
+              "roll": 169.7,
+              "yaw": 0.112,
+              "pitch": 0.671
+            },
+            "torso": {
+              "center": {
+                "x": 57.1,
+                "y": 22.9
+              },
+              "angle": 93.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 96.8,
+                "y": 25.5
+              },
+              "angle": 4.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.1,
+                "y": 51.6
+              },
+              "angle": -99.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 64.7,
+                "y": 113.4
+              },
+              "angle": -1.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.3,
+                "y": 117
+              },
+              "angle": -45
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 60.6,
+              "y": 13.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.5,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 57.9,
+              "y": 10,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.1,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 55.2,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.2,
+              "y": 23.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.1,
+              "y": 23.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82.3,
+              "y": 25.4,
+              "v": 0.999
+            },
+            "rightElbow": {
+              "x": 39.7,
+              "y": 38.8,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 97.1,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightWrist": {
+              "x": 37.2,
+              "y": 53.5,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 102,
+              "y": 25,
+              "v": 1
+            },
+            "rightIndex": {
+              "x": 38,
+              "y": 58,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 66.3,
+              "y": 57.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 53.6,
+              "y": 58.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 67.3,
+              "y": 84,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 46.5,
+              "y": 84.6,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 68.5,
+              "y": 107.8,
+              "v": 0.993
+            },
+            "rightAnkle": {
+              "x": 39.4,
+              "y": 111.6,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 65.9,
+              "y": 112.8,
+              "v": 0.977
+            },
+            "rightHeel": {
+              "x": 38,
+              "y": 116,
+              "v": 0.983
+            },
+            "leftFootIndex": {
+              "x": 78,
+              "y": 114.1,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 41.8,
+              "y": 121.7,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.2,
+                "y": 10.6
+              },
+              "roll": 165.4,
+              "yaw": 0.084,
+              "pitch": 0.652
+            },
+            "torso": {
+              "center": {
+                "x": 58.2,
+                "y": 23.4
+              },
+              "angle": 93
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.1,
+                "y": 25.4
+              },
+              "angle": 4.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.2,
+                "y": 53.5
+              },
+              "angle": -79.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 65.9,
+                "y": 112.8
+              },
+              "angle": -6.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38,
+                "y": 116
+              },
+              "angle": -56.3
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.99,
+          "keypoints": {
+            "nose": {
+              "x": 64.4,
+              "y": 12,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.8,
+              "y": 9.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 62.1,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.5,
+              "y": 10.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 58.9,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.6,
+              "y": 22.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 89.2,
+              "y": 22.8,
+              "v": 0.997
+            },
+            "rightElbow": {
+              "x": 36.4,
+              "y": 36.4,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 107,
+              "y": 22.2,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 33.4,
+              "y": 50.6,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 111.1,
+              "y": 22.1,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 34.9,
+              "y": 55.1,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 65.3,
+              "y": 59.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 52.3,
+              "y": 59.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 75.2,
+              "y": 83.6,
+              "v": 0.958
+            },
+            "rightKnee": {
+              "x": 41.5,
+              "y": 86.3,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 77.2,
+              "y": 107.6,
+              "v": 0.972
+            },
+            "rightAnkle": {
+              "x": 30.7,
+              "y": 113.2,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 74.2,
+              "y": 113,
+              "v": 0.932
+            },
+            "rightHeel": {
+              "x": 30,
+              "y": 117.4,
+              "v": 0.945
+            },
+            "leftFootIndex": {
+              "x": 87.5,
+              "y": 115.6,
+              "v": 0.976
+            },
+            "rightFootIndex": {
+              "x": 30,
+              "y": 124,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 64,
+                "y": 9.6
+              },
+              "roll": -180,
+              "yaw": 0.122,
+              "pitch": 0.649
+            },
+            "torso": {
+              "center": {
+                "x": 59.8,
+                "y": 22.2
+              },
+              "angle": 88.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 107,
+                "y": 22.2
+              },
+              "angle": 1.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.4,
+                "y": 50.6
+              },
+              "angle": -71.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.2,
+                "y": 113
+              },
+              "angle": -11.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 30,
+                "y": 117.4
+              },
+              "angle": -90
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 47.8,
+              "y": 13,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 49,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 45.1,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 48.3,
+              "y": 11.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 41,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 52.9,
+              "y": 22.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 33.8,
+              "y": 23.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 69,
+              "y": 24.6,
+              "v": 0.992
+            },
+            "rightElbow": {
+              "x": 23,
+              "y": 39.3,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 85.1,
+              "y": 24.1,
+              "v": 1
+            },
+            "rightWrist": {
+              "x": 38.2,
+              "y": 36.2,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 89.7,
+              "y": 24.2,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 42.8,
+              "y": 32.1,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 51.4,
+              "y": 59.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 39.1,
+              "y": 59.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 64.5,
+              "y": 83.5,
+              "v": 0.979
+            },
+            "rightKnee": {
+              "x": 30.4,
+              "y": 87.1,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 59.1,
+              "y": 107.1,
+              "v": 0.98
+            },
+            "rightAnkle": {
+              "x": 20.4,
+              "y": 113.4,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 55.8,
+              "y": 111.9,
+              "v": 0.968
+            },
+            "rightHeel": {
+              "x": 18.3,
+              "y": 117.7,
+              "v": 0.957
+            },
+            "leftFootIndex": {
+              "x": 69.9,
+              "y": 114.1,
+              "v": 0.984
+            },
+            "rightFootIndex": {
+              "x": 21.9,
+              "y": 122.9,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 47.1,
+                "y": 10.4
+              },
+              "roll": 171.3,
+              "yaw": 0.19,
+              "pitch": 0.659
+            },
+            "torso": {
+              "center": {
+                "x": 43.3,
+                "y": 23
+              },
+              "angle": 93
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.1,
+                "y": 24.1
+              },
+              "angle": -1.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.2,
+                "y": 36.2
+              },
+              "angle": 41.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 55.8,
+                "y": 111.9
+              },
+              "angle": -8.9
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 18.3,
+                "y": 117.7
+              },
+              "angle": -55.3
+            }
+          }
+        }
+      ]
+    },
+    "light_kick": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 65.9,
+              "y": 11.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.2,
+              "y": 9.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.4,
+              "y": 8.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.6,
+              "y": 11,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.5,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.7,
+              "y": 23.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54,
+              "y": 23.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.9,
+              "y": 39.3,
+              "v": 0.986
+            },
+            "rightElbow": {
+              "x": 46.1,
+              "y": 38.8,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 87.1,
+              "y": 51.1,
+              "v": 0.999
+            },
+            "rightWrist": {
+              "x": 44.1,
+              "y": 52.8,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 88.8,
+              "y": 54.8,
+              "v": 0.998
+            },
+            "rightIndex": {
+              "x": 44.2,
+              "y": 57.6,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 72.4,
+              "y": 57.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.6,
+              "y": 57.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74,
+              "y": 83.1,
+              "v": 0.969
+            },
+            "rightKnee": {
+              "x": 53.1,
+              "y": 84.2,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 74.8,
+              "y": 106.6,
+              "v": 0.986
+            },
+            "rightAnkle": {
+              "x": 45.5,
+              "y": 112.4,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 71.8,
+              "y": 112.1,
+              "v": 0.947
+            },
+            "rightHeel": {
+              "x": 44,
+              "y": 116.6,
+              "v": 0.976
+            },
+            "leftFootIndex": {
+              "x": 83.2,
+              "y": 113.7,
+              "v": 0.99
+            },
+            "rightFootIndex": {
+              "x": 47.3,
+              "y": 122.7,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 65.8,
+                "y": 9.4
+              },
+              "roll": 168.2,
+              "yaw": 0.02,
+              "pitch": 0.51
+            },
+            "torso": {
+              "center": {
+                "x": 63.9,
+                "y": 23.5
+              },
+              "angle": 93.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.1,
+                "y": 51.1
+              },
+              "angle": -65.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.1,
+                "y": 52.8
+              },
+              "angle": -88.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.8,
+                "y": 112.1
+              },
+              "angle": -8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44,
+                "y": 116.6
+              },
+              "angle": -61.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.986,
+          "keypoints": {
+            "nose": {
+              "x": 70.4,
+              "y": 11.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 70.5,
+              "y": 9.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.6,
+              "y": 8.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.4,
+              "y": 10,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 62.8,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.2,
+              "y": 23.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.9,
+              "y": 23,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.9,
+              "y": 39.4,
+              "v": 0.735
+            },
+            "rightElbow": {
+              "x": 45.4,
+              "y": 39.1,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 81.8,
+              "y": 48.6,
+              "v": 0.982
+            },
+            "rightWrist": {
+              "x": 42.7,
+              "y": 53.4,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 85.2,
+              "y": 50.4,
+              "v": 0.986
+            },
+            "rightIndex": {
+              "x": 42.9,
+              "y": 57.3,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 72.6,
+              "y": 58.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.3,
+              "y": 60,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 99.2,
+              "y": 64.3,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 52.3,
+              "y": 87.3,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 84.5,
+              "y": 85.3,
+              "v": 0.995
+            },
+            "rightAnkle": {
+              "x": 40.7,
+              "y": 113.7,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 78.3,
+              "y": 87.9,
+              "v": 0.991
+            },
+            "rightHeel": {
+              "x": 37.8,
+              "y": 117,
+              "v": 0.989
+            },
+            "leftFootIndex": {
+              "x": 89.6,
+              "y": 97.6,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 42.3,
+              "y": 123.7,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 69.1,
+                "y": 9.2
+              },
+              "roll": 170.2,
+              "yaw": 0.459,
+              "pitch": 0.663
+            },
+            "torso": {
+              "center": {
+                "x": 63.6,
+                "y": 23.2
+              },
+              "angle": 95.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 81.8,
+                "y": 48.6
+              },
+              "angle": -27.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 42.7,
+                "y": 53.4
+              },
+              "angle": -87.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.3,
+                "y": 87.9
+              },
+              "angle": -40.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 37.8,
+                "y": 117
+              },
+              "angle": -56.1
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 67.4,
+              "y": 14,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.8,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.7,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.3,
+              "y": 10.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 73.5,
+              "y": 24,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54,
+              "y": 23.6,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.9,
+              "y": 40.3,
+              "v": 0.975
+            },
+            "rightElbow": {
+              "x": 46.9,
+              "y": 38.9,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 86.4,
+              "y": 51.2,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 44.1,
+              "y": 53.2,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 88.5,
+              "y": 53.5,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 44.5,
+              "y": 58.3,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 72.3,
+              "y": 57.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.5,
+              "y": 58.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 96.4,
+              "y": 63.9,
+              "v": 0.999
+            },
+            "rightKnee": {
+              "x": 53.7,
+              "y": 85.5,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 82.8,
+              "y": 84.7,
+              "v": 0.99
+            },
+            "rightAnkle": {
+              "x": 46.6,
+              "y": 112.3,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 76.8,
+              "y": 86.5,
+              "v": 0.973
+            },
+            "rightHeel": {
+              "x": 44.4,
+              "y": 115.9,
+              "v": 0.979
+            },
+            "leftFootIndex": {
+              "x": 86.2,
+              "y": 97.8,
+              "v": 0.991
+            },
+            "rightFootIndex": {
+              "x": 49,
+              "y": 122,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.8,
+                "y": 10.9
+              },
+              "roll": 166.3,
+              "yaw": 0.154,
+              "pitch": 0.735
+            },
+            "torso": {
+              "center": {
+                "x": 63.8,
+                "y": 23.8
+              },
+              "angle": 93.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.4,
+                "y": 51.2
+              },
+              "angle": -47.6
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.1,
+                "y": 53.2
+              },
+              "angle": -85.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 76.8,
+                "y": 86.5
+              },
+              "angle": -50.2
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.4,
+                "y": 115.9
+              },
+              "angle": -53
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 61.5,
+              "y": 12.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 63.1,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.9,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.4,
+              "y": 11.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 55.3,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.4,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 48.6,
+              "y": 24,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83,
+              "y": 25.9,
+              "v": 0.998
+            },
+            "rightElbow": {
+              "x": 40.2,
+              "y": 38.5,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 97.2,
+              "y": 26,
+              "v": 1
+            },
+            "rightWrist": {
+              "x": 37.7,
+              "y": 52.5,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 102.1,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightIndex": {
+              "x": 38.9,
+              "y": 55.7,
+              "v": 0.994
+            },
+            "leftHip": {
+              "x": 68.4,
+              "y": 56.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.4,
+              "y": 58.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 93.4,
+              "y": 62.5,
+              "v": 0.998
+            },
+            "rightKnee": {
+              "x": 49.8,
+              "y": 86,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 80.7,
+              "y": 83.9,
+              "v": 0.984
+            },
+            "rightAnkle": {
+              "x": 42.4,
+              "y": 112.1,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 75.1,
+              "y": 85.9,
+              "v": 0.962
+            },
+            "rightHeel": {
+              "x": 40.6,
+              "y": 115.8,
+              "v": 0.976
+            },
+            "leftFootIndex": {
+              "x": 85.7,
+              "y": 96,
+              "v": 0.986
+            },
+            "rightFootIndex": {
+              "x": 44.7,
+              "y": 123,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 61,
+                "y": 10.1
+              },
+              "roll": 165.3,
+              "yaw": 0.115,
+              "pitch": 0.564
+            },
+            "torso": {
+              "center": {
+                "x": 58.5,
+                "y": 23.6
+              },
+              "angle": 96.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 97.2,
+                "y": 26
+              },
+              "angle": 5.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 37.7,
+                "y": 52.5
+              },
+              "angle": -69.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 75.1,
+                "y": 85.9
+              },
+              "angle": -43.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.6,
+                "y": 115.8
+              },
+              "angle": -60.3
+            }
+          }
+        }
+      ]
+    },
+    "heavy_kick": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.993,
+          "keypoints": {
+            "nose": {
+              "x": 64.7,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.3,
+              "y": 10.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.5,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.1,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.4,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 65.1,
+              "y": 25,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.4,
+              "y": 23.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 70.8,
+              "y": 40.1,
+              "v": 0.903
+            },
+            "rightElbow": {
+              "x": 43.5,
+              "y": 40,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 83.6,
+              "y": 35.5,
+              "v": 0.99
+            },
+            "rightWrist": {
+              "x": 44.6,
+              "y": 56.6,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 87.9,
+              "y": 32.1,
+              "v": 0.991
+            },
+            "rightIndex": {
+              "x": 45.8,
+              "y": 60.7,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 64.9,
+              "y": 59.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62,
+              "y": 58.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 63.5,
+              "y": 88.6,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 93.5,
+              "y": 52.3,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 60.2,
+              "y": 116.3,
+              "v": 0.999
+            },
+            "rightAnkle": {
+              "x": 84.9,
+              "y": 77.9,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 56.9,
+              "y": 122.6,
+              "v": 0.999
+            },
+            "rightHeel": {
+              "x": 79.5,
+              "y": 81,
+              "v": 0.988
+            },
+            "leftFootIndex": {
+              "x": 71.1,
+              "y": 123.6,
+              "v": 0.999
+            },
+            "rightFootIndex": {
+              "x": 89.6,
+              "y": 91.3,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.4,
+                "y": 10
+              },
+              "roll": 166.7,
+              "yaw": 0.333,
+              "pitch": 0.627
+            },
+            "torso": {
+              "center": {
+                "x": 58.8,
+                "y": 24.1
+              },
+              "angle": 97.6
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 83.6,
+                "y": 35.5
+              },
+              "angle": 38.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.6,
+                "y": 56.6
+              },
+              "angle": -73.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 56.9,
+                "y": 122.6
+              },
+              "angle": -4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 79.5,
+                "y": 81
+              },
+              "angle": -45.6
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 64.1,
+              "y": 13,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 60.7,
+              "y": 11,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 64.3,
+              "y": 11.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 56.9,
+              "y": 12.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 67.6,
+              "y": 24.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.8,
+              "y": 24.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.2,
+              "y": 36,
+              "v": 0.915
+            },
+            "rightElbow": {
+              "x": 43.3,
+              "y": 41.6,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 86.9,
+              "y": 28.3,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 43.5,
+              "y": 58.5,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 89.7,
+              "y": 24.1,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 46.3,
+              "y": 63,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 70.5,
+              "y": 59.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 68.9,
+              "y": 57.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.1,
+              "y": 88.1,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 98.2,
+              "y": 43.7,
+              "v": 0.997
+            },
+            "leftAnkle": {
+              "x": 67.1,
+              "y": 117.2,
+              "v": 1
+            },
+            "rightAnkle": {
+              "x": 94.8,
+              "y": 71,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 64.6,
+              "y": 123.1,
+              "v": 0.999
+            },
+            "rightHeel": {
+              "x": 89.3,
+              "y": 74.7,
+              "v": 0.991
+            },
+            "leftFootIndex": {
+              "x": 78.5,
+              "y": 124.2,
+              "v": 1
+            },
+            "rightFootIndex": {
+              "x": 101.2,
+              "y": 83.1,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.9,
+                "y": 10.9
+              },
+              "roll": -176,
+              "yaw": 0.29,
+              "pitch": 0.499
+            },
+            "torso": {
+              "center": {
+                "x": 59.7,
+                "y": 24.5
+              },
+              "angle": 106.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.9,
+                "y": 28.3
+              },
+              "angle": 56.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.5,
+                "y": 58.5
+              },
+              "angle": -58.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 64.6,
+                "y": 123.1
+              },
+              "angle": -4.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 89.3,
+                "y": 74.7
+              },
+              "angle": -35.2
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 51.6,
+              "y": 17.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 52.9,
+              "y": 15.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49.5,
+              "y": 15.3,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 52.6,
+              "y": 15.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46.4,
+              "y": 15.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 56.1,
+              "y": 28.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 39,
+              "y": 28.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.6,
+              "y": 32,
+              "v": 0.965
+            },
+            "rightElbow": {
+              "x": 30,
+              "y": 43.2,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 79.4,
+              "y": 20.9,
+              "v": 0.987
+            },
+            "rightWrist": {
+              "x": 23.7,
+              "y": 57,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 80.6,
+              "y": 16.9,
+              "v": 0.986
+            },
+            "rightIndex": {
+              "x": 23.8,
+              "y": 61.8,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 58.4,
+              "y": 60.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56.7,
+              "y": 58.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 54.8,
+              "y": 90.3,
+              "v": 0.98
+            },
+            "rightKnee": {
+              "x": 85.4,
+              "y": 44.1,
+              "v": 0.987
+            },
+            "leftAnkle": {
+              "x": 49.2,
+              "y": 117,
+              "v": 0.997
+            },
+            "rightAnkle": {
+              "x": 110.5,
+              "y": 37.3,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 46.4,
+              "y": 122.3,
+              "v": 0.999
+            },
+            "rightHeel": {
+              "x": 113.7,
+              "y": 41.3,
+              "v": 0.998
+            },
+            "leftFootIndex": {
+              "x": 59.6,
+              "y": 123.8,
+              "v": 0.997
+            },
+            "rightFootIndex": {
+              "x": 120.2,
+              "y": 26.9,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.2,
+                "y": 15.4
+              },
+              "roll": 178.3,
+              "yaw": 0.118,
+              "pitch": 0.691
+            },
+            "torso": {
+              "center": {
+                "x": 47.6,
+                "y": 28.4
+              },
+              "angle": 107.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 79.4,
+                "y": 20.9
+              },
+              "angle": 73.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 23.7,
+                "y": 57
+              },
+              "angle": -88.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 46.4,
+                "y": 122.3
+              },
+              "angle": -6.5
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 113.7,
+                "y": 41.3
+              },
+              "angle": 65.7
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 51.4,
+              "y": 17.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 53.1,
+              "y": 14.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 48.9,
+              "y": 14.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 53.5,
+              "y": 15.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 45.8,
+              "y": 15.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 56.3,
+              "y": 28.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.2,
+              "y": 27.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.8,
+              "y": 32.4,
+              "v": 0.952
+            },
+            "rightElbow": {
+              "x": 30.5,
+              "y": 43.1,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 79.1,
+              "y": 21.8,
+              "v": 0.984
+            },
+            "rightWrist": {
+              "x": 24.1,
+              "y": 57.1,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 80.4,
+              "y": 16.9,
+              "v": 0.984
+            },
+            "rightIndex": {
+              "x": 23.8,
+              "y": 62.2,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 58.4,
+              "y": 60.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57.7,
+              "y": 58.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 55.5,
+              "y": 91.1,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 85.3,
+              "y": 44.3,
+              "v": 0.984
+            },
+            "leftAnkle": {
+              "x": 50.2,
+              "y": 118,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 110.3,
+              "y": 37.3,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 47.6,
+              "y": 123.2,
+              "v": 0.999
+            },
+            "rightHeel": {
+              "x": 114,
+              "y": 42.7,
+              "v": 0.997
+            },
+            "leftFootIndex": {
+              "x": 60.8,
+              "y": 123.6,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 119.8,
+              "y": 27.1,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51,
+                "y": 14.6
+              },
+              "roll": -177.3,
+              "yaw": 0.095,
+              "pitch": 0.595
+            },
+            "torso": {
+              "center": {
+                "x": 48.3,
+                "y": 27.9
+              },
+              "angle": 107.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 79.1,
+                "y": 21.8
+              },
+              "angle": 75.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 24.1,
+                "y": 57.1
+              },
+              "angle": -93.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 47.6,
+                "y": 123.2
+              },
+              "angle": -1.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 114,
+                "y": 42.7
+              },
+              "angle": 69.6
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.996,
+          "keypoints": {
+            "nose": {
+              "x": 53.1,
+              "y": 15.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54.6,
+              "y": 13.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 50.7,
+              "y": 13.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.8,
+              "y": 14.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 47.7,
+              "y": 13.8,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 58,
+              "y": 27.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.5,
+              "y": 26.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.8,
+              "y": 30.8,
+              "v": 0.972
+            },
+            "rightElbow": {
+              "x": 31.8,
+              "y": 41.2,
+              "v": 1
+            },
+            "leftWrist": {
+              "x": 79.3,
+              "y": 19.1,
+              "v": 0.989
+            },
+            "rightWrist": {
+              "x": 25.9,
+              "y": 55.6,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 80.3,
+              "y": 15.3,
+              "v": 0.988
+            },
+            "rightIndex": {
+              "x": 25.8,
+              "y": 60.4,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 59.4,
+              "y": 58.4,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 57,
+              "y": 57.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 55.6,
+              "y": 89.9,
+              "v": 0.988
+            },
+            "rightKnee": {
+              "x": 83.4,
+              "y": 42.1,
+              "v": 0.984
+            },
+            "leftAnkle": {
+              "x": 50,
+              "y": 116.9,
+              "v": 0.998
+            },
+            "rightAnkle": {
+              "x": 109.4,
+              "y": 34.6,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 47.6,
+              "y": 122.2,
+              "v": 0.999
+            },
+            "rightHeel": {
+              "x": 112.4,
+              "y": 38.3,
+              "v": 0.997
+            },
+            "leftFootIndex": {
+              "x": 59.7,
+              "y": 123.4,
+              "v": 0.998
+            },
+            "rightFootIndex": {
+              "x": 118.3,
+              "y": 23.4,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 52.7,
+                "y": 13.4
+              },
+              "roll": -178.5,
+              "yaw": 0.115,
+              "pitch": 0.449
+            },
+            "torso": {
+              "center": {
+                "x": 49.3,
+                "y": 26.8
+              },
+              "angle": 106.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 79.3,
+                "y": 19.1
+              },
+              "angle": 75.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 25.9,
+                "y": 55.6
+              },
+              "angle": -91.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 47.6,
+                "y": 122.2
+              },
+              "angle": -5.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 112.4,
+                "y": 38.3
+              },
+              "angle": 68.4
+            }
+          }
+        }
+      ]
+    },
+    "special": {
+      "frameCount": 5,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.881,
+          "keypoints": {
+            "nose": {
+              "x": 66.6,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68,
+              "y": 9.9,
+              "v": 0.999
+            },
+            "rightEye": {
+              "x": 64.9,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 68.9,
+              "y": 10.9,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 62.7,
+              "y": 10.7,
+              "v": 0.998
+            },
+            "leftShoulder": {
+              "x": 76.9,
+              "y": 24,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.7,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 80.7,
+              "y": 40.5,
+              "v": 0.722
+            },
+            "rightElbow": {
+              "x": 57.1,
+              "y": 38.6,
+              "v": 0.697
+            },
+            "leftWrist": {
+              "x": 77.3,
+              "y": 50.8,
+              "v": 0.712
+            },
+            "rightWrist": {
+              "x": 64.9,
+              "y": 48,
+              "v": 0.363
+            },
+            "leftIndex": {
+              "x": 75.4,
+              "y": 52,
+              "v": 0.751
+            },
+            "rightIndex": {
+              "x": 67.6,
+              "y": 49.3,
+              "v": 0.381
+            },
+            "leftHip": {
+              "x": 68.7,
+              "y": 59.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.7,
+              "y": 58.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 72.5,
+              "y": 83.3,
+              "v": 0.865
+            },
+            "rightKnee": {
+              "x": 55.3,
+              "y": 84.7,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 74,
+              "y": 107.5,
+              "v": 0.981
+            },
+            "rightAnkle": {
+              "x": 45.8,
+              "y": 113.5,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 71.4,
+              "y": 112.9,
+              "v": 0.919
+            },
+            "rightHeel": {
+              "x": 44,
+              "y": 118.4,
+              "v": 0.911
+            },
+            "leftFootIndex": {
+              "x": 74.4,
+              "y": 116.2,
+              "v": 0.981
+            },
+            "rightFootIndex": {
+              "x": 49,
+              "y": 122.8,
+              "v": 0.992
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.5,
+                "y": 9.9
+              },
+              "roll": -180,
+              "yaw": 0.048,
+              "pitch": 0.903
+            },
+            "torso": {
+              "center": {
+                "x": 65.8,
+                "y": 23.8
+              },
+              "angle": 88.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 77.3,
+                "y": 50.8
+              },
+              "angle": -147.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 64.9,
+                "y": 48
+              },
+              "angle": -25.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 71.4,
+                "y": 112.9
+              },
+              "angle": -47.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44,
+                "y": 118.4
+              },
+              "angle": -41.3
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.969,
+          "keypoints": {
+            "nose": {
+              "x": 62.2,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 64.5,
+              "y": 9.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 60,
+              "y": 9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.6,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.5,
+              "y": 10,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.6,
+              "y": 23.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.1,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 75.2,
+              "y": 40,
+              "v": 0.964
+            },
+            "rightElbow": {
+              "x": 42.9,
+              "y": 37,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 82.2,
+              "y": 52.7,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 39.7,
+              "y": 53.2,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 85.1,
+              "y": 56.1,
+              "v": 0.995
+            },
+            "rightIndex": {
+              "x": 40.3,
+              "y": 58.5,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 67.9,
+              "y": 57.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.9,
+              "y": 57.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 69.7,
+              "y": 83.6,
+              "v": 0.827
+            },
+            "rightKnee": {
+              "x": 49.1,
+              "y": 85,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 70.8,
+              "y": 106.8,
+              "v": 0.931
+            },
+            "rightAnkle": {
+              "x": 41.1,
+              "y": 111.4,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 68,
+              "y": 112.2,
+              "v": 0.779
+            },
+            "rightHeel": {
+              "x": 39.4,
+              "y": 115.4,
+              "v": 0.858
+            },
+            "leftFootIndex": {
+              "x": 78.3,
+              "y": 114.7,
+              "v": 0.954
+            },
+            "rightFootIndex": {
+              "x": 42.8,
+              "y": 122.6,
+              "v": 0.991
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 62.3,
+                "y": 9.4
+              },
+              "roll": 169.9,
+              "yaw": -0.011,
+              "pitch": 0.394
+            },
+            "torso": {
+              "center": {
+                "x": 60.9,
+                "y": 23.5
+              },
+              "angle": 91.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 82.2,
+                "y": 52.7
+              },
+              "angle": -49.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.7,
+                "y": 53.2
+              },
+              "angle": -83.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68,
+                "y": 112.2
+              },
+              "angle": -13.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.4,
+                "y": 115.4
+              },
+              "angle": -64.7
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.857,
+          "keypoints": {
+            "nose": {
+              "x": 48.8,
+              "y": 16.3,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 50.4,
+              "y": 14.1,
+              "v": 0.997
+            },
+            "rightEye": {
+              "x": 46.6,
+              "y": 13.4,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 50.3,
+              "y": 14.5,
+              "v": 0.998
+            },
+            "rightEar": {
+              "x": 43.1,
+              "y": 13.9,
+              "v": 0.996
+            },
+            "leftShoulder": {
+              "x": 55.5,
+              "y": 27.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 36.3,
+              "y": 26.1,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 66.5,
+              "y": 31.4,
+              "v": 0.474
+            },
+            "rightElbow": {
+              "x": 50.8,
+              "y": 29.7,
+              "v": 0.926
+            },
+            "leftWrist": {
+              "x": 71.6,
+              "y": 32.3,
+              "v": 0.403
+            },
+            "rightWrist": {
+              "x": 68.8,
+              "y": 30.9,
+              "v": 0.837
+            },
+            "leftIndex": {
+              "x": 72.1,
+              "y": 31,
+              "v": 0.49
+            },
+            "rightIndex": {
+              "x": 72.5,
+              "y": 30.8,
+              "v": 0.799
+            },
+            "leftHip": {
+              "x": 50.9,
+              "y": 63.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 37.2,
+              "y": 63.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.4,
+              "y": 81.7,
+              "v": 0.907
+            },
+            "rightKnee": {
+              "x": 23.3,
+              "y": 88.9,
+              "v": 0.948
+            },
+            "leftAnkle": {
+              "x": 63.6,
+              "y": 104.4,
+              "v": 0.858
+            },
+            "rightAnkle": {
+              "x": 6.9,
+              "y": 110.1,
+              "v": 0.959
+            },
+            "leftHeel": {
+              "x": 59.2,
+              "y": 109,
+              "v": 0.786
+            },
+            "rightHeel": {
+              "x": 5.1,
+              "y": 112.8,
+              "v": 0.553
+            },
+            "leftFootIndex": {
+              "x": 73.7,
+              "y": 113,
+              "v": 0.86
+            },
+            "rightFootIndex": {
+              "x": 5.9,
+              "y": 120.3,
+              "v": 0.913
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 48.5,
+                "y": 13.8
+              },
+              "roll": 169.6,
+              "yaw": 0.078,
+              "pitch": 0.66
+            },
+            "torso": {
+              "center": {
+                "x": 45.9,
+                "y": 26.7
+              },
+              "angle": 87.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 71.6,
+                "y": 32.3
+              },
+              "angle": 69
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 68.8,
+                "y": 30.9
+              },
+              "angle": 1.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 59.2,
+                "y": 109
+              },
+              "angle": -15.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 5.1,
+                "y": 112.8
+              },
+              "angle": -83.9
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.971,
+          "keypoints": {
+            "nose": {
+              "x": 51.9,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 54,
+              "y": 9.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49.9,
+              "y": 8.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 54.9,
+              "y": 10.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46.9,
+              "y": 9.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 59.4,
+              "y": 24.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.5,
+              "y": 22.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 60.6,
+              "y": 39.8,
+              "v": 0.749
+            },
+            "rightElbow": {
+              "x": 31.9,
+              "y": 38,
+              "v": 0.996
+            },
+            "leftWrist": {
+              "x": 70.1,
+              "y": 49.3,
+              "v": 0.975
+            },
+            "rightWrist": {
+              "x": 29.5,
+              "y": 52.4,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 73.5,
+              "y": 52.6,
+              "v": 0.975
+            },
+            "rightIndex": {
+              "x": 30,
+              "y": 57.3,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 58.3,
+              "y": 57.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.6,
+              "y": 57.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 59,
+              "y": 83.6,
+              "v": 0.892
+            },
+            "rightKnee": {
+              "x": 37.9,
+              "y": 84.7,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 59.8,
+              "y": 107.5,
+              "v": 0.966
+            },
+            "rightAnkle": {
+              "x": 30.4,
+              "y": 113.1,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 57,
+              "y": 113,
+              "v": 0.879
+            },
+            "rightHeel": {
+              "x": 29.2,
+              "y": 117.8,
+              "v": 0.925
+            },
+            "leftFootIndex": {
+              "x": 70.1,
+              "y": 114.6,
+              "v": 0.979
+            },
+            "rightFootIndex": {
+              "x": 33.1,
+              "y": 123.6,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 52,
+                "y": 9
+              },
+              "roll": 170.3,
+              "yaw": -0.012,
+              "pitch": 0.613
+            },
+            "torso": {
+              "center": {
+                "x": 50,
+                "y": 23.5
+              },
+              "angle": 93.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 70.1,
+                "y": 49.3
+              },
+              "angle": -44.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.5,
+                "y": 52.4
+              },
+              "angle": -84.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 57,
+                "y": 113
+              },
+              "angle": -7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 29.2,
+                "y": 117.8
+              },
+              "angle": -56.1
+            }
+          }
+        },
+        {
+          "index": 4,
+          "detected": true,
+          "avgVisibility": 0.984,
+          "keypoints": {
+            "nose": {
+              "x": 51.5,
+              "y": 12.7,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 53.7,
+              "y": 10.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 49.2,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 55.4,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 46.2,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 60.7,
+              "y": 22.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 40.3,
+              "y": 23.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 66.8,
+              "y": 38.5,
+              "v": 0.94
+            },
+            "rightElbow": {
+              "x": 31.6,
+              "y": 38.2,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 72.8,
+              "y": 49.8,
+              "v": 0.991
+            },
+            "rightWrist": {
+              "x": 28.6,
+              "y": 52.6,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 73.9,
+              "y": 54.5,
+              "v": 0.989
+            },
+            "rightIndex": {
+              "x": 29.7,
+              "y": 57.2,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 58.1,
+              "y": 57.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 45.4,
+              "y": 57.4,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 58.7,
+              "y": 83.4,
+              "v": 0.918
+            },
+            "rightKnee": {
+              "x": 38.1,
+              "y": 84.9,
+              "v": 0.998
+            },
+            "leftAnkle": {
+              "x": 60.3,
+              "y": 107,
+              "v": 0.976
+            },
+            "rightAnkle": {
+              "x": 30.4,
+              "y": 113,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 57.8,
+              "y": 112.7,
+              "v": 0.909
+            },
+            "rightHeel": {
+              "x": 28.8,
+              "y": 117,
+              "v": 0.947
+            },
+            "leftFootIndex": {
+              "x": 68.1,
+              "y": 114.2,
+              "v": 0.984
+            },
+            "rightFootIndex": {
+              "x": 32.8,
+              "y": 122.9,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 51.5,
+                "y": 9.9
+              },
+              "roll": 171.2,
+              "yaw": 0.011,
+              "pitch": 0.626
+            },
+            "torso": {
+              "center": {
+                "x": 50.5,
+                "y": 23
+              },
+              "angle": 92.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 72.8,
+                "y": 49.8
+              },
+              "angle": -76.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 28.6,
+                "y": 52.6
+              },
+              "angle": -76.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 57.8,
+                "y": 112.7
+              },
+              "angle": -8.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 28.8,
+                "y": 117
+              },
+              "angle": -55.9
+            }
+          }
+        }
+      ]
+    },
+    "block": {
+      "frameCount": 2,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.94,
+          "keypoints": {
+            "nose": {
+              "x": 58.5,
+              "y": 10.7,
+              "v": 0.998
+            },
+            "leftEye": {
+              "x": 60.1,
+              "y": 8.7,
+              "v": 0.995
+            },
+            "rightEye": {
+              "x": 56.3,
+              "y": 9.3,
+              "v": 0.998
+            },
+            "leftEar": {
+              "x": 61.9,
+              "y": 8.7,
+              "v": 0.997
+            },
+            "rightEar": {
+              "x": 54.3,
+              "y": 9.9,
+              "v": 0.995
+            },
+            "leftShoulder": {
+              "x": 69.2,
+              "y": 19.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.6,
+              "y": 19.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.5,
+              "y": 35.4,
+              "v": 0.754
+            },
+            "rightElbow": {
+              "x": 57,
+              "y": 31.7,
+              "v": 0.924
+            },
+            "leftWrist": {
+              "x": 73.9,
+              "y": 24,
+              "v": 0.893
+            },
+            "rightWrist": {
+              "x": 71.9,
+              "y": 23.9,
+              "v": 0.929
+            },
+            "leftIndex": {
+              "x": 75,
+              "y": 18.5,
+              "v": 0.891
+            },
+            "rightIndex": {
+              "x": 74.9,
+              "y": 19.6,
+              "v": 0.893
+            },
+            "leftHip": {
+              "x": 64.4,
+              "y": 57.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.9,
+              "y": 56.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.5,
+              "y": 84.1,
+              "v": 0.759
+            },
+            "rightKnee": {
+              "x": 44.9,
+              "y": 84.7,
+              "v": 0.99
+            },
+            "leftAnkle": {
+              "x": 66.1,
+              "y": 106.9,
+              "v": 0.953
+            },
+            "rightAnkle": {
+              "x": 37.1,
+              "y": 111.8,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 63.4,
+              "y": 111.9,
+              "v": 0.855
+            },
+            "rightHeel": {
+              "x": 35.6,
+              "y": 115.6,
+              "v": 0.867
+            },
+            "leftFootIndex": {
+              "x": 74.8,
+              "y": 113.9,
+              "v": 0.958
+            },
+            "rightFootIndex": {
+              "x": 39.9,
+              "y": 122.4,
+              "v": 0.988
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 58.2,
+                "y": 9
+              },
+              "roll": -171,
+              "yaw": 0.078,
+              "pitch": 0.442
+            },
+            "torso": {
+              "center": {
+                "x": 59.4,
+                "y": 19.9
+              },
+              "angle": 88.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.9,
+                "y": 24
+              },
+              "angle": 78.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 71.9,
+                "y": 23.9
+              },
+              "angle": 55.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 63.4,
+                "y": 111.9
+              },
+              "angle": -10
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.6,
+                "y": 115.6
+              },
+              "angle": -57.7
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.941,
+          "keypoints": {
+            "nose": {
+              "x": 58.1,
+              "y": 12.1,
+              "v": 0.999
+            },
+            "leftEye": {
+              "x": 59.5,
+              "y": 9.8,
+              "v": 0.998
+            },
+            "rightEye": {
+              "x": 55.7,
+              "y": 9.4,
+              "v": 0.999
+            },
+            "leftEar": {
+              "x": 60.2,
+              "y": 10.3,
+              "v": 0.999
+            },
+            "rightEar": {
+              "x": 52.7,
+              "y": 9.8,
+              "v": 0.999
+            },
+            "leftShoulder": {
+              "x": 66.4,
+              "y": 22.2,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.8,
+              "y": 22.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.1,
+              "y": 35.7,
+              "v": 0.732
+            },
+            "rightElbow": {
+              "x": 55.9,
+              "y": 32.6,
+              "v": 0.955
+            },
+            "leftWrist": {
+              "x": 74.2,
+              "y": 23.9,
+              "v": 0.884
+            },
+            "rightWrist": {
+              "x": 69,
+              "y": 21.9,
+              "v": 0.976
+            },
+            "leftIndex": {
+              "x": 73,
+              "y": 19.5,
+              "v": 0.879
+            },
+            "rightIndex": {
+              "x": 72.1,
+              "y": 17.4,
+              "v": 0.959
+            },
+            "leftHip": {
+              "x": 64.4,
+              "y": 57.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.1,
+              "y": 57.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 65.1,
+              "y": 84.6,
+              "v": 0.756
+            },
+            "rightKnee": {
+              "x": 43.8,
+              "y": 85.1,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 66.5,
+              "y": 107.4,
+              "v": 0.93
+            },
+            "rightAnkle": {
+              "x": 36.7,
+              "y": 112.4,
+              "v": 0.993
+            },
+            "leftHeel": {
+              "x": 64.4,
+              "y": 112.5,
+              "v": 0.817
+            },
+            "rightHeel": {
+              "x": 36,
+              "y": 116.3,
+              "v": 0.862
+            },
+            "leftFootIndex": {
+              "x": 73.7,
+              "y": 114.6,
+              "v": 0.939
+            },
+            "rightFootIndex": {
+              "x": 38.1,
+              "y": 122.1,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 57.6,
+                "y": 9.6
+              },
+              "roll": 174,
+              "yaw": 0.131,
+              "pitch": 0.654
+            },
+            "torso": {
+              "center": {
+                "x": 56.1,
+                "y": 22.2
+              },
+              "angle": 92.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 74.2,
+                "y": 23.9
+              },
+              "angle": 105.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 69,
+                "y": 21.9
+              },
+              "angle": 55.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 64.4,
+                "y": 112.5
+              },
+              "angle": -12.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36,
+                "y": 116.3
+              },
+              "angle": -70.1
+            }
+          }
+        }
+      ]
+    },
+    "hurt": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.988,
+          "keypoints": {
+            "nose": {
+              "x": 79.1,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 80.4,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 77,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 79.6,
+              "y": 12.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 72.9,
+              "y": 9.5,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.9,
+              "y": 26.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 61.8,
+              "y": 18.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 74.8,
+              "y": 43,
+              "v": 0.923
+            },
+            "rightElbow": {
+              "x": 46.5,
+              "y": 30.2,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 80.8,
+              "y": 54.9,
+              "v": 0.993
+            },
+            "rightWrist": {
+              "x": 36.8,
+              "y": 43.9,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 83.3,
+              "y": 58.1,
+              "v": 0.992
+            },
+            "rightIndex": {
+              "x": 35.3,
+              "y": 48,
+              "v": 0.997
+            },
+            "leftHip": {
+              "x": 61.4,
+              "y": 56.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 50.2,
+              "y": 54.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.7,
+              "y": 80.2,
+              "v": 0.977
+            },
+            "rightKnee": {
+              "x": 45.8,
+              "y": 84.8,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 70.6,
+              "y": 106.3,
+              "v": 0.97
+            },
+            "rightAnkle": {
+              "x": 36.8,
+              "y": 112.9,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 66.7,
+              "y": 111.2,
+              "v": 0.932
+            },
+            "rightHeel": {
+              "x": 34,
+              "y": 117.3,
+              "v": 0.958
+            },
+            "leftFootIndex": {
+              "x": 81.9,
+              "y": 113,
+              "v": 0.983
+            },
+            "rightFootIndex": {
+              "x": 38.4,
+              "y": 124.1,
+              "v": 0.996
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 78.7,
+                "y": 11.3
+              },
+              "roll": 154.8,
+              "yaw": 0.106,
+              "pitch": 0.772
+            },
+            "torso": {
+              "center": {
+                "x": 69.4,
+                "y": 22.5
+              },
+              "angle": 67.7
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.8,
+                "y": 54.9
+              },
+              "angle": -52
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 36.8,
+                "y": 43.9
+              },
+              "angle": -110.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 66.7,
+                "y": 111.2
+              },
+              "angle": -6.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 34,
+                "y": 117.3
+              },
+              "angle": -57.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 77.5,
+              "y": 13,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 79.5,
+              "y": 10.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 75.6,
+              "y": 10.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 80.4,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 72.9,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 83.3,
+              "y": 23,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 65.5,
+              "y": 19.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 96.8,
+              "y": 23.6,
+              "v": 0.979
+            },
+            "rightElbow": {
+              "x": 53,
+              "y": 32.9,
+              "v": 0.986
+            },
+            "leftWrist": {
+              "x": 90.6,
+              "y": 9.1,
+              "v": 0.993
+            },
+            "rightWrist": {
+              "x": 46.6,
+              "y": 48.5,
+              "v": 0.991
+            },
+            "leftIndex": {
+              "x": 86.6,
+              "y": 5.6,
+              "v": 0.984
+            },
+            "rightIndex": {
+              "x": 46,
+              "y": 53,
+              "v": 0.982
+            },
+            "leftHip": {
+              "x": 75,
+              "y": 57.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 63.2,
+              "y": 55.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 88,
+              "y": 81.4,
+              "v": 0.957
+            },
+            "rightKnee": {
+              "x": 57.5,
+              "y": 85.1,
+              "v": 0.996
+            },
+            "leftAnkle": {
+              "x": 82.5,
+              "y": 106.9,
+              "v": 0.964
+            },
+            "rightAnkle": {
+              "x": 49.7,
+              "y": 112.4,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 78.1,
+              "y": 111.6,
+              "v": 0.907
+            },
+            "rightHeel": {
+              "x": 47.8,
+              "y": 116.4,
+              "v": 0.929
+            },
+            "leftFootIndex": {
+              "x": 93.9,
+              "y": 114.4,
+              "v": 0.965
+            },
+            "rightFootIndex": {
+              "x": 51.4,
+              "y": 123.6,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 77.6,
+                "y": 10.5
+              },
+              "roll": 172.7,
+              "yaw": -0.013,
+              "pitch": 0.649
+            },
+            "torso": {
+              "center": {
+                "x": 74.4,
+                "y": 21.5
+              },
+              "angle": 81.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.6,
+                "y": 9.1
+              },
+              "angle": 138.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 46.6,
+                "y": 48.5
+              },
+              "angle": -97.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 78.1,
+                "y": 111.6
+              },
+              "angle": -10
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 47.8,
+                "y": 116.4
+              },
+              "angle": -63.4
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.989,
+          "keypoints": {
+            "nose": {
+              "x": 73.1,
+              "y": 13.9,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 75.8,
+              "y": 12.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 71.4,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 76.2,
+              "y": 13.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 68.3,
+              "y": 9.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 77.1,
+              "y": 25.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 58.2,
+              "y": 21.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.2,
+              "y": 42,
+              "v": 0.971
+            },
+            "rightElbow": {
+              "x": 46.7,
+              "y": 36.4,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 80.7,
+              "y": 54.3,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 42.6,
+              "y": 51.9,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 82,
+              "y": 58.4,
+              "v": 0.996
+            },
+            "rightIndex": {
+              "x": 42,
+              "y": 56.2,
+              "v": 0.995
+            },
+            "leftHip": {
+              "x": 71.2,
+              "y": 57.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58,
+              "y": 57.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 74.7,
+              "y": 82.9,
+              "v": 0.944
+            },
+            "rightKnee": {
+              "x": 51.3,
+              "y": 84.3,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 75.7,
+              "y": 107.6,
+              "v": 0.98
+            },
+            "rightAnkle": {
+              "x": 43.3,
+              "y": 112,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 72.8,
+              "y": 112.7,
+              "v": 0.922
+            },
+            "rightHeel": {
+              "x": 41.4,
+              "y": 116.2,
+              "v": 0.958
+            },
+            "leftFootIndex": {
+              "x": 84.9,
+              "y": 114,
+              "v": 0.987
+            },
+            "rightFootIndex": {
+              "x": 44.8,
+              "y": 123.5,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 73.6,
+                "y": 11.1
+              },
+              "roll": 152.4,
+              "yaw": -0.101,
+              "pitch": 0.574
+            },
+            "torso": {
+              "center": {
+                "x": 67.7,
+                "y": 23.3
+              },
+              "angle": 84.9
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.7,
+                "y": 54.3
+              },
+              "angle": -72.4
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 42.6,
+                "y": 51.9
+              },
+              "angle": -97.9
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.8,
+                "y": 112.7
+              },
+              "angle": -6.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 41.4,
+                "y": 116.2
+              },
+              "angle": -65
+            }
+          }
+        }
+      ]
+    },
+    "knockdown": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.984,
+          "keypoints": {
+            "nose": {
+              "x": 78.7,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 80.5,
+              "y": 13.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 76.1,
+              "y": 14,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 81.8,
+              "y": 14.1,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 74.2,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 86.2,
+              "y": 26.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 63.8,
+              "y": 22.4,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 97.5,
+              "y": 39.8,
+              "v": 0.974
+            },
+            "rightElbow": {
+              "x": 47.9,
+              "y": 20.2,
+              "v": 0.985
+            },
+            "leftWrist": {
+              "x": 90.7,
+              "y": 33.9,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 46.5,
+              "y": 7.8,
+              "v": 1
+            },
+            "leftIndex": {
+              "x": 86.1,
+              "y": 28,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 48.3,
+              "y": 3.7,
+              "v": 1
+            },
+            "leftHip": {
+              "x": 72.6,
+              "y": 62.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59,
+              "y": 61.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95.5,
+              "y": 76.3,
+              "v": 0.981
+            },
+            "rightKnee": {
+              "x": 49.7,
+              "y": 90,
+              "v": 0.988
+            },
+            "leftAnkle": {
+              "x": 78.7,
+              "y": 96.4,
+              "v": 0.942
+            },
+            "rightAnkle": {
+              "x": 37.6,
+              "y": 115.7,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 73.2,
+              "y": 97.5,
+              "v": 0.929
+            },
+            "rightHeel": {
+              "x": 35.3,
+              "y": 119.1,
+              "v": 0.897
+            },
+            "leftFootIndex": {
+              "x": 80.9,
+              "y": 110.2,
+              "v": 0.967
+            },
+            "rightFootIndex": {
+              "x": 38.3,
+              "y": 125.6,
+              "v": 0.986
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 78.3,
+                "y": 14
+              },
+              "roll": -178.7,
+              "yaw": 0.091,
+              "pitch": 0.534
+            },
+            "torso": {
+              "center": {
+                "x": 75,
+                "y": 24.5
+              },
+              "angle": 76.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.7,
+                "y": 33.9
+              },
+              "angle": 127.9
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 46.5,
+                "y": 7.8
+              },
+              "angle": 66.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 73.2,
+                "y": 97.5
+              },
+              "angle": -58.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 35.3,
+                "y": 119.1
+              },
+              "angle": -65.2
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.991,
+          "keypoints": {
+            "nose": {
+              "x": 63.7,
+              "y": 11.5,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.7,
+              "y": 9.7,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61,
+              "y": 9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 66.5,
+              "y": 11.2,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.5,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 71.2,
+              "y": 24.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 52.5,
+              "y": 24.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.7,
+              "y": 39.4,
+              "v": 0.961
+            },
+            "rightElbow": {
+              "x": 45.2,
+              "y": 40.5,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 87,
+              "y": 47.5,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 41.8,
+              "y": 57.8,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 90.3,
+              "y": 50.3,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 42.6,
+              "y": 62.4,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 76.6,
+              "y": 56.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 64,
+              "y": 58.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 92.7,
+              "y": 79.9,
+              "v": 0.995
+            },
+            "rightKnee": {
+              "x": 58.8,
+              "y": 87,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 77.9,
+              "y": 99.6,
+              "v": 0.971
+            },
+            "rightAnkle": {
+              "x": 46.5,
+              "y": 113.9,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 72.5,
+              "y": 100.9,
+              "v": 0.922
+            },
+            "rightHeel": {
+              "x": 44.1,
+              "y": 118.2,
+              "v": 0.979
+            },
+            "leftFootIndex": {
+              "x": 80.6,
+              "y": 112.5,
+              "v": 0.977
+            },
+            "rightFootIndex": {
+              "x": 49.3,
+              "y": 123.4,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.4,
+                "y": 9.4
+              },
+              "roll": 171.5,
+              "yaw": 0.074,
+              "pitch": 0.452
+            },
+            "torso": {
+              "center": {
+                "x": 61.9,
+                "y": 24.7
+              },
+              "angle": 104.4
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87,
+                "y": 47.5
+              },
+              "angle": -40.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.8,
+                "y": 57.8
+              },
+              "angle": -80.1
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72.5,
+                "y": 100.9
+              },
+              "angle": -55.1
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.1,
+                "y": 118.2
+              },
+              "angle": -45
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 79.2,
+              "y": 15.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 81.2,
+              "y": 13.2,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 77.8,
+              "y": 10.7,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 80,
+              "y": 12.9,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 73.4,
+              "y": 8.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.5,
+              "y": 25.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.8,
+              "y": 17.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.2,
+              "y": 40,
+              "v": 0.983
+            },
+            "rightElbow": {
+              "x": 43.9,
+              "y": 25.8,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 89.4,
+              "y": 51,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 29.5,
+              "y": 34.7,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 91.2,
+              "y": 54.8,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 27.5,
+              "y": 37.9,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 60.3,
+              "y": 56.2,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.2,
+              "y": 53.7,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.4,
+              "y": 77.1,
+              "v": 0.964
+            },
+            "rightKnee": {
+              "x": 55.7,
+              "y": 82.8,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 64.8,
+              "y": 98.4,
+              "v": 0.924
+            },
+            "rightAnkle": {
+              "x": 43,
+              "y": 108.4,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 59.2,
+              "y": 101,
+              "v": 0.851
+            },
+            "rightHeel": {
+              "x": 38.7,
+              "y": 110.6,
+              "v": 0.958
+            },
+            "leftFootIndex": {
+              "x": 67,
+              "y": 113.3,
+              "v": 0.949
+            },
+            "rightFootIndex": {
+              "x": 44.3,
+              "y": 124.2,
+              "v": 0.995
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 79.5,
+                "y": 12
+              },
+              "roll": 143.7,
+              "yaw": -0.071,
+              "pitch": 0.77
+            },
+            "torso": {
+              "center": {
+                "x": 68.7,
+                "y": 21.4
+              },
+              "angle": 67.5
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 89.4,
+                "y": 51
+              },
+              "angle": -64.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 29.5,
+                "y": 34.7
+              },
+              "angle": -122
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 59.2,
+                "y": 101
+              },
+              "angle": -57.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 38.7,
+                "y": 110.6
+              },
+              "angle": -67.6
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.995,
+          "keypoints": {
+            "nose": {
+              "x": 71.6,
+              "y": 14.2,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.9,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 69.6,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 74.2,
+              "y": 13.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.4,
+              "y": 9.9,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.5,
+              "y": 26.4,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.8,
+              "y": 19.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.6,
+              "y": 42.3,
+              "v": 0.995
+            },
+            "rightElbow": {
+              "x": 42.3,
+              "y": 32.9,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 85.8,
+              "y": 54.4,
+              "v": 1
+            },
+            "rightWrist": {
+              "x": 33.7,
+              "y": 47.4,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 87.2,
+              "y": 58.4,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 32.4,
+              "y": 52.5,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 62.2,
+              "y": 56.8,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.3,
+              "y": 55.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 80.3,
+              "y": 76.8,
+              "v": 0.997
+            },
+            "rightKnee": {
+              "x": 42.8,
+              "y": 84.2,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 67.4,
+              "y": 97.9,
+              "v": 0.985
+            },
+            "rightAnkle": {
+              "x": 34.5,
+              "y": 112.3,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 61.7,
+              "y": 100.3,
+              "v": 0.954
+            },
+            "rightHeel": {
+              "x": 32.2,
+              "y": 116.2,
+              "v": 0.972
+            },
+            "leftFootIndex": {
+              "x": 72.7,
+              "y": 110.3,
+              "v": 0.987
+            },
+            "rightFootIndex": {
+              "x": 36.5,
+              "y": 124.1,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 71.8,
+                "y": 11.5
+              },
+              "roll": 154,
+              "yaw": -0.031,
+              "pitch": 0.575
+            },
+            "torso": {
+              "center": {
+                "x": 64.7,
+                "y": 22.8
+              },
+              "angle": 75.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.8,
+                "y": 54.4
+              },
+              "angle": -70.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 33.7,
+                "y": 47.4
+              },
+              "angle": -104.3
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.7,
+                "y": 100.3
+              },
+              "angle": -42.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.2,
+                "y": 116.2
+              },
+              "angle": -61.4
+            }
+          }
+        }
+      ]
+    },
+    "victory": {
+      "frameCount": 4,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.984,
+          "keypoints": {
+            "nose": {
+              "x": 57.4,
+              "y": 15,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 57.7,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 54.9,
+              "y": 13.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 57.5,
+              "y": 12.8,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 51.6,
+              "y": 14,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 61.1,
+              "y": 24.5,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 45.7,
+              "y": 26,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.9,
+              "y": 18.9,
+              "v": 0.969
+            },
+            "rightElbow": {
+              "x": 36.7,
+              "y": 40.8,
+              "v": 0.992
+            },
+            "leftWrist": {
+              "x": 78.9,
+              "y": 6.2,
+              "v": 0.996
+            },
+            "rightWrist": {
+              "x": 34,
+              "y": 57.2,
+              "v": 0.992
+            },
+            "leftIndex": {
+              "x": 78.6,
+              "y": 2.4,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 33.6,
+              "y": 61.3,
+              "v": 0.986
+            },
+            "leftHip": {
+              "x": 59.7,
+              "y": 59.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 49.5,
+              "y": 60.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 71.4,
+              "y": 84.4,
+              "v": 0.938
+            },
+            "rightKnee": {
+              "x": 43.8,
+              "y": 87.3,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 65.5,
+              "y": 108.3,
+              "v": 0.967
+            },
+            "rightAnkle": {
+              "x": 35.1,
+              "y": 113.5,
+              "v": 0.995
+            },
+            "leftHeel": {
+              "x": 61.9,
+              "y": 113.1,
+              "v": 0.921
+            },
+            "rightHeel": {
+              "x": 32.5,
+              "y": 117.2,
+              "v": 0.927
+            },
+            "leftFootIndex": {
+              "x": 76.6,
+              "y": 114.9,
+              "v": 0.977
+            },
+            "rightFootIndex": {
+              "x": 38.6,
+              "y": 124.1,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 56.3,
+                "y": 13
+              },
+              "roll": -171.9,
+              "yaw": 0.389,
+              "pitch": 0.707
+            },
+            "torso": {
+              "center": {
+                "x": 53.4,
+                "y": 25.3
+              },
+              "angle": 92
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 78.9,
+                "y": 6.2
+              },
+              "angle": 94.5
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 34,
+                "y": 57.2
+              },
+              "angle": -95.6
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61.9,
+                "y": 113.1
+              },
+              "angle": -7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 32.5,
+                "y": 117.2
+              },
+              "angle": -48.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.997,
+          "keypoints": {
+            "nose": {
+              "x": 66.1,
+              "y": 12.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 68.6,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 63.8,
+              "y": 9.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 70.3,
+              "y": 11.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 61.2,
+              "y": 10.1,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.5,
+              "y": 23.9,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 54.8,
+              "y": 23.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 79.8,
+              "y": 39.8,
+              "v": 0.997
+            },
+            "rightElbow": {
+              "x": 46.4,
+              "y": 39.1,
+              "v": 0.999
+            },
+            "leftWrist": {
+              "x": 87.8,
+              "y": 51.2,
+              "v": 1
+            },
+            "rightWrist": {
+              "x": 44.7,
+              "y": 53.9,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 89,
+              "y": 55.2,
+              "v": 0.999
+            },
+            "rightIndex": {
+              "x": 45.2,
+              "y": 58.4,
+              "v": 0.998
+            },
+            "leftHip": {
+              "x": 72.8,
+              "y": 58.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 60.1,
+              "y": 58.2,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 73.8,
+              "y": 84.5,
+              "v": 0.984
+            },
+            "rightKnee": {
+              "x": 53.5,
+              "y": 85.1,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 74.7,
+              "y": 108.4,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 45.3,
+              "y": 112.5,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 72,
+              "y": 113.4,
+              "v": 0.974
+            },
+            "rightHeel": {
+              "x": 44,
+              "y": 117.2,
+              "v": 0.983
+            },
+            "leftFootIndex": {
+              "x": 84.7,
+              "y": 113.9,
+              "v": 0.996
+            },
+            "rightFootIndex": {
+              "x": 47.1,
+              "y": 122.7,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.2,
+                "y": 10
+              },
+              "roll": 166,
+              "yaw": -0.02,
+              "pitch": 0.465
+            },
+            "torso": {
+              "center": {
+                "x": 64.7,
+                "y": 23.8
+              },
+              "angle": 93
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 87.8,
+                "y": 51.2
+              },
+              "angle": -73.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 44.7,
+                "y": 53.9
+              },
+              "angle": -83.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 72,
+                "y": 113.4
+              },
+              "angle": -2.3
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44,
+                "y": 117.2
+              },
+              "angle": -60.6
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.972,
+          "keypoints": {
+            "nose": {
+              "x": 61.4,
+              "y": 12,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 62.9,
+              "y": 10,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 58.9,
+              "y": 9.6,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 63.3,
+              "y": 10.6,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 55.4,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 68.7,
+              "y": 23.1,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 49.1,
+              "y": 23.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.3,
+              "y": 23.9,
+              "v": 0.984
+            },
+            "rightElbow": {
+              "x": 41.2,
+              "y": 37.9,
+              "v": 0.984
+            },
+            "leftWrist": {
+              "x": 85.4,
+              "y": 10.1,
+              "v": 0.997
+            },
+            "rightWrist": {
+              "x": 38.4,
+              "y": 50.6,
+              "v": 0.984
+            },
+            "leftIndex": {
+              "x": 84.9,
+              "y": 5.9,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 38.8,
+              "y": 55.7,
+              "v": 0.972
+            },
+            "leftHip": {
+              "x": 66.4,
+              "y": 57.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 54,
+              "y": 57.9,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 68.4,
+              "y": 84,
+              "v": 0.846
+            },
+            "rightKnee": {
+              "x": 47.3,
+              "y": 84.9,
+              "v": 0.995
+            },
+            "leftAnkle": {
+              "x": 69.5,
+              "y": 107.6,
+              "v": 0.932
+            },
+            "rightAnkle": {
+              "x": 40,
+              "y": 113.3,
+              "v": 0.996
+            },
+            "leftHeel": {
+              "x": 67.1,
+              "y": 113.1,
+              "v": 0.822
+            },
+            "rightHeel": {
+              "x": 39.1,
+              "y": 117.4,
+              "v": 0.91
+            },
+            "leftFootIndex": {
+              "x": 78.4,
+              "y": 114,
+              "v": 0.949
+            },
+            "rightFootIndex": {
+              "x": 42.4,
+              "y": 122.5,
+              "v": 0.993
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 60.9,
+                "y": 9.8
+              },
+              "roll": 174.3,
+              "yaw": 0.124,
+              "pitch": 0.547
+            },
+            "torso": {
+              "center": {
+                "x": 58.9,
+                "y": 23.2
+              },
+              "angle": 92.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.4,
+                "y": 10.1
+              },
+              "angle": 96.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 38.4,
+                "y": 50.6
+              },
+              "angle": -85.5
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 67.1,
+                "y": 113.1
+              },
+              "angle": -4.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.1,
+                "y": 117.4
+              },
+              "angle": -57.1
+            }
+          }
+        },
+        {
+          "index": 3,
+          "detected": true,
+          "avgVisibility": 0.967,
+          "keypoints": {
+            "nose": {
+              "x": 64,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 65.2,
+              "y": 11.3,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 61.5,
+              "y": 10.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 65.3,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 57.9,
+              "y": 10.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 70.3,
+              "y": 22.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 50.3,
+              "y": 23.2,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 82,
+              "y": 23.5,
+              "v": 0.964
+            },
+            "rightElbow": {
+              "x": 42.7,
+              "y": 38.6,
+              "v": 0.984
+            },
+            "leftWrist": {
+              "x": 85.2,
+              "y": 9.5,
+              "v": 0.994
+            },
+            "rightWrist": {
+              "x": 39.6,
+              "y": 53.1,
+              "v": 0.985
+            },
+            "leftIndex": {
+              "x": 84.6,
+              "y": 5.3,
+              "v": 0.99
+            },
+            "rightIndex": {
+              "x": 40.5,
+              "y": 57.9,
+              "v": 0.973
+            },
+            "leftHip": {
+              "x": 68.6,
+              "y": 57.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 55.9,
+              "y": 57.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70,
+              "y": 83.8,
+              "v": 0.813
+            },
+            "rightKnee": {
+              "x": 48.7,
+              "y": 85,
+              "v": 0.992
+            },
+            "leftAnkle": {
+              "x": 70.9,
+              "y": 107.2,
+              "v": 0.93
+            },
+            "rightAnkle": {
+              "x": 41.2,
+              "y": 113,
+              "v": 0.994
+            },
+            "leftHeel": {
+              "x": 68.3,
+              "y": 112.9,
+              "v": 0.816
+            },
+            "rightHeel": {
+              "x": 39.7,
+              "y": 116.5,
+              "v": 0.877
+            },
+            "leftFootIndex": {
+              "x": 79.4,
+              "y": 113.8,
+              "v": 0.943
+            },
+            "rightFootIndex": {
+              "x": 43.6,
+              "y": 123.1,
+              "v": 0.989
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 63.4,
+                "y": 10.9
+              },
+              "roll": 167.8,
+              "yaw": 0.172,
+              "pitch": 0.713
+            },
+            "torso": {
+              "center": {
+                "x": 60.3,
+                "y": 23
+              },
+              "angle": 93.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 85.2,
+                "y": 9.5
+              },
+              "angle": 98.1
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.6,
+                "y": 53.1
+              },
+              "angle": -79.4
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.3,
+                "y": 112.9
+              },
+              "angle": -4.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 39.7,
+                "y": 116.5
+              },
+              "angle": -59.4
+            }
+          }
+        }
+      ]
+    },
+    "defeat": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.951,
+          "keypoints": {
+            "nose": {
+              "x": 70.6,
+              "y": 13.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 72,
+              "y": 10.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 67.9,
+              "y": 10,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.3,
+              "y": 11.4,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.1,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 76.3,
+              "y": 22.7,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.4,
+              "y": 23.5,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 77.9,
+              "y": 38.5,
+              "v": 0.534
+            },
+            "rightElbow": {
+              "x": 50.6,
+              "y": 39.8,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 80.6,
+              "y": 51.9,
+              "v": 0.704
+            },
+            "rightWrist": {
+              "x": 48.6,
+              "y": 54.5,
+              "v": 0.998
+            },
+            "leftIndex": {
+              "x": 81.4,
+              "y": 56.6,
+              "v": 0.715
+            },
+            "rightIndex": {
+              "x": 48.9,
+              "y": 58.6,
+              "v": 0.996
+            },
+            "leftHip": {
+              "x": 74.8,
+              "y": 57.3,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 62.3,
+              "y": 57.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 76.3,
+              "y": 84,
+              "v": 0.977
+            },
+            "rightKnee": {
+              "x": 55.5,
+              "y": 84.6,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 77.1,
+              "y": 108.3,
+              "v": 0.994
+            },
+            "rightAnkle": {
+              "x": 47.2,
+              "y": 113.6,
+              "v": 1
+            },
+            "leftHeel": {
+              "x": 74.5,
+              "y": 113.4,
+              "v": 0.972
+            },
+            "rightHeel": {
+              "x": 46.6,
+              "y": 118.3,
+              "v": 0.986
+            },
+            "leftFootIndex": {
+              "x": 86.5,
+              "y": 114.2,
+              "v": 0.995
+            },
+            "rightFootIndex": {
+              "x": 49.1,
+              "y": 122.9,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70,
+                "y": 10.5
+              },
+              "roll": 167.6,
+              "yaw": 0.155,
+              "pitch": 0.631
+            },
+            "torso": {
+              "center": {
+                "x": 66.9,
+                "y": 23.1
+              },
+              "angle": 92.8
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 80.6,
+                "y": 51.9
+              },
+              "angle": -80.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 48.6,
+                "y": 54.5
+              },
+              "angle": -85.8
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 74.5,
+                "y": 113.4
+              },
+              "angle": -3.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 46.6,
+                "y": 118.3
+              },
+              "angle": -61.5
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.988,
+          "keypoints": {
+            "nose": {
+              "x": 72.4,
+              "y": 13.6,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.7,
+              "y": 12.1,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 70.3,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 72.8,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 66.4,
+              "y": 9.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 72.3,
+              "y": 23.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 55.1,
+              "y": 20.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 73.6,
+              "y": 40.2,
+              "v": 0.977
+            },
+            "rightElbow": {
+              "x": 46.5,
+              "y": 36.8,
+              "v": 0.997
+            },
+            "leftWrist": {
+              "x": 77.3,
+              "y": 53.6,
+              "v": 0.998
+            },
+            "rightWrist": {
+              "x": 43.6,
+              "y": 53.1,
+              "v": 0.996
+            },
+            "leftIndex": {
+              "x": 78.6,
+              "y": 57.9,
+              "v": 0.997
+            },
+            "rightIndex": {
+              "x": 44.2,
+              "y": 57.5,
+              "v": 0.993
+            },
+            "leftHip": {
+              "x": 68.9,
+              "y": 57.6,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 56,
+              "y": 57.1,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 70.5,
+              "y": 82.6,
+              "v": 0.955
+            },
+            "rightKnee": {
+              "x": 48.8,
+              "y": 84.4,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 71.6,
+              "y": 106.2,
+              "v": 0.972
+            },
+            "rightAnkle": {
+              "x": 42.5,
+              "y": 112.6,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 68.8,
+              "y": 111.8,
+              "v": 0.914
+            },
+            "rightHeel": {
+              "x": 40.9,
+              "y": 116.8,
+              "v": 0.953
+            },
+            "leftFootIndex": {
+              "x": 80.3,
+              "y": 113.3,
+              "v": 0.984
+            },
+            "rightFootIndex": {
+              "x": 45.3,
+              "y": 122.7,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 72,
+                "y": 11.3
+              },
+              "roll": 153.4,
+              "yaw": 0.105,
+              "pitch": 0.618
+            },
+            "torso": {
+              "center": {
+                "x": 63.7,
+                "y": 22.2
+              },
+              "angle": 88
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 77.3,
+                "y": 53.6
+              },
+              "angle": -73.2
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 43.6,
+                "y": 53.1
+              },
+              "angle": -82.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68.8,
+                "y": 111.8
+              },
+              "angle": -7.4
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 40.9,
+                "y": 116.8
+              },
+              "angle": -53.3
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.983,
+          "keypoints": {
+            "nose": {
+              "x": 77,
+              "y": 17.1,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 78.3,
+              "y": 14.9,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 76.1,
+              "y": 13.5,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 76.7,
+              "y": 13.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 72.4,
+              "y": 10.4,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.7,
+              "y": 21.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.5,
+              "y": 17.7,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 71.7,
+              "y": 38,
+              "v": 0.865
+            },
+            "rightElbow": {
+              "x": 45.3,
+              "y": 33.5,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 73.4,
+              "y": 51.7,
+              "v": 0.972
+            },
+            "rightWrist": {
+              "x": 39.1,
+              "y": 48.4,
+              "v": 0.997
+            },
+            "leftIndex": {
+              "x": 74,
+              "y": 55.8,
+              "v": 0.964
+            },
+            "rightIndex": {
+              "x": 38,
+              "y": 52.5,
+              "v": 0.993
+            },
+            "leftHip": {
+              "x": 63.1,
+              "y": 53.5,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 51.2,
+              "y": 53.3,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 66.7,
+              "y": 80.6,
+              "v": 0.979
+            },
+            "rightKnee": {
+              "x": 45,
+              "y": 82.9,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 67.9,
+              "y": 105.9,
+              "v": 0.985
+            },
+            "rightAnkle": {
+              "x": 38.7,
+              "y": 112.5,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 65.1,
+              "y": 111.2,
+              "v": 0.937
+            },
+            "rightHeel": {
+              "x": 36.8,
+              "y": 116.7,
+              "v": 0.944
+            },
+            "leftFootIndex": {
+              "x": 77.6,
+              "y": 112.9,
+              "v": 0.99
+            },
+            "rightFootIndex": {
+              "x": 41.6,
+              "y": 123.6,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 77.2,
+                "y": 14.2
+              },
+              "roll": 147.5,
+              "yaw": -0.077,
+              "pitch": 1.112
+            },
+            "torso": {
+              "center": {
+                "x": 66.1,
+                "y": 19.8
+              },
+              "angle": 75.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 73.4,
+                "y": 51.7
+              },
+              "angle": -81.7
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.1,
+                "y": 48.4
+              },
+              "angle": -105
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 65.1,
+                "y": 111.2
+              },
+              "angle": -7.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 36.8,
+                "y": 116.7
+              },
+              "angle": -55.2
+            }
+          }
+        }
+      ]
+    },
+    "jump": {
+      "frameCount": 3,
+      "frames": [
+        {
+          "index": 0,
+          "detected": true,
+          "avgVisibility": 0.981,
+          "keypoints": {
+            "nose": {
+              "x": 70.4,
+              "y": 14.4,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 73.5,
+              "y": 12.4,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 68.2,
+              "y": 10.9,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 75.3,
+              "y": 13.7,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 64.8,
+              "y": 11.3,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 78.1,
+              "y": 28.3,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 57.7,
+              "y": 25.3,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 78.8,
+              "y": 46.3,
+              "v": 0.802
+            },
+            "rightElbow": {
+              "x": 46,
+              "y": 42.1,
+              "v": 0.995
+            },
+            "leftWrist": {
+              "x": 86.8,
+              "y": 56,
+              "v": 0.956
+            },
+            "rightWrist": {
+              "x": 41.6,
+              "y": 58.4,
+              "v": 0.993
+            },
+            "leftIndex": {
+              "x": 91,
+              "y": 58.6,
+              "v": 0.963
+            },
+            "rightIndex": {
+              "x": 41.7,
+              "y": 62.8,
+              "v": 0.99
+            },
+            "leftHip": {
+              "x": 73.5,
+              "y": 64.1,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 59.7,
+              "y": 62.8,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 87.4,
+              "y": 91.2,
+              "v": 0.987
+            },
+            "rightKnee": {
+              "x": 69.7,
+              "y": 89.5,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 66.4,
+              "y": 108.8,
+              "v": 0.986
+            },
+            "rightAnkle": {
+              "x": 49.1,
+              "y": 106.8,
+              "v": 0.997
+            },
+            "leftHeel": {
+              "x": 61,
+              "y": 108.1,
+              "v": 0.947
+            },
+            "rightHeel": {
+              "x": 44.4,
+              "y": 106.3,
+              "v": 0.968
+            },
+            "leftFootIndex": {
+              "x": 62.5,
+              "y": 124.7,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 46.4,
+              "y": 122.8,
+              "v": 0.997
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 70.9,
+                "y": 11.7
+              },
+              "roll": 164.2,
+              "yaw": -0.082,
+              "pitch": 0.499
+            },
+            "torso": {
+              "center": {
+                "x": 67.9,
+                "y": 26.8
+              },
+              "angle": 88
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 86.8,
+                "y": 56
+              },
+              "angle": -31.8
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 41.6,
+                "y": 58.4
+              },
+              "angle": -88.7
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 61,
+                "y": 108.1
+              },
+              "angle": -84.8
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 44.4,
+                "y": 106.3
+              },
+              "angle": -83.1
+            }
+          }
+        },
+        {
+          "index": 1,
+          "detected": true,
+          "avgVisibility": 0.991,
+          "keypoints": {
+            "nose": {
+              "x": 79.6,
+              "y": 16.3,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 81.2,
+              "y": 13.8,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 77.3,
+              "y": 12.4,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 80.5,
+              "y": 14.3,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 72.1,
+              "y": 11.7,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 81.2,
+              "y": 28.8,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 60.1,
+              "y": 23.8,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 83.7,
+              "y": 48,
+              "v": 0.912
+            },
+            "rightElbow": {
+              "x": 42.8,
+              "y": 37.5,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 95.2,
+              "y": 42.1,
+              "v": 0.988
+            },
+            "rightWrist": {
+              "x": 30.4,
+              "y": 51.3,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 99.3,
+              "y": 36.4,
+              "v": 0.989
+            },
+            "rightIndex": {
+              "x": 28.3,
+              "y": 56.5,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 74.5,
+              "y": 66.7,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 61.3,
+              "y": 66.5,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 97,
+              "y": 92.1,
+              "v": 0.991
+            },
+            "rightKnee": {
+              "x": 81.2,
+              "y": 83.3,
+              "v": 1
+            },
+            "leftAnkle": {
+              "x": 73.4,
+              "y": 109.9,
+              "v": 0.98
+            },
+            "rightAnkle": {
+              "x": 59.9,
+              "y": 106.6,
+              "v": 0.998
+            },
+            "leftHeel": {
+              "x": 68,
+              "y": 109.5,
+              "v": 0.962
+            },
+            "rightHeel": {
+              "x": 53.8,
+              "y": 106.3,
+              "v": 0.986
+            },
+            "leftFootIndex": {
+              "x": 68.4,
+              "y": 126,
+              "v": 0.986
+            },
+            "rightFootIndex": {
+              "x": 57.1,
+              "y": 123.3,
+              "v": 0.998
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 79.3,
+                "y": 13.1
+              },
+              "roll": 160.3,
+              "yaw": 0.084,
+              "pitch": 0.772
+            },
+            "torso": {
+              "center": {
+                "x": 70.7,
+                "y": 26.3
+              },
+              "angle": 86.1
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 95.2,
+                "y": 42.1
+              },
+              "angle": 54.3
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 30.4,
+                "y": 51.3
+              },
+              "angle": -112
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 68,
+                "y": 109.5
+              },
+              "angle": -88.6
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 53.8,
+                "y": 106.3
+              },
+              "angle": -79
+            }
+          }
+        },
+        {
+          "index": 2,
+          "detected": true,
+          "avgVisibility": 0.994,
+          "keypoints": {
+            "nose": {
+              "x": 67.9,
+              "y": 14.8,
+              "v": 1
+            },
+            "leftEye": {
+              "x": 69.3,
+              "y": 12.5,
+              "v": 1
+            },
+            "rightEye": {
+              "x": 64.6,
+              "y": 11.2,
+              "v": 1
+            },
+            "leftEar": {
+              "x": 69.4,
+              "y": 13.5,
+              "v": 1
+            },
+            "rightEar": {
+              "x": 60.4,
+              "y": 12.2,
+              "v": 1
+            },
+            "leftShoulder": {
+              "x": 74.8,
+              "y": 29.6,
+              "v": 1
+            },
+            "rightShoulder": {
+              "x": 51.8,
+              "y": 27.9,
+              "v": 1
+            },
+            "leftElbow": {
+              "x": 81.1,
+              "y": 47.8,
+              "v": 0.967
+            },
+            "rightElbow": {
+              "x": 42.3,
+              "y": 44.8,
+              "v": 0.998
+            },
+            "leftWrist": {
+              "x": 90.2,
+              "y": 61.6,
+              "v": 0.995
+            },
+            "rightWrist": {
+              "x": 39.2,
+              "y": 60.6,
+              "v": 0.999
+            },
+            "leftIndex": {
+              "x": 91.8,
+              "y": 65.2,
+              "v": 0.994
+            },
+            "rightIndex": {
+              "x": 39.5,
+              "y": 66.7,
+              "v": 0.999
+            },
+            "leftHip": {
+              "x": 72.7,
+              "y": 66.9,
+              "v": 1
+            },
+            "rightHip": {
+              "x": 58.1,
+              "y": 66.6,
+              "v": 1
+            },
+            "leftKnee": {
+              "x": 95.3,
+              "y": 91.3,
+              "v": 0.99
+            },
+            "rightKnee": {
+              "x": 78.8,
+              "y": 83.6,
+              "v": 0.999
+            },
+            "leftAnkle": {
+              "x": 71.9,
+              "y": 110.4,
+              "v": 0.985
+            },
+            "rightAnkle": {
+              "x": 57.7,
+              "y": 106.7,
+              "v": 0.999
+            },
+            "leftHeel": {
+              "x": 66.7,
+              "y": 109.9,
+              "v": 0.961
+            },
+            "rightHeel": {
+              "x": 52.6,
+              "y": 106.9,
+              "v": 0.987
+            },
+            "leftFootIndex": {
+              "x": 67.6,
+              "y": 125.5,
+              "v": 0.989
+            },
+            "rightFootIndex": {
+              "x": 55.8,
+              "y": 122.9,
+              "v": 0.999
+            }
+          },
+          "derived": {
+            "head": {
+              "center": {
+                "x": 66.9,
+                "y": 11.9
+              },
+              "roll": 164.5,
+              "yaw": 0.195,
+              "pitch": 0.605
+            },
+            "torso": {
+              "center": {
+                "x": 63.3,
+                "y": 28.8
+              },
+              "angle": 93.2
+            },
+            "leftHand": {
+              "anchor": {
+                "x": 90.2,
+                "y": 61.6
+              },
+              "angle": -66
+            },
+            "rightHand": {
+              "anchor": {
+                "x": 39.2,
+                "y": 60.6
+              },
+              "angle": -87.2
+            },
+            "leftFoot": {
+              "anchor": {
+                "x": 66.7,
+                "y": 109.9
+              },
+              "angle": -86.7
+            },
+            "rightFoot": {
+              "anchor": {
+                "x": 52.6,
+                "y": 106.9
+              },
+              "angle": -78.7
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/asset-pipeline/cli.js
+++ b/scripts/asset-pipeline/cli.js
@@ -4,14 +4,15 @@
  * cli.js -- Asset pipeline entry point for A Los Traques
  *
  * Usage:
- *   node scripts/asset-pipeline/cli.js <type> <config.json> [--skip-generate] [--delay N] [--retries N] [--ref PATH]
+ *   node scripts/asset-pipeline/cli.js <type> <config.json> [--skip-generate] [--delay N] [--retries N] [--ref PATH] [--debug]
  *
- * Types: fighter, portrait, stage, ui, reference
+ * Types: fighter, portrait, stage, ui, reference, poses
  */
 
 import fs from 'node:fs';
 import { runFighterPipeline } from './pipelines/fighter.js';
 import { runPortraitPipeline } from './pipelines/portrait.js';
+import { runPosesPipeline } from './pipelines/poses.js';
 import { runReferencePipeline } from './pipelines/reference.js';
 import { runStagePipeline } from './pipelines/stage.js';
 import { runUIPipeline } from './pipelines/ui.js';
@@ -22,6 +23,7 @@ const PIPELINES = {
   stage: runStagePipeline,
   ui: runUIPipeline,
   reference: runReferencePipeline,
+  poses: runPosesPipeline,
 };
 
 function parseArgs() {
@@ -33,6 +35,7 @@ function parseArgs() {
     delay: 3000,
     retries: 3,
     refs: [],
+    debug: false,
   };
 
   const positional = [];
@@ -50,6 +53,9 @@ function parseArgs() {
       case '--ref':
         opts.refs.push(args[++i]);
         break;
+      case '--debug':
+        opts.debug = true;
+        break;
       default:
         positional.push(args[i]);
     }
@@ -65,7 +71,7 @@ async function main() {
 
   if (!opts.type || !opts.configPath) {
     console.error(
-      'Usage: node cli.js <type> <config.json> [--skip-generate] [--delay N] [--retries N]',
+      'Usage: node cli.js <type> <config.json> [--skip-generate] [--delay N] [--retries N] [--debug]',
     );
     console.error(`Types: ${Object.keys(PIPELINES).join(', ')}`);
     process.exit(1);
@@ -94,6 +100,7 @@ async function main() {
   config.skipGenerate = opts.skipGenerate;
   config.delay = opts.delay;
   config.retries = opts.retries;
+  config.debug = opts.debug;
 
   // Merge reference images from CLI --ref flags with manifest referenceImages
   const manifestRefs = config.referenceImages || [];

--- a/scripts/asset-pipeline/pipelines/poses.js
+++ b/scripts/asset-pipeline/pipelines/poses.js
@@ -1,0 +1,197 @@
+/**
+ * poses.js — Extract per-frame pose keypoints from fighter sprite strips.
+ *
+ * For each animation strip `{output}/{anim}.png`, splits the horizontal
+ * strip into 128x128 frames, invokes the Python MediaPipe detector once
+ * per animation, computes derived orientation angles, and writes a single
+ * consolidated `{output}/poses.json` covering every animation.
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computeDerived } from '../pose/orientations.js';
+import { appendHorizontal, getImageDimensions } from '../process.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const POSE_PYTHON_DIR = path.resolve(__dirname, '..', 'pose');
+const DETECT_SCRIPT = path.join(POSE_PYTHON_DIR, 'detect.py');
+const FRAME_SIZE = 128;
+const DEFAULT_ANIMATIONS = [
+  'idle',
+  'walk',
+  'light_punch',
+  'heavy_punch',
+  'light_kick',
+  'heavy_kick',
+  'special',
+  'block',
+  'hurt',
+  'knockdown',
+  'victory',
+  'defeat',
+  'jump',
+];
+
+function splitStrip(stripPath, outDir, frameCount) {
+  fs.mkdirSync(outDir, { recursive: true });
+  const alreadySplit = Array.from({ length: frameCount }, (_, i) =>
+    path.join(outDir, `frame_${i}.png`),
+  ).every((p) => fs.existsSync(p));
+  if (alreadySplit) return;
+
+  for (const f of fs.readdirSync(outDir)) {
+    if (/^frame_\d+(_debug)?\.png$/.test(f)) {
+      fs.unlinkSync(path.join(outDir, f));
+    }
+  }
+
+  // +repage BEFORE -crop is critical: the fighter pipeline leaves a
+  // 128x128 page geometry on the strip, and -crop would otherwise respect
+  // that and produce only the first frame.
+  execSync(
+    `magick "${stripPath}" +repage -crop ${FRAME_SIZE}x${FRAME_SIZE} +repage "${path.join(outDir, 'frame_%d.png')}"`,
+    { stdio: ['ignore', 'pipe', 'inherit'] },
+  );
+}
+
+function runDetector(frameDir, debugDir) {
+  const debugArg = debugDir ? ` --debug-dir "${debugDir}"` : '';
+  const cmd = `uv run --project "${POSE_PYTHON_DIR}" python "${DETECT_SCRIPT}" --input-dir "${frameDir}"${debugArg}`;
+
+  const stdout = execSync(cmd, {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+    maxBuffer: 64 * 1024 * 1024,
+  });
+
+  return JSON.parse(stdout);
+}
+
+function assembleDebugStrip(debugDir, frameCount, outputPath) {
+  const paths = [];
+  for (let i = 0; i < frameCount; i++) {
+    const p = path.join(debugDir, `frame_${i}_debug.png`);
+    if (!fs.existsSync(p)) return false;
+    paths.push(p);
+  }
+  appendHorizontal(paths, outputPath);
+  return true;
+}
+
+function writeAtomic(filePath, data) {
+  const tmp = `${filePath}.tmp`;
+  fs.writeFileSync(tmp, data);
+  fs.renameSync(tmp, filePath);
+}
+
+/**
+ * @param {object} config
+ * @param {string} config.output - Fighter output dir (e.g. "public/assets/fighters/simon/")
+ * @param {string} config.fighter - Fighter id (e.g. "simon")
+ * @param {string[]} [config.animations] - Animations to process
+ * @param {string} [config.rawDir="assets/_raw/poses"] - Intermediate frame dir
+ * @param {number} [config.minVisibility=0.3] - Landmark visibility threshold
+ * @param {boolean} [config.debug=false] - Emit skeleton-overlay previews
+ */
+export async function runPosesPipeline(config) {
+  const {
+    output,
+    fighter,
+    animations = DEFAULT_ANIMATIONS,
+    rawDir = 'assets/_raw/poses',
+    minVisibility = 0.3,
+    debug = false,
+  } = config;
+
+  if (!output) throw new Error('poses manifest missing "output"');
+  if (!fighter) throw new Error('poses manifest missing "fighter"');
+
+  const animationsOut = {};
+  const errors = [];
+  const summary = [];
+
+  for (const anim of animations) {
+    const stripPath = path.join(output, `${anim}.png`);
+    if (!fs.existsSync(stripPath)) {
+      console.warn(`  - skip ${anim}: strip not found at ${stripPath}`);
+      continue;
+    }
+
+    const dims = getImageDimensions(stripPath);
+    if (dims.height !== FRAME_SIZE || dims.width % FRAME_SIZE !== 0) {
+      errors.push({
+        name: `${fighter}/${anim}`,
+        error: `unexpected strip dimensions ${dims.width}x${dims.height} (expected Nx128)`,
+      });
+      continue;
+    }
+    const frameCount = dims.width / FRAME_SIZE;
+
+    const frameDir = path.join(rawDir, fighter, anim);
+    const debugDir = debug ? frameDir : null;
+
+    try {
+      splitStrip(stripPath, frameDir, frameCount);
+    } catch (err) {
+      errors.push({ name: `${fighter}/${anim}`, error: `split failed: ${err.message}` });
+      continue;
+    }
+
+    let frames;
+    try {
+      frames = runDetector(frameDir, debugDir);
+    } catch (err) {
+      errors.push({ name: `${fighter}/${anim}`, error: `detector failed: ${err.message}` });
+      continue;
+    }
+
+    const enriched = frames.map((f) => ({
+      index: f.index,
+      detected: f.detected,
+      avgVisibility: f.avgVisibility,
+      keypoints: f.keypoints,
+      derived: f.detected ? computeDerived(f.keypoints, minVisibility) : null,
+    }));
+
+    animationsOut[anim] = { frameCount, frames: enriched };
+
+    const detectedCount = enriched.filter((f) => f.detected).length;
+    summary.push(
+      `  - ${fighter}/${anim}: ${detectedCount}/${frameCount} frames detected` +
+        (detectedCount < frameCount ? ' (review debug strip)' : ''),
+    );
+
+    if (debug) {
+      const debugStripPath = path.join(rawDir, fighter, `${anim}_debug.png`);
+      try {
+        assembleDebugStrip(frameDir, frameCount, debugStripPath);
+      } catch (err) {
+        console.warn(`  - debug strip failed for ${anim}: ${err.message}`);
+      }
+    }
+  }
+
+  const manifest = {
+    version: 1,
+    fighter,
+    frameSize: FRAME_SIZE,
+    model: 'mediapipe-pose-blazepose-ghum-heavy',
+    generatedAt: new Date().toISOString(),
+    animations: animationsOut,
+  };
+
+  fs.mkdirSync(output, { recursive: true });
+  const outPath = path.join(output, 'poses.json');
+  writeAtomic(outPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  console.log('');
+  for (const line of summary) console.log(line);
+
+  return {
+    success: errors.length === 0,
+    output: outPath,
+    errors,
+  };
+}

--- a/scripts/asset-pipeline/pose/detect.py
+++ b/scripts/asset-pipeline/pose/detect.py
@@ -1,0 +1,227 @@
+"""MediaPipe pose detector for fighter sprite frames.
+
+Reads every `frame_*.png` in --input-dir, composites each RGBA frame over
+mid-gray, runs MediaPipe PoseLandmarker (heavy variant), and emits one JSON
+array on stdout containing per-frame keypoints in pixel space.
+
+When --debug-dir is provided, also writes a skeleton-overlay PNG per frame.
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+import cv2
+import mediapipe as mp
+import numpy as np
+from mediapipe.tasks import python as mp_python
+from mediapipe.tasks.python import vision as mp_vision
+
+MODEL_URL = (
+    "https://storage.googleapis.com/mediapipe-models/pose_landmarker/"
+    "pose_landmarker_heavy/float16/latest/pose_landmarker_heavy.task"
+)
+MODEL_DIR = Path(__file__).resolve().parent / "models"
+MODEL_PATH = MODEL_DIR / "pose_landmarker_heavy.task"
+
+# PoseLandmarker indices (same as legacy PoseLandmark enum).
+LANDMARK_MAP = {
+    "nose": 0,
+    "leftEye": 2,
+    "rightEye": 5,
+    "leftEar": 7,
+    "rightEar": 8,
+    "leftShoulder": 11,
+    "rightShoulder": 12,
+    "leftElbow": 13,
+    "rightElbow": 14,
+    "leftWrist": 15,
+    "rightWrist": 16,
+    "leftIndex": 19,
+    "rightIndex": 20,
+    "leftHip": 23,
+    "rightHip": 24,
+    "leftKnee": 25,
+    "rightKnee": 26,
+    "leftAnkle": 27,
+    "rightAnkle": 28,
+    "leftHeel": 29,
+    "rightHeel": 30,
+    "leftFootIndex": 31,
+    "rightFootIndex": 32,
+}
+
+# Bone connections for the debug overlay (drawn in image space with OpenCV).
+POSE_CONNECTIONS = [
+    (11, 12), (11, 13), (13, 15), (12, 14), (14, 16),  # arms + shoulders
+    (11, 23), (12, 24), (23, 24),                       # torso
+    (23, 25), (25, 27), (27, 29), (29, 31), (27, 31),   # left leg
+    (24, 26), (26, 28), (28, 30), (30, 32), (28, 32),   # right leg
+    (0, 2), (2, 7), (0, 5), (5, 8),                     # face
+]
+
+FRAME_RE = re.compile(r"frame_(\d+)\.png$")
+
+
+def ensure_model() -> Path:
+    """Download the PoseLandmarker model if it isn't cached yet."""
+    if MODEL_PATH.exists():
+        return MODEL_PATH
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"Downloading pose model to {MODEL_PATH} ...", file=sys.stderr)
+    urllib.request.urlretrieve(MODEL_URL, MODEL_PATH)
+    return MODEL_PATH
+
+
+def load_frame_rgb(path: Path) -> np.ndarray:
+    """Load a PNG and composite any alpha channel over mid-gray (128,128,128).
+
+    MediaPipe ignores alpha and treats transparent pixels as solid black, which
+    produces a hard silhouette edge and confuses the pose model. Compositing
+    onto neutral gray gives the character a clean, body-agnostic background.
+    """
+    img = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+    if img is None:
+        raise RuntimeError(f"Failed to read image: {path}")
+
+    if img.ndim == 2:
+        img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+    elif img.shape[2] == 4:
+        bgr = img[:, :, :3].astype(np.float32)
+        alpha = (img[:, :, 3:4].astype(np.float32)) / 255.0
+        bg = np.full_like(bgr, 128.0)
+        composite = bgr * alpha + bg * (1.0 - alpha)
+        img = composite.astype(np.uint8)
+
+    return cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+
+
+def detect_frame(detector, rgb: np.ndarray) -> tuple[dict | None, float, list | None]:
+    """Run pose detection on one RGB frame.
+
+    Returns (keypoints_dict_or_none, avg_visibility, landmarks_list_or_none).
+    The landmarks list is the raw 33-element array, returned so callers can
+    draw debug overlays without re-running inference.
+    """
+    h, w = rgb.shape[:2]
+    mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb)
+    result = detector.detect(mp_image)
+
+    if not result.pose_landmarks:
+        return None, 0.0, None
+
+    landmarks = result.pose_landmarks[0]
+
+    keypoints = {}
+    visibilities = []
+    for name, idx in LANDMARK_MAP.items():
+        lm = landmarks[idx]
+        keypoints[name] = {
+            "x": round(lm.x * w, 1),
+            "y": round(lm.y * h, 1),
+            "v": round(lm.visibility, 3),
+        }
+        visibilities.append(lm.visibility)
+
+    avg_vis = round(float(np.mean(visibilities)), 3) if visibilities else 0.0
+    return keypoints, avg_vis, landmarks
+
+
+def draw_debug(rgb: np.ndarray, landmarks) -> np.ndarray:
+    """Return a BGR image with a skeleton drawn on top of the input frame."""
+    bgr = cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR).copy()
+    if landmarks is None:
+        return bgr
+
+    h, w = bgr.shape[:2]
+    pts = []
+    for lm in landmarks:
+        pts.append((int(lm.x * w), int(lm.y * h), lm.visibility))
+
+    for a, b in POSE_CONNECTIONS:
+        if pts[a][2] < 0.3 or pts[b][2] < 0.3:
+            continue
+        cv2.line(bgr, pts[a][:2], pts[b][:2], (255, 255, 255), 1)
+
+    for name, idx in LANDMARK_MAP.items():
+        x, y, v = pts[idx]
+        if v < 0.3:
+            continue
+        cv2.circle(bgr, (x, y), 2, (0, 255, 0), -1)
+
+    return bgr
+
+
+def list_frames(input_dir: Path) -> list[tuple[int, Path]]:
+    """Return [(index, path), ...] sorted by frame index."""
+    frames = []
+    for p in input_dir.iterdir():
+        m = FRAME_RE.match(p.name)
+        if m:
+            frames.append((int(m.group(1)), p))
+    frames.sort(key=lambda t: t[0])
+    return frames
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", required=True, type=Path)
+    parser.add_argument("--debug-dir", type=Path, default=None)
+    args = parser.parse_args()
+
+    frames = list_frames(args.input_dir)
+    if not frames:
+        print(f"No frame_*.png found in {args.input_dir}", file=sys.stderr)
+        return 1
+
+    if args.debug_dir is not None:
+        args.debug_dir.mkdir(parents=True, exist_ok=True)
+
+    model_path = ensure_model()
+    options = mp_vision.PoseLandmarkerOptions(
+        base_options=mp_python.BaseOptions(model_asset_path=str(model_path)),
+        running_mode=mp_vision.RunningMode.IMAGE,
+        num_poses=1,
+        min_pose_detection_confidence=0.3,
+        min_pose_presence_confidence=0.3,
+        min_tracking_confidence=0.3,
+        output_segmentation_masks=False,
+    )
+
+    output = []
+    with mp_vision.PoseLandmarker.create_from_options(options) as detector:
+        for idx, path in frames:
+            rgb = load_frame_rgb(path)
+            keypoints, avg_vis, landmarks = detect_frame(detector, rgb)
+
+            if keypoints is None:
+                output.append({
+                    "index": idx,
+                    "detected": False,
+                    "avgVisibility": 0.0,
+                    "keypoints": None,
+                })
+            else:
+                output.append({
+                    "index": idx,
+                    "detected": True,
+                    "avgVisibility": avg_vis,
+                    "keypoints": keypoints,
+                })
+
+            if args.debug_dir is not None:
+                debug_img = draw_debug(rgb, landmarks)
+                cv2.imwrite(
+                    str(args.debug_dir / f"frame_{idx}_debug.png"), debug_img
+                )
+
+    json.dump(output, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/asset-pipeline/pose/orientations.js
+++ b/scripts/asset-pipeline/pose/orientations.js
@@ -1,0 +1,144 @@
+/**
+ * orientations.js — Derive orientation angles from MediaPipe keypoints.
+ *
+ * All output angles are in degrees, counter-clockwise from the positive
+ * x-axis. Image y-axis is flipped inside each atan2 call so "up" reads as
+ * positive. Phaser rotates clockwise, so renderer-side code must negate.
+ */
+
+const RAD2DEG = 180 / Math.PI;
+
+function angleDeg(from, to) {
+  return Math.atan2(-(to.y - from.y), to.x - from.x) * RAD2DEG;
+}
+
+function midpoint(a, b) {
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+}
+
+function distance(a, b) {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function visible(kp, minVisibility) {
+  return kp != null && typeof kp.v === 'number' && kp.v >= minVisibility;
+}
+
+function allVisible(keypoints, names, minVisibility) {
+  for (const name of names) {
+    if (!visible(keypoints[name], minVisibility)) return false;
+  }
+  return true;
+}
+
+function round1(n) {
+  const r = Math.round(n * 10) / 10;
+  return r === 0 ? 0 : r;
+}
+
+function round3(n) {
+  const r = Math.round(n * 1000) / 1000;
+  return r === 0 ? 0 : r;
+}
+
+function roundPoint(p) {
+  return { x: round1(p.x), y: round1(p.y) };
+}
+
+function deriveHead(kp, minVis) {
+  if (!allVisible(kp, ['leftEye', 'rightEye', 'nose'], minVis)) return null;
+  const eyeMid = midpoint(kp.leftEye, kp.rightEye);
+  const eyeDist = distance(kp.leftEye, kp.rightEye);
+  if (eyeDist < 1e-3) return null;
+
+  const roll = angleDeg(kp.leftEye, kp.rightEye);
+  const yaw = (kp.nose.x - eyeMid.x) / eyeDist;
+  const pitch = (kp.nose.y - eyeMid.y) / eyeDist;
+
+  return {
+    center: roundPoint(eyeMid),
+    roll: round1(roll),
+    yaw: round3(yaw),
+    pitch: round3(pitch),
+  };
+}
+
+function deriveTorso(kp, minVis) {
+  if (!allVisible(kp, ['leftShoulder', 'rightShoulder', 'leftHip', 'rightHip'], minVis)) {
+    return null;
+  }
+  const shoulderMid = midpoint(kp.leftShoulder, kp.rightShoulder);
+  const hipMid = midpoint(kp.leftHip, kp.rightHip);
+  return {
+    center: roundPoint(shoulderMid),
+    angle: round1(angleDeg(hipMid, shoulderMid)),
+  };
+}
+
+function deriveHand(kp, side, minVis) {
+  const wristName = `${side}Wrist`;
+  const indexName = `${side}Index`;
+  const elbowName = `${side}Elbow`;
+  if (!visible(kp[wristName], minVis)) return null;
+
+  const wrist = kp[wristName];
+  const index = kp[indexName];
+  const elbow = kp[elbowName];
+
+  let angle;
+  if (visible(index, minVis)) {
+    angle = angleDeg(wrist, index);
+  } else if (visible(elbow, minVis)) {
+    angle = angleDeg(elbow, wrist);
+  } else {
+    return null;
+  }
+
+  return { anchor: roundPoint(wrist), angle: round1(angle) };
+}
+
+function deriveFoot(kp, side, minVis) {
+  const heelName = `${side}Heel`;
+  const footName = `${side}FootIndex`;
+  const ankleName = `${side}Ankle`;
+  if (!visible(kp[heelName], minVis) && !visible(kp[ankleName], minVis)) return null;
+
+  const heel = kp[heelName];
+  const foot = kp[footName];
+  const ankle = kp[ankleName];
+
+  let anchor;
+  let angle;
+  if (visible(heel, minVis) && visible(foot, minVis)) {
+    anchor = heel;
+    angle = angleDeg(heel, foot);
+  } else if (visible(ankle, minVis) && visible(foot, minVis)) {
+    anchor = ankle;
+    angle = angleDeg(ankle, foot);
+  } else {
+    return null;
+  }
+
+  return { anchor: roundPoint(anchor), angle: round1(angle) };
+}
+
+/**
+ * Compute derived orientation fields from a keypoints object.
+ *
+ * @param {Object|null} keypoints - Named keypoints {name: {x, y, v}} or null.
+ * @param {number} [minVisibility=0.3] - Minimum visibility to use a keypoint.
+ * @returns {Object|null} {head, torso, leftHand, rightHand, leftFoot, rightFoot}
+ *   with any field null if input keypoints are missing/low confidence.
+ *   Returns null if keypoints is null.
+ */
+export function computeDerived(keypoints, minVisibility = 0.3) {
+  if (!keypoints) return null;
+  return {
+    head: deriveHead(keypoints, minVisibility),
+    torso: deriveTorso(keypoints, minVisibility),
+    leftHand: deriveHand(keypoints, 'left', minVisibility),
+    rightHand: deriveHand(keypoints, 'right', minVisibility),
+    leftFoot: deriveFoot(keypoints, 'left', minVisibility),
+    rightFoot: deriveFoot(keypoints, 'right', minVisibility),
+  };
+}

--- a/scripts/asset-pipeline/pose/pyproject.toml
+++ b/scripts/asset-pipeline/pose/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "a-los-traques-pose"
+version = "0.1.0"
+description = "MediaPipe pose detector for fighter sprite keypoint extraction"
+requires-python = ">=3.10,<3.13"
+dependencies = [
+  "mediapipe>=0.10.9,<0.11",
+  "opencv-python-headless>=4.8",
+  "numpy>=1.24,<2",
+]

--- a/scripts/asset-pipeline/pose/uv.lock
+++ b/scripts/asset-pipeline/pose/uv.lock
@@ -1,0 +1,543 @@
+version = 1
+revision = 3
+requires-python = ">=3.10, <3.13"
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
+
+[[package]]
+name = "a-los-traques-pose"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "mediapipe" },
+    { name = "numpy" },
+    { name = "opencv-python-headless" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mediapipe", specifier = ">=0.10.9,<0.11" },
+    { name = "numpy", specifier = ">=1.24,<2" },
+    { name = "opencv-python-headless", specifier = ">=4.8" },
+]
+
+[[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/a3/da4153ec8fe25d263aa48c1a4cbde7f49b59af86f0b6f7862788c60da737/contourpy-1.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ba38e3f9f330af820c4b27ceb4b9c7feee5fe0493ea53a8720f4792667465934", size = 268551, upload-time = "2025-04-15T17:34:46.581Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6c/330de89ae1087eb622bfca0177d32a7ece50c3ef07b28002de4757d9d875/contourpy-1.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dc41ba0714aa2968d1f8674ec97504a8f7e334f48eeacebcaa6256213acb0989", size = 253399, upload-time = "2025-04-15T17:34:51.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bd/20c6726b1b7f81a8bee5271bed5c165f0a8e1f572578a9d27e2ccb763cb2/contourpy-1.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9be002b31c558d1ddf1b9b415b162c603405414bacd6932d031c5b5a8b757f0d", size = 312061, upload-time = "2025-04-15T17:34:55.961Z" },
+    { url = "https://files.pythonhosted.org/packages/22/fc/a9665c88f8a2473f823cf1ec601de9e5375050f1958cbb356cdf06ef1ab6/contourpy-1.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2e74acbcba3bfdb6d9d8384cdc4f9260cae86ed9beee8bd5f54fee49a430b9", size = 351956, upload-time = "2025-04-15T17:35:00.992Z" },
+    { url = "https://files.pythonhosted.org/packages/25/eb/9f0a0238f305ad8fb7ef42481020d6e20cf15e46be99a1fcf939546a177e/contourpy-1.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e259bced5549ac64410162adc973c5e2fb77f04df4a439d00b478e57a0e65512", size = 320872, upload-time = "2025-04-15T17:35:06.177Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5c/1ee32d1c7956923202f00cf8d2a14a62ed7517bdc0ee1e55301227fc273c/contourpy-1.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad687a04bc802cbe8b9c399c07162a3c35e227e2daccf1668eb1f278cb698631", size = 325027, upload-time = "2025-04-15T17:35:11.244Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bf/9baed89785ba743ef329c2b07fd0611d12bfecbedbdd3eeecf929d8d3b52/contourpy-1.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cdd22595308f53ef2f891040ab2b93d79192513ffccbd7fe19be7aa773a5e09f", size = 1306641, upload-time = "2025-04-15T17:35:26.701Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/cc/74e5e83d1e35de2d28bd97033426b450bc4fd96e092a1f7a63dc7369b55d/contourpy-1.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b4f54d6a2defe9f257327b0f243612dd051cc43825587520b1bf74a31e2f6ef2", size = 1374075, upload-time = "2025-04-15T17:35:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/42/17f3b798fd5e033b46a16f8d9fcb39f1aba051307f5ebf441bad1ecf78f8/contourpy-1.3.2-cp310-cp310-win32.whl", hash = "sha256:f939a054192ddc596e031e50bb13b657ce318cf13d264f095ce9db7dc6ae81c0", size = 177534, upload-time = "2025-04-15T17:35:46.554Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ec/5162b8582f2c994721018d0c9ece9dc6ff769d298a8ac6b6a652c307e7df/contourpy-1.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:c440093bbc8fc21c637c03bafcbef95ccd963bc6e0514ad887932c18ca2a759a", size = 221188, upload-time = "2025-04-15T17:35:50.064Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/b9/ede788a0b56fc5b071639d06c33cb893f68b1178938f3425debebe2dab78/contourpy-1.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6a37a2fb93d4df3fc4c0e363ea4d16f83195fc09c891bc8ce072b9d084853445", size = 269636, upload-time = "2025-04-15T17:35:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/75/3469f011d64b8bbfa04f709bfc23e1dd71be54d05b1b083be9f5b22750d1/contourpy-1.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b7cd50c38f500bbcc9b6a46643a40e0913673f869315d8e70de0438817cb7773", size = 254636, upload-time = "2025-04-15T17:35:58.283Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2f/95adb8dae08ce0ebca4fd8e7ad653159565d9739128b2d5977806656fcd2/contourpy-1.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6658ccc7251a4433eebd89ed2672c2ed96fba367fd25ca9512aa92a4b46c4f1", size = 313053, upload-time = "2025-04-15T17:36:03.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a6/8ccf97a50f31adfa36917707fe39c9a0cbc24b3bbb58185577f119736cc9/contourpy-1.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:70771a461aaeb335df14deb6c97439973d253ae70660ca085eec25241137ef43", size = 352985, upload-time = "2025-04-15T17:36:08.275Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b6/7925ab9b77386143f39d9c3243fdd101621b4532eb126743201160ffa7e6/contourpy-1.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65a887a6e8c4cd0897507d814b14c54a8c2e2aa4ac9f7686292f9769fcf9a6ab", size = 323750, upload-time = "2025-04-15T17:36:13.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f3/20c5d1ef4f4748e52d60771b8560cf00b69d5c6368b5c2e9311bcfa2a08b/contourpy-1.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3859783aefa2b8355697f16642695a5b9792e7a46ab86da1118a4a23a51a33d7", size = 326246, upload-time = "2025-04-15T17:36:18.329Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e5/9dae809e7e0b2d9d70c52b3d24cba134dd3dad979eb3e5e71f5df22ed1f5/contourpy-1.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eab0f6db315fa4d70f1d8ab514e527f0366ec021ff853d7ed6a2d33605cf4b83", size = 1308728, upload-time = "2025-04-15T17:36:33.878Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/0058ba34aeea35c0b442ae61a4f4d4ca84d6df8f91309bc2d43bb8dd248f/contourpy-1.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d91a3ccc7fea94ca0acab82ceb77f396d50a1f67412efe4c526f5d20264e6ecd", size = 1375762, upload-time = "2025-04-15T17:36:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/09/33/7174bdfc8b7767ef2c08ed81244762d93d5c579336fc0b51ca57b33d1b80/contourpy-1.3.2-cp311-cp311-win32.whl", hash = "sha256:1c48188778d4d2f3d48e4643fb15d8608b1d01e4b4d6b0548d9b336c28fc9b6f", size = 178196, upload-time = "2025-04-15T17:36:55.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fe/4029038b4e1c4485cef18e480b0e2cd2d755448bb071eb9977caac80b77b/contourpy-1.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:5ebac872ba09cb8f2131c46b8739a7ff71de28a24c869bcad554477eb089a878", size = 222017, upload-time = "2025-04-15T17:36:58.576Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/44785876384eff370c251d58fd65f6ad7f39adce4a093c934d4a67a7c6b6/contourpy-1.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4caf2bcd2969402bf77edc4cb6034c7dd7c0803213b3523f111eb7460a51b8d2", size = 271580, upload-time = "2025-04-15T17:37:03.105Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3b/0004767622a9826ea3d95f0e9d98cd8729015768075d61f9fea8eeca42a8/contourpy-1.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:82199cb78276249796419fe36b7386bd8d2cc3f28b3bc19fe2454fe2e26c4c15", size = 255530, upload-time = "2025-04-15T17:37:07.026Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bb/7bd49e1f4fa805772d9fd130e0d375554ebc771ed7172f48dfcd4ca61549/contourpy-1.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:106fab697af11456fcba3e352ad50effe493a90f893fca6c2ca5c033820cea92", size = 307688, upload-time = "2025-04-15T17:37:11.481Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/97/e1d5dbbfa170725ef78357a9a0edc996b09ae4af170927ba8ce977e60a5f/contourpy-1.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d14f12932a8d620e307f715857107b1d1845cc44fdb5da2bc8e850f5ceba9f87", size = 347331, upload-time = "2025-04-15T17:37:18.212Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/66/e69e6e904f5ecf6901be3dd16e7e54d41b6ec6ae3405a535286d4418ffb4/contourpy-1.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:532fd26e715560721bb0d5fc7610fce279b3699b018600ab999d1be895b09415", size = 318963, upload-time = "2025-04-15T17:37:22.76Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/32/b8a1c8965e4f72482ff2d1ac2cd670ce0b542f203c8e1d34e7c3e6925da7/contourpy-1.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26b383144cf2d2c29f01a1e8170f50dacf0eac02d64139dcd709a8ac4eb3cfe", size = 323681, upload-time = "2025-04-15T17:37:33.001Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c6/12a7e6811d08757c7162a541ca4c5c6a34c0f4e98ef2b338791093518e40/contourpy-1.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c49f73e61f1f774650a55d221803b101d966ca0c5a2d6d5e4320ec3997489441", size = 1308674, upload-time = "2025-04-15T17:37:48.64Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/8a/bebe5a3f68b484d3a2b8ffaf84704b3e343ef1addea528132ef148e22b3b/contourpy-1.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d80b2c0300583228ac98d0a927a1ba6a2ba6b8a742463c564f1d419ee5b211e", size = 1380480, upload-time = "2025-04-15T17:38:06.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/db/fcd325f19b5978fb509a7d55e06d99f5f856294c1991097534360b307cf1/contourpy-1.3.2-cp312-cp312-win32.whl", hash = "sha256:90df94c89a91b7362e1142cbee7568f86514412ab8a2c0d0fca72d7e91b62912", size = 178489, upload-time = "2025-04-15T17:38:10.338Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/fadd0b92ffa7b5eb5949bf340a63a4a496a6930a6c37a7ba0f12acb076d6/contourpy-1.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:8c942a01d9163e2e5cfb05cb66110121b8d07ad438a17f9e766317bcb62abf73", size = 223042, upload-time = "2025-04-15T17:38:14.239Z" },
+    { url = "https://files.pythonhosted.org/packages/33/05/b26e3c6ecc05f349ee0013f0bb850a761016d89cec528a98193a48c34033/contourpy-1.3.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:fd93cc7f3139b6dd7aab2f26a90dde0aa9fc264dbf70f6740d498a70b860b82c", size = 265681, upload-time = "2025-04-15T17:44:59.314Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/25/ac07d6ad12affa7d1ffed11b77417d0a6308170f44ff20fa1d5aa6333f03/contourpy-1.3.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:107ba8a6a7eec58bb475329e6d3b95deba9440667c4d62b9b6063942b61d7f16", size = 315101, upload-time = "2025-04-15T17:45:04.165Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/4d/5bb3192bbe9d3f27e3061a6a8e7733c9120e203cb8515767d30973f71030/contourpy-1.3.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ded1706ed0c1049224531b81128efbd5084598f18d8a2d9efae833edbd2b40ad", size = 220599, upload-time = "2025-04-15T17:45:08.456Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c0/91f1215d0d9f9f343e4773ba6c9b89e8c0cc7a64a6263f21139da639d848/contourpy-1.3.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5f5964cdad279256c084b69c3f412b7801e15356b16efa9d78aa974041903da0", size = 266807, upload-time = "2025-04-15T17:45:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/79/6be7e90c955c0487e7712660d6cead01fa17bff98e0ea275737cc2bc8e71/contourpy-1.3.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49b65a95d642d4efa8f64ba12558fcb83407e58a2dfba9d796d77b63ccfcaff5", size = 318729, upload-time = "2025-04-15T17:45:20.166Z" },
+    { url = "https://files.pythonhosted.org/packages/87/68/7f46fb537958e87427d98a4074bcde4b67a70b04900cfc5ce29bc2f556c1/contourpy-1.3.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8c5acb8dddb0752bf252e01a3035b21443158910ac16a3b0d20e7fed7d534ce5", size = 221791, upload-time = "2025-04-15T17:45:24.794Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/2e/c4390a31919d8a78b90e8ecf87cd4b4c4f05a5b48d05ec17db8e5404c6f4/contourpy-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:709a48ef9a690e1343202916450bc48b9e51c049b089c7f79a267b46cffcdaa1", size = 288773, upload-time = "2025-07-26T12:01:02.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/44/c4b0b6095fef4dc9c420e041799591e3b63e9619e3044f7f4f6c21c0ab24/contourpy-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23416f38bfd74d5d28ab8429cc4d63fa67d5068bd711a85edb1c3fb0c3e2f381", size = 270149, upload-time = "2025-07-26T12:01:04.072Z" },
+    { url = "https://files.pythonhosted.org/packages/30/2e/dd4ced42fefac8470661d7cb7e264808425e6c5d56d175291e93890cce09/contourpy-1.3.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:929ddf8c4c7f348e4c0a5a3a714b5c8542ffaa8c22954862a46ca1813b667ee7", size = 329222, upload-time = "2025-07-26T12:01:05.688Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/74/cc6ec2548e3d276c71389ea4802a774b7aa3558223b7bade3f25787fafc2/contourpy-1.3.3-cp311-cp311-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9e999574eddae35f1312c2b4b717b7885d4edd6cb46700e04f7f02db454e67c1", size = 377234, upload-time = "2025-07-26T12:01:07.054Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b3/64ef723029f917410f75c09da54254c5f9ea90ef89b143ccadb09df14c15/contourpy-1.3.3-cp311-cp311-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0bf67e0e3f482cb69779dd3061b534eb35ac9b17f163d851e2a547d56dba0a3a", size = 380555, upload-time = "2025-07-26T12:01:08.801Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/4b/6157f24ca425b89fe2eb7e7be642375711ab671135be21e6faa100f7448c/contourpy-1.3.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51e79c1f7470158e838808d4a996fa9bac72c498e93d8ebe5119bc1e6becb0db", size = 355238, upload-time = "2025-07-26T12:01:10.319Z" },
+    { url = "https://files.pythonhosted.org/packages/98/56/f914f0dd678480708a04cfd2206e7c382533249bc5001eb9f58aa693e200/contourpy-1.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:598c3aaece21c503615fd59c92a3598b428b2f01bfb4b8ca9c4edeecc2438620", size = 1326218, upload-time = "2025-07-26T12:01:12.659Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d7/4a972334a0c971acd5172389671113ae82aa7527073980c38d5868ff1161/contourpy-1.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:322ab1c99b008dad206d406bb61d014cf0174df491ae9d9d0fac6a6fda4f977f", size = 1392867, upload-time = "2025-07-26T12:01:15.533Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3e/f2cc6cd56dc8cff46b1a56232eabc6feea52720083ea71ab15523daab796/contourpy-1.3.3-cp311-cp311-win32.whl", hash = "sha256:fd907ae12cd483cd83e414b12941c632a969171bf90fc937d0c9f268a31cafff", size = 183677, upload-time = "2025-07-26T12:01:17.088Z" },
+    { url = "https://files.pythonhosted.org/packages/98/4b/9bd370b004b5c9d8045c6c33cf65bae018b27aca550a3f657cdc99acdbd8/contourpy-1.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:3519428f6be58431c56581f1694ba8e50626f2dd550af225f82fb5f5814d2a42", size = 225234, upload-time = "2025-07-26T12:01:18.256Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b6/71771e02c2e004450c12b1120a5f488cad2e4d5b590b1af8bad060360fe4/contourpy-1.3.3-cp311-cp311-win_arm64.whl", hash = "sha256:15ff10bfada4bf92ec8b31c62bf7c1834c244019b4a33095a68000d7075df470", size = 193123, upload-time = "2025-07-26T12:01:19.848Z" },
+    { url = "https://files.pythonhosted.org/packages/be/45/adfee365d9ea3d853550b2e735f9d66366701c65db7855cd07621732ccfc/contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb", size = 293419, upload-time = "2025-07-26T12:01:21.16Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6", size = 273979, upload-time = "2025-07-26T12:01:22.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/a12359b9b2ca3a845e8f7f9ac08bdf776114eb931392fcad91743e2ea17b/contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7", size = 332653, upload-time = "2025-07-26T12:01:24.155Z" },
+    { url = "https://files.pythonhosted.org/packages/63/12/897aeebfb475b7748ea67b61e045accdfcf0d971f8a588b67108ed7f5512/contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8", size = 379536, upload-time = "2025-07-26T12:01:25.91Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8a/a8c584b82deb248930ce069e71576fc09bd7174bbd35183b7943fb1064fd/contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea", size = 384397, upload-time = "2025-07-26T12:01:27.152Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1", size = 362601, upload-time = "2025-07-26T12:01:28.808Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0a/a3fe3be3ee2dceb3e615ebb4df97ae6f3828aa915d3e10549ce016302bd1/contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7", size = 1331288, upload-time = "2025-07-26T12:01:31.198Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1d/acad9bd4e97f13f3e2b18a3977fe1b4a37ecf3d38d815333980c6c72e963/contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411", size = 1403386, upload-time = "2025-07-26T12:01:33.947Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8f/5847f44a7fddf859704217a99a23a4f6417b10e5ab1256a179264561540e/contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69", size = 185018, upload-time = "2025-07-26T12:01:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b", size = 226567, upload-time = "2025-07-26T12:01:36.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e2/f05240d2c39a1ed228d8328a78b6f44cd695f7ef47beb3e684cf93604f86/contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc", size = 193655, upload-time = "2025-07-26T12:01:37.999Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/29/8dcfe16f0107943fa92388c23f6e05cff0ba58058c4c95b00280d4c75a14/contourpy-1.3.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:cd5dfcaeb10f7b7f9dc8941717c6c2ade08f587be2226222c12b25f0483ed497", size = 278809, upload-time = "2025-07-26T12:02:52.74Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/8b37ef4f7dafeb335daee3c8254645ef5725be4d9c6aa70b50ec46ef2f7e/contourpy-1.3.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:0c1fc238306b35f246d61a1d416a627348b5cf0648648a031e14bb8705fcdfe8", size = 261593, upload-time = "2025-07-26T12:02:54.037Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/59/ebfb8c677c75605cc27f7122c90313fd2f375ff3c8d19a1694bda74aaa63/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f9aad7de812d6541d29d2bbf8feb22ff7e1c299523db288004e3157ff4674e", size = 302202, upload-time = "2025-07-26T12:02:55.947Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/37/21972a15834d90bfbfb009b9d004779bd5a07a0ec0234e5ba8f64d5736f4/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989", size = 329207, upload-time = "2025-07-26T12:02:57.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/bd257695f39d05594ca4ad60df5bcb7e32247f9951fd09a9b8edb82d1daa/contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77", size = 225315, upload-time = "2025-07-26T12:02:58.801Z" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.62.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d", size = 3580737, upload-time = "2026-03-13T13:54:25.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/532ed43808b469c807e8cb6b21358da3fe6fd51486b3a8c93db0bb5d957f/fonttools-4.62.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ad5cca75776cd453b1b035b530e943334957ae152a36a88a320e779d61fc980c", size = 2873740, upload-time = "2026-03-13T13:52:11.822Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e4/2318d2b430562da7227010fb2bb029d2fa54d7b46443ae8942bab224e2a0/fonttools-4.62.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0b3ae47e8636156a9accff64c02c0924cbebad62854c4a6dbdc110cd5b4b341a", size = 2417649, upload-time = "2026-03-13T13:52:14.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/28/40f15523b5188598018e7956899fed94eb7debec89e2dd70cb4a8df90492/fonttools-4.62.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b9e288b4da2f64fd6180644221749de651703e8d0c16bd4b719533a3a7d6e3", size = 4935213, upload-time = "2026-03-13T13:52:17.399Z" },
+    { url = "https://files.pythonhosted.org/packages/42/09/7dbe3d7023f57d9b580cfa832109d521988112fd59dddfda3fddda8218f9/fonttools-4.62.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7bca7a1c1faf235ffe25d4f2e555246b4750220b38de8261d94ebc5ce8a23c23", size = 4892374, upload-time = "2026-03-13T13:52:20.175Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/2d/84509a2e32cb925371560ef5431365d8da2183c11d98e5b4b8b4e42426a5/fonttools-4.62.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b4e0fcf265ad26e487c56cb12a42dffe7162de708762db951e1b3f755319507d", size = 4911856, upload-time = "2026-03-13T13:52:22.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/80/df28131379eed93d9e6e6fccd3bf6e3d077bebbfe98cc83f21bbcd83ed02/fonttools-4.62.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2d850f66830a27b0d498ee05adb13a3781637b1826982cd7e2b3789ef0cc71ae", size = 5031712, upload-time = "2026-03-13T13:52:25.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/03/3c8f09aad64230cd6d921ae7a19f9603c36f70930b00459f112706f6769a/fonttools-4.62.1-cp310-cp310-win32.whl", hash = "sha256:486f32c8047ccd05652aba17e4a8819a3a9d78570eb8a0e3b4503142947880ed", size = 1507878, upload-time = "2026-03-13T13:52:28.149Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ec/f53f626f8f3e89f4cadd8fc08f3452c8fd182c951ad5caa35efac22b29ab/fonttools-4.62.1-cp310-cp310-win_amd64.whl", hash = "sha256:5a648bde915fba9da05ae98856987ca91ba832949a9e2888b48c47ef8b96c5a9", size = 1556766, upload-time = "2026-03-13T13:52:30.814Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/23ff32561ec8d45a4d48578b4d241369d9270dc50926c017570e60893701/fonttools-4.62.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:40975849bac44fb0b9253d77420c6d8b523ac4dcdcefeff6e4d706838a5b80f7", size = 2871039, upload-time = "2026-03-13T13:52:33.127Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7f/66d3f8a9338a9b67fe6e1739f47e1cd5cee78bd3bc1206ef9b0b982289a5/fonttools-4.62.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9dde91633f77fa576879a0c76b1d89de373cae751a98ddf0109d54e173b40f14", size = 2416346, upload-time = "2026-03-13T13:52:35.676Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/53/5276ceba7bff95da7793a07c5284e1da901cf00341ce5e2f3273056c0cca/fonttools-4.62.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6acb4109f8bee00fec985c8c7afb02299e35e9c94b57287f3ea542f28bd0b0a7", size = 5100897, upload-time = "2026-03-13T13:52:38.102Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a1/40a5c4d8e28b0851d53a8eeeb46fbd73c325a2a9a165f290a5ed90e6c597/fonttools-4.62.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1c5c25671ce8805e0d080e2ffdeca7f1e86778c5cbfbeae86d7f866d8830517b", size = 5071078, upload-time = "2026-03-13T13:52:41.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/d378fca4c65ea1956fee6d90ace6e861776809cbbc5af22388a090c3c092/fonttools-4.62.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a5d8825e1140f04e6c99bb7d37a9e31c172f3bc208afbe02175339e699c710e1", size = 5076908, upload-time = "2026-03-13T13:52:44.122Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d9/ae6a1d0693a4185a84605679c8a1f719a55df87b9c6e8e817bfdd9ef5936/fonttools-4.62.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:268abb1cb221e66c014acc234e872b7870d8b5d4657a83a8f4205094c32d2416", size = 5202275, upload-time = "2026-03-13T13:52:46.591Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6c/af95d9c4efb15cabff22642b608342f2bd67137eea6107202d91b5b03184/fonttools-4.62.1-cp311-cp311-win32.whl", hash = "sha256:942b03094d7edbb99bdf1ae7e9090898cad7bf9030b3d21f33d7072dbcb51a53", size = 2293075, upload-time = "2026-03-13T13:52:48.711Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/97/bf54c5b3f2be34e1f143e6db838dfdc54f2ffa3e68c738934c82f3b2a08d/fonttools-4.62.1-cp311-cp311-win_amd64.whl", hash = "sha256:e8514f4924375f77084e81467e63238b095abda5107620f49421c368a6017ed2", size = 2344593, upload-time = "2026-03-13T13:52:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d4/dbacced3953544b9a93088cc10ef2b596d348c983d5c67a404fa41ec51ba/fonttools-4.62.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:90365821debbd7db678809c7491ca4acd1e0779b9624cdc6ddaf1f31992bf974", size = 2870219, upload-time = "2026-03-13T13:52:53.664Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9e/a769c8e99b81e5a87ab7e5e7236684de4e96246aae17274e5347d11ebd78/fonttools-4.62.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12859ff0b47dd20f110804c3e0d0970f7b832f561630cd879969011541a464a9", size = 2414891, upload-time = "2026-03-13T13:52:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936", size = 5033197, upload-time = "2026-03-13T13:52:59.179Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392", size = 4988768, upload-time = "2026-03-13T13:53:02.761Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04", size = 4971512, upload-time = "2026-03-13T13:53:05.678Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d", size = 5122723, upload-time = "2026-03-13T13:53:08.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/47/b3a5342d381595ef439adec67848bed561ab7fdb1019fa522e82101b7d9c/fonttools-4.62.1-cp312-cp312-win32.whl", hash = "sha256:a24decd24d60744ee8b4679d38e88b8303d86772053afc29b19d23bb8207803c", size = 2281278, upload-time = "2026-03-13T13:53:10.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b1/0c2ab56a16f409c6c8a68816e6af707827ad5d629634691ff60a52879792/fonttools-4.62.1-cp312-cp312-win_amd64.whl", hash = "sha256:9e7863e10b3de72376280b515d35b14f5eeed639d1aa7824f4cf06779ec65e42", size = 2331414, upload-time = "2026-03-13T13:53:13.992Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/f8/06549565caa026e540b7e7bab5c5a90eb7ca986015f4c48dace243cd24d9/kiwisolver-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:32cc0a5365239a6ea0c6ed461e8838d053b57e397443c0ca894dcc8e388d4374", size = 122802, upload-time = "2026-03-09T13:12:37.515Z" },
+    { url = "https://files.pythonhosted.org/packages/84/eb/8476a0818850c563ff343ea7c9c05dcdcbd689a38e01aa31657df01f91fa/kiwisolver-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cc0b66c1eec9021353a4b4483afb12dfd50e3669ffbb9152d6842eb34c7e29fd", size = 66216, upload-time = "2026-03-09T13:12:38.812Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/f9c8a6b4c21aed4198566e45923512986d6cef530e7263b3a5f823546561/kiwisolver-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:86e0287879f75621ae85197b0877ed2f8b7aa57b511c7331dce2eb6f4de7d476", size = 63917, upload-time = "2026-03-09T13:12:40.053Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/0e/ba4ae25d03722f64de8b2c13e80d82ab537a06b30fc7065183c6439357e3/kiwisolver-1.5.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:62f59da443c4f4849f73a51a193b1d9d258dcad0c41bc4d1b8fb2bcc04bfeb22", size = 1628776, upload-time = "2026-03-09T13:12:41.976Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e4/3f43a011bc8a0860d1c96f84d32fa87439d3feedf66e672fef03bf5e8bac/kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9190426b7aa26c5229501fa297b8d0653cfd3f5a36f7990c264e157cbf886b3b", size = 1228164, upload-time = "2026-03-09T13:12:44.002Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/34/3a901559a1e0c218404f9a61a93be82d45cb8f44453ba43088644980f033/kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c8277104ded0a51e699c8c3aff63ce2c56d4ed5519a5f73e0fd7057f959a2b9e", size = 1246656, upload-time = "2026-03-09T13:12:45.557Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9e/f78c466ea20527822b95ad38f141f2de1dcd7f23fb8716b002b0d91bbe59/kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8f9baf6f0a6e7571c45c8863010b45e837c3ee1c2c77fcd6ef423be91b21fedb", size = 1295562, upload-time = "2026-03-09T13:12:47.562Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/66/fd0e4a612e3a286c24e6d6f3a5428d11258ed1909bc530ba3b59807fd980/kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cff8e5383db4989311f99e814feeb90c4723eb4edca425b9d5d9c3fefcdd9537", size = 2178473, upload-time = "2026-03-09T13:12:50.254Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8e/6cac929e0049539e5ee25c1ee937556f379ba5204840d03008363ced662d/kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ebae99ed6764f2b5771c522477b311be313e8841d2e0376db2b10922daebbba4", size = 2274035, upload-time = "2026-03-09T13:12:51.785Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d3/9d0c18f1b52ea8074b792452cf17f1f5a56bd0302a85191f405cfbf9da16/kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:d5cd5189fc2b6a538b75ae45433140c4823463918f7b1617c31e68b085c0022c", size = 2443217, upload-time = "2026-03-09T13:12:53.329Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2a/6e19368803a038b2a90857bf4ee9e3c7b667216d045866bf22d3439fd75e/kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f42c23db5d1521218a3276bb08666dcb662896a0be7347cba864eca45ff64ede", size = 2249196, upload-time = "2026-03-09T13:12:55.057Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2b/3f641dfcbe72e222175d626bacf2f72c3b34312afec949dd1c50afa400f5/kiwisolver-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:94eff26096eb5395136634622515b234ecb6c9979824c1f5004c6e3c3c85ccd2", size = 73389, upload-time = "2026-03-09T13:12:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/da/88/299b137b9e0025d8982e03d2d52c123b0a2b159e84b0ef1501ef446339cf/kiwisolver-1.5.0-cp310-cp310-win_arm64.whl", hash = "sha256:dd952e03bfbb096cfe2dd35cd9e00f269969b67536cb4370994afc20ff2d0875", size = 64782, upload-time = "2026-03-09T13:12:57.609Z" },
+    { url = "https://files.pythonhosted.org/packages/12/dd/a495a9c104be1c476f0386e714252caf2b7eca883915422a64c50b88c6f5/kiwisolver-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9eed0f7edbb274413b6ee781cca50541c8c0facd3d6fd289779e494340a2b85c", size = 122798, upload-time = "2026-03-09T13:12:58.963Z" },
+    { url = "https://files.pythonhosted.org/packages/11/60/37b4047a2af0cf5ef6d8b4b26e91829ae6fc6a2d1f74524bcb0e7cd28a32/kiwisolver-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c4923e404d6bcd91b6779c009542e5647fef32e4a5d75e115e3bbac6f2335eb", size = 66216, upload-time = "2026-03-09T13:13:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/aa/510dc933d87767584abfe03efa445889996c70c2990f6f87c3ebaa0a18c5/kiwisolver-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0df54df7e686afa55e6f21fb86195224a6d9beb71d637e8d7920c95cf0f89aac", size = 63911, upload-time = "2026-03-09T13:13:01.671Z" },
+    { url = "https://files.pythonhosted.org/packages/80/46/bddc13df6c2a40741e0cc7865bb1c9ed4796b6760bd04ce5fae3928ef917/kiwisolver-1.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2517e24d7315eb51c10664cdb865195df38ab74456c677df67bb47f12d088a27", size = 1438209, upload-time = "2026-03-09T13:13:03.385Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d6/76621246f5165e5372f02f5e6f3f48ea336a8f9e96e43997d45b240ed8cd/kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff710414307fefa903e0d9bdf300972f892c23477829f49504e59834f4195398", size = 1248888, upload-time = "2026-03-09T13:13:05.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c1/31559ec6fb39a5b48035ce29bb63ade628f321785f38c384dee3e2c08bc1/kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6176c1811d9d5a04fa391c490cc44f451e240697a16977f11c6f722efb9041db", size = 1266304, upload-time = "2026-03-09T13:13:06.743Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ef/1cb8276f2d29cc6a41e0a042f27946ca347d3a4a75acf85d0a16aa6dcc82/kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50847dca5d197fcbd389c805aa1a1cf32f25d2e7273dc47ab181a517666b68cc", size = 1319650, upload-time = "2026-03-09T13:13:08.607Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e4/5ba3cecd7ce6236ae4a80f67e5d5531287337d0e1f076ca87a5abe4cd5d0/kiwisolver-1.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:01808c6d15f4c3e8559595d6d1fe6411c68e4a3822b4b9972b44473b24f4e679", size = 970949, upload-time = "2026-03-09T13:13:10.299Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/69/dc61f7ae9a2f071f26004ced87f078235b5507ab6e5acd78f40365655034/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f1f9f4121ec58628c96baa3de1a55a4e3a333c5102c8e94b64e23bf7b2083309", size = 2199125, upload-time = "2026-03-09T13:13:11.841Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7b/abbe0f1b5afa85f8d084b73e90e5f801c0939eba16ac2e49af7c61a6c28d/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b7d335370ae48a780c6e6a6bbfa97342f563744c39c35562f3f367665f5c1de2", size = 2293783, upload-time = "2026-03-09T13:13:14.399Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/80/5908ae149d96d81580d604c7f8aefd0e98f4fd728cf172f477e9f2a81744/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:800ee55980c18545af444d93fdd60c56b580db5cc54867d8cbf8a1dc0829938c", size = 1960726, upload-time = "2026-03-09T13:13:16.047Z" },
+    { url = "https://files.pythonhosted.org/packages/84/08/a78cb776f8c085b7143142ce479859cfec086bd09ee638a317040b6ef420/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:c438f6ca858697c9ab67eb28246c92508af972e114cac34e57a6d4ba17a3ac08", size = 2464738, upload-time = "2026-03-09T13:13:17.897Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e1/65584da5356ed6cb12c63791a10b208860ac40a83de165cb6a6751a686e3/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8c63c91f95173f9c2a67c7c526b2cea976828a0e7fced9cdcead2802dc10f8a4", size = 2270718, upload-time = "2026-03-09T13:13:19.421Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6c/28f17390b62b8f2f520e2915095b3c94d88681ecf0041e75389d9667f202/kiwisolver-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:beb7f344487cdcb9e1efe4b7a29681b74d34c08f0043a327a74da852a6749e7b", size = 73480, upload-time = "2026-03-09T13:13:20.818Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/0e/2ee5debc4f77a625778fec5501ff3e8036fe361b7ee28ae402a485bb9694/kiwisolver-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:ad4ae4ffd1ee9cd11357b4c66b612da9888f4f4daf2f36995eda64bd45370cac", size = 64930, upload-time = "2026-03-09T13:13:21.997Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b2/818b74ebea34dabe6d0c51cb1c572e046730e64844da6ed646d5298c40ce/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9", size = 123158, upload-time = "2026-03-09T13:13:23.127Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d9/405320f8077e8e1c5c4bd6adc45e1e6edf6d727b6da7f2e2533cf58bff71/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588", size = 66388, upload-time = "2026-03-09T13:13:24.765Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9f/795fedf35634f746151ca8839d05681ceb6287fbed6cc1c9bf235f7887c2/kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819", size = 64068, upload-time = "2026-03-09T13:13:25.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f", size = 1477934, upload-time = "2026-03-09T13:13:27.166Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf", size = 1278537, upload-time = "2026-03-09T13:13:28.707Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/9b782923aada3fafb1d6b84e13121954515c669b18af0c26e7d21f579855/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d", size = 1296685, upload-time = "2026-03-09T13:13:30.528Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/83241b6634b04fe44e892688d5208332bde130f38e610c0418f9ede47ded/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083", size = 1346024, upload-time = "2026-03-09T13:13:32.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/db/30ed226fb271ae1a6431fc0fe0edffb2efe23cadb01e798caeb9f2ceae8f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6", size = 987241, upload-time = "2026-03-09T13:13:34.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/c314595208e4c9587652d50959ead9e461995389664e490f4dce7ff0f782/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1", size = 2227742, upload-time = "2026-03-09T13:13:36.4Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/43/0499cec932d935229b5543d073c2b87c9c22846aab48881e9d8d6e742a2d/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0", size = 2323966, upload-time = "2026-03-09T13:13:38.204Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/79b0d760907965acfd9d61826a3d41f8f093c538f55cd2633d3f0db269f6/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15", size = 1977417, upload-time = "2026-03-09T13:13:39.966Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/01d0537c41cb75a551a438c3c7a80d0c60d60b81f694dac83dd436aec0d0/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314", size = 2491238, upload-time = "2026-03-09T13:13:41.698Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947, upload-time = "2026-03-09T13:13:43.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/0348374369ca588f8fe9c338fae49fa4e16eeb10ffb3d012f23a54578a9e/kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384", size = 73569, upload-time = "2026-03-09T13:13:45.792Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/192b26196e2316e2bd29deef67e37cdf9870d9af8e085e521afff0fed526/kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7", size = 64997, upload-time = "2026-03-09T13:13:46.878Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fa/2910df836372d8761bb6eff7d8bdcb1613b5c2e03f260efe7abe34d388a7/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797", size = 130262, upload-time = "2026-03-09T13:15:35.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6f/6fd4f690a40c2582fa34b97d2678f718acf3706b91d270c65ecb455d0a06/kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:295d9ffe712caa9f8a3081de8d32fc60191b4b51c76f02f951fd8407253528f4", size = 59606, upload-time = "2026-03-09T13:15:40.81Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a0/2355d5e3b338f13ce63f361abb181e3b6ea5fffdb73f739b3e80efa76159/kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:51e8c4084897de9f05898c2c2a39af6318044ae969d46ff7a34ed3f96274adca", size = 57537, upload-time = "2026-03-09T13:15:42.071Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b9/1d50e610ecadebe205b71d6728fd224ce0e0ca6aba7b9cbe1da049203ac5/kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b83af57bdddef03c01a9138034c6ff03181a3028d9a1003b301eb1a55e161a3f", size = 79888, upload-time = "2026-03-09T13:15:43.317Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ee/b85ffcd75afed0357d74f0e6fc02a4507da441165de1ca4760b9f496390d/kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf4679a3d71012a7c2bf360e5cd878fbd5e4fcac0896b56393dec239d81529ed", size = 77584, upload-time = "2026-03-09T13:15:44.605Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/dd/644d0dde6010a8583b4cd66dd41c5f83f5325464d15c4f490b3340ab73b4/kiwisolver-1.5.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:41024ed50e44ab1a60d3fe0a9d15a4ccc9f5f2b1d814ff283c8d01134d5b81bc", size = 73390, upload-time = "2026-03-09T13:15:45.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/eb/5fcbbbf9a0e2c3a35effb88831a483345326bbc3a030a3b5b69aee647f84/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ec4c85dc4b687c7f7f15f553ff26a98bfe8c58f5f7f0ac8905f0ba4c7be60232", size = 59532, upload-time = "2026-03-09T13:15:47.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9b/e17104555bb4db148fd52327feea1e96be4b88e8e008b029002c281a21ab/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:12e91c215a96e39f57989c8912ae761286ac5a9584d04030ceb3368a357f017a", size = 57420, upload-time = "2026-03-09T13:15:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/48/44/2b5b95b7aa39fb2d8d9d956e0f3d5d45aef2ae1d942d4c3ffac2f9cfed1a/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737", size = 79892, upload-time = "2026-03-09T13:15:49.694Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7d/7157f9bba6b455cfb4632ed411e199fc8b8977642c2b12082e1bd9e6d173/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daae526907e262de627d8f70058a0f64acc9e2641c164c99c8f594b34a799a16", size = 77603, upload-time = "2026-03-09T13:15:50.945Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/dd/8050c947d435c8d4bc94e3252f4d8bb8a76cfb424f043a8680be637a57f1/kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1", size = 73558, upload-time = "2026-03-09T13:15:52.112Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.10.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/76/d3c6e3a13fe484ebe7718d14e269c9569c4eb0020a968a327acb3b9a8fe6/matplotlib-3.10.8.tar.gz", hash = "sha256:2299372c19d56bcd35cf05a2738308758d32b9eaed2371898d8f5bd33f084aa3", size = 34806269, upload-time = "2025-12-10T22:56:51.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/a30bd917018ad220c400169fba298f2bb7003c8ccbc0c3e24ae2aacad1e8/matplotlib-3.10.8-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:00270d217d6b20d14b584c521f810d60c5c78406dc289859776550df837dcda7", size = 8239828, upload-time = "2025-12-10T22:55:02.313Z" },
+    { url = "https://files.pythonhosted.org/packages/58/27/ca01e043c4841078e82cf6e80a6993dfecd315c3d79f5f3153afbb8e1ec6/matplotlib-3.10.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:37b3c1cc42aa184b3f738cfa18c1c1d72fd496d85467a6cf7b807936d39aa656", size = 8128050, upload-time = "2025-12-10T22:55:04.997Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/aa/7ab67f2b729ae6a91bcf9dcac0affb95fb8c56f7fd2b2af894ae0b0cf6fa/matplotlib-3.10.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ee40c27c795bda6a5292e9cff9890189d32f7e3a0bf04e0e3c9430c4a00c37df", size = 8700452, upload-time = "2025-12-10T22:55:07.47Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ae/2d5817b0acee3c49b7e7ccfbf5b273f284957cc8e270adf36375db353190/matplotlib-3.10.8-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a48f2b74020919552ea25d222d5cc6af9ca3f4eb43a93e14d068457f545c2a17", size = 9534928, upload-time = "2025-12-10T22:55:10.566Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5b/8e66653e9f7c39cb2e5cab25fce4810daffa2bff02cbf5f3077cea9e942c/matplotlib-3.10.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f254d118d14a7f99d616271d6c3c27922c092dac11112670b157798b89bf4933", size = 9586377, upload-time = "2025-12-10T22:55:12.362Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e2/fd0bbadf837f81edb0d208ba8f8cb552874c3b16e27cb91a31977d90875d/matplotlib-3.10.8-cp310-cp310-win_amd64.whl", hash = "sha256:f9b587c9c7274c1613a30afabf65a272114cd6cdbe67b3406f818c79d7ab2e2a", size = 8128127, upload-time = "2025-12-10T22:55:14.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/86/de7e3a1cdcfc941483af70609edc06b83e7c8a0e0dc9ac325200a3f4d220/matplotlib-3.10.8-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6be43b667360fef5c754dda5d25a32e6307a03c204f3c0fc5468b78fa87b4160", size = 8251215, upload-time = "2025-12-10T22:55:16.175Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/14/baad3222f424b19ce6ad243c71de1ad9ec6b2e4eb1e458a48fdc6d120401/matplotlib-3.10.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a2b336e2d91a3d7006864e0990c83b216fcdca64b5a6484912902cef87313d78", size = 8139625, upload-time = "2025-12-10T22:55:17.712Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a0/7024215e95d456de5883e6732e708d8187d9753a21d32f8ddb3befc0c445/matplotlib-3.10.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efb30e3baaea72ce5928e32bab719ab4770099079d66726a62b11b1ef7273be4", size = 8712614, upload-time = "2025-12-10T22:55:20.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f4/b8347351da9a5b3f41e26cf547252d861f685c6867d179a7c9d60ad50189/matplotlib-3.10.8-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d56a1efd5bfd61486c8bc968fa18734464556f0fb8e51690f4ac25d85cbbbbc2", size = 9540997, upload-time = "2025-12-10T22:55:23.258Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c0/c7b914e297efe0bc36917bf216b2acb91044b91e930e878ae12981e461e5/matplotlib-3.10.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:238b7ce5717600615c895050239ec955d91f321c209dd110db988500558e70d6", size = 9596825, upload-time = "2025-12-10T22:55:25.217Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a4bbc01c237ab710a1f22b4da72f4ff6d77eb4c7735ea9811a94ae239067/matplotlib-3.10.8-cp311-cp311-win_amd64.whl", hash = "sha256:18821ace09c763ec93aef5eeff087ee493a24051936d7b9ebcad9662f66501f9", size = 8135090, upload-time = "2025-12-10T22:55:27.162Z" },
+    { url = "https://files.pythonhosted.org/packages/89/dd/a0b6588f102beab33ca6f5218b31725216577b2a24172f327eaf6417d5c9/matplotlib-3.10.8-cp311-cp311-win_arm64.whl", hash = "sha256:bab485bcf8b1c7d2060b4fcb6fc368a9e6f4cd754c9c2fea281f4be21df394a2", size = 8012377, upload-time = "2025-12-10T22:55:29.185Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/67/f997cdcbb514012eb0d10cd2b4b332667997fb5ebe26b8d41d04962fa0e6/matplotlib-3.10.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:64fcc24778ca0404ce0cb7b6b77ae1f4c7231cdd60e6778f999ee05cbd581b9a", size = 8260453, upload-time = "2025-12-10T22:55:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/07d5f5c7f7c994f12c768708bd2e17a4f01a2b0f44a1c9eccad872433e2e/matplotlib-3.10.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b9a5ca4ac220a0cdd1ba6bcba3608547117d30468fefce49bb26f55c1a3d5c58", size = 8148321, upload-time = "2025-12-10T22:55:33.265Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f3/c5195b1ae57ef85339fd7285dfb603b22c8b4e79114bae5f4f0fcf688677/matplotlib-3.10.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3ab4aabc72de4ff77b3ec33a6d78a68227bf1123465887f9905ba79184a1cc04", size = 8716944, upload-time = "2025-12-10T22:55:34.922Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f9/7638f5cc82ec8a7aa005de48622eecc3ed7c9854b96ba15bd76b7fd27574/matplotlib-3.10.8-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24d50994d8c5816ddc35411e50a86ab05f575e2530c02752e02538122613371f", size = 9550099, upload-time = "2025-12-10T22:55:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/78cd5920d35b29fd2a0fe894de8adf672ff52939d2e9b43cb83cd5ce1bc7/matplotlib-3.10.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:99eefd13c0dc3b3c1b4d561c1169e65fe47aab7b8158754d7c084088e2329466", size = 9613040, upload-time = "2025-12-10T22:55:38.715Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4e/c10f171b6e2f44d9e3a2b96efa38b1677439d79c99357600a62cc1e9594e/matplotlib-3.10.8-cp312-cp312-win_amd64.whl", hash = "sha256:dd80ecb295460a5d9d260df63c43f4afbdd832d725a531f008dad1664f458adf", size = 8142717, upload-time = "2025-12-10T22:55:41.103Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/76/934db220026b5fef85f45d51a738b91dea7d70207581063cd9bd8fafcf74/matplotlib-3.10.8-cp312-cp312-win_arm64.whl", hash = "sha256:3c624e43ed56313651bc18a47f838b60d7b8032ed348911c54906b130b20071b", size = 8012751, upload-time = "2025-12-10T22:55:42.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/43/31d59500bb950b0d188e149a2e552040528c13d6e3d6e84d0cccac593dcd/matplotlib-3.10.8-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:f97aeb209c3d2511443f8797e3e5a569aebb040d4f8bc79aa3ee78a8fb9e3dd8", size = 8237252, upload-time = "2025-12-10T22:56:39.529Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2c/615c09984f3c5f907f51c886538ad785cf72e0e11a3225de2c0f9442aecc/matplotlib-3.10.8-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:fb061f596dad3a0f52b60dc6a5dec4a0c300dec41e058a7efe09256188d170b7", size = 8124693, upload-time = "2025-12-10T22:56:41.758Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e1/2757277a1c56041e1fc104b51a0f7b9a4afc8eb737865d63cababe30bc61/matplotlib-3.10.8-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12d90df9183093fcd479f4172ac26b322b1248b15729cb57f42f71f24c7e37a3", size = 8702205, upload-time = "2025-12-10T22:56:43.415Z" },
+    { url = "https://files.pythonhosted.org/packages/04/30/3afaa31c757f34b7725ab9d2ba8b48b5e89c2019c003e7d0ead143aabc5a/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6da7c2ce169267d0d066adcf63758f0604aa6c3eebf67458930f9d9b79ad1db1", size = 8249198, upload-time = "2025-12-10T22:56:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2f/6334aec331f57485a642a7c8be03cb286f29111ae71c46c38b363230063c/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9153c3292705be9f9c64498a8872118540c3f4123d1a1c840172edf262c8be4a", size = 8136817, upload-time = "2025-12-10T22:56:47.339Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e4/6d6f14b2a759c622f191b2d67e9075a3f56aaccb3be4bb9bb6890030d0a0/matplotlib-3.10.8-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ae029229a57cd1e8fe542485f27e7ca7b23aa9e8944ddb4985d0bc444f1eca2", size = 8713867, upload-time = "2025-12-10T22:56:48.954Z" },
+]
+
+[[package]]
+name = "mediapipe"
+version = "0.10.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "flatbuffers" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "opencv-contrib-python" },
+    { name = "sounddevice" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/10/593aa6429e6e2dc309b19761804b7992d61a0ef485339435f164b83c2759/mediapipe-0.10.33-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f8dd00affe7d02479cb2e5af8ca5899d2618d6cbc316507a56d41cf62cdbc4d2", size = 29397266, upload-time = "2026-03-18T22:15:58.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bc/0695a2af4e35a8cbeaf0957eb2342acc1541ab363f36e8b51018193e05df/mediapipe-0.10.33-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:410e796215d9eb2cf1fdd6aecbf416abab6e74a5eea5572f4b6da94658c764d9", size = 11377495, upload-time = "2026-03-18T22:16:01.08Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e9/c11a67dfffc2e2d9f9e68e790fc1f1342962669a0d8546c9a479a18c07a2/mediapipe-0.10.33-py3-none-win_amd64.whl", hash = "sha256:25c336c1697d51dddde99dd4568f2a22a1ac46f3f28f5a5bf583a4edf55a282d", size = 10574424, upload-time = "2026-03-18T22:16:03.087Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "1.26.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/94/ace0fdea5241a27d13543ee117cbc65868e82213fb31a8eb7fe9ff23f313/numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0", size = 20631468, upload-time = "2024-02-05T23:48:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/b24208eba89f9d1b58c1668bc6c8c4fd472b20c45573cb767f59d49fb0f6/numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a", size = 13966411, upload-time = "2024-02-05T23:48:29.038Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a5/4beee6488160798683eed5bdb7eead455892c3b4e1f78d79d8d3f3b084ac/numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4", size = 14219016, upload-time = "2024-02-05T23:48:54.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f", size = 18240889, upload-time = "2024-02-05T23:49:25.361Z" },
+    { url = "https://files.pythonhosted.org/packages/24/03/6f229fe3187546435c4f6f89f6d26c129d4f5bed40552899fcf1f0bf9e50/numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a", size = 13876746, upload-time = "2024-02-05T23:49:51.983Z" },
+    { url = "https://files.pythonhosted.org/packages/39/fe/39ada9b094f01f5a35486577c848fe274e374bbf8d8f472e1423a0bbd26d/numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2", size = 18078620, upload-time = "2024-02-05T23:50:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ef/6ad11d51197aad206a9ad2286dc1aac6a378059e06e8cf22cd08ed4f20dc/numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07", size = 5972659, upload-time = "2024-02-05T23:50:35.834Z" },
+    { url = "https://files.pythonhosted.org/packages/19/77/538f202862b9183f54108557bfda67e17603fc560c384559e769321c9d92/numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5", size = 15808905, upload-time = "2024-02-05T23:51:03.701Z" },
+    { url = "https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71", size = 20630554, upload-time = "2024-02-05T23:51:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/2e/151484f49fd03944c4a3ad9c418ed193cfd02724e138ac8a9505d056c582/numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef", size = 13997127, upload-time = "2024-02-05T23:52:15.314Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e", size = 14222994, upload-time = "2024-02-05T23:52:47.569Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5", size = 18252005, upload-time = "2024-02-05T23:53:15.637Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bf/2b1aaf8f525f2923ff6cfcf134ae5e750e279ac65ebf386c75a0cf6da06a/numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a", size = 13885297, upload-time = "2024-02-05T23:53:42.16Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a0/4e0f14d847cfc2a633a1c8621d00724f3206cfeddeb66d35698c4e2cf3d2/numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a", size = 18093567, upload-time = "2024-02-05T23:54:11.696Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b7/a734c733286e10a7f1a8ad1ae8c90f2d33bf604a96548e0a4a3a6739b468/numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20", size = 5968812, upload-time = "2024-02-05T23:54:26.453Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6b/5610004206cf7f8e7ad91c5a85a8c71b2f2f8051a0c0c4d5916b76d6cbb2/numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2", size = 15811913, upload-time = "2024-02-05T23:54:53.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901, upload-time = "2024-02-05T23:55:32.801Z" },
+    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b", size = 13685868, upload-time = "2024-02-05T23:55:56.28Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b", size = 13925109, upload-time = "2024-02-05T23:56:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed", size = 17950613, upload-time = "2024-02-05T23:56:56.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a", size = 13572172, upload-time = "2024-02-05T23:57:21.56Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643, upload-time = "2024-02-05T23:57:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803, upload-time = "2024-02-05T23:58:08.963Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754, upload-time = "2024-02-05T23:58:36.364Z" },
+]
+
+[[package]]
+name = "opencv-contrib-python"
+version = "4.11.0.86"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/51/3ceb85ecff5f26994b7aae2922b1aa38148dbfe88cab13d63bc6facbac88/opencv-contrib-python-4.11.0.86.tar.gz", hash = "sha256:4ff773dab44911da366b906621c9592d4eb96f6ad3777098933a23f064aab38e", size = 150559874, upload-time = "2025-01-16T13:53:08.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/78/b504ca8f7a312918d184e0b8093c62bc9a110d8154f658b591ef5c020d65/opencv_contrib_python-4.11.0.86-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:d911cedc511d98f79994580b245d59fc97f57f0f9923a99945d8b92c7ac671f6", size = 46276766, upload-time = "2025-01-16T13:52:46.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/07/68e0b24217671b65c23e105bb7afd4ef4fd01507670cf5e61373d9efd6b5/opencv_contrib_python-4.11.0.86-cp37-abi3-macosx_13_0_x86_64.whl", hash = "sha256:e10a293af18aa5f842d012fa14e87345b3ee06db4c29bd592ff94b51f7ffca2b", size = 66524088, upload-time = "2025-01-16T13:55:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/7b/7e1471aa92f9f3c1bd8dbe624622b62add6f734db34fbbb9974e2ec70c34/opencv_contrib_python-4.11.0.86-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f21034bc8b00eb286a0a0a92b99767bf596bfe426cf4bc2e79647d64ad0dd6da", size = 47870560, upload-time = "2025-01-16T13:51:48.592Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/13/756b13b8d5d417a0b4c3bf6ceafb59df0ed05cec7fedc2490bbbf5e60ebc/opencv_contrib_python-4.11.0.86-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c47c0ef1098461cdc6fa1cdce4c942b8ec974c87423f4b5951443d26bb9ae407", size = 69098423, upload-time = "2025-01-16T13:52:46.84Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8b/4f63d2fdcfceab528bff10c9d8d2a4e6230098e0b0af54e3e8e91b420ea0/opencv_contrib_python-4.11.0.86-cp37-abi3-win32.whl", hash = "sha256:194841c664ceaa0692410b4ed0af557425608e33db3a181ded28b87acb66748d", size = 35156028, upload-time = "2025-01-16T13:52:30.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c6/146487546adc4726f0be591a65b466973feaa58cc3db711087e802e940fb/opencv_contrib_python-4.11.0.86-cp37-abi3-win_amd64.whl", hash = "sha256:654758a9ae8ca9a75fca7b64b19163636534f0eedffe1e14c3d7218988625c8d", size = 46185163, upload-time = "2025-01-16T13:52:39.745Z" },
+]
+
+[[package]]
+name = "opencv-python-headless"
+version = "4.11.0.86"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz", hash = "sha256:996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798", size = 95177929, upload-time = "2025-01-16T13:53:40.22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/53/2c50afa0b1e05ecdb4603818e85f7d174e683d874ef63a6abe3ac92220c8/opencv_python_headless-4.11.0.86-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:48128188ade4a7e517237c8e1e11a9cdf5c282761473383e77beb875bb1e61ca", size = 37326460, upload-time = "2025-01-16T13:52:57.015Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/43/68555327df94bb9b59a1fd645f63fafb0762515344d2046698762fc19d58/opencv_python_headless-4.11.0.86-cp37-abi3-macosx_13_0_x86_64.whl", hash = "sha256:a66c1b286a9de872c343ee7c3553b084244299714ebb50fbdcd76f07ebbe6c81", size = 56723330, upload-time = "2025-01-16T13:55:45.731Z" },
+    { url = "https://files.pythonhosted.org/packages/45/be/1438ce43ebe65317344a87e4b150865c5585f4c0db880a34cdae5ac46881/opencv_python_headless-4.11.0.86-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6efabcaa9df731f29e5ea9051776715b1bdd1845d7c9530065c7951d2a2899eb", size = 29487060, upload-time = "2025-01-16T13:51:59.625Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5c/c139a7876099916879609372bfa513b7f1257f7f1a908b0bdc1c2328241b/opencv_python_headless-4.11.0.86-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e0a27c19dd1f40ddff94976cfe43066fbbe9dfbb2ec1907d66c19caef42a57b", size = 49969856, upload-time = "2025-01-16T13:53:29.654Z" },
+    { url = "https://files.pythonhosted.org/packages/95/dd/ed1191c9dc91abcc9f752b499b7928aacabf10567bb2c2535944d848af18/opencv_python_headless-4.11.0.86-cp37-abi3-win32.whl", hash = "sha256:f447d8acbb0b6f2808da71fddd29c1cdd448d2bc98f72d9bb78a7a898fc9621b", size = 29324425, upload-time = "2025-01-16T13:52:49.048Z" },
+    { url = "https://files.pythonhosted.org/packages/86/8a/69176a64335aed183529207ba8bc3d329c2999d852b4f3818027203f50e6/opencv_python_headless-4.11.0.86-cp37-abi3-win_amd64.whl", hash = "sha256:6c304df9caa7a6a5710b91709dd4786bf20a74d57672b3c31f7033cc638174ca", size = 39402386, upload-time = "2025-01-16T13:52:56.418Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/aa/d0b28e1c811cd4d5f5c2bfe2e022292bd255ae5744a3b9ac7d6c8f72dd75/pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f", size = 5354355, upload-time = "2026-04-01T14:42:15.402Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8e/1d5b39b8ae2bd7650d0c7b6abb9602d16043ead9ebbfef4bc4047454da2a/pillow-12.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e589959f10d9824d39b350472b92f0ce3b443c0a3442ebf41c40cb8361c5b97", size = 4695871, upload-time = "2026-04-01T14:42:18.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c5/dcb7a6ca6b7d3be41a76958e90018d56c8462166b3ef223150360850c8da/pillow-12.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a52edc8bfff4429aaabdf4d9ee0daadbbf8562364f940937b941f87a4290f5ff", size = 6269734, upload-time = "2026-04-01T14:42:20.608Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f1/aa1bb13b2f4eba914e9637893c73f2af8e48d7d4023b9d3750d4c5eb2d0c/pillow-12.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:975385f4776fafde056abb318f612ef6285b10a1f12b8570f3647ad0d74b48ec", size = 8076080, upload-time = "2026-04-01T14:42:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/2a/8c79d6a53169937784604a8ae8d77e45888c41537f7f6f65ed1f407fe66d/pillow-12.2.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd9c0c7a0c681a347b3194c500cb1e6ca9cab053ea4d82a5cf45b6b754560136", size = 6382236, upload-time = "2026-04-01T14:42:25.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/42/bbcb6051030e1e421d103ce7a8ecadf837aa2f39b8f82ef1a8d37c3d4ebc/pillow-12.2.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88d387ff40b3ff7c274947ed3125dedf5262ec6919d83946753b5f3d7c67ea4c", size = 7070220, upload-time = "2026-04-01T14:42:28.68Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e1/c2a7d6dd8cfa6b231227da096fd2d58754bab3603b9d73bf609d3c18b64f/pillow-12.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:51c4167c34b0d8ba05b547a3bb23578d0ba17b80a5593f93bd8ecb123dd336a3", size = 6493124, upload-time = "2026-04-01T14:42:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/41/7c8617da5d32e1d2f026e509484fdb6f3ad7efaef1749a0c1928adbb099e/pillow-12.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:34c0d99ecccea270c04882cb3b86e7b57296079c9a4aff88cb3b33563d95afaa", size = 7194324, upload-time = "2026-04-01T14:42:34.615Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/de/a777627e19fd6d62f84070ee1521adde5eeda4855b5cf60fe0b149118bca/pillow-12.2.0-cp310-cp310-win32.whl", hash = "sha256:b85f66ae9eb53e860a873b858b789217ba505e5e405a24b85c0464822fe88032", size = 6376363, upload-time = "2026-04-01T14:42:37.19Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/34/fc4cb5204896465842767b96d250c08410f01f2f28afc43b257de842eed5/pillow-12.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:673aa32138f3e7531ccdbca7b3901dba9b70940a19ccecc6a37c77d5fdeb05b5", size = 7083523, upload-time = "2026-04-01T14:42:39.62Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/a0/32852d36bc7709f14dc3f64f929a275e958ad8c19a6deba9610d458e28b3/pillow-12.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:3e080565d8d7c671db5802eedfb438e5565ffa40115216eabb8cd52d0ecce024", size = 2463318, upload-time = "2026-04-01T14:42:42.063Z" },
+    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347, upload-time = "2026-04-01T14:42:44.255Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873, upload-time = "2026-04-01T14:42:46.452Z" },
+    { url = "https://files.pythonhosted.org/packages/df/21/e3fbdf54408a973c7f7f89a23b2cb97a7ef30c61ab4142af31eee6aebc88/pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7", size = 6280168, upload-time = "2026-04-01T14:42:49.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188, upload-time = "2026-04-01T14:42:51.735Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/220a5994ef1b10e70e85748b75649d77d506499352be135a4989c957b701/pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705", size = 6394401, upload-time = "2026-04-01T14:42:54.343Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655, upload-time = "2026-04-01T14:42:56.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3d/45132c57d5fb4b5744567c3817026480ac7fc3ce5d4c47902bc0e7f6f853/pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b", size = 6503105, upload-time = "2026-04-01T14:42:59.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402, upload-time = "2026-04-01T14:43:02.664Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/2941e42858ebb67e50ae741473de81c2984e6eff7b397017623c676e2e8d/pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808", size = 6378149, upload-time = "2026-04-01T14:43:05.274Z" },
+    { url = "https://files.pythonhosted.org/packages/69/42/836b6f3cd7f3e5fa10a1f1a5420447c17966044c8fbf589cc0452d5502db/pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60", size = 7082626, upload-time = "2026-04-01T14:43:08.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/88/549194b5d6f1f494b485e493edc6693c0a16f4ada488e5bd974ed1f42fad/pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe", size = 2463531, upload-time = "2026-04-01T14:43:10.743Z" },
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969, upload-time = "2026-04-01T14:45:55.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674, upload-time = "2026-04-01T14:45:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/37/664fca7201f8bb2aa1d20e2c3d5564a62e6ae5111741966c8319ca802361/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f", size = 5288479, upload-time = "2026-04-01T14:46:01.141Z" },
+    { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230, upload-time = "2026-04-01T14:46:03.874Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sounddevice"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/f9/2592608737553638fca98e21e54bfec40bf577bb98a61b2770c912aab25e/sounddevice-0.5.5.tar.gz", hash = "sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3", size = 143191, upload-time = "2026-01-23T18:36:43.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/0a/478e441fd049002cf308520c0d62dd8333e7c6cc8d997f0dda07b9fbcc46/sounddevice-0.5.5-py3-none-any.whl", hash = "sha256:30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f", size = 32807, upload-time = "2026-01-23T18:36:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f9/c037c35f6d0b6bc3bc7bfb314f1d6f1f9a341328ef47cd63fc4f850a7b27/sounddevice-0.5.5-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:05eb9fd6c54c38d67741441c19164c0dae8ce80453af2d8c4ad2e7823d15b722", size = 108557, upload-time = "2026-01-23T18:36:37.41Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a1/d19dd9889cd4bce2e233c4fac007cd8daaf5b9fe6e6a5d432cf17be0b807/sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103", size = 317765, upload-time = "2026-01-23T18:36:39.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0e/002ed7c4c1c2ab69031f78989d3b789fee3a7fba9e586eb2b81688bf4961/sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519", size = 365324, upload-time = "2026-01-23T18:36:40.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/39/a61d4b83a7746b70d23d9173be688c0c6bfc7173772344b7442c2c155497/sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6", size = 317115, upload-time = "2026-01-23T18:36:42.235Z" },
+]

--- a/tests/unit/orientations.test.js
+++ b/tests/unit/orientations.test.js
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import { computeDerived } from '../../scripts/asset-pipeline/pose/orientations.js';
+
+const V = 0.9;
+
+function kp(overrides = {}) {
+  const base = {
+    nose: { x: 70, y: 30, v: V },
+    leftEye: { x: 60, y: 30, v: V },
+    rightEye: { x: 80, y: 30, v: V },
+    leftEar: { x: 55, y: 32, v: V },
+    rightEar: { x: 85, y: 32, v: V },
+    leftShoulder: { x: 50, y: 80, v: V },
+    rightShoulder: { x: 90, y: 80, v: V },
+    leftElbow: { x: 40, y: 100, v: V },
+    rightElbow: { x: 100, y: 100, v: V },
+    leftWrist: { x: 30, y: 120, v: V },
+    rightWrist: { x: 110, y: 120, v: V },
+    leftIndex: { x: 30, y: 130, v: V },
+    rightIndex: { x: 110, y: 130, v: V },
+    leftHip: { x: 55, y: 140, v: V },
+    rightHip: { x: 85, y: 140, v: V },
+    leftKnee: { x: 55, y: 180, v: V },
+    rightKnee: { x: 85, y: 180, v: V },
+    leftAnkle: { x: 55, y: 220, v: V },
+    rightAnkle: { x: 85, y: 220, v: V },
+    leftHeel: { x: 55, y: 224, v: V },
+    rightHeel: { x: 85, y: 224, v: V },
+    leftFootIndex: { x: 70, y: 226, v: V },
+    rightFootIndex: { x: 100, y: 226, v: V },
+  };
+  return { ...base, ...overrides };
+}
+
+describe('computeDerived', () => {
+  it('returns null for null keypoints', () => {
+    expect(computeDerived(null)).toBeNull();
+  });
+
+  it('head roll is 0 when eyes are level', () => {
+    const d = computeDerived(kp());
+    expect(d.head.roll).toBe(0);
+  });
+
+  it('head roll is positive when right eye is higher (image y smaller)', () => {
+    const d = computeDerived(
+      kp({
+        leftEye: { x: 60, y: 30, v: V },
+        rightEye: { x: 80, y: 20, v: V },
+      }),
+    );
+    expect(d.head.roll).toBeCloseTo(26.6, 1);
+  });
+
+  it('head roll is negative when right eye is lower', () => {
+    const d = computeDerived(
+      kp({
+        leftEye: { x: 60, y: 30, v: V },
+        rightEye: { x: 80, y: 40, v: V },
+      }),
+    );
+    expect(d.head.roll).toBeCloseTo(-26.6, 1);
+  });
+
+  it('head yaw is 0 when nose is centered on eye midpoint', () => {
+    const d = computeDerived(kp());
+    expect(d.head.yaw).toBe(0);
+  });
+
+  it('head yaw is positive when nose is right of eye midpoint', () => {
+    const d = computeDerived(kp({ nose: { x: 75, y: 30, v: V } }));
+    expect(d.head.yaw).toBeGreaterThan(0);
+  });
+
+  it('head center is the midpoint of the eyes', () => {
+    const d = computeDerived(kp());
+    expect(d.head.center).toEqual({ x: 70, y: 30 });
+  });
+
+  it('torso angle is 90 when fully upright', () => {
+    const d = computeDerived(kp());
+    expect(d.torso.angle).toBe(90);
+  });
+
+  it('torso angle is less than 90 when leaning right', () => {
+    const d = computeDerived(
+      kp({
+        leftShoulder: { x: 70, y: 80, v: V },
+        rightShoulder: { x: 110, y: 80, v: V },
+      }),
+    );
+    expect(d.torso.angle).toBeLessThan(90);
+    expect(d.torso.angle).toBeGreaterThan(0);
+  });
+
+  it('hand angle is 90 when index is directly above wrist', () => {
+    const d = computeDerived(
+      kp({
+        rightWrist: { x: 110, y: 120, v: V },
+        rightIndex: { x: 110, y: 100, v: V },
+      }),
+    );
+    expect(d.rightHand.angle).toBe(90);
+  });
+
+  it('hand angle is 0 when index is directly right of wrist', () => {
+    const d = computeDerived(
+      kp({
+        rightWrist: { x: 64, y: 64, v: V },
+        rightIndex: { x: 84, y: 64, v: V },
+      }),
+    );
+    expect(d.rightHand.angle).toBe(0);
+  });
+
+  it('foot angle is 0 when toe points right (horizontal foot)', () => {
+    const d = computeDerived(
+      kp({
+        rightHeel: { x: 85, y: 224, v: V },
+        rightFootIndex: { x: 105, y: 224, v: V },
+      }),
+    );
+    expect(d.rightFoot.angle).toBe(0);
+  });
+
+  it('skips head when eye visibility is below threshold', () => {
+    const d = computeDerived(
+      kp({
+        leftEye: { x: 60, y: 30, v: 0.1 },
+      }),
+    );
+    expect(d.head).toBeNull();
+  });
+
+  it('falls back to elbow→wrist for hand angle when index is low-vis', () => {
+    const d = computeDerived(
+      kp({
+        rightElbow: { x: 110, y: 100, v: V },
+        rightWrist: { x: 110, y: 120, v: V },
+        rightIndex: { x: 110, y: 130, v: 0.1 },
+      }),
+    );
+    expect(d.rightHand.angle).toBe(-90);
+  });
+
+  it('honors custom minVisibility', () => {
+    const d = computeDerived(
+      kp({
+        leftEye: { x: 60, y: 30, v: 0.5 },
+      }),
+      0.6,
+    );
+    expect(d.head).toBeNull();
+  });
+
+  it('hand returns null when wrist is not visible', () => {
+    const d = computeDerived(
+      kp({
+        rightWrist: { x: 110, y: 120, v: 0.1 },
+      }),
+    );
+    expect(d.rightHand).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- New `poses` asset pipeline that extracts per-frame keypoints and orientation angles from fighter sprite strips via MediaPipe PoseLandmarker (heavy variant)
- Emits one consolidated `poses.json` per fighter with 23 landmarks + derived head/torso/hand/foot angles, enabling runtime attachment of visual elements (hats, weapons, VFX) with correct rotation
- `/generate-poses` skill + CLAUDE.md docs for the workflow, plus pose data committed for all 16 fighters

## Detection coverage

| Tier | Fighters | Rate |
|------|----------|------|
| Perfect (50/50) | simon, jeka, carito, peks, sun, gartner, migue, bozzi | 100% |
| Near-perfect | chicha, lini, angy (49/50), cata (48/50) | 96–98% |
| Partial | mao (38/50) | 76% |
| Lower | richi (23/50), cami (23/50), alv (9/50) | 18–46% |

Low-coverage fighters have stylized sprites that confuse MediaPipe; frames marked `detected: false` are safely skipped by runtime code or can be interpolated from neighbors.

## Notes

- Python detector managed by `uv` with its own `pyproject.toml` under `scripts/asset-pipeline/pose/`. Model weights (~30MB) auto-download on first run and are gitignored.
- Must be run after `/generate-fighter` Phase 4 — facing fixes swap left/right keypoints post-hoc.
- `magick +repage -crop 128x128 +repage` is critical; strips have a 128x128 page geometry that would otherwise make `-crop` emit only the first frame.

## Test plan

- [x] Unit tests for orientation math (`tests/unit/orientations.test.js`)
- [x] Lint clean (`bun run lint`)
- [x] Debug strips reviewed for simon (idle, light_punch, knockdown) — skeleton tracks character body
- [x] All 16 fighters produce valid `poses.json` with expected schema
- [ ] Wire runtime consumer (hat/VFX attachment) — follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)