### PR TITLE
feat(fighter): rename Adilnosuke to Motauakiller

### DIFF
--- a/src/data/fighters.json
+++ b/src/data/fighters.json
@@ -926,7 +926,7 @@
   },
   {
     "id": "adil",
-    "name": "Adilnosuke",
+    "name": "Motauakiller",
     "subtitle": "El Samurai del Compas",
     "description": "Samurai dancer with long flowing dark hair and a short beard, wearing a vibrant patchwork kimono with panels of green, red, yellow, blue, and purple, tied at the waist with a brown obi sash. Orange flames swirl around both fists and around his hip. Traditional white tabi socks and gray zori sandals. Lean athletic build, mid-dance fighting stance blending kendo poses with rhythmic movement.",
     "color": "0xFF6B35",


### PR DESCRIPTION
## Summary
- Renames the display name of the 17th fighter from **Adilnosuke** to **Motauakiller**.
- Internal ID stays `adil`, so all sprite, portrait, pose, and manifest paths under `public/assets/fighters/adil/` and `assets/manifests/*_adil.json` remain valid — no asset regeneration needed.

## Why a follow-up PR
This commit was pushed to the original branch after #135 was already merged, so it slipped out of that PR.

## Test plan
- [x] `bun run test:run tests/data` — fighter data validation still passes (14/14)
- [ ] Browser smoke-test: select screen shows "Motauakiller" instead of "Adilnosuke"; sprites, portrait, intro dialog still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)