### PR TITLE
fix(auth): pass redirectTo in Google OAuth so session lands on /play

### DIFF
--- a/packages/game/src/services/supabase.js
+++ b/packages/game/src/services/supabase.js
@@ -54,14 +54,20 @@ export async function signUp(email, password, nickname) {
 }
 
 /**
- * Log in using Google OAuth
+ * Log in using Google OAuth. We explicitly set `redirectTo` to the current
+ * URL so Supabase brings the user back to `/play` (and keeps any query
+ * params like `?room=`). Without this, Supabase falls back to the project's
+ * Site URL — which for us is the marketing `/` page, where no Supabase
+ * client is initialised to consume the `#access_token=…` hash. The user
+ * would then land on / "logged in" as far as Google is concerned but the
+ * session would never reach localStorage, so the game (on /play) still
+ * sees them as anonymous.
  */
 export async function logInWithGoogle() {
+  const redirectTo = typeof window !== 'undefined' ? window.location.href : undefined;
   const { data, error } = await requireClient().auth.signInWithOAuth({
     provider: 'google',
-    options: {
-      // Supabase automatically picks up the current URL to return to
-    },
+    options: { redirectTo },
   });
   if (error) throw error;
   return data;


### PR DESCRIPTION
## Summary

- Google OAuth was landing at `https://alostraques.com/#access_token=...` (the marketing page) instead of `/play`, so the session was never picked up.
- Adds `redirectTo: window.location.href` to `logInWithGoogle` in the game package.

## Repro before fix

1. Visit `/play`, click *Iniciar sesión con Google*.
2. Pick a Google account.
3. Redirected to `https://alostraques.com/#access_token=eyJhbGc…`.
4. Click *Jugar* → back on `/play` → still prompted to log in.

The hash is there, but:
- `/` is the Next marketing page — no Supabase client is initialised, so the hash never becomes a localStorage session.
- Navigating to `/play` via a Next `<Link>` strips the hash, so the game's Supabase client (initialised at scene boot) also never sees it.

## Why it wasn't happening elsewhere

`apps/web/app/join/JoinClient.tsx:222` already passed `redirectTo: window.location.href` — the `/join` Google flow has always returned to `/join`. The game's `packages/game/src/services/supabase.js#logInWithGoogle` was the only call site missing it; the stale comment "Supabase automatically picks up the current URL to return to" is factually wrong — when `redirectTo` is omitted, Supabase uses the project's Site URL.

## Test plan

- [ ] Local: `bun run dev:mp` → go to `http://localhost:3000/play` → click Google login → should land back on `/play` with the session picked up (watch localStorage for `sb-*-auth-token`).
- [ ] Prod: same flow on `https://alostraques.com/play` after deploy.
- [ ] Email/password login unaffected (different code path, no OAuth redirect).
- [ ] Tournament `/join?room=…` Google flow unaffected (already had redirectTo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)