### PR TITLE
feat(blog-mine): five-agent blog backlog miner + drafter

### DIFF
--- a/.claude/agents/blog-drafter.md
+++ b/.claude/agents/blog-drafter.md
@@ -1,0 +1,73 @@
+---
+name: blog-drafter
+description: Expands a single blog backlog entry into a draft Markdown post under apps/web/content/blog/_drafts/. Reads supporting refs (PRs, RFCs, transcripts, code) to verify claims and quote accurately. Voice depends on the entry's audience tag. Use only from the /blog-expand orchestrator.
+tools: Bash, Read, Write, Grep
+---
+
+# blog-drafter
+
+You expand one backlog entry into a draft Markdown post. The orchestrator passes you the entry JSON and the path to write to.
+
+## Inputs (from the orchestrator prompt)
+
+- The full entry JSON.
+- `draft_path` — relative path under `apps/web/content/blog/_drafts/<slug>.md`.
+
+## Steps
+
+1. Read every `supporting` ref:
+
+   - `pr` → `gh pr view <N> --json title,body,files,reviewComments,commits` then `gh pr diff <N> | head -300`.
+   - `rfc` → `cat docs/rfcs/<ref>`.
+   - `commit` → `git show <sha> --stat` then `git show <sha> -- <file>` for relevant files.
+   - `code` → `Read` the file (slice if large).
+   - `transcript` → `head -200` and `tail -400` of the JSONL; sample middle chunks if needed.
+
+2. **Verify claims against source code, not PR descriptions.** PR descriptions can be wrong or out of date. If a claim in the hook is contradicted by the code, prefer the code and adjust the post.
+
+3. Write the post to `draft_path` with frontmatter:
+
+   ```markdown
+   ---
+   title: "<title>"
+   date: "TBD"
+   summary: "<one-sentence summary>"
+   audience: "<es-friends|en-tech|both>"
+   status: "draft"
+   ---
+   ```
+
+4. Apply voice rules per `audience`:
+
+   ### es-friends
+   - Warm, casual, project-diary. In-jokes about friends-as-fighters welcome.
+   - Short paragraphs. First-person plural ("hicimos", "decidimos", "nos rompimos").
+   - 300–600 words.
+   - Reference one-shot: read `apps/web/content/blog/welcome.md` for tone.
+
+   ### en-tech
+   - Concrete, no-fluff, code over prose. Julia Evans / Dan Luu vibe.
+   - Lead with the bug or surprising fact, not "in this post we will".
+   - Short paragraphs, code blocks with `file:line` refs, no apology paragraphs.
+   - 1200–2500 words.
+
+   ### both
+   - Pick the primary language from the source material (most RFCs are English; transcripts are mixed).
+   - Lean tech-English voice. The other language is produced by a separate `/blog-expand` run after manually flipping the audience tag (out of scope here).
+
+5. **Honor `notes`** as steering. Examples: "lead with the bug, not the architecture", "skip the merge timeline", "pair with PR #97 for the asymmetric variant". Notes override your own structural instincts.
+
+6. Add a "Sources" section at the end listing the supporting refs as links:
+   - PRs: `[#N — title](https://github.com/<owner>/<repo>/pull/N)` (find owner/repo via `gh repo view --json nameWithOwner -q .nameWithOwner`).
+   - RFCs: relative link `[<filename>](../docs/rfcs/<filename>)`.
+   - Code: `[<path>](../<path>#L<line>)`.
+   - Transcripts: do **not** link (they're local files); list as plain text.
+
+7. Print to stdout the relative path you wrote: `apps/web/content/blog/_drafts/<slug>.md`. No other output.
+
+## Hard constraints
+
+- Do not modify `docs/blog-backlog.json` — the orchestrator does that.
+- Do not move files out of `_drafts/`.
+- Never invent code, file paths, line numbers, or PR numbers. Always quote from what you read.
+- If you can't verify a claim, soften it ("I think", "from the diff it looks like") or drop it.

--- a/.claude/agents/pr-miner.md
+++ b/.claude/agents/pr-miner.md
@@ -1,0 +1,80 @@
+---
+name: pr-miner
+description: Mines merged PRs in the A Los Traques repo for blog-post candidates. Reads PRs above a given cursor, judges interestingness, and returns a JSON candidate list. Use only from the /blog-mine orchestrator.
+tools: Bash, Read
+---
+
+# pr-miner
+
+You scan merged PRs above a cursor and return blog-post candidate ideas as JSON. You do **not** read code beyond what `gh` returns. Your job is to triage signal, not verify.
+
+## Inputs (from the orchestrator prompt)
+
+- `since_pr_number` — only consider PRs with number strictly greater than this.
+- `repo_path` — absolute path to the working tree.
+
+## Steps
+
+1. List candidate PRs:
+
+   ```bash
+   gh pr list --state merged --limit 200 --json number,title,body,mergedAt,files,author --search "is:merged sort:created-asc"
+   ```
+
+   Filter client-side to `number > since_pr_number`. Sort ascending.
+
+2. For each PR, read just enough to decide: title + body + file list. Skim review comments only when the PR feels promising:
+
+   ```bash
+   gh pr view <N> --json title,body,files,reviewComments,mergedAt,baseRefName,headRefName
+   ```
+
+3. Judge interestingness against these themes (in priority order):
+
+   - **Rollback netcode** (frame skipping, prediction pruning, desync detection, asymmetric RTT)
+   - **Simulation determinism** (FixedPoint math, event-driven presentation, FightRecorder, checksums)
+   - **AI asset generation** (Gemini pipeline, pose estimation, accessory calibration, prompt engineering)
+   - **RFC-driven workflow** (RFC referenced in body, multi-phase rollout, design-then-build cadence)
+   - **Multiplayer debuggability** (Logger, telemetry, debug bundles, diagnostics endpoint)
+   - **Asset pipeline plumbing** (build hooks, manifest generation, calibration tooling)
+   - **Gnarly bug stories** (root cause was non-obvious, fix was small relative to debugging)
+   - **Process / tooling** (Claude skills, GitHub Actions for @claude, code-review skill)
+
+   **Skip:** routine fixes, lint/format-only PRs, dependency bumps, copy edits, single-file UI tweaks without a story.
+
+4. For each interesting PR, emit a candidate object. **Pick `audience`** based on the topic:
+   - Friends-Spanish if the story is project-internal (a friend's fighter rebalance, a UI in-joke, a "the time we broke X right before the party").
+   - Tech-English for generalizable engineering content (rollback, determinism, AI dev workflow).
+   - Use `both` only when the topic genuinely lands in both audiences.
+
+5. Output **only** a JSON array on stdout, no prose, no markdown fences. Schema per item:
+
+   ```json
+   {
+     "title": "Rollback netcode: why we kill audio during resimulation",
+     "hook": "GGPO-style rollback re-runs the simulation up to 7 frames per misprediction. Naive code re-fires every hit-spark and KO sound. Here's the event-bus refactor that fixed it.",
+     "audience": "en-tech",
+     "targetLength": 1800,
+     "supporting": [{ "type": "pr", "number": 91 }],
+     "rationale": "Concrete bug → architectural fix → generalizable lesson."
+   }
+   ```
+
+6. Also emit the new cursor (highest PR number you scanned) on the very last line as JSON:
+
+   ```json
+   {"_cursor": {"pr": 151}}
+   ```
+
+## Voice for `hook`
+
+- One to three sentences. Lead with the surprising fact or the concrete bug, not "in this post we will".
+- Tech audience: code over prose, file:line refs welcome.
+- Friends audience: warm, first-person plural ("hicimos", "decidimos").
+
+## Hard constraints
+
+- No prose outside the JSON array and the `_cursor` line.
+- `targetLength`: 300–600 for friends, 1200–2500 for tech.
+- Never invent PR numbers; every entry must reference a PR you actually read.
+- Do not write to disk. The orchestrator handles persistence.

--- a/.claude/agents/rfc-miner.md
+++ b/.claude/agents/rfc-miner.md
@@ -1,0 +1,67 @@
+---
+name: rfc-miner
+description: Mines docs/rfcs/*.md in the A Los Traques repo for blog-post candidates. Reads RFCs above a given cursor, classifies how each could become a post (lift-and-edit, pair-with-PR, too-dry-to-stand-alone), and returns a JSON candidate list. Use only from the /blog-mine orchestrator.
+tools: Bash, Read
+---
+
+# rfc-miner
+
+You scan RFC files in `docs/rfcs/` above a cursor and return blog-post candidates.
+
+## Inputs (from the orchestrator prompt)
+
+- `since_rfc_filename` — only consider RFC filenames lexicographically greater than this. Pass empty string to scan all.
+- `repo_path` — absolute path to the working tree.
+
+## Steps
+
+1. List RFC files:
+
+   ```bash
+   ls docs/rfcs/*.md
+   ```
+
+   Filter to filenames > `since_rfc_filename`. Sort ascending.
+
+2. For each RFC, read the full file (they are typically <500 lines):
+
+   ```bash
+   cat docs/rfcs/<file>
+   ```
+
+3. Classify each RFC:
+
+   - **lift-and-edit**: RFC is already a near-complete narrative (problem → design → implementation notes) and could become a post with editing. Most of yours fall here.
+   - **pair-with-PR**: RFC is a design doc; the post needs the implementation reality from the PR. Emit a candidate with `supporting` referencing both the RFC and a relevant PR if you can identify one from the RFC body or status. Otherwise leave `supporting` to just the RFC and note in `rationale` that pairing is needed.
+   - **too-dry**: pure infrastructure / process RFC with no narrative arc (skip it).
+
+4. For each non-skip RFC, emit a candidate. Match RFC topic to audience:
+   - Most RFCs are tech-English material.
+   - Process/workflow RFCs (e.g., "we adopted RFCs", "AI dev workflow") can be `both`.
+
+5. Output a JSON array on stdout (no prose, no fences), and the cursor on the final line:
+
+   ```json
+   {"_cursor": {"rfc": "0019-nextjs-monorepo-restructure.md"}}
+   ```
+
+   Cursor = lexicographically greatest filename you scanned.
+
+## Schema per item
+
+```json
+{
+  "title": "Why we wrote 19 RFCs for a friends' fighting game",
+  "hook": "...",
+  "audience": "en-tech",
+  "targetLength": 2000,
+  "supporting": [{ "type": "rfc", "ref": "0019-nextjs-monorepo-restructure.md" }],
+  "rationale": "Lift-and-edit; the RFC is already structured as problem→design→phases."
+}
+```
+
+## Hard constraints
+
+- No prose outside the JSON array and the `_cursor` line.
+- `supporting[].type` for RFCs is `"rfc"` and `ref` is the bare filename (no `docs/rfcs/` prefix).
+- Do not write to disk.

--- a/.claude/agents/transcript-miner.md
+++ b/.claude/agents/transcript-miner.md
@@ -1,0 +1,96 @@
+---
+name: transcript-miner
+description: Mines Claude Code session transcripts (JSONL) for blog-post candidates about AI-assisted development on A Los Traques. Reads sessions newer than a cursor across both personal and standard Claude installs, joins to PRs by worktree slug when possible. Use only from the /blog-mine orchestrator.
+tools: Bash, Read
+---
+
+# transcript-miner
+
+You scan Claude Code transcript JSONL files for AI-dev meta-stories: prompts that worked vs didn't, multi-agent designs, hard-to-debug agent behaviors, the RFC-driven workflow in action, the "we built an agent team to do X" pattern.
+
+## Inputs (from the orchestrator prompt)
+
+- `since_transcript_mtime` — ISO timestamp; only consider files with mtime > this.
+- Transcript roots:
+  - `~/.claude-personal/projects/` (primary, `CLAUDE_CONFIG_DIR=~/.claude-personal`)
+  - `~/.claude/projects/` (standard install, occasional accidental use)
+
+## Steps
+
+1. List transcript files for this project from both roots:
+
+   ```bash
+   find ~/.claude-personal/projects -path '*a-los-traques*' -name '*.jsonl' -newermt <since> 2>/dev/null
+   find ~/.claude/projects -path '*a-los-traques*' -name '*.jsonl' -newermt <since> 2>/dev/null
+   ```
+
+2. For each session file, the directory name encodes the worktree:
+
+   - `-Users-simon-personal-a-los-traques` → main repo, no worktree.
+   - `-Users-simon-personal-a-los-traques--claude-worktrees-<slug>` → worktree `<slug>`.
+
+3. Each JSONL file may be large. Read in chunks; do not load entire transcripts into context if a file exceeds ~2000 lines:
+
+   ```bash
+   wc -l <file>
+   head -200 <file>          # initial setup, user prompt
+   tail -400 <file>          # final outcome, what shipped
+   ```
+
+   Sample middle chunks only if the start/end signal something interesting.
+
+4. Look for these meta-story patterns:
+
+   - **Multi-agent designs**: brainstorming an agent team (like this very feature).
+   - **Prompt iteration**: a skill that needed three rewrites before it stopped misfiring.
+   - **Hard agent debugging**: an agent that confidently produced wrong output; how it got caught.
+   - **RFC-driven cadence**: spec → plan → execution loops, esp. when the spec changed mid-flight.
+   - **Tooling discoveries**: skills, hooks, slash commands, subagent dispatch patterns.
+   - **Notable failures**: a session that wasted hours on the wrong thing.
+
+5. Try to join sessions to PRs: search the worktree slug against PR head branches:
+
+   ```bash
+   gh pr list --state merged --limit 200 --json number,headRefName --search "is:merged"
+   ```
+
+   If the slug matches `worktree-<branch>`, link the candidate's `supporting` to that PR.
+
+6. Output a JSON array on stdout (no prose, no fences) plus a cursor line:
+
+   ```json
+   {"_cursor": {"transcript": "2026-05-01T16:00:00Z"}}
+   ```
+
+   Cursor = ISO timestamp of the newest transcript file mtime you scanned.
+
+## Schema per item
+
+```json
+{
+  "title": "Designing an agent team to suggest blog posts about an agent-team-built game",
+  "hook": "We have 19 RFCs and 30 PRs of source material and zero blog posts. So we designed five agents to do the triage.",
+  "audience": "en-tech",
+  "targetLength": 2200,
+  "supporting": [
+    { "type": "transcript", "ref": "/Users/simon/.claude-personal/projects/.../<sessionid>.jsonl" }
+  ],
+  "rationale": "Meta-story about using subagent dispatch + brainstorming skill to design tooling for the project."
+}
+```
+
+When you can join to a PR, include both refs:
+
+```json
+"supporting": [
+  { "type": "transcript", "ref": "..." },
+  { "type": "pr", "number": 132 }
+]
+```
+
+## Hard constraints
+
+- No prose outside the JSON array and the `_cursor` line.
+- `transcript.ref` is the absolute path to the JSONL file.
+- Do not write to disk.
+- If a session is mostly noise (failed attempts, debugging an unrelated tool), skip it.

--- a/.claude/skills/blog-expand/SKILL.md
+++ b/.claude/skills/blog-expand/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: blog-expand
+description: Expand a single blog backlog entry into a draft Markdown post under apps/web/content/blog/_drafts/. Reads supporting refs (PRs, RFCs, transcripts, code) to verify claims. Use when the user types /blog-expand <id> or asks to "draft the post about X", "expand backlog entry Y", "write the rollback post".
+---
+
+# /blog-expand
+
+Expand one backlog entry into a draft post.
+
+## Workflow
+
+### 1. Resolve the id
+
+The user passes an id as the slash command argument (e.g. `/blog-expand rollback-resimulation-events-2a3f`).
+
+If no id is provided, list `proposed` and `greenlit` entries with their ids and ask the user which to expand.
+
+### 2. Fetch the entry
+
+```bash
+node scripts/blog-backlog/cli.js get <id>
+```
+
+If the CLI exits non-zero, the id is wrong. Suggest the closest matches by listing `id`s from `cat docs/blog-backlog.json`.
+
+### 3. Refuse on bad status
+
+- `status: rejected` → refuse: "this entry is rejected; flip status to `proposed` if you want to resurrect it."
+- `status: published` → refuse.
+- `status: drafted` → ask the user explicitly: "draft already exists at `<draftPath>`. Overwrite? (yes/no)"
+
+### 4. Compute draft path
+
+```
+apps/web/content/blog/_drafts/<id>.md
+```
+
+### 5. Dispatch the drafter subagent
+
+```
+Agent({
+  subagent_type: "blog-drafter",
+  prompt: `Entry: <full entry JSON>. draft_path: apps/web/content/blog/_drafts/<id>.md. <full blog-drafter prompt>`
+})
+```
+
+The drafter writes the file directly and returns the relative path on stdout.
+
+### 6. Update the backlog
+
+```bash
+node scripts/blog-backlog/cli.js update <id> --status drafted --draftPath "apps/web/content/blog/_drafts/<id>.md"
+```
+
+### 7. Report to the user
+
+- Path to the draft.
+- Word count: `wc -w apps/web/content/blog/_drafts/<id>.md`.
+- Reminder: drafts under `_drafts/` are not picked up by `apps/web/lib/blog.ts`. Move the file up one directory and set `date:` (replacing `TBD`) when ready to publish.
+
+## Failure modes
+
+- **Drafter writes nothing** → don't update the backlog. Report the failure.
+- **Path collision** with an existing draft → covered by the `drafted` status check above.
+
+## Hard constraints
+
+- Don't move the draft out of `_drafts/`. Publication is a manual step.
+- Don't change `audience`, `notes`, `rationale`, or `supporting` on the entry.
+- Don't overwrite without explicit consent.

--- a/.claude/skills/blog-expand/SKILL.md
+++ b/.claude/skills/blog-expand/SKILL.md
@@ -37,10 +37,14 @@ apps/web/content/blog/_drafts/<id>.md
 
 ### 5. Dispatch the drafter subagent
 
+The drafter agent definition lives in `.claude/agents/blog-drafter.md`. Read it and inline its body as the prompt for a `general-purpose` Agent dispatch (custom subagent_types only auto-register at session start; this dispatches via the always-available `general-purpose` agent).
+
 ```
+drafterBody = Read('.claude/agents/blog-drafter.md')
+
 Agent({
-  subagent_type: "blog-drafter",
-  prompt: `Entry: <full entry JSON>. draft_path: apps/web/content/blog/_drafts/<id>.md. <full blog-drafter prompt>`
+  subagent_type: "general-purpose",
+  prompt: `Entry: <full entry JSON>\ndraft_path: apps/web/content/blog/_drafts/<id>.md\n\n---\n\n${drafterBody}`
 })
 ```
 

--- a/.claude/skills/blog-mine/SKILL.md
+++ b/.claude/skills/blog-mine/SKILL.md
@@ -35,12 +35,27 @@ You'll need the existing entries' `id`, `title`, `hook`, `supporting`, `status` 
 
 ### 4. Dispatch the three miners in parallel
 
-Use a single message with three Agent tool calls (see "## Using your tools" in the system prompt — independent calls go in one message).
+The miner agent definitions live in `.claude/agents/{pr-miner,rfc-miner,transcript-miner}.md`. Read each file and inline its full body as the prompt for a `general-purpose` Agent dispatch — that way the skill works in any Claude Code session (custom subagent_types only auto-register at session start; this dispatches via the always-available `general-purpose` agent).
+
+Use a single message with three Agent tool calls (independent calls go in one message — see "## Using your tools" in the system prompt).
 
 ```
-Agent({ subagent_type: "pr-miner", prompt: "since_pr_number=<N>, repo_path=<cwd>. <full pr-miner prompt>" })
-Agent({ subagent_type: "rfc-miner", prompt: "since_rfc_filename=<F>, repo_path=<cwd>. <full rfc-miner prompt>" })
-Agent({ subagent_type: "transcript-miner", prompt: "since_transcript_mtime=<T>. <full transcript-miner prompt>" })
+prBody = Read('.claude/agents/pr-miner.md')
+rfcBody = Read('.claude/agents/rfc-miner.md')
+transcriptBody = Read('.claude/agents/transcript-miner.md')
+
+Agent({
+  subagent_type: "general-purpose",
+  prompt: `Inputs:\n- since_pr_number: <N>\n- repo_path: <cwd>\n\n---\n\n${prBody}`
+})
+Agent({
+  subagent_type: "general-purpose",
+  prompt: `Inputs:\n- since_rfc_filename: "<F>"\n- repo_path: <cwd>\n\n---\n\n${rfcBody}`
+})
+Agent({
+  subagent_type: "general-purpose",
+  prompt: `Inputs:\n- since_transcript_mtime: <T>\n- transcript_roots: ~/.claude-personal/projects, ~/.claude/projects\n\n---\n\n${transcriptBody}`
+})
 ```
 
 Each subagent returns its candidate JSON array + `_cursor` line on stdout (in its final message).

--- a/.claude/skills/blog-mine/SKILL.md
+++ b/.claude/skills/blog-mine/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: blog-mine
+description: Run the blog-post backlog miner. Reads the cursor in docs/blog-backlog.json, dispatches pr-miner / rfc-miner / transcript-miner in parallel, runs LLM-judged dedup against existing entries, and writes the updated backlog. Incremental — only scans material since the last run. Use when the user types /blog-mine or asks to "find new blog ideas", "scan PRs for posts", "update the backlog".
+---
+
+# /blog-mine
+
+Mine new blog-post ideas from PRs, RFCs, and Claude Code transcripts.
+
+## Workflow
+
+### 1. Bootstrap
+
+```bash
+node scripts/blog-backlog/cli.js init
+```
+
+(no-op if the backlog already exists).
+
+### 2. Read the current cursor
+
+```bash
+node scripts/blog-backlog/cli.js cursor
+```
+
+The output is a JSON object like `{"pr": 151, "rfc": "0019-nextjs-monorepo-restructure.md", "transcript": "2026-05-01T16:00:00Z"}`.
+
+### 3. Read the existing backlog (for dedup judgment)
+
+```bash
+cat docs/blog-backlog.json
+```
+
+You'll need the existing entries' `id`, `title`, `hook`, `supporting`, `status` to judge dedup. Do **not** consider entries with `status: "rejected"` for merging — they're suppressed forever — but **do** consider them for skip-suggestion (don't re-suggest a rejected idea).
+
+### 4. Dispatch the three miners in parallel
+
+Use a single message with three Agent tool calls (see "## Using your tools" in the system prompt — independent calls go in one message).
+
+```
+Agent({ subagent_type: "pr-miner", prompt: "since_pr_number=<N>, repo_path=<cwd>. <full pr-miner prompt>" })
+Agent({ subagent_type: "rfc-miner", prompt: "since_rfc_filename=<F>, repo_path=<cwd>. <full rfc-miner prompt>" })
+Agent({ subagent_type: "transcript-miner", prompt: "since_transcript_mtime=<T>. <full transcript-miner prompt>" })
+```
+
+Each subagent returns its candidate JSON array + `_cursor` line on stdout (in its final message).
+
+### 5. Parse miner outputs
+
+Each miner's last message ends with a `_cursor` JSON line. Strip it from the candidates array. Aggregate all candidates from all three miners into one list.
+
+### 6. Run LLM-judged dedup against the existing backlog
+
+For each candidate, decide one of:
+
+- **`new`** — no existing entry covers this material.
+- **`merge` into `<id>`** — an existing entry covers the same story (semantic overlap on title+hook, OR overlapping `supporting` set, OR clear topical match). Pick the existing entry whose scope subsumes this candidate.
+- **`skip`** — exact dup of an existing rejected entry, or this candidate is too thin to add value.
+
+**Mechanical rule (always applies first):** if a candidate's `supporting` set has a PR# or RFC ref already present in any non-rejected entry, default to merge into that entry unless the title/hook clearly indicate a different story.
+
+### 7. Build the merge plan
+
+```json
+{
+  "new": [<candidate>, ...],
+  "merge": [{ "intoId": "<existing-id>", "candidate": <candidate> }, ...],
+  "skip": [<candidate>, ...],
+  "cursor": {
+    "pr": <highest pr scanned>,
+    "rfc": "<lexicographically last rfc scanned>",
+    "transcript": "<latest transcript mtime scanned>"
+  }
+}
+```
+
+Write to a temp file:
+
+```bash
+cat > /tmp/blog-mine-plan.json <<'EOF'
+<plan json>
+EOF
+```
+
+### 8. Apply the plan
+
+```bash
+node scripts/blog-backlog/cli.js apply --plan /tmp/blog-mine-plan.json
+```
+
+Output is `{"added": N, "merged": M, "skipped": K, "cursor": {...}}`.
+
+### 9. Report
+
+Tell the user:
+
+- N new entries added (list titles).
+- M existing entries had refs merged in (list ids + titles).
+- K candidates skipped.
+- New cursor.
+- Suggest: "Review `docs/blog-backlog.json`. Edit `status: greenlit` on ones you want, `status: rejected` on ones you don't, and use `notes:` to steer the drafter. Run `/blog-expand <id>` to draft a post."
+
+## Failure modes
+
+- **A miner returns malformed JSON** → log to the user, skip that miner's output, continue with the others. Do not abort.
+- **`gh` not authenticated** → tell the user `gh auth login` is needed for pr-miner.
+- **No new material since last cursor** → all three miners return empty arrays. Print "Nothing new since last run." and exit without writing.
+
+## Hard constraints
+
+- Never edit `docs/blog-backlog.json` directly. Always go through `cli.js apply`.
+- Never edit the `status` or `notes` fields of existing entries during a merge — those are user-owned.
+- Do not call `/blog-expand` automatically. The user picks which ideas to expand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,17 @@ Markdown docs with Mermaid diagrams in `docs/`. When making significant changes 
 - `docs/rfcs/0015-local-multiplayer-tournament.md` — Local multiplayer tournament + VS Local (N human players, split keyboard)
 - `docs/rfcs/0019-nextjs-monorepo-restructure.md` — The monorepo migration this repo ran through (phases 1–6, all shipped)
 
+## Blog Backlog
+
+A five-agent system mines this repo's PRs, RFCs, and Claude Code session transcripts for blog-post candidates, deduped into `docs/blog-backlog.json`. Voice and audience are tagged per article (`es-friends`, `en-tech`, or `both`).
+
+- **`/blog-mine`** — incremental scan. Reads the cursor in `docs/blog-backlog.json`, dispatches `pr-miner` / `rfc-miner` / `transcript-miner` in parallel, dedups against existing entries, writes updated backlog. Run after merging interesting PRs.
+- **`/blog-expand <id>`** — promote one backlog entry to a draft under `apps/web/content/blog/_drafts/<id>.md`. Drafter reads supporting refs (PR diffs, RFCs, transcripts, code) and verifies claims against source — PR descriptions are hints, not authoritative. Move the draft up one directory + set `date:` to publish.
+- **Manual feedback loop**: edit `status` (`proposed | greenlit | rejected | drafted | published`) and `notes` on backlog entries to steer the system. The orchestrator respects user-set fields on merge.
+- **Backlog manipulation CLI**: `node scripts/blog-backlog/cli.js {init|cursor|apply|get|update}`. Used internally by the slash commands; safe to call by hand.
+- Transcript ingestion reads both `~/.claude-personal/projects/*a-los-traques*` and `~/.claude/projects/*a-los-traques*` (some sessions accidentally landed on the company install).
+- Spec: `docs/superpowers/specs/2026-05-01-blog-article-agent-team-design.md`. Plan: `docs/superpowers/plans/2026-05-01-blog-article-agent-team.md`.
+
 ## Balance Simulation
 
 Headless pipeline that runs AI-vs-AI fights to identify overpowered/underpowered fighters. Uses the pure simulation layer (no Phaser) with seeded AIController for deterministic, reproducible results.

--- a/apps/web/content/blog/_drafts/5-segundos-para-reconectarse-sin-perder-la-pelea-8965.md
+++ b/apps/web/content/blog/_drafts/5-segundos-para-reconectarse-sin-perder-la-pelea-8965.md
@@ -1,0 +1,75 @@
+---
+title: "20 segundos para reconectarse sin perder la pelea"
+date: "TBD"
+summary: "Cómo el rollback, una pausa con cartelito y un timer del server convierten un bajón de señal en un susto que no te cuesta el round."
+audience: "es-friends"
+status: "draft"
+---
+
+Imaginate la escena: estás peleando en línea desde el celu, tirando una special
+cuando justo el ascensor te come la señal. Antes, eso era game over: el
+oponente veía "DESCONECTADO" y te perdiste el round (y la dignidad). Ahora hay
+una red de tres capas que aguanta el bajón sin que ninguno de los dos se
+entere demasiado.
+
+## Capa 1: el rollback no se da cuenta
+
+Los primeros 117ms de silencio (7 frames a 60 fps, el `maxRollbackFrames`
+default) ni siquiera disparan nada. El sistema de rollback ya predice tus
+inputs cuando hay un poco de lag — repite tu última dirección, asume que no
+estás atacando — y cuando llegan los inputs reales, si pifió, rebobina y
+vuelve a simular. Para una desconexión cortita esto basta: el opo no ve
+absolutamente nada raro.
+
+## Capa 2: pausa con cuenta regresiva
+
+Si la cosa dura más, FightScene levanta un overlay negro semi-transparente con
+un cartelito que dice **"RECONECTANDO..."** y abajo una cuenta regresiva en
+segundos. La simulación se pausa — los timers, los inputs, el round, todo
+congelado. Ningún jugador puede aprovechar para hacer trampita: si vos te
+desconectaste, el opo también ve la pausa y espera.
+
+Mientras tanto, el server arrancó un timer de **20 segundos** y le reservó tu
+slot. Tu fighter sigue ahí, parado, esperándote.
+
+## Capa 3: rejoin
+
+Cuando vuelve el WiFi, PartySocket reconecta solito y el cliente manda
+`{ type: 'rejoin', slot: N }`. El server cancela el timer, te devuelve el
+asiento y le avisa al opo con `opponent_reconnected`. La pausa se levanta y
+seguís peleando como si nada hubiera pasado. Bonus: el WebRTC también se
+re-negocia en background, así que volvés a P2P sin notarlo.
+
+Si te tardás más de 20 segundos, ahí sí: el server expira el grace period y
+manda `return_to_select` al que se quedó (o `disconnect`, si la pelea ni
+había arrancado). El que sobrevivió no queda colgado en una FightScene
+zombie — vuelve a la pantalla de selección y puede esperar a otro
+contrincante.
+
+## Por qué 20 segundos y no 5
+
+La idea original era 5. En la práctica el celular tarda más de lo que uno
+piensa en reencontrarse con la red — Safari en iOS especialmente puede demorar
+varios segundos solo en disparar el evento `close` del WebSocket. Después suma
+un par de pongs perdidos para que el cliente note el bajón (`PONG_TIMEOUT_MS`
+son 6 segundos) y ya consumiste medio presupuesto antes de empezar a contar.
+Con 20 segundos hay aire para casi cualquier bache de cobertura sin
+abandonar la pelea.
+
+## El estado del cuarto importa
+
+El truco fino es que el server recuerda en `_stateBeforeGrace` qué estaba
+pasando antes del bajón. Si la pelea no había empezado todavía (estaban en
+selección o cargando), una expiración manda al otro de vuelta al menú con la
+sala todavía viva. Si estaban peleando en serio, manda `return_to_select` y
+la sala queda lista para un nuevo opo. Sin esto, una desconexión cualquiera
+te dejaba mirando una pantalla congelada para siempre.
+
+Moraleja: si se te corta WhatsApp mientras estás peleando, respirá. Tenés
+tiempo.
+
+## Fuentes
+
+- [#22 — Graceful reconnection during fight](https://github.com/simon0191/a-los-traques/pull/22)
+- `apps/party/server.js`, `packages/game/src/systems/ReconnectionManager.js`,
+  `packages/game/src/scenes/FightScene.js`, `docs/graceful-reconnection.md`

--- a/apps/web/content/blog/_drafts/designing-an-agent-team-to-suggest-blog-posts-about-an-agent-06ea.md
+++ b/apps/web/content/blog/_drafts/designing-an-agent-team-to-suggest-blog-posts-about-an-agent-06ea.md
@@ -1,0 +1,313 @@
+---
+title: "Designing an agent team to suggest blog posts about an agent-team-built game"
+date: "TBD"
+summary: "Five Claude subagents triage 21 RFCs, 97 merged PRs, and a year of session transcripts into a deduped backlog of blog-post candidates — the post you're reading was suggested by the system it describes."
+audience: "en-tech"
+status: "draft"
+---
+
+This post was suggested by the agent team it describes.
+
+The repo has 21 RFCs in `docs/rfcs/`, 97 merged PRs, and a few hundred Claude
+Code session transcripts. The blog has one post — a welcome message. Manually
+trawling that history for article-worthy stories never happened, because of
+course it didn't. So we built a small team of subagents to do the triage:
+three parallel miners scan PRs, RFCs, and transcripts, an editor merges and
+dedupes the candidates against a JSON backlog, and a drafter expands one
+chosen entry into a draft Markdown post.
+
+The first end-to-end run produced 39 raw candidates that deduped to 31 backlog
+entries. One of them was this post. The drafter is what you're reading.
+
+A few things turned out to matter that I didn't predict from the spec, so the
+rest of this is the dirty version: the part where the design met reality and
+adjusted.
+
+## The premise
+
+The constraint that drove every architectural choice: **manual triage doesn't
+happen**. If the system requires me to remember to run a script on Sundays, or
+to scroll through PR titles when I have ten minutes, it will produce zero blog
+posts forever. Same as the existing zero.
+
+So the system has to be cheap to invoke (`/blog-mine`), incremental (only
+scans material newer than a stored cursor), and durable (writes a backlog
+file I can read on a phone). The output isn't a draft — it's a list of
+*candidates* the user can browse, reject, or greenlight. Drafting only
+happens on demand, one entry at a time, via `/blog-expand <id>`. The expensive
+work is gated behind an explicit user action.
+
+The other constraint: **PR descriptions can lie**. They're written before the
+PR merges; they get edited mid-review; they sometimes describe an
+intermediate version of the code. The miners can hint at what's interesting,
+but the drafter has to verify against actual source code before it ships
+anything. More on that below — it caught real bugs in the smoke test.
+
+## Five agents, two slash commands
+
+The shape settled at five named agents:
+
+```
+/blog-mine                       /blog-expand <id>
+     │                                  │
+     ▼                                  ▼
+┌─────────────┐                   ┌──────────────┐
+│  Editor     │                   │  Drafter     │
+│ (orches.)   │                   │  (single)    │
+└─────┬───────┘                   └──────┬───────┘
+      │ reads cursor                     │
+      │ dispatches in parallel:          │ reads supporting refs
+      │                                  │ writes _drafts/<slug>.md
+      ▼                                  ▼
+┌──────────┬──────────┬─────────────┐
+│ pr-miner │ rfc-miner│ transcript- │
+│          │          │ miner       │
+└────┬─────┴────┬─────┴──────┬──────┘
+     │          │            │
+     └──────────┴────────────┘
+                │ candidates → Editor
+                ▼
+       merge + dedupe → docs/blog-backlog.json
+```
+
+Three things justify three parallel miners instead of one general-purpose one:
+
+**1. Each source has its own access pattern.** The PR miner shells out to `gh
+pr list` and `gh pr view`. The RFC miner does `cat docs/rfcs/*.md`. The
+transcript miner walks `~/.claude-personal/projects/*a-los-traques*` and
+`~/.claude/projects/*a-los-traques*` (I sometimes use the company install by
+accident), reads JSONL files in chunks, and tries to join sessions to PRs by
+matching the worktree slug against PR head branch names. None of those
+pipelines look like each other.
+
+**2. Each source needs different judgment.** PRs get filtered by interestingness
+heuristics ("rollback netcode" yes, "lint fix" no). RFCs get classified as
+*lift-and-edit* (already a near-complete narrative), *pair-with-PR* (design
+doc that needs the implementation reality), or *too-dry* (skip). Transcripts
+look for AI-dev meta-stories: prompts that worked vs didn't, multi-agent
+designs, hard agent debugging. Trying to encode all that into one prompt
+would mean the agent context-switches mid-response.
+
+**3. Parallelism is free here.** The three miners have no shared state. They
+read different files, return different candidate arrays. The editor merges
+them after. Three Agent dispatches in one message, three responses in roughly
+the time of the slowest one.
+
+Why a separate editor at all? **To keep judgment separate from mutation.** The
+miners produce candidates. The editor decides which are new, which merge into
+existing entries, which are duplicates of rejected ones. Then a deterministic
+CLI applies the merge plan to the JSON file. The agent never edits the
+backlog directly. If the agent's dedup judgment is wrong, the worst case is
+duplicate entries — never corrupted JSON, never a lost user-set
+`status: rejected`, never a wrong cursor.
+
+## The mechanical-vs-LLM split
+
+The interesting line in this design is between what the LLM does and what a
+plain Node script does.
+
+LLM does:
+- Reads source material (PR bodies, RFC text, transcript chunks)
+- Judges interestingness against a list of themes
+- Picks a title and audience tag
+- Decides whether a candidate is new, a merge, or a skip vs the existing backlog
+- Writes the eventual draft prose
+
+A 167-line Node CLI does:
+- Loads and validates the backlog JSON (`scripts/blog-backlog/backlog.js`)
+- Generates stable ids from title + supporting refs
+  (`scripts/blog-backlog/id.js`)
+- Applies a merge plan to the backlog (`scripts/blog-backlog/dedup.js`)
+- Bumps cursors so the next run is incremental
+- Refuses to write malformed entries
+
+This split matters because the deterministic stuff is testable. The CLI has 27
+unit tests covering load/save round-trips, schema validation, id stability
+(same inputs → same id, regardless of supporting-ref order), and merge-plan
+application (does a merge preserve user-set `status` and `notes`? does it
+dedupe supporting refs by key?). When the agent's dedup judgment turns out to
+be off, those tests still pass because they're testing the mutation layer,
+not the judgment layer. The agent can be wrong without corrupting the file.
+
+The id rule is small but load-bearing. The id is
+`<kebab-slug-of-title>-<4-char-hash-of-supporting-refs>` — a SHA1 of sorted
+ref keys, sliced to four hex chars. From `scripts/blog-backlog/id.js`:
+
+```js
+export function makeId(title, supporting) {
+  const slug = slugify(title);
+  const refs = supporting.map(refKey).sort().join('|');
+  const hash = createHash('sha1').update(refs).digest('hex').slice(0, 4);
+  return `${slug}-${hash}`;
+}
+```
+
+The sort matters: if a re-run produces the same logical entry but lists its
+refs in a different order, the id should still be stable. Otherwise dedup
+fails and the backlog grows duplicates forever.
+
+## The bug the design did not see coming
+
+The first time `/blog-mine` ran, it failed three times in a row. The error
+text:
+
+```
+Agent type 'pr-miner' not found.
+Available agents: claude-code-guide, Explore, general-purpose, Plan,
+                  statusline-setup, superpowers:code-reviewer
+```
+
+`pr-miner` was sitting right there in `.claude/agents/pr-miner.md`. The
+plan called for the orchestrator to dispatch via `subagent_type: "pr-miner"`.
+Same for `rfc-miner` and `transcript-miner`. None of them registered.
+
+The reason: custom subagent types in `.claude/agents/<name>.md` only get
+loaded into the agent registry at session start. We had created those files
+in the same session that was now trying to use them. They wouldn't be
+available until the next session — which is too late, because the slash
+command has to work *now*.
+
+The fix was a one-paragraph change in the skill markdown:
+
+> Read each file and inline its full body as the prompt for a `general-purpose`
+> Agent dispatch — that way the skill works in any Claude Code session
+> (custom subagent_types only auto-register at session start; this dispatches
+> via the always-available `general-purpose` agent).
+
+Now `/blog-mine` reads `.claude/agents/pr-miner.md` from disk, drops the body
+into the prompt for a `general-purpose` Agent dispatch, and gets the same
+behavior. The agent file is still the canonical source of truth for the
+miner's prompt — but the dispatch mechanism is whatever's actually available
+right now.
+
+This is the kind of thing you can't write into a spec because you don't know
+about it until you trip on it. The shape of the system didn't have to change
+— five agents, two skills, three parallel miners, all the same. The
+*implementation detail* of how a slash command refers to an agent had to
+change, in three files, after the design met reality.
+
+## The drafter caught real bugs
+
+The first smoke run also produced two drafts to validate both voice paths.
+One was an `en-tech` post about the fighter balance simulation. The other
+was an `es-friends` post about graceful reconnection. The miners produced
+plausible-looking hooks for both. The drafter's job was to verify them against
+actual source code before writing anything.
+
+The reconnection hook said:
+
+> Cuando el celular pierde señal en plena pelea, el rollback aguanta los
+> primeros 117ms en silencio (8 frames de input prediction). [...] el
+> server reserva tu slot 5 segundos.
+
+Three numbers in that sentence; two of them were wrong. The drafter opened
+`apps/party/server.js`:
+
+```js
+const GRACE_PERIOD_MS = 20000;
+```
+
+20 seconds, not 5. And `packages/game/src/scenes/FightScene.js`:
+
+```js
+maxRollbackFrames: 7 * speed,
+```
+
+7 frames, not 8. The hook had been written from PR #22's description without
+checking whether the constants had drifted in the year and a half since merge.
+They had.
+
+The balance-sim hook said the project has 16 fighters. `packages/game/src/data/fighters.json`
+has 17 — one was added after the original rebalance. The drafter caught that
+too and adjusted the title to be honest about it: *Tier-listing 16 fighters
+with 28,900 AI-vs-AI fights in 18 seconds*, with the body explaining the
+17×17 matrix and noting that Motauakiller is the post-rebalance addition.
+
+This is the part of the design I was most nervous about — agents confidently
+asserting fake numbers — and the part that worked best in practice. The
+discipline is one bullet in the drafter's prompt:
+
+> Verify claims against source code, not PR descriptions. PR descriptions can
+> be wrong or out of date. If a claim in the hook is contradicted by the code,
+> prefer the code and adjust the post.
+
+Combined with `Read` access to the actual source files, that turned out to be
+enough. The drafter didn't ship any of the wrong numbers. It opened the
+relevant constants files, found the truth, and quietly rewrote the prose.
+
+## Three subagents in parallel from one message
+
+The other thing the shape of the design forced into the open: when you
+dispatch parallel agents, you do it in *one* message with multiple tool
+calls, not three sequential messages. The blog-mine skill spells this out:
+
+> Use a single message with three Agent tool calls (independent calls go in
+> one message — see "## Using your tools" in the system prompt).
+
+If you dispatch them sequentially the parallelism is gone — the orchestrator
+waits for the first miner to return before starting the second. Three
+sequential dispatches turn what should be a one-minute run into three minutes
+of wall time, all of it serialized for no reason.
+
+The other failure mode is dispatching three agents in three messages and then
+trying to coordinate their output in a fourth. By the time you do that the
+context has all three responses inlined; you've used context budget for
+nothing. One message, three calls, one response with three tool results, then
+the editor reads them. Clean.
+
+## What the first run produced
+
+After the registration fix, end-to-end:
+
+- 39 raw candidates from the three miners (pr-miner returned the most;
+  transcript-miner returned the fewest because most sessions are noise)
+- 31 backlog entries after dedup
+- 29 `en-tech`, 2 `es-friends`
+- Cursor advanced to PR #151, RFC `0019-nextjs-monorepo-restructure.md`,
+  transcript timestamp `2026-05-01T20:01:51Z`
+- Two validation drafts: one tech-English (1550 words, target 1200–2500),
+  one Spanish-friends (573 words, target 300–600)
+
+The full backlog lives at `docs/blog-backlog.json`. It's checked in so it
+survives machine swaps and so I can browse it on a phone. Each entry has
+fields the user can edit: `status` (`proposed`, `greenlit`, `rejected`,
+`drafted`, `published`), `notes` (free-form steering for the drafter), and
+`audience`. The Editor agent respects `status: rejected` permanently — it
+won't re-suggest the idea on future runs even if a new PR makes the
+material come up again.
+
+## What I'd do differently
+
+A few things bug me about the current shape that I'm leaving for v2:
+
+**Concurrency is a file-level lock.** If two `/blog-mine` runs happen at the
+same time (different sessions, different worktrees), the second one blows up
+on the lockfile. Fine for a one-user system, would not survive a team.
+
+**The transcript miner is the loudest.** It reads everything from two
+directories and produces a lot of weak signal. About 80% of the candidates
+it generates get deduped or skipped. I could narrow its prompt further but
+the failure modes there are hard to predict because every session is
+different.
+
+**Audience selection is heuristic.** The miners pick `en-tech`, `es-friends`,
+or `both` based on whether the topic is project-internal or generalizable.
+The user can flip it, but the right answer for some entries is genuinely
+both, and that requires two `/blog-expand` runs because v1 only writes one
+draft per invocation. Fine. Not a blocker.
+
+**No background scheduling.** I'd like a Sunday-morning cron that runs
+`/blog-mine` and writes a one-line summary to a file I can glance at. That's
+maybe an hour of work and would change the surface area of the system from
+"a thing I invoke" to "a thing that runs on its own and saves up findings."
+
+## Sources
+
+- [../docs/superpowers/specs/2026-05-01-blog-article-agent-team-design.md](../docs/superpowers/specs/2026-05-01-blog-article-agent-team-design.md)
+- [../docs/superpowers/plans/2026-05-01-blog-article-agent-team.md](../docs/superpowers/plans/2026-05-01-blog-article-agent-team.md)
+- [#152 — feat(blog-mine): five-agent blog backlog miner + drafter](https://github.com/simon0191/a-los-traques/pull/152)
+- Transcript: `~/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-blogs/8e2285b4-d498-4b5e-929d-80c46f72ab6a.jsonl`
+- [scripts/blog-backlog/id.js](../scripts/blog-backlog/id.js)
+- [scripts/blog-backlog/dedup.js](../scripts/blog-backlog/dedup.js)
+- [.claude/skills/blog-mine/SKILL.md](../.claude/skills/blog-mine/SKILL.md)
+- [.claude/agents/blog-drafter.md](../.claude/agents/blog-drafter.md)

--- a/apps/web/content/blog/_drafts/how-a-single-missing-input-frame-creates-an-unfixable-desync-3cc8.md
+++ b/apps/web/content/blog/_drafts/how-a-single-missing-input-frame-creates-an-unfixable-desync-3cc8.md
@@ -1,0 +1,297 @@
+---
+title: "How a single missing input frame creates an unfixable desync"
+date: "TBD"
+summary: "When the adaptive input delay bumped from 3 to 4, our rollback netcode silently dropped one frame from localInputHistory — and that single hole desynced the match every 9 seconds."
+audience: "en-tech"
+status: "draft"
+---
+
+We had four desyncs per online match. Always under asymmetric RTT (one peer
+local, one on BrowserStack via the hybrid E2E test). Always after the same
+pattern: match → desync → match → desync. The resync mechanism worked. New
+desyncs kept coming.
+
+Three out of four desyncs landed exactly 14 frames after a frame number we
+could pre-compute from RTT samples alone. That's not random. That's a bug
+with a clock.
+
+## How inputs are stored in our rollback netcode
+
+Each frame, the local peer encodes its input and stores it at a *future*
+frame — `currentFrame + inputDelay`. The future-store is what gives both
+peers time to confirm each other's inputs before they're needed for
+simulation.
+
+```js
+// packages/game/src/systems/RollbackManager.js
+const targetFrame = this.currentFrame + this.inputDelay;
+this.localInputHistory.set(targetFrame, encodedLocal);
+```
+
+With `inputDelay = 3`, consecutive frames produce a contiguous sequence:
+
+```
+advance(frame=10) → localInputHistory[13] = input
+advance(frame=11) → localInputHistory[14] = input
+advance(frame=12) → localInputHistory[15] = input  // contiguous
+```
+
+The remote peer eventually receives those entries through `sendInput()` and
+slots them into its own `remoteInputHistory`. When confirmed inputs arrive,
+the rollback manager checks them against the prediction it used for that
+frame. Mismatch → restore snapshot, replay.
+
+## The bump that drops a frame
+
+Every 180 frames (~3 seconds) `_recalculateInputDelay()` runs. It reads
+the measured RTT, divides by the fixed-step duration, and picks an optimal
+delay clamped to the range `[3, 5]`:
+
+```js
+// packages/game/src/systems/RollbackManager.js:481
+_recalculateInputDelay() {
+  const rtt = this.nm.rtt;
+  if (!rtt) return;
+  const oneWayFrames = Math.ceil(rtt / 16.667);
+  const optimal = Math.max(ONLINE_INPUT_DELAY_FRAMES, Math.min(5, oneWayFrames + 1));
+  if (optimal > this.inputDelay) {
+    this.inputDelay = Math.min(this.inputDelay + 1, optimal);
+  } else {
+    this.inputDelay = optimal;
+  }
+  this.maxRollbackFrames = Math.max(7, this.inputDelay * 2 + 1);
+}
+```
+
+Now the failure case. Imagine RTT just nudged `inputDelay` from 3 to 4
+between frames 899 and 900:
+
+```
+advance(frame=899, delay=3) → localInputHistory[902] = input
+// _recalculateInputDelay() runs at frame 900, delay becomes 4
+advance(frame=900, delay=4) → localInputHistory[904] = input
+//                                        Frame 903 is NEVER stored
+```
+
+The targets jumped from 902 to 904. Frame 903 has no local entry. There's
+no `localInputHistory.set(903, ...)` anywhere in the system. The slot
+isn't late — it doesn't exist.
+
+## Why the gap is permanent
+
+The `_recalculateInputDelay()` ramp-up is capped at +1 per call:
+`Math.min(this.inputDelay + 1, optimal)`. Even if RTT spikes from 20ms to
+80ms (giving an optimal of 6), the delay only crawls 3→4→5→6 over three
+recalculation intervals — about 9 seconds. That cap is what makes the gap
+always exactly one frame, but it's also what guarantees the gap *recurs*
+every time RTT drifts upward.
+
+When the simulation runs and asks "what was P2's input on frame 903?", two
+things happen on the two peers:
+
+```js
+// packages/game/src/systems/RollbackManager.js:466
+_getInputForFrame(frame, isP1) {
+  const isLocal = (isP1 && this.localSlot === 0) || (!isP1 && this.localSlot === 1);
+  if (isLocal) {
+    return this.localInputHistory.get(frame) || EMPTY_INPUT;
+  }
+  if (this.remoteInputHistory.has(frame)) {
+    return this.remoteInputHistory.get(frame);
+  }
+  if (this.predictedRemoteInputs.has(frame)) {
+    return this.predictedRemoteInputs.get(frame);
+  }
+  return predictInput(this.lastConfirmedRemoteInput);
+}
+```
+
+P2 (the local peer for that input): no entry → `EMPTY_INPUT` → the
+fighter stops moving.
+
+P1 (remote viewpoint): no confirmed input arrives because P2 never *sent*
+one for frame 903 → falls through to `predictInput(lastConfirmedRemoteInput)`
+→ which is just `lastInput & MOVEMENT_MASK` (`0b00001111`), preserving
+movement bits, zeroing attack bits → if the last confirmed P2 input was
+"hold right", P1 thinks P2 keeps holding right.
+
+Two peers, two different inputs for the same frame, two different sims.
+Position diverges.
+
+The state divergence is bounded — the next confirmed input for frame 904
+will overwrite the prediction starting at 904, both peers walk forward in
+lock-step again. But frame 903's contribution to position is permanent
+unless someone rolls back through it. Nobody will, because rollback fires
+on a confirmed-vs-prediction mismatch, and the confirmed input for 903
+never arrives. There is nothing to compare against. The mispredicted frame
+is invisible.
+
+## The 14-frame fingerprint
+
+Checksums fire every 30 frames at a fixed safety offset. The current code
+computes the offset at construction:
+
+```js
+// packages/game/src/systems/RollbackManager.js:86
+this._checksumSafeOffset = Math.max(maxRollbackFrames, MAX_ADAPTIVE_ROLLBACK_FRAMES) + 2;
+```
+
+That works out to `max(7, 11) + 2 = 13`. Given the 30-frame checksum
+interval, the first checksum frame at or beyond `gap + 13` is always
+`gap + 14`. (The math: checksums fire at multiples of 30; the offset is 13;
+for any gap frame, the next eligible checksum frame is `gap + 14`.) So if
+the bug is real, the desync should always show up exactly 14 frames after
+a gap.
+
+We pulled the debug bundle from a hybrid E2E run (P1 = local Playwright,
+P2 = BrowserStack Chrome on Win11; `seed=42`, simon vs jeka on beach). P2
+had 449 rollbacks, max depth 7, four desyncs. RTT averaged 36ms with
+spikes to 42ms — exactly enough to oscillate `oneWayFrames` between 2 and
+3, which oscillates `optimal` between 3 and 4.
+
+We computed the predicted gap frames from P2's 19 RTT samples and the
+adaptive-delay formula, then matched them against the four observed
+desync frames. Three of four desyncs landed at the predicted `gap + 14`:
+
+| Gap Frame | Last P2 Input | `predictInput()` | Equals EMPTY? | Desync Frame |
+|-----------|---------------|-------------------|---------------|--------------|
+| 183       | 260 (up+sp)   | 4 (up)            | Yes (race)    | None         |
+| 903       | 2 (right)     | 2 (right)         | No            | 917          |
+| 1443      | 128 (hk)      | 0                 | Yes           | None         |
+| 2343      | 8 (down)      | 8 (down)          | No            | 2537 (later) |
+| 3063      | 1 (left)      | 1 (left)          | No            | 3077         |
+| 3423      | 2 (right)     | 2 (right)         | No            | 3437         |
+
+The "harmless" rows are gaps where the prediction happened to equal
+`EMPTY_INPUT`: when the last input was attack-only (e.g. heavy kick =
+`128`), `128 & 0b1111 = 0`, so both peers see no movement. No divergence.
+That's why one of the four desyncs is shifted — frame 2343's gap *did*
+diverge, but the divergence didn't cross a checksum boundary cleanly until
+frame 2537.
+
+The pattern in the checksum log around each desync was tidy:
+
+```
+Frame 887: P1=−917249474   P2=−917249474   match
+Frame 917: P1=−612355444   P2=−1686097764  DESYNC  ← gap at 903
+Frame 947: P1= 350984532   P2= 350984532   match   ← fixed by resync
+```
+
+Every 30 frames a desync fires, the resync mechanism kicks in, both peers
+agree on the next checksum, and then the next adaptive-delay bump opens
+another gap and we do it again.
+
+## Why only the BrowserStack peer
+
+P1 (local, RTT ~20ms): `oneWayFrames = ceil(20/16.667) = 2`, `optimal = 3`,
+delay never moves off the floor of 3. No bumps, no gaps.
+
+P2 (BrowserStack, RTT ~36ms with jitter): `oneWayFrames` oscillates
+between 2 and 3 as RTT drifts across 33ms (`16.667 * 2`), so `optimal`
+oscillates between 3 and 4. Every 3→4 transition opens a gap; every 4→3
+transition causes a *collision* — two consecutive `advance()` calls
+target the same frame.
+
+Asymmetric RTT was the trigger because only the higher-RTT peer crossed
+the boundary that flips `oneWayFrames`. A symmetric setup either both
+floors at 3 (no problem) or both bumps in lockstep (then both have gaps,
+but they happen to agree on the prediction often enough).
+
+## The fix: fill the gap, send each filled frame
+
+The fix is small and lives in `advance()`. Track the previous target
+frame; on each call, if the new target jumped past `lastTarget + 1`, fill
+every gap frame in `localInputHistory` with the current input *and* send
+each gap frame to the remote so they get a confirmed input instead of a
+permanent prediction.
+
+```js
+// packages/game/src/systems/RollbackManager.js:128
+if (this._lastLocalTargetFrame >= 0 && targetFrame > this._lastLocalTargetFrame + 1) {
+  for (let f = this._lastLocalTargetFrame + 1; f < targetFrame; f++) {
+    this.localInputHistory.set(f, encodedLocal);
+  }
+}
+```
+
+Then in the network-send block:
+
+```js
+// packages/game/src/systems/RollbackManager.js:146
+if (this._lastLocalTargetFrame >= 0 && targetFrame > this._lastLocalTargetFrame + 1) {
+  for (let f = this._lastLocalTargetFrame + 1; f < targetFrame; f++) {
+    const hist = [];
+    for (let i = 1; i <= INPUT_REDUNDANCY; i++) {
+      const hf = f - i;
+      if (this.localInputHistory.has(hf)) hist.push([hf, this.localInputHistory.get(hf)]);
+    }
+    this.nm.sendInput(f, rawLocalInput, hist);
+  }
+}
+```
+
+Picking the *current* input as the gap-frame value isn't ideal — strictly,
+the player held something during that 16ms — but it's the best we have
+without modifying the input pipeline upstream of `advance()`. And it's
+identical to what would have happened if `inputDelay` had stayed at 3:
+that same `encodedLocal` would have been stored at `frame+3`. The peer
+receives a real input for frame 903, so it isn't predicting forever.
+
+## The mirror bug: collisions when delay decreases
+
+Once we wrote the gap-fill, the symmetric case became obvious. Ramp-down
+is *not* capped — `this.inputDelay = optimal` runs immediately when
+`optimal <= this.inputDelay`. So a delay drop of exactly 1 (e.g. 4→3)
+makes two consecutive `advance()` calls target the same frame:
+
+```
+advance(frame=899, delay=4) → localInputHistory[903] = inputA
+// delay becomes 3
+advance(frame=900, delay=3) → localInputHistory[903] = inputB  ← overwrites
+```
+
+Without protection, the second write overwrites the first. The remote peer
+might receive both messages out of order, or only one. If it sees inputA
+first, then inputB arrives, it triggers an unnecessary rollback; if inputB
+gets dropped on an unreliable transport, the two peers permanently
+disagree about frame 903.
+
+The fix is one `has()` check — first-written input wins:
+
+```js
+// packages/game/src/systems/RollbackManager.js:138
+const alreadyStored = this.localInputHistory.has(targetFrame);
+if (!alreadyStored) {
+  this.localInputHistory.set(targetFrame, encodedLocal);
+}
+// ... later, only send if !alreadyStored
+```
+
+The collision case is harmless in practice today (the rollback machinery
+converges either way), but the fix is two lines and it removes a
+message-loss hazard.
+
+## What we learned
+
+- Future-store input designs (encoded delay, schedule into the buffer,
+  process later) have a hidden invariant: *the writer must produce a
+  contiguous sequence of target frames*. Anything that mutates the offset
+  while the writer is running breaks the invariant in a way the consumer
+  cannot detect.
+- Asymmetric RTT is the meanest test environment. Symmetric setups mask
+  half the bugs because both peers cross thresholds together. The hybrid
+  E2E setup (Playwright local + BrowserStack remote) is the only thing
+  that flushed this one out.
+- "Three of four desyncs land at exactly `gap + 14`" was the moment the
+  bug stopped being mysterious. If you can predict a failure from inputs
+  the system has already exposed (RTT samples, the delay formula, the
+  checksum offset), you don't need a stack trace — you have a model.
+
+## Sources
+
+- [#97 — fix: desync under asymmetric rollback — adaptive input delay gap](https://github.com/simon0191/a-los-traques/pull/97)
+- [0014-fix-desync-adaptive-delay-gap.md](../docs/rfcs/0014-fix-desync-adaptive-delay-gap.md)
+- [packages/game/src/systems/RollbackManager.js#L119](../packages/game/src/systems/RollbackManager.js#L119) — `advance()` with the gap-fill and collision-skip
+- [packages/game/src/systems/RollbackManager.js#L466](../packages/game/src/systems/RollbackManager.js#L466) — `_getInputForFrame()` showing the `EMPTY_INPUT` fallback
+- [packages/game/src/systems/RollbackManager.js#L481](../packages/game/src/systems/RollbackManager.js#L481) — `_recalculateInputDelay()` with the +1 ramp-up cap
+- [packages/sim/src/InputBuffer.js#L64](../packages/sim/src/InputBuffer.js#L64) — `predictInput()` (movement-bits-only)

--- a/apps/web/content/blog/_drafts/tier-listing-16-fighters-with-28-900-ai-vs-ai-fights-in-18-s-92b9.md
+++ b/apps/web/content/blog/_drafts/tier-listing-16-fighters-with-28-900-ai-vs-ai-fights-in-18-s-92b9.md
@@ -1,0 +1,258 @@
+---
+title: "Tier-listing 16 fighters with 28,900 AI-vs-AI fights in 18 seconds"
+date: "TBD"
+summary: "The pure simulation already runs without Phaser, so we let two AIs hammer each other 28,900 times to find out which fighter was overpowered."
+audience: "en-tech"
+status: "draft"
+---
+
+Players said some fighters felt overpowered. We had no data — just vibes. The
+game has 17 fighters (16 at the time of the original rebalance, before
+Motauakiller was added), each with their own stats and frame data on five
+moves. Manual balancing is guesswork at that surface area.
+
+So we let the game balance itself. Both peers in online play already run a
+pure-JS simulation with zero Phaser dependencies — that's how rollback netcode
+works at all. If the sim runs headless during a match, it runs headless in a
+script. Plug in two seeded AI controllers, run 100 fights per matchup across
+the full 17×17 matrix, and you get a tier list in under 20 seconds.
+
+## The sim is already pure
+
+The hard part was already done. `packages/sim/` exports `tick(p1, p2, combat,
+p1Input, p2Input, frame)` — pure integer math, deterministic, no scene, no
+sprites. The same function powers online matches and rollback resimulation.
+
+What we needed was a way to drive it from AI decisions instead of human
+inputs. The catch: `AIController.applyDecisions()` mutates the fighter
+directly, but `tick()` expects encoded integer inputs and applies them via
+`applyInputToFighter()`. Use both and you double-apply.
+
+The fix is a tiny adapter (`scripts/balance-sim/ai-input-adapter.js`):
+
+```js
+export function getEncodedInput(ai) {
+  ai.update(0, 0); // ticks frame counter; fires think() on interval
+
+  const d = ai.decision;
+
+  const encoded = encodeInput({
+    left: d.moveDir < 0, right: d.moveDir > 0,
+    up: d.jump, down: d.block,
+    lp: d.attack === 'lightPunch', hp: d.attack === 'heavyPunch',
+    lk: d.attack === 'lightKick',  hk: d.attack === 'heavyKick',
+    sp: d.attack === 'special',
+  });
+
+  // Consume single-shot decisions so they don't repeat every frame
+  // until the next think() cycle. Movement (moveDir) persists intentionally.
+  if (d.jump) d.jump = false;
+  if (d.attack) d.attack = null;
+
+  return encoded;
+}
+```
+
+The AI runs as normal, populates `decision`, we read it, encode it, hand it to
+`tick()`. Single-shot actions (jumps, attacks) get nulled after consumption so
+they fire on one frame — same semantics as a human pressing and releasing a
+button.
+
+`AIController` was already seedable. It uses mulberry32 internally
+(`setSeed(n)` then `_rng()` for all decisions). Same seed, same fight, every
+time.
+
+## Match runner
+
+The runner (`scripts/balance-sim/match-runner.js`) is a 60-line loop:
+
+```js
+for (; !combat.matchOver && frame < MAX_FRAMES; frame++) {
+  // Fast-forward round transitions (skip 300 dead frames between rounds)
+  if (!combat.roundActive && combat.transitionTimer > 0) {
+    combat.transitionTimer = 0;
+    p1.resetForRound(P1_START_X);
+    p2.resetForRound(P2_START_X);
+    combat.timer = ROUND_TIME;
+    combat._timerAccumulator = 0;
+    combat.roundActive = true;
+    roundStartFrame = frame;
+  }
+
+  const p1Input = getEncodedInput(ai1);
+  const p2Input = getEncodedInput(ai2);
+  const { events } = tick(p1, p2, combat, p1Input, p2Input, frame);
+
+  // collect stats from events…
+}
+```
+
+Two real things in there worth noting:
+
+1. **Skip the round transitions.** A full match plays three rounds with a
+   300-frame cooldown between each. That's ~10 seconds of dead air per match
+   we don't need. Force-resetting the transition timer to zero saves something
+   like 40% of total simulation frames across the matrix.
+
+2. **The events array is the API.** `tick()` returns `{ state, events,
+   roundEvent }`. Stats come from filtering events: `hit`, `hit_blocked`,
+   `whiff`, `special_charge`, `round_ko`, `round_timeup`. No log-scraping, no
+   instrumentation, no diff between runs. The same events feed the audio and
+   VFX bridges in the real game — they're free here.
+
+## P1 won 79% of mirror matches
+
+First run: every mirror matchup (Simo vs Simo, etc.) showed P1 winning 65–79%
+of the time. Mirrors should converge to 50% — same fighter, same AI, same
+difficulty.
+
+The bias was structural. `tick()` processes P1's input first, then P2's. Hit
+detection, attack resolution, anything that depends on processing order tilts
+toward whoever moves first. With identical inputs both fighters often want to
+attack on the same frame; the one who got their input applied first lands the
+hit.
+
+The fix is one of the cheapest possible: alternate sides each fight.
+`scripts/balance-sim/match-runner.js`:
+
+```js
+if (i % 2 === 0) {
+  results.push(runMatch(p1Id, p2Id, seed, difficulty));
+} else {
+  const flipped = runMatch(p2Id, p1Id, seed, difficulty);
+  // Flip perspective so p1Id is always "P1" in aggregation
+  results.push({ ...flipped,
+    winnerIndex: flipped.winnerIndex === 0 ? 1 : 0,
+    p1Stats: flipped.p2Stats, p2Stats: flipped.p1Stats,
+    // …
+  });
+}
+```
+
+Each fighter spends equal time as the slot that ticks first. The bias is still
+there for any individual fight, but it cancels in aggregate. Mirrors now sit
+at ~50% — the bias didn't go away, it just stopped being a confounder.
+
+Worth flagging though: this isn't a fix to the underlying issue. P1 still has
+a tick-order advantage in real online matches. We just don't measure it
+anymore.
+
+## What the data showed
+
+Pre-rebalance, with the original power/defense numbers, the tier list was
+brutal:
+
+```
+S-tier (>57%): Simo 79%, Camilo 78%, Sun 77%, Alv 76%, Mao 67%
+D-tier (<43%): Peks 22%, Chicha 21%, Carito 18%, LinaPcmn 17%
+Spread: 16% → 79%
+```
+
+The single biggest finding was the formula in `packages/sim/src/combat-math.js`.
+The original numbers:
+
+- Power multiplier: `700 + power*100` → range `0.8x` to `1.2x` (50% damage swing)
+- Defense multiplier: `1100 - def*40` → range `0.9x` to `1.06x` (16% swing)
+
+Power was a 50% damage swing. Defense barely moved the needle. A power-4
+fighter against a defense-1 fighter dealt nearly 1.5× damage on every hit. The
+power stat was, effectively, the only stat.
+
+Iteration 1 narrowed power and widened defense. The current code:
+
+```js
+// packages/sim/src/combat-math.js
+export function calculateDamage(baseDamage, attackerPower, defenderDefense) {
+  const powerMod = 850 + attackerPower * 50;   // 0.90x..1.10x
+  const defMod  = 1200 - defenderDefense * 60; // 0.90x..1.14x
+  return Math.round((baseDamage * powerMod * defMod) / 1_000_000);
+}
+```
+
+The `1_000_000` is from running both modifiers at 1000× scale and combining —
+keeps everything in integer math so the simulation stays bit-exact across
+peers.
+
+That alone wasn't enough. D-tier fighters were double-penalized: low power
+*and* low base damage on their moves. So iteration 2 added base damage to
+Jeka, Chicha, Carito, Peks, Lini, Gartner, Angy. Iterations 3 and 4 walked
+back fast fighters that had overshot (1-frame-startup light punches plus a
+damage buff was too much) and trimmed the remaining outliers.
+
+After four passes, the spread closed from `16%–79%` to `45%–57%`. Every
+fighter was within striking distance of 50%.
+
+## Drift
+
+The post-rebalance numbers I just quoted are from PR #94 in April. Today, a
+fresh run looks different:
+
+```
+S: Sun (64.3%), Motauakiller (59.0%)
+A: Panchito 56.9%, Angy 53.8%, Simo 53.6%, Cata 53.5%
+B: Alv 52.6%, LinaPcmn 52.0%, Migue 51.4%, Jecat 48.9%
+C: Bozz 46.0%, Mao 45.5%, Carito 44.3%
+D: Peks 42.8%, Chicha 41.7%, Ric 41.5%, Camilo 41.4%
+```
+
+Spread is back to `41% → 64%`. Sun is dominating again, Camilo cratered.
+Motauakiller showed up after the rebalance and walked into A-tier without any
+tuning. The April fix wasn't a permanent solution — it was a snapshot, and
+the snapshot has aged.
+
+This is the actual point of the pipeline: balance isn't done, it's *cheap to
+re-check*. Run `bun run balance` after any stat change, get a tier list, see
+what broke. The cycle from "I want to nerf Sun's heavy kick by one frame" to
+"here's the new tier list" is about 30 seconds.
+
+## Some things that surprised me
+
+- **The `special` stat (range 2–5) is dead.** Nothing reads it. Fighters with
+  special 5 — Chicha, Peks, Carito — got literally zero benefit. They were
+  also the ones at the bottom of D-tier. Whether anyone ever wires it up or
+  the field gets deleted is a separate question.
+
+- **All 17 fighters had a 100% KO rate.** Not a single fight ended on the
+  round timer. AI-vs-AI on hard difficulty is aggressive enough that someone
+  always dies first. Useful as a sanity check — if the timer started winning
+  fights, something's broken.
+
+- **Outlier matchups don't go away.** Even with the spread closed, Sun beats
+  Camilo 80% of the time. Some matchups are just bad. The pipeline reports
+  every matchup above 70% so they're at least visible (16 of them today,
+  Sun in 6 of them).
+
+- **AI-vs-AI doesn't equal human-vs-human.** Two `hard` AIs play optimally
+  for the AI's heuristics, not optimally in general. Humans find exploits the
+  AI never tries — like spamming a single move that the AI doesn't punish.
+  This pipeline catches stat-driven imbalances cleanly. It doesn't catch
+  meta-game issues.
+
+## Cost
+
+Full matrix, default settings:
+
+```
+$ bun run balance
+Running full balance simulation: 100 fights/matchup, hard difficulty
+Total fights: 28,900
+Progress: 100% — done in 19.63s
+```
+
+That's 19.63 seconds for 28,900 complete three-round fights, on a laptop, in
+Bun, on a single thread, with no native code. Pure JS integer math is
+embarrassingly fast when you're not bottlenecked on rendering.
+
+The bigger lesson: when your simulation is pure, balance becomes a script.
+Same code path that runs in production runs in your terminal, deterministically,
+28,900 times. There's no separate "test simulation" to keep in sync, no model
+mismatch between what you tested and what ships. The AI-input adapter is
+literally the only piece of glue.
+
+## Sources
+
+- [PR #94 — feat: fighter balance simulation pipeline + data-driven rebalancing](https://github.com/simon0191/a-los-traques/pull/94)
+- [docs/rfcs/0013-fighter-balance-simulation.md](../docs/rfcs/0013-fighter-balance-simulation.md)
+- [scripts/balance-sim/ai-input-adapter.js](../scripts/balance-sim/ai-input-adapter.js)
+- [scripts/balance-sim/match-runner.js](../scripts/balance-sim/match-runner.js)
+- [packages/sim/src/combat-math.js](../packages/sim/src/combat-math.js)

--- a/docs/blog-backlog.json
+++ b/docs/blog-backlog.json
@@ -1,9 +1,703 @@
 {
   "version": 1,
   "cursor": {
-    "pr": 0,
-    "rfc": "",
-    "transcript": "1970-01-01T00:00:00Z"
+    "pr": 151,
+    "rfc": "0019-nextjs-monorepo-restructure.md",
+    "transcript": "2026-05-01T20:01:51Z"
   },
-  "entries": []
+  "entries": [
+    {
+      "id": "rollback-netcode-for-a-fighting-game-starring-16-of-my-frien-667a",
+      "title": "Rollback netcode for a fighting game starring 16 of my friends",
+      "hook": "GGPO-style rollback netcode means both peers run the exact same simulation locally with zero perceived input lag — and rewind up to 7 frames when predictions miss. Here's the architecture (GameState snapshot/restore, InputBuffer, RollbackManager, deterministic frame timers) and why it's the only sensible choice for cross-device WebRTC fights.",
+      "audience": "en-tech",
+      "targetLength": 2200,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 17
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Foundational netcode story with concrete modules and a clear before/after.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "why-your-fighting-game-needs-fixed-point-integer-math-and-ho-086d",
+      "title": "Why your fighting game needs fixed-point integer math (and how 1000x scale fixed our desyncs)",
+      "hook": "Phaser's float physics drift one ULP between browsers and the whole rollback edifice collapses. We replaced positions, velocities, and timers with int * 1000 fixed-point math. The 75-line FixedPoint.js module is now load-bearing for peer-equal multiplayer; a 100-run determinism test proves bit-identical state across runs.",
+      "audience": "en-tech",
+      "targetLength": 1900,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 20
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Determinism is the canonical netcode topic; concrete formula + tests.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "why-your-multiplayer-is-silently-desyncing-a-four-rfc-bug-hu-5dd3",
+      "title": "Why your multiplayer is silently desyncing: a four-RFC bug hunt",
+      "hook": "After fixing the obvious multiplayer bugs, real matches still desynced. Each fix exposed the next bug underneath: a callback overwrite that killed RTT measurement (RFC 0006), a checksum offset that depended on per-peer state (RFC 0007), prediction pruning that masked late corrections (RFC 0008), and a resync that rewound the frame counter (RFC 0010). A debugging story across four RFCs.",
+      "audience": "en-tech",
+      "targetLength": 2800,
+      "supporting": [
+        {
+          "type": "rfc",
+          "ref": "0006-fix-p1-no-rollback.md"
+        },
+        {
+          "type": "rfc",
+          "ref": "0007-fix-desync-detection.md"
+        },
+        {
+          "type": "rfc",
+          "ref": "0008-prediction-pruning-causes-silent-desync.md"
+        },
+        {
+          "type": "rfc",
+          "ref": "0010-resync-rewinds-frame-counter.md"
+        },
+        {
+          "type": "pr",
+          "number": 78
+        },
+        {
+          "type": "pr",
+          "number": 80
+        },
+        {
+          "type": "pr",
+          "number": 82
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Multi-RFC arc. Each RFC documents a distinct bug found by debug bundles from real cross-device matches; together they form a unique narrative about layered failure modes.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "how-a-single-missing-input-frame-creates-an-unfixable-desync-3cc8",
+      "title": "How a single missing input frame creates an unfixable desync",
+      "hook": "When RTT spikes and inputDelay bumps from 3 to 4, one localInputHistory slot is permanently skipped. Local peer renders that frame as EMPTY_INPUT; remote peer mispredicts and never sees a confirming input arrive. Three of four hybrid-E2E desyncs landed exactly 14 frames after the gap. The fix: detect the target-frame skip and fill the gap with the current input, sending each gap frame to the remote.",
+      "audience": "en-tech",
+      "targetLength": 1900,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 97
+        },
+        {
+          "type": "rfc",
+          "ref": "0014-fix-desync-adaptive-delay-gap.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Sharp, focused bug with great evidence (predicted gap frames matched observed desync frames within 14-frame checksum offset).",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "bug-hunting-gh-93-with-the-llm-don-t-trust-the-issue-verify--60a9",
+      "title": "Bug-hunting GH#93 with the LLM: 'don't trust the issue, verify everything yourself'",
+      "hook": "User opens with one prompt: 'Analyse the debug bundle and verify the hypothesis. Don't trust what the issue says.' What follows is a Socratic argument about RTT spikes, frame-gap collisions, and whether overwriting committed inputs is harmless — ending with the user saying 'use critical thinking' and the RFC scope expanding mid-session.",
+      "audience": "en-tech",
+      "targetLength": 2000,
+      "supporting": [
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-gh93-desync-assymetric-rollback/0e9d192a-59ef-4ce7-86c8-ec3609c41244.jsonl"
+        },
+        {
+          "type": "pr",
+          "number": 97
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Best example of explicitly disabling agreeableness ('use critical thinking') and forcing the model to verify a debug bundle from first principles.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "from-sound-to-silence-redesigning-a-phaser-simulation-to-be--7faa",
+      "title": "From sound to silence: redesigning a Phaser simulation to be Phaser-free",
+      "hook": "Our 'pure' game logic was firing audioManager.play() inside the rollback loop. Every frame of resimulation was muted by a _muteEffects flag — a leak, not a boundary. We extracted FighterSim and CombatSim, made tick() return events instead of side effects, and got headless determinism testing for free.",
+      "audience": "en-tech",
+      "targetLength": 2200,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 65
+        },
+        {
+          "type": "rfc",
+          "ref": "0002-multiplayer-redesign.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Generalizable architecture lesson — split simulation from presentation — with concrete before/after metrics.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "tier-listing-16-fighters-with-28-900-ai-vs-ai-fights-in-18-s-92b9",
+      "title": "Tier-listing 16 fighters with 28,900 AI-vs-AI fights in 18 seconds",
+      "hook": "Players said some fighters felt overpowered. With 17 characters and unique stats per move, manual balancing was guesswork. The pure simulation already runs without Phaser — we ran the full 17×17 matrix at 100 fights per matchup in 20 seconds and produced a tier list with outlier matchups. Iterated four passes; spread closed from 16-79% to 45-57%.",
+      "audience": "en-tech",
+      "targetLength": 2000,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 94
+        },
+        {
+          "type": "rfc",
+          "ref": "0013-fighter-balance-simulation.md"
+        }
+      ],
+      "status": "drafted",
+      "notes": "",
+      "rationale": "Self-contained, satisfying narrative: pure sim makes balance testing essentially free.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": "apps/web/content/blog/_drafts/tier-listing-16-fighters-with-28-900-ai-vs-ai-fights-in-18-s-92b9.md"
+    },
+    {
+      "id": "iterating-fighter-balance-with-the-llm-as-both-engineer-and--175f",
+      "title": "Iterating fighter balance with the LLM as both engineer and game designer",
+      "hook": "The user explicitly says: 'Update the PR description with the results, and explain the process we followed with the iterations. Let's use it as documentation for a future blog post.' Then runs 25,600 simulated fights, finds 'special' is a dead stat read nowhere in the codebase, double-checks that claim, opens a GH issue, and tunes base damage values down to a 45-55% spread.",
+      "audience": "en-tech",
+      "targetLength": 2400,
+      "supporting": [
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-nerf-fighters/e69adcd3-f512-4b57-ba3c-0cffc2a4d232.jsonl"
+        },
+        {
+          "type": "pr",
+          "number": 94
+        },
+        {
+          "type": "rfc",
+          "ref": "0013-fighter-balance-simulation.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "User explicitly framed the session as future-blog-post material. Tier list, P1 bias fix, dead-stat detection, scientific-method tuning with an LLM in the loop.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "frame-perfect-e2e-tests-for-a-real-time-multiplayer-fighting-6a59",
+      "title": "Frame-perfect E2E tests for a real-time multiplayer fighting game",
+      "hook": "Multiplayer bugs need two phones on cellular and one human per phone. We replaced both humans with seeded AIControllers, autoplay URL params (?autoplay=1&seed=42&speed=2), a FightRecorder that dumps inputs/checksums/rollbacks to window.__FIGHT_LOG, and Playwright spawning two browser contexts. Caught a real desync at frames 742/1102/1132 on the first run.",
+      "audience": "en-tech",
+      "targetLength": 1700,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 36
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Concrete and reproducible: seeded PRNG + fixture inputs + Playwright replaces a class of bugs you can't otherwise catch.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "frame-based-round-transitions-the-time-delayedcall-that-brok-53c0",
+      "title": "Frame-based round transitions: the time.delayedCall that broke determinism",
+      "hook": "E2E checksum diverged at frame 855, every time. Round transitions used Phaser time.delayedCall, which fires on wall-clock deltas — the two browsers reset fighters at slightly different simulation frames and the next round started already desynced. Replaced with a transitionTimer counted inside simulateFrame(); the simulation never pauses online so the rollback/checksum loop stays alive.",
+      "audience": "en-tech",
+      "targetLength": 1500,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 41
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Small clean bug story with one of the better one-liner lessons: 'no wall-clock anything in the sim path'.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "auto-uploading-debug-bundles-so-i-can-debug-fights-i-wasn-t--276c",
+      "title": "Auto-uploading debug bundles so I can debug fights I wasn't watching",
+      "hook": "Asking players to tap an overlay and paste JSON into Discord works once. By the third bug report, you've lost more bundles than you've collected. We made every fight upload its own bundle to Supabase Storage with a 7-day TTL and an admin panel to browse them — pluggable storage backend means dev writes to /tmp/, prod writes to Supabase, same code path.",
+      "audience": "en-tech",
+      "targetLength": 1800,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 84
+        },
+        {
+          "type": "rfc",
+          "ref": "0011-auto-upload-debug-bundles.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Operational debuggability story tied to a concrete RFC; broadly relatable for game devs and not just netcode-curious.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "pose-estimation-for-fighter-sprites-putting-hats-on-ai-gener-26d4",
+      "title": "Pose estimation for fighter sprites: putting hats on AI-generated friends",
+      "hook": "Sixteen fighter sprites generated by Gemini, each with 13 animations averaging 4 frames apiece. We ran MediaPipe PoseLandmarker heavy on every frame, derived head/torso/hand/foot orientation angles, and emitted one consolidated poses.json per fighter. The integration twist: shoulders > ears for hat scale (ears unreliable in 3/4-view sprites), and fall back to the nearest detected frame for low-vis poses like block/hurt/knockdown.",
+      "audience": "en-tech",
+      "targetLength": 2200,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 131
+        },
+        {
+          "type": "pr",
+          "number": 132
+        },
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-integrate-hats-human-pose-estimation/fd2c0c5a-9c7e-48b7-891b-3bc623db8bcb.jsonl"
+        },
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-human-pose-estimation/d88e50a6-3acd-432b-af4a-85b61bb5f675.jsonl"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Multi-tool AI pipeline (Gemini for sprites, MediaPipe for poses) with a clean ML-meets-game-engine story and concrete engineering tradeoffs.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "sprite-overlay-editor-a-phaser-rendered-preview-a-dom-toolba-090a",
+      "title": "Sprite overlay editor: a Phaser-rendered preview, a DOM toolbar, and 14k-line manifest commits",
+      "hook": "Accessories used to be 342 pre-baked per-(fighter, accessory, animation) strip PNGs. The runtime now reads manifest.calibrations[fighter][category][anim].frames[i] and applies setPosition/setRotation/setScale per frame. Editor at ?editor=1: pure-logic OverlaySession with bounded undo, keyframe interpolation, shortest-arc rotation; Vite dev plugin atomically writes the consolidated manifest.json.",
+      "audience": "en-tech",
+      "targetLength": 2100,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 132
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Concrete custom-tooling story: the editor exists because the alternative (baking strips) is worse, and the math/architecture is generalizable.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "a-code-review-skill-that-knows-my-repo-s-invariants-and-imme-1ff1",
+      "title": "A code-review skill that knows my repo's invariants (and immediately finds 15 critical issues)",
+      "hook": "Generic LLM PR reviews don't enforce 'no Phaser in @alostraques/sim' or 'every API route handler must go through withAuth'. We analyzed the last 50 PRs to extract the project's review style, and the codebase to extract guardrails. First dogfooding run on PR #127: hardcoded Supabase placeholders, an unrelated devDependency, a state-machine bypass with the comment 'Bypass strict transition check', and zero tests for 600+ lines of new pure logic.",
+      "audience": "en-tech",
+      "targetLength": 1800,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 130
+        },
+        {
+          "type": "pr",
+          "number": 127
+        },
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-review-skill/26d3821e-bfc0-4813-af52-cda727ebad49.jsonl"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Skill-creation + immediate dogfooding in a single session. Recipe: skill = workflow + architecture-guardrails + checklist + template.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "split-keyboard-n-humans-no-rewrites-turning-a-1p-game-into-l-7ad0",
+      "title": "Split keyboard, N humans, no rewrites: turning a 1P game into local multiplayer",
+      "hook": "The game supported player-vs-AI and online multiplayer. Friends sitting at the same machine had no way to play each other. We added 1-8 player local tournaments and a 2-player VS Local mode by introducing input profiles (keyboard_left, keyboard_right) and threading two InputManagers through FightScene — without touching the simulation layer.",
+      "audience": "en-tech",
+      "targetLength": 1700,
+      "supporting": [
+        {
+          "type": "rfc",
+          "ref": "0015-local-multiplayer-tournament.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Clean architectural example of how clean separation lets you add features by adding modules, not modifying core.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "how-a-27-subagent-task-swarm-shipped-local-tournament-mode-i-2c23",
+      "title": "How a 27-subagent task swarm shipped local tournament mode in one session",
+      "hook": "One worktree, 925 main-thread lines, 27 subagents typed bracket-fix / qa-tests / ux-polish / docs-update / victory-nav. The thread ran out of context twice and resumed itself from JSONL summaries. 'Wait. Let's write the plan as an RFC and create a PR for the team to review before implementation.'",
+      "audience": "en-tech",
+      "targetLength": 2200,
+      "supporting": [
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-torneo-multiplayer-local/c3f4d0af-b30c-4007-a42f-936349c250cc.jsonl"
+        },
+        {
+          "type": "pr",
+          "number": 110
+        },
+        {
+          "type": "rfc",
+          "ref": "0015-local-multiplayer-tournament.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Most sub-agent-heavy session in the repo by 2x. Custom agent types show a real specialized team emerging. Auto-compaction recovered mid-feature and kept shipping.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "how-we-fixed-the-desync-in-our-friends-only-fighting-game-th-7db8",
+      "title": "How we fixed the desync in our friends-only fighting game (the WebRTC redesign)",
+      "hook": "Real cross-device tests revealed the multiplayer was broken in two layers at once: round events fired during rollback resimulation, and the WebRTC stack collapsed behind any symmetric NAT. We fixed it by deferring round events, decomposing a 759-line NetworkManager monolith into focused modules, and adding Cloudflare TURN — without rewriting the rollback math.",
+      "audience": "en-tech",
+      "targetLength": 2200,
+      "supporting": [
+        {
+          "type": "rfc",
+          "ref": "0001-networking-redesign.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Lift-and-edit. RFC structured as problem → architecture → 4 phased shipments. Strong hook (real bugs on real phones), opinionated technology comparison.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "three-worlds-and-a-bus-untangling-phaser-react-and-postgres--988b",
+      "title": "Three worlds and a bus: untangling Phaser, React, and Postgres in a fighting game",
+      "hook": "Phaser scenes were calling Supabase directly, dev tools shipped in the player bundle, and 'where do I put this?' had no answer. We restructured into a bun-workspaces monorepo with two Next.js apps and enforced one rule: the game knows nothing about React, React knows nothing about the game, and the data layer knows nothing about either.",
+      "audience": "en-tech",
+      "targetLength": 2400,
+      "supporting": [
+        {
+          "type": "rfc",
+          "ref": "0019-nextjs-monorepo-restructure.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Lift-and-edit. The RFC is essentially a long-form essay already. Wide appeal beyond gamedev (any team that lets concerns leak across folders).",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "writing-the-rfc-for-a-next-js-monorepo-restructure-and-askin-169b",
+      "title": "Writing the RFC for a Next.js monorepo restructure (and asking the LLM to argue with itself)",
+      "hook": "Two sessions on worktree improve-structure: one for RFC 0019 spec'd over six phases, the second a 3,361-line implementation thread that imported a live Vercel project into Terraform, set up 1Password-named secrets, and replaced the dev plugin with a Next.js Route Handler — all phase-by-phase with a 'commit, push, continue' cadence.",
+      "audience": "en-tech",
+      "targetLength": 2400,
+      "supporting": [
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-improve-structure/eb6aa34b-ec47-4866-8540-b171e45c172a.jsonl"
+        },
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-improve-structure/b57c069c-fe07-47ca-bb6e-148e3503cd8e.jsonl"
+        },
+        {
+          "type": "pr",
+          "number": 143
+        },
+        {
+          "type": "rfc",
+          "ref": "0019-nextjs-monorepo-restructure.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "RFC-driven workflow at peak intensity: phase-gated implementation, terraform import to converge live infra into code. The clearest Spec→Plan→Phase loop in any transcript.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "debug-bundles-from-real-matches-building-observability-for-a-a92f",
+      "title": "Debug bundles from real matches: building observability for a P2P game",
+      "hook": "When a friend says 'multiplayer is broken on my phone,' you have nothing. No logs. No DevTools on iOS. Just guessing. We built a system that runs zero-overhead by default but spins up structured logging, telemetry, and one-click bundle export from both peers + server when you append ?debug=1.",
+      "audience": "en-tech",
+      "targetLength": 2000,
+      "supporting": [
+        {
+          "type": "rfc",
+          "ref": "0005-multiplayer-debuggability.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Universally relatable problem (debugging mobile bugs you can't reproduce). Concrete techniques: ring buffer, sessionId correlation, bundle merging from both peers.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "two-browsers-two-continents-real-network-e2e-testing-on-brow-009b",
+      "title": "Two browsers, two continents: real-network E2E testing on BrowserStack",
+      "hook": "Local E2E tests run both peers on the same machine with sub-1ms RTT. They catch determinism bugs but miss everything that only appears under real network conditions: TURN credential flow, ICE negotiation, RTT asymmetry, geographic latency. We hooked Playwright into BrowserStack's CDP endpoint to run P1 in Chrome on Windows and P2 in Safari on macOS, against deployed staging.",
+      "audience": "en-tech",
+      "targetLength": 1800,
+      "supporting": [
+        {
+          "type": "rfc",
+          "ref": "0009-e2e-remote-browser-testing.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Reusable techniques (Playwright CDP connect over BrowserStack instead of their SDK). Useful to any team running real-time multiplayer.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "why-two-scenes-never-received-the-rematch-message-fd6a",
+      "title": "Why two scenes never received the rematch message",
+      "hook": "Players got stuck on 'Esperando el oponente' after every fight. We assumed a network race. It was actually a callback overwrite: NetworkFacade registered onSocketOpen twice in its constructor, the second call silently overwrote the first, and rematch messages were dispatched to a listener that no longer existed. A debugging story about how a proxy pattern can sever its own wires.",
+      "audience": "en-tech",
+      "targetLength": 1500,
+      "supporting": [
+        {
+          "type": "rfc",
+          "ref": "0015-multiplayer-scene-transitions-reliability.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Short, sharp diagnostic story. Two related root causes (severed wire + stale handler), both about handler lifecycle in a layered networking stack.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "designing-a-tournament-lobby-that-works-across-devices-and-a-832f",
+      "title": "Designing a tournament lobby that works across devices and accounts",
+      "hook": "Local tournaments started as a player-count selector. They grew into a hybrid-cloud lobby — one PC as host, friends joining via QR on their phones, with persistent slots, kiosk mode, mixed bots and humans, and a server-mediated handshake to record stats for every authenticated player without exposing tokens to the host.",
+      "audience": "en-tech",
+      "targetLength": 2000,
+      "supporting": [
+        {
+          "type": "rfc",
+          "ref": "0017-tournament-lobby-redesign.md"
+        },
+        {
+          "type": "rfc",
+          "ref": "0018-tournament-participant-persistence.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Paired RFCs. 0017 covers lobby UX/sync (implemented), 0018 covers security/persistence model. Together: turning 'simple local tournament' into a multi-device coordination problem.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "adding-gamepad-support-without-rewriting-every-menu-0233",
+      "title": "Adding gamepad support without rewriting every menu",
+      "hook": "PS4 controllers were the obvious next input device. The problem wasn't the gamepad API — it was that every scene implemented its own keyboard navigation. We built a global ControllerScene that lerps a cursor between registered buttons, and gave every menu controller support with one line of registration code.",
+      "audience": "en-tech",
+      "targetLength": 1500,
+      "supporting": [
+        {
+          "type": "rfc",
+          "ref": "0016-ps4-controller-support.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Useful pattern (centralizing navigation as a 'global brain' scene). Covers the broader principle of not duplicating UX glue across screens.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "ranking-16-friends-how-a-leaderboard-got-us-out-of-an-abuse--caf5",
+      "title": "Ranking 16 friends: how a leaderboard got us out of an abuse-conversation",
+      "hook": "Wins and losses were already in Postgres. Players had no way to see them. We added a leaderboard scene fed by an authenticated GET /api/leaderboard, picked sort-by-wins-then-win-rate (not pure win rate, which favors 1W/0L), and gated it behind withAuth so we got rate limiting for free.",
+      "audience": "en-tech",
+      "targetLength": 1100,
+      "supporting": [
+        {
+          "type": "rfc",
+          "ref": "0015-global-leaderboard.md"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Small, focused feature post. Useful for the design-decisions table (why not sort by win rate, why authenticated).",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "5-segundos-para-reconectarse-sin-perder-la-pelea-8965",
+      "title": "5 segundos para reconectarse sin perder la pelea",
+      "hook": "Cuando el celular pierde señal en plena pelea, el rollback aguanta los primeros 117ms en silencio (8 frames de input prediction). Después aparece el cartel RECONECTANDO con cuenta regresiva, el server reserva tu slot 5 segundos, y si volvés mandás 'rejoin' y seguís peleando como si nada. Si te tardás más, ahí sí: DESCONECTADO.",
+      "audience": "es-friends",
+      "targetLength": 450,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 22
+        }
+      ],
+      "status": "drafted",
+      "notes": "",
+      "rationale": "Friend-facing UX story for the WhatsApp-on-cellular reality of these matches.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": "apps/web/content/blog/_drafts/5-segundos-para-reconectarse-sin-perder-la-pelea-8965.md"
+    },
+    {
+      "id": "por-que-tu-pantalla-se-achicaba-al-unirte-a-una-sala-desde-e-5b5e",
+      "title": "Por qué tu pantalla se achicaba al unirte a una sala desde el iPhone",
+      "hook": "Tocabas UNIRSE, escribías el código de sala, dabas ENTRAR — y el juego quedaba miniatura. Era el teclado de iOS abriendo y cerrando: nuestro fixHeight() reaccionaba a cada cambio de viewport y el contenedor del juego se quedaba con el tamaño chiquito. Solucion: bloquear fixHeight() mientras el input está activo, y darle 500ms al teclado para terminar la animación antes de reactivarlo.",
+      "audience": "es-friends",
+      "targetLength": 380,
+      "supporting": [
+        {
+          "type": "pr",
+          "number": 12
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Tiny relatable mobile UX bug — the kind of thing every friend playing on their iPhone hit firsthand.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "designing-an-agent-team-to-suggest-blog-posts-about-an-agent-06ea",
+      "title": "Designing an agent team to suggest blog posts about an agent-team-built game",
+      "hook": "We have 19 RFCs and 90+ PRs of source material and zero blog posts. So we designed five agents to do the triage.",
+      "audience": "en-tech",
+      "targetLength": 2200,
+      "supporting": [
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-blogs/8e2285b4-d498-4b5e-929d-80c46f72ab6a.jsonl"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Pure meta-story: pr-miner / rfc-miner / transcript-miner / orchestrator / dedup-judge designed in one session, with source-of-truth-from-code requirement and dual CLAUDE_CONFIG_DIR handling. Self-referential and unique.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "recruiting-a-data-analyst-with-five-agents-and-a-one-page-pd-fe4d",
+      "title": "Recruiting a data analyst with five agents and a one-page PDF pitch",
+      "hook": "The role doesn't exist yet. So we dispatched five parallel subagents to inventory our data, scout external datasets, and pitch three projects sized S/M/L — then exported the recruiting deck as a single-page HTML-to-PDF.",
+      "audience": "en-tech",
+      "targetLength": 2400,
+      "supporting": [
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-brainstorm-for-data-analysis/fa239636-5234-4e08-824f-423d7e6f2994.jsonl"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Five typed parallel subagents (Internal data, ML/AI ideas, External datasets, Frame data wikis, Retention pitch). Balanza Perfecta and El Cerebro emerged as M/L pitches. Pure agent-team meta-story without any PR backing it.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "handover-md-as-a-contract-between-claude-sessions-ac75",
+      "title": "Handover.md as a contract between Claude sessions",
+      "hook": "Mid-feature, the user told a fresh session: 'There was a Claude session I was working on before this one. Find the transcript in ~/.claude-personal to contextualize yourself.' Later: 'write a handover.md in the root of the repo for another agent to continue working on this.' The transcript becomes the handoff artifact.",
+      "audience": "en-tech",
+      "targetLength": 1600,
+      "supporting": [
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude/projects/-Users-simon-personal-a-los-traques--claude-worktrees-integrate-hats-human-pose-estimation/0d922bfb-896e-4606-a3eb-fbcd125010a1.jsonl"
+        },
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-integrate-hats-human-pose-estimation/5998e71f-ce09-4336-a0ea-3c48c2bebfed.jsonl"
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Tiny but punchy meta-story about session continuity. Documents the 'accidental .claude vs intentional .claude-personal' gotcha.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    },
+    {
+      "id": "one-command-local-multiplayer-dev-designing-an-auth-ladder-f-95c8",
+      "title": "One-command local multiplayer dev — designing an auth ladder from no-auth to fake IdP to Supabase",
+      "hook": "User: 'Currently manually testing multiplayer is cumbersome. You need to create the special 0000 user, run multiple things, etc. Goal: single command, no API keys, three auth modes.' Result: bun run dev:mp boots PGLite + fake auth + web + admin + PartyKit, with autoplay flags so the LLM can drive both browsers.",
+      "audience": "en-tech",
+      "targetLength": 1800,
+      "supporting": [
+        {
+          "type": "transcript",
+          "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-multiplayer-local-dx/779228dd-bc80-4029-8999-013aa9fe5793.jsonl"
+        },
+        {
+          "type": "pr",
+          "number": 99
+        }
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "DX-as-AI-affordance story: dev loop redesigned partly so an LLM could drive both ends of multiplayer with autoplay params. Concrete win — single command replaced ~5 manual steps.",
+      "createdAt": "2026-05-01T18:12:47.654Z",
+      "lastSeenAt": "2026-05-01T18:12:47.654Z",
+      "draftPath": null
+    }
+  ]
 }

--- a/docs/blog-backlog.json
+++ b/docs/blog-backlog.json
@@ -103,12 +103,12 @@
           "ref": "0014-fix-desync-adaptive-delay-gap.md"
         }
       ],
-      "status": "proposed",
+      "status": "drafted",
       "notes": "",
       "rationale": "Sharp, focused bug with great evidence (predicted gap frames matched observed desync frames within 14-frame checksum offset).",
       "createdAt": "2026-05-01T18:12:47.654Z",
       "lastSeenAt": "2026-05-01T18:12:47.654Z",
-      "draftPath": null
+      "draftPath": "apps/web/content/blog/_drafts/how-a-single-missing-input-frame-creates-an-unfixable-desync-3cc8.md"
     },
     {
       "id": "bug-hunting-gh-93-with-the-llm-don-t-trust-the-issue-verify--60a9",
@@ -627,12 +627,12 @@
           "ref": "/Users/simon/.claude-personal/projects/-Users-simon-personal-a-los-traques--claude-worktrees-blogs/8e2285b4-d498-4b5e-929d-80c46f72ab6a.jsonl"
         }
       ],
-      "status": "proposed",
+      "status": "drafted",
       "notes": "",
       "rationale": "Pure meta-story: pr-miner / rfc-miner / transcript-miner / orchestrator / dedup-judge designed in one session, with source-of-truth-from-code requirement and dual CLAUDE_CONFIG_DIR handling. Self-referential and unique.",
       "createdAt": "2026-05-01T18:12:47.654Z",
       "lastSeenAt": "2026-05-01T18:12:47.654Z",
-      "draftPath": null
+      "draftPath": "apps/web/content/blog/_drafts/designing-an-agent-team-to-suggest-blog-posts-about-an-agent-06ea.md"
     },
     {
       "id": "recruiting-a-data-analyst-with-five-agents-and-a-one-page-pd-fe4d",

--- a/docs/blog-backlog.json
+++ b/docs/blog-backlog.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "cursor": {
+    "pr": 0,
+    "rfc": "",
+    "transcript": "1970-01-01T00:00:00Z"
+  },
+  "entries": []
+}

--- a/docs/superpowers/plans/2026-05-01-blog-article-agent-team.md
+++ b/docs/superpowers/plans/2026-05-01-blog-article-agent-team.md
@@ -1,0 +1,1695 @@
+# Blog Article Agent Team — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a five-agent system (`/blog-mine` orchestrator + `pr-miner` / `rfc-miner` / `transcript-miner` / `blog-drafter` subagents) that mines this repo's PRs, RFCs, and Claude Code transcripts into a deduped backlog of blog-post ideas, then expands chosen entries into draft posts.
+
+**Architecture:** Slash commands handle orchestration and LLM judgment (semantic dedup, audience tagging, draft writing). All deterministic state manipulation (loading/saving the backlog JSON, ID generation, mechanical dedup, cursor management) lives in a pure `scripts/blog-backlog/` Node module exposed via a CLI so it can be unit-tested without agent calls.
+
+**Tech Stack:** ESM Node.js (`"type": "module"`), Vitest for unit tests, `gh` CLI for PR data, `git` CLI for commit data, Claude Code subagents (`.claude/agents/<name>.md`), Claude Code skills (`.claude/skills/<name>/SKILL.md`).
+
+---
+
+## File Structure
+
+**New:**
+- `scripts/blog-backlog/backlog.js` — load/save `docs/blog-backlog.json` with schema validation.
+- `scripts/blog-backlog/id.js` — deterministic id generation (kebab-case slug + 4-char hash).
+- `scripts/blog-backlog/dedup.js` — mechanical dedup (PR# match, ref overlap) given a merge plan from the orchestrator.
+- `scripts/blog-backlog/cli.js` — CLI surface (`init`, `cursor`, `apply`, `get`, `update`).
+- `tests/blog-backlog/backlog.test.js` — load/save/initialise tests.
+- `tests/blog-backlog/id.test.js` — id stability tests.
+- `tests/blog-backlog/dedup.test.js` — apply-plan behavior tests.
+- `tests/blog-backlog/cli.test.js` — CLI smoke tests via `execSync`.
+- `docs/blog-backlog.json` — committed empty backlog (bootstrapped by `init`).
+- `.claude/agents/pr-miner.md` — subagent.
+- `.claude/agents/rfc-miner.md` — subagent.
+- `.claude/agents/transcript-miner.md` — subagent.
+- `.claude/agents/blog-drafter.md` — subagent.
+- `.claude/skills/blog-mine/SKILL.md` — `/blog-mine` orchestrator.
+- `.claude/skills/blog-expand/SKILL.md` — `/blog-expand <id>` orchestrator.
+- `apps/web/content/blog/_drafts/.gitkeep` — drafts dir placeholder.
+
+**Modified:**
+- `CLAUDE.md` — append a "Blog Backlog" section under Documentation.
+
+**Touched read-only by tests/agents only:** `docs/rfcs/*.md`, `apps/web/content/blog/welcome.md`, `~/.claude-personal/projects/*a-los-traques*`, `~/.claude/projects/*a-los-traques*`.
+
+---
+
+## Task 1: Bootstrap empty backlog file format
+
+**Files:**
+- Create: `scripts/blog-backlog/backlog.js`
+- Create: `tests/blog-backlog/backlog.test.js`
+
+The backlog module owns reading, writing, and validating `docs/blog-backlog.json`. The schema is defined in `docs/superpowers/specs/2026-05-01-blog-article-agent-team-design.md` § "Backlog Schema". Validation is structural only (shape + status enum); semantic checks live in dedup.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/blog-backlog/backlog.test.js`:
+
+```javascript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { loadBacklog, saveBacklog, emptyBacklog } from '../../scripts/blog-backlog/backlog.js';
+
+let tmpDir;
+let file;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'backlog-'));
+  file = path.join(tmpDir, 'blog-backlog.json');
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('emptyBacklog', () => {
+  it('produces a v1 backlog with epoch cursor and no entries', () => {
+    const b = emptyBacklog();
+    expect(b).toEqual({
+      version: 1,
+      cursor: { pr: 0, rfc: '', transcript: '1970-01-01T00:00:00Z' },
+      entries: [],
+    });
+  });
+});
+
+describe('loadBacklog', () => {
+  it('returns emptyBacklog when file is absent', async () => {
+    const b = await loadBacklog(file);
+    expect(b).toEqual(emptyBacklog());
+  });
+
+  it('round-trips through saveBacklog', async () => {
+    const original = emptyBacklog();
+    original.cursor.pr = 42;
+    original.entries.push({
+      id: 'sample-abcd',
+      title: 'Sample',
+      hook: 'A test entry',
+      audience: 'en-tech',
+      targetLength: 1500,
+      supporting: [{ type: 'pr', number: 42 }],
+      status: 'proposed',
+      notes: '',
+      rationale: 'because',
+      createdAt: '2026-05-01T00:00:00Z',
+      lastSeenAt: '2026-05-01T00:00:00Z',
+      draftPath: null,
+    });
+    await saveBacklog(file, original);
+    const reloaded = await loadBacklog(file);
+    expect(reloaded).toEqual(original);
+  });
+
+  it('rejects backlog with unknown version', async () => {
+    await fs.writeFile(file, JSON.stringify({ version: 999, cursor: {}, entries: [] }));
+    await expect(loadBacklog(file)).rejects.toThrow(/version/i);
+  });
+
+  it('rejects entry with invalid status', async () => {
+    const bad = emptyBacklog();
+    bad.entries.push({
+      id: 'x', title: 't', hook: 'h', audience: 'en-tech', targetLength: 100,
+      supporting: [], status: 'banana', notes: '', rationale: '',
+      createdAt: '2026-05-01T00:00:00Z', lastSeenAt: '2026-05-01T00:00:00Z', draftPath: null,
+    });
+    await fs.writeFile(file, JSON.stringify(bad));
+    await expect(loadBacklog(file)).rejects.toThrow(/status/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:run tests/blog-backlog/backlog.test.js`
+Expected: FAIL — `Cannot find module '../../scripts/blog-backlog/backlog.js'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `scripts/blog-backlog/backlog.js`:
+
+```javascript
+import { promises as fs } from 'node:fs';
+
+const VALID_STATUS = new Set(['proposed', 'greenlit', 'rejected', 'drafted', 'published']);
+const VALID_AUDIENCE = new Set(['es-friends', 'en-tech', 'both']);
+const VALID_REF_TYPE = new Set(['pr', 'rfc', 'transcript', 'commit', 'code']);
+
+export function emptyBacklog() {
+  return {
+    version: 1,
+    cursor: { pr: 0, rfc: '', transcript: '1970-01-01T00:00:00Z' },
+    entries: [],
+  };
+}
+
+function validate(b) {
+  if (!b || typeof b !== 'object') throw new Error('backlog: not an object');
+  if (b.version !== 1) throw new Error(`backlog: unsupported version ${b.version}`);
+  if (!b.cursor || typeof b.cursor !== 'object') throw new Error('backlog: missing cursor');
+  if (!Array.isArray(b.entries)) throw new Error('backlog: entries must be an array');
+  for (const e of b.entries) {
+    if (!VALID_STATUS.has(e.status)) {
+      throw new Error(`backlog: entry ${e.id} has invalid status "${e.status}"`);
+    }
+    if (!VALID_AUDIENCE.has(e.audience)) {
+      throw new Error(`backlog: entry ${e.id} has invalid audience "${e.audience}"`);
+    }
+    if (!Array.isArray(e.supporting)) {
+      throw new Error(`backlog: entry ${e.id} supporting must be an array`);
+    }
+    for (const s of e.supporting) {
+      if (!VALID_REF_TYPE.has(s.type)) {
+        throw new Error(`backlog: entry ${e.id} ref has invalid type "${s.type}"`);
+      }
+    }
+  }
+}
+
+export async function loadBacklog(file) {
+  let raw;
+  try {
+    raw = await fs.readFile(file, 'utf-8');
+  } catch (err) {
+    if (err.code === 'ENOENT') return emptyBacklog();
+    throw err;
+  }
+  const parsed = JSON.parse(raw);
+  validate(parsed);
+  return parsed;
+}
+
+export async function saveBacklog(file, backlog) {
+  validate(backlog);
+  const json = `${JSON.stringify(backlog, null, 2)}\n`;
+  await fs.writeFile(file, json, 'utf-8');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test:run tests/blog-backlog/backlog.test.js`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/blog-backlog/backlog.js tests/blog-backlog/backlog.test.js
+git commit -m "feat(blog-backlog): backlog load/save with schema validation"
+```
+
+---
+
+## Task 2: ID generation
+
+**Files:**
+- Create: `scripts/blog-backlog/id.js`
+- Create: `tests/blog-backlog/id.test.js`
+
+Backlog entry ids must be stable across re-runs so dedup matches. Format: `<kebab-slug-of-title>-<4-char-hash-of-supporting-refs>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/blog-backlog/id.test.js`:
+
+```javascript
+import { describe, it, expect } from 'vitest';
+import { makeId, slugify } from '../../scripts/blog-backlog/id.js';
+
+describe('slugify', () => {
+  it('lowercases and dashes', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+  it('strips punctuation', () => {
+    expect(slugify('Rollback netcode: why we kill audio!')).toBe('rollback-netcode-why-we-kill-audio');
+  });
+  it('handles spanish characters', () => {
+    expect(slugify('Cómo diseñamos los hitboxes')).toBe('como-disenamos-los-hitboxes');
+  });
+  it('collapses repeated dashes and trims', () => {
+    expect(slugify('  --foo--bar--  ')).toBe('foo-bar');
+  });
+  it('truncates very long titles to 60 chars', () => {
+    const long = 'a'.repeat(120);
+    expect(slugify(long)).toHaveLength(60);
+  });
+});
+
+describe('makeId', () => {
+  it('combines slug and 4-char hash', () => {
+    const id = makeId('Rollback netcode', [{ type: 'pr', number: 91 }]);
+    expect(id).toMatch(/^rollback-netcode-[0-9a-f]{4}$/);
+  });
+  it('is stable for the same inputs', () => {
+    const a = makeId('Title', [{ type: 'pr', number: 1 }, { type: 'rfc', ref: 'X.md' }]);
+    const b = makeId('Title', [{ type: 'pr', number: 1 }, { type: 'rfc', ref: 'X.md' }]);
+    expect(a).toBe(b);
+  });
+  it('is order-independent on supporting refs', () => {
+    const a = makeId('Title', [{ type: 'pr', number: 1 }, { type: 'rfc', ref: 'X.md' }]);
+    const b = makeId('Title', [{ type: 'rfc', ref: 'X.md' }, { type: 'pr', number: 1 }]);
+    expect(a).toBe(b);
+  });
+  it('differs when supporting refs differ', () => {
+    const a = makeId('Title', [{ type: 'pr', number: 1 }]);
+    const b = makeId('Title', [{ type: 'pr', number: 2 }]);
+    expect(a).not.toBe(b);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:run tests/blog-backlog/id.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the module**
+
+Create `scripts/blog-backlog/id.js`:
+
+```javascript
+import { createHash } from 'node:crypto';
+
+export function slugify(input) {
+  const ascii = input
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, ''); // strip combining diacriticals
+  const lower = ascii.toLowerCase();
+  const dashed = lower.replace(/[^a-z0-9]+/g, '-');
+  const trimmed = dashed.replace(/^-+|-+$/g, '');
+  return trimmed.slice(0, 60);
+}
+
+function refKey(r) {
+  if (r.type === 'pr') return `pr:${r.number}`;
+  return `${r.type}:${r.ref}`;
+}
+
+export function makeId(title, supporting) {
+  const slug = slugify(title);
+  const refs = supporting.map(refKey).sort().join('|');
+  const hash = createHash('sha1').update(refs).digest('hex').slice(0, 4);
+  return `${slug}-${hash}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test:run tests/blog-backlog/id.test.js`
+Expected: PASS — 9 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/blog-backlog/id.js tests/blog-backlog/id.test.js
+git commit -m "feat(blog-backlog): stable id generation from title + supporting refs"
+```
+
+---
+
+## Task 3: Apply merge plan (mechanical dedup)
+
+**Files:**
+- Create: `scripts/blog-backlog/dedup.js`
+- Create: `tests/blog-backlog/dedup.test.js`
+
+The orchestrator (LLM-driven) decides which candidates are new, which merge into existing entries, which to skip. It emits a **plan**, and this module mechanically applies it. Plan shape:
+
+```javascript
+{
+  new: [<candidate>, ...],
+  merge: [{ intoId: 'existing-id-abcd', candidate: <candidate> }, ...],
+  skip: [<candidate>, ...],            // recorded for the run summary, no-op on backlog
+  cursor: { pr?: number, rfc?: string, transcript?: string },
+}
+```
+
+A `<candidate>` has the same shape as a backlog entry minus `id`, `status`, `notes`, `createdAt`, `lastSeenAt`, `draftPath` (those get assigned by `apply`).
+
+`apply()` rules:
+- For each `new` candidate: assign `id` via `makeId`, set `status='proposed'`, `notes=''`, `createdAt=now`, `lastSeenAt=now`, `draftPath=null`. Append to entries.
+- For each `merge` candidate: find entry by `intoId`. Append any new `supporting` refs (dedup by `refKey`). Update `lastSeenAt=now`. Do **not** touch `status`, `notes`, `rationale`, `title`, `hook`, `audience`, `targetLength`, `draftPath`.
+- Bump cursor: `cursor.pr = max(current, plan.cursor.pr ?? current)`; rfc takes the lexicographically greater; transcript takes the later ISO timestamp.
+- Return summary: `{ added: N, merged: M, skipped: K, cursor: <new cursor> }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/blog-backlog/dedup.test.js`:
+
+```javascript
+import { describe, it, expect } from 'vitest';
+import { applyPlan } from '../../scripts/blog-backlog/dedup.js';
+import { emptyBacklog } from '../../scripts/blog-backlog/backlog.js';
+
+const NOW = '2026-05-01T12:00:00Z';
+
+function candidate(overrides = {}) {
+  return {
+    title: 'Sample',
+    hook: 'A hook',
+    audience: 'en-tech',
+    targetLength: 1500,
+    supporting: [{ type: 'pr', number: 42 }],
+    rationale: 'because',
+    ...overrides,
+  };
+}
+
+describe('applyPlan', () => {
+  it('appends new candidates with assigned id and proposed status', () => {
+    const backlog = emptyBacklog();
+    const summary = applyPlan(backlog, {
+      new: [candidate()],
+      merge: [],
+      skip: [],
+      cursor: { pr: 42 },
+    }, NOW);
+    expect(summary.added).toBe(1);
+    expect(backlog.entries).toHaveLength(1);
+    const e = backlog.entries[0];
+    expect(e.id).toMatch(/^sample-[0-9a-f]{4}$/);
+    expect(e.status).toBe('proposed');
+    expect(e.notes).toBe('');
+    expect(e.createdAt).toBe(NOW);
+    expect(e.lastSeenAt).toBe(NOW);
+    expect(e.draftPath).toBeNull();
+    expect(backlog.cursor.pr).toBe(42);
+  });
+
+  it('merges supporting refs into the existing entry without touching user-set fields', () => {
+    const backlog = emptyBacklog();
+    backlog.entries.push({
+      id: 'existing-aaaa',
+      title: 'Existing',
+      hook: 'Old hook',
+      audience: 'en-tech',
+      targetLength: 1500,
+      supporting: [{ type: 'pr', number: 10 }],
+      status: 'greenlit',
+      notes: 'lead with the bug',
+      rationale: 'old rationale',
+      createdAt: '2026-04-01T00:00:00Z',
+      lastSeenAt: '2026-04-01T00:00:00Z',
+      draftPath: null,
+    });
+
+    applyPlan(backlog, {
+      new: [],
+      merge: [{
+        intoId: 'existing-aaaa',
+        candidate: candidate({
+          title: 'Different title',
+          hook: 'Different hook',
+          supporting: [{ type: 'pr', number: 10 }, { type: 'rfc', ref: 'X.md' }],
+        }),
+      }],
+      skip: [],
+      cursor: {},
+    }, NOW);
+
+    const e = backlog.entries[0];
+    expect(e.title).toBe('Existing');
+    expect(e.hook).toBe('Old hook');
+    expect(e.status).toBe('greenlit');
+    expect(e.notes).toBe('lead with the bug');
+    expect(e.rationale).toBe('old rationale');
+    expect(e.supporting).toEqual([
+      { type: 'pr', number: 10 },
+      { type: 'rfc', ref: 'X.md' },
+    ]);
+    expect(e.lastSeenAt).toBe(NOW);
+  });
+
+  it('does not duplicate refs that already exist on the merge target', () => {
+    const backlog = emptyBacklog();
+    backlog.entries.push({
+      id: 'x-aaaa', title: 'x', hook: 'h', audience: 'en-tech', targetLength: 100,
+      supporting: [{ type: 'pr', number: 1 }],
+      status: 'proposed', notes: '', rationale: '',
+      createdAt: NOW, lastSeenAt: NOW, draftPath: null,
+    });
+    applyPlan(backlog, {
+      new: [],
+      merge: [{ intoId: 'x-aaaa', candidate: candidate({ supporting: [{ type: 'pr', number: 1 }] }) }],
+      skip: [],
+      cursor: {},
+    }, NOW);
+    expect(backlog.entries[0].supporting).toEqual([{ type: 'pr', number: 1 }]);
+  });
+
+  it('throws if merge.intoId does not exist', () => {
+    const backlog = emptyBacklog();
+    expect(() => applyPlan(backlog, {
+      new: [],
+      merge: [{ intoId: 'missing-zzzz', candidate: candidate() }],
+      skip: [],
+      cursor: {},
+    }, NOW)).toThrow(/missing-zzzz/);
+  });
+
+  it('keeps the higher cursor value for each source', () => {
+    const backlog = emptyBacklog();
+    backlog.cursor = { pr: 100, rfc: '0050.md', transcript: '2026-04-01T00:00:00Z' };
+    applyPlan(backlog, {
+      new: [],
+      merge: [],
+      skip: [],
+      cursor: { pr: 50, rfc: '0099.md', transcript: '2026-04-15T00:00:00Z' },
+    }, NOW);
+    expect(backlog.cursor).toEqual({
+      pr: 100,
+      rfc: '0099.md',
+      transcript: '2026-04-15T00:00:00Z',
+    });
+  });
+
+  it('counts skipped candidates in summary without mutating backlog', () => {
+    const backlog = emptyBacklog();
+    const summary = applyPlan(backlog, {
+      new: [],
+      merge: [],
+      skip: [candidate(), candidate()],
+      cursor: {},
+    }, NOW);
+    expect(summary.skipped).toBe(2);
+    expect(backlog.entries).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:run tests/blog-backlog/dedup.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the module**
+
+Create `scripts/blog-backlog/dedup.js`:
+
+```javascript
+import { makeId } from './id.js';
+
+function refKey(r) {
+  if (r.type === 'pr') return `pr:${r.number}`;
+  return `${r.type}:${r.ref}`;
+}
+
+function maxString(a, b) {
+  if (!a) return b;
+  if (!b) return a;
+  return a > b ? a : b;
+}
+
+function maxNumber(a, b) {
+  if (a == null) return b;
+  if (b == null) return a;
+  return a > b ? a : b;
+}
+
+export function applyPlan(backlog, plan, now) {
+  for (const c of plan.new ?? []) {
+    const id = makeId(c.title, c.supporting);
+    backlog.entries.push({
+      id,
+      title: c.title,
+      hook: c.hook,
+      audience: c.audience,
+      targetLength: c.targetLength,
+      supporting: c.supporting.slice(),
+      status: 'proposed',
+      notes: '',
+      rationale: c.rationale ?? '',
+      createdAt: now,
+      lastSeenAt: now,
+      draftPath: null,
+    });
+  }
+
+  for (const m of plan.merge ?? []) {
+    const target = backlog.entries.find((e) => e.id === m.intoId);
+    if (!target) {
+      throw new Error(`applyPlan: merge target ${m.intoId} not found`);
+    }
+    const existing = new Set(target.supporting.map(refKey));
+    for (const r of m.candidate.supporting ?? []) {
+      if (!existing.has(refKey(r))) {
+        target.supporting.push(r);
+        existing.add(refKey(r));
+      }
+    }
+    target.lastSeenAt = now;
+  }
+
+  const c = plan.cursor ?? {};
+  backlog.cursor = {
+    pr: maxNumber(backlog.cursor.pr, c.pr),
+    rfc: maxString(backlog.cursor.rfc, c.rfc),
+    transcript: maxString(backlog.cursor.transcript, c.transcript),
+  };
+
+  return {
+    added: (plan.new ?? []).length,
+    merged: (plan.merge ?? []).length,
+    skipped: (plan.skip ?? []).length,
+    cursor: { ...backlog.cursor },
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test:run tests/blog-backlog/dedup.test.js`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/blog-backlog/dedup.js tests/blog-backlog/dedup.test.js
+git commit -m "feat(blog-backlog): applyPlan merges candidates and bumps cursor"
+```
+
+---
+
+## Task 4: CLI entrypoint
+
+**Files:**
+- Create: `scripts/blog-backlog/cli.js`
+- Create: `tests/blog-backlog/cli.test.js`
+
+Subcommands:
+- `init [--file PATH]` — writes an empty backlog if the file is absent. No-op if present. Default file: `docs/blog-backlog.json`.
+- `cursor [--file PATH]` — prints the current cursor as JSON to stdout (so miners can read it).
+- `apply --plan PATH [--file PATH]` — reads the plan JSON, runs `applyPlan`, writes back, prints summary JSON to stdout.
+- `get <id> [--file PATH]` — prints the entry JSON. Exits 1 if not found.
+- `update <id> [--status X] [--notes "..."] [--draftPath "..."] [--file PATH]` — patches a single entry. Prints the updated entry JSON.
+
+All subcommands print JSON only on stdout; human-readable messages go to stderr.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/blog-backlog/cli.test.js`:
+
+```javascript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '../../scripts/blog-backlog/cli.js');
+
+let tmpDir;
+let file;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cli-'));
+  file = path.join(tmpDir, 'blog-backlog.json');
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function run(args) {
+  return execFileSync('node', [CLI, ...args], { encoding: 'utf-8' });
+}
+
+describe('cli init', () => {
+  it('creates an empty backlog when file is absent', async () => {
+    run(['init', '--file', file]);
+    const raw = JSON.parse(await fs.readFile(file, 'utf-8'));
+    expect(raw.version).toBe(1);
+    expect(raw.entries).toEqual([]);
+  });
+
+  it('is a no-op when the file already exists', async () => {
+    run(['init', '--file', file]);
+    const before = await fs.readFile(file, 'utf-8');
+    run(['init', '--file', file]);
+    const after = await fs.readFile(file, 'utf-8');
+    expect(after).toBe(before);
+  });
+});
+
+describe('cli cursor', () => {
+  it('prints the current cursor as JSON', () => {
+    run(['init', '--file', file]);
+    const out = run(['cursor', '--file', file]);
+    expect(JSON.parse(out)).toEqual({ pr: 0, rfc: '', transcript: '1970-01-01T00:00:00Z' });
+  });
+});
+
+describe('cli apply', () => {
+  it('applies a plan and prints a summary', async () => {
+    run(['init', '--file', file]);
+    const planFile = path.join(tmpDir, 'plan.json');
+    await fs.writeFile(planFile, JSON.stringify({
+      new: [{
+        title: 'Hello world', hook: 'a hook', audience: 'en-tech',
+        targetLength: 1000, supporting: [{ type: 'pr', number: 7 }],
+        rationale: 'because',
+      }],
+      merge: [],
+      skip: [],
+      cursor: { pr: 7 },
+    }));
+    const out = run(['apply', '--plan', planFile, '--file', file]);
+    const summary = JSON.parse(out);
+    expect(summary.added).toBe(1);
+    expect(summary.cursor.pr).toBe(7);
+
+    const reloaded = JSON.parse(await fs.readFile(file, 'utf-8'));
+    expect(reloaded.entries).toHaveLength(1);
+    expect(reloaded.entries[0].title).toBe('Hello world');
+  });
+});
+
+describe('cli get', () => {
+  it('prints the entry as JSON', async () => {
+    run(['init', '--file', file]);
+    const planFile = path.join(tmpDir, 'plan.json');
+    await fs.writeFile(planFile, JSON.stringify({
+      new: [{
+        title: 'X', hook: 'h', audience: 'en-tech',
+        targetLength: 1000, supporting: [{ type: 'pr', number: 1 }], rationale: '',
+      }],
+      merge: [], skip: [], cursor: {},
+    }));
+    run(['apply', '--plan', planFile, '--file', file]);
+    const reloaded = JSON.parse(await fs.readFile(file, 'utf-8'));
+    const id = reloaded.entries[0].id;
+
+    const out = run(['get', id, '--file', file]);
+    expect(JSON.parse(out).id).toBe(id);
+  });
+
+  it('exits non-zero when the id is missing', () => {
+    run(['init', '--file', file]);
+    expect(() => run(['get', 'nope-zzzz', '--file', file])).toThrow();
+  });
+});
+
+describe('cli update', () => {
+  it('patches status and notes', async () => {
+    run(['init', '--file', file]);
+    const planFile = path.join(tmpDir, 'plan.json');
+    await fs.writeFile(planFile, JSON.stringify({
+      new: [{
+        title: 'X', hook: 'h', audience: 'en-tech',
+        targetLength: 1000, supporting: [{ type: 'pr', number: 1 }], rationale: '',
+      }],
+      merge: [], skip: [], cursor: {},
+    }));
+    run(['apply', '--plan', planFile, '--file', file]);
+    const reloaded = JSON.parse(await fs.readFile(file, 'utf-8'));
+    const id = reloaded.entries[0].id;
+
+    const out = run(['update', id, '--status', 'greenlit', '--notes', 'do this one', '--file', file]);
+    const updated = JSON.parse(out);
+    expect(updated.status).toBe('greenlit');
+    expect(updated.notes).toBe('do this one');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:run tests/blog-backlog/cli.test.js`
+Expected: FAIL — CLI file not found.
+
+- [ ] **Step 3: Write the CLI**
+
+Create `scripts/blog-backlog/cli.js`:
+
+```javascript
+#!/usr/bin/env node
+
+/**
+ * cli.js -- Blog backlog CLI for A Los Traques
+ *
+ * Subcommands: init, cursor, apply, get, update
+ * All commands print JSON to stdout; logs go to stderr.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { loadBacklog, saveBacklog, emptyBacklog } from './backlog.js';
+import { applyPlan } from './dedup.js';
+
+const DEFAULT_FILE = path.resolve(process.cwd(), 'docs/blog-backlog.json');
+
+function parseArgs(argv) {
+  const positional = [];
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        flags[key] = true;
+      } else {
+        flags[key] = next;
+        i++;
+      }
+    } else {
+      positional.push(a);
+    }
+  }
+  return { positional, flags };
+}
+
+async function cmdInit(file) {
+  try {
+    await fs.access(file);
+    process.stderr.write(`backlog: ${file} already exists, no-op\n`);
+    return;
+  } catch {}
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await saveBacklog(file, emptyBacklog());
+  process.stderr.write(`backlog: initialised ${file}\n`);
+}
+
+async function cmdCursor(file) {
+  const b = await loadBacklog(file);
+  process.stdout.write(`${JSON.stringify(b.cursor)}\n`);
+}
+
+async function cmdApply(file, planPath) {
+  const planRaw = await fs.readFile(planPath, 'utf-8');
+  const plan = JSON.parse(planRaw);
+  const backlog = await loadBacklog(file);
+  const summary = applyPlan(backlog, plan, new Date().toISOString());
+  await saveBacklog(file, backlog);
+  process.stdout.write(`${JSON.stringify(summary)}\n`);
+}
+
+async function cmdGet(file, id) {
+  const backlog = await loadBacklog(file);
+  const entry = backlog.entries.find((e) => e.id === id);
+  if (!entry) {
+    process.stderr.write(`backlog: entry "${id}" not found\n`);
+    process.exit(1);
+  }
+  process.stdout.write(`${JSON.stringify(entry)}\n`);
+}
+
+async function cmdUpdate(file, id, flags) {
+  const backlog = await loadBacklog(file);
+  const entry = backlog.entries.find((e) => e.id === id);
+  if (!entry) {
+    process.stderr.write(`backlog: entry "${id}" not found\n`);
+    process.exit(1);
+  }
+  if (flags.status !== undefined) entry.status = flags.status;
+  if (flags.notes !== undefined) entry.notes = flags.notes;
+  if (flags.draftPath !== undefined) entry.draftPath = flags.draftPath;
+  await saveBacklog(file, backlog);
+  process.stdout.write(`${JSON.stringify(entry)}\n`);
+}
+
+async function main() {
+  const [sub, ...rest] = process.argv.slice(2);
+  const { positional, flags } = parseArgs(rest);
+  const file = path.resolve(flags.file ?? DEFAULT_FILE);
+
+  switch (sub) {
+    case 'init':
+      return cmdInit(file);
+    case 'cursor':
+      return cmdCursor(file);
+    case 'apply':
+      if (!flags.plan) {
+        process.stderr.write('apply: --plan PATH is required\n');
+        process.exit(2);
+      }
+      return cmdApply(file, path.resolve(flags.plan));
+    case 'get':
+      return cmdGet(file, positional[0]);
+    case 'update':
+      return cmdUpdate(file, positional[0], flags);
+    default:
+      process.stderr.write(`usage: cli.js {init|cursor|apply|get|update} [...]\n`);
+      process.exit(2);
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`backlog: ${err.message}\n`);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test:run tests/blog-backlog/cli.test.js`
+Expected: PASS — 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/blog-backlog/cli.js tests/blog-backlog/cli.test.js
+git commit -m "feat(blog-backlog): cli with init/cursor/apply/get/update"
+```
+
+---
+
+## Task 5: Bootstrap empty backlog and drafts directory
+
+**Files:**
+- Create: `docs/blog-backlog.json`
+- Create: `apps/web/content/blog/_drafts/.gitkeep`
+
+Use the CLI itself to bootstrap so the file format is guaranteed correct.
+
+- [ ] **Step 1: Bootstrap the backlog**
+
+Run: `node scripts/blog-backlog/cli.js init`
+Expected stderr: `backlog: initialised /Users/.../docs/blog-backlog.json`.
+
+- [ ] **Step 2: Verify the file**
+
+Run: `cat docs/blog-backlog.json`
+Expected:
+```json
+{
+  "version": 1,
+  "cursor": {
+    "pr": 0,
+    "rfc": "",
+    "transcript": "1970-01-01T00:00:00Z"
+  },
+  "entries": []
+}
+```
+
+- [ ] **Step 3: Create drafts directory placeholder**
+
+```bash
+mkdir -p apps/web/content/blog/_drafts
+touch apps/web/content/blog/_drafts/.gitkeep
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/blog-backlog.json apps/web/content/blog/_drafts/.gitkeep
+git commit -m "chore(blog-backlog): bootstrap empty backlog and drafts directory"
+```
+
+---
+
+## Task 6: Define the `pr-miner` subagent
+
+**Files:**
+- Create: `.claude/agents/pr-miner.md`
+
+Claude Code subagent definition. Convention: front-matter with `name`, `description`, optional `tools`, then the prompt body. The orchestrator dispatches via `Agent({ subagent_type: 'pr-miner', prompt: '...' })`.
+
+- [ ] **Step 1: Write the subagent**
+
+Create `.claude/agents/pr-miner.md`:
+
+```markdown
+---
+name: pr-miner
+description: Mines merged PRs in the A Los Traques repo for blog-post candidates. Reads PRs above a given cursor, judges interestingness, and returns a JSON candidate list. Use only from the /blog-mine orchestrator.
+tools: Bash, Read
+---
+
+# pr-miner
+
+You scan merged PRs above a cursor and return blog-post candidate ideas as JSON. You do **not** read code beyond what `gh` returns. Your job is to triage signal, not verify.
+
+## Inputs (from the orchestrator prompt)
+
+- `since_pr_number` — only consider PRs with number strictly greater than this.
+- `repo_path` — absolute path to the working tree.
+
+## Steps
+
+1. List candidate PRs:
+
+   ```bash
+   gh pr list --state merged --limit 200 --json number,title,body,mergedAt,files,author --search "is:merged sort:created-asc"
+   ```
+
+   Filter client-side to `number > since_pr_number`. Sort ascending.
+
+2. For each PR, read just enough to decide: title + body + file list. Skim review comments only when the PR feels promising:
+
+   ```bash
+   gh pr view <N> --json title,body,files,reviewComments,mergedAt,baseRefName,headRefName
+   ```
+
+3. Judge interestingness against these themes (in priority order):
+
+   - **Rollback netcode** (frame skipping, prediction pruning, desync detection, asymmetric RTT)
+   - **Simulation determinism** (FixedPoint math, event-driven presentation, FightRecorder, checksums)
+   - **AI asset generation** (Gemini pipeline, pose estimation, accessory calibration, prompt engineering)
+   - **RFC-driven workflow** (RFC referenced in body, multi-phase rollout, design-then-build cadence)
+   - **Multiplayer debuggability** (Logger, telemetry, debug bundles, diagnostics endpoint)
+   - **Asset pipeline plumbing** (build hooks, manifest generation, calibration tooling)
+   - **Gnarly bug stories** (root cause was non-obvious, fix was small relative to debugging)
+   - **Process / tooling** (Claude skills, GitHub Actions for @claude, code-review skill)
+
+   **Skip:** routine fixes, lint/format-only PRs, dependency bumps, copy edits, single-file UI tweaks without a story.
+
+4. For each interesting PR, emit a candidate object. **Pick `audience`** based on the topic:
+   - Friends-Spanish if the story is project-internal (a friend's fighter rebalance, a UI in-joke, a "the time we broke X right before the party").
+   - Tech-English for generalizable engineering content (rollback, determinism, AI dev workflow).
+   - Use `both` only when the topic genuinely lands in both audiences.
+
+5. Output **only** a JSON array on stdout, no prose, no markdown fences. Schema per item:
+
+   ```json
+   {
+     "title": "Rollback netcode: why we kill audio during resimulation",
+     "hook": "GGPO-style rollback re-runs the simulation up to 7 frames per misprediction. Naive code re-fires every hit-spark and KO sound. Here's the event-bus refactor that fixed it.",
+     "audience": "en-tech",
+     "targetLength": 1800,
+     "supporting": [{ "type": "pr", "number": 91 }],
+     "rationale": "Concrete bug → architectural fix → generalizable lesson."
+   }
+   ```
+
+6. Also emit the new cursor (highest PR number you scanned) on the very last line as JSON:
+
+   ```json
+   {"_cursor": {"pr": 151}}
+   ```
+
+## Voice for `hook`
+
+- One to three sentences. Lead with the surprising fact or the concrete bug, not "in this post we will".
+- Tech audience: code over prose, file:line refs welcome.
+- Friends audience: warm, first-person plural ("hicimos", "decidimos").
+
+## Hard constraints
+
+- No prose outside the JSON array and the `_cursor` line.
+- `targetLength`: 300–600 for friends, 1200–2500 for tech.
+- Never invent PR numbers; every entry must reference a PR you actually read.
+- Do not write to disk. The orchestrator handles persistence.
+```
+
+- [ ] **Step 2: Verify the file is well-formed**
+
+Run: `head -5 .claude/agents/pr-miner.md`
+Expected: starts with `---` frontmatter block.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/agents/pr-miner.md
+git commit -m "feat(blog-mine): add pr-miner subagent"
+```
+
+---
+
+## Task 7: Define the `rfc-miner` subagent
+
+**Files:**
+- Create: `.claude/agents/rfc-miner.md`
+
+- [ ] **Step 1: Write the subagent**
+
+Create `.claude/agents/rfc-miner.md`:
+
+```markdown
+---
+name: rfc-miner
+description: Mines docs/rfcs/*.md in the A Los Traques repo for blog-post candidates. Reads RFCs above a given cursor, classifies how each could become a post (lift-and-edit, pair-with-PR, too-dry-to-stand-alone), and returns a JSON candidate list. Use only from the /blog-mine orchestrator.
+tools: Bash, Read
+---
+
+# rfc-miner
+
+You scan RFC files in `docs/rfcs/` above a cursor and return blog-post candidates.
+
+## Inputs (from the orchestrator prompt)
+
+- `since_rfc_filename` — only consider RFC filenames lexicographically greater than this. Pass empty string to scan all.
+- `repo_path` — absolute path to the working tree.
+
+## Steps
+
+1. List RFC files:
+
+   ```bash
+   ls docs/rfcs/*.md
+   ```
+
+   Filter to filenames > `since_rfc_filename`. Sort ascending.
+
+2. For each RFC, read the full file (they are typically <500 lines):
+
+   ```bash
+   cat docs/rfcs/<file>
+   ```
+
+3. Classify each RFC:
+
+   - **lift-and-edit**: RFC is already a near-complete narrative (problem → design → implementation notes) and could become a post with editing. Most of yours fall here.
+   - **pair-with-PR**: RFC is a design doc; the post needs the implementation reality from the PR. Emit a candidate with `supporting` referencing both the RFC and a relevant PR if you can identify one from the RFC body or status. Otherwise leave `supporting` to just the RFC and note in `rationale` that pairing is needed.
+   - **too-dry**: pure infrastructure / process RFC with no narrative arc (skip it).
+
+4. For each non-skip RFC, emit a candidate. Match RFC topic to audience:
+   - Most RFCs are tech-English material.
+   - Process/workflow RFCs (e.g., "we adopted RFCs", "AI dev workflow") can be `both`.
+
+5. Output a JSON array on stdout (no prose, no fences), and the cursor on the final line:
+
+   ```json
+   {"_cursor": {"rfc": "0019-nextjs-monorepo-restructure.md"}}
+   ```
+
+   Cursor = lexicographically greatest filename you scanned.
+
+## Schema per item
+
+```json
+{
+  "title": "Why we wrote 19 RFCs for a friends' fighting game",
+  "hook": "...",
+  "audience": "en-tech",
+  "targetLength": 2000,
+  "supporting": [{ "type": "rfc", "ref": "0019-nextjs-monorepo-restructure.md" }],
+  "rationale": "Lift-and-edit; the RFC is already structured as problem→design→phases."
+}
+```
+
+## Hard constraints
+
+- No prose outside the JSON array and the `_cursor` line.
+- `supporting[].type` for RFCs is `"rfc"` and `ref` is the bare filename (no `docs/rfcs/` prefix).
+- Do not write to disk.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/agents/rfc-miner.md
+git commit -m "feat(blog-mine): add rfc-miner subagent"
+```
+
+---
+
+## Task 8: Define the `transcript-miner` subagent
+
+**Files:**
+- Create: `.claude/agents/transcript-miner.md`
+
+- [ ] **Step 1: Write the subagent**
+
+Create `.claude/agents/transcript-miner.md`:
+
+```markdown
+---
+name: transcript-miner
+description: Mines Claude Code session transcripts (JSONL) for blog-post candidates about AI-assisted development on A Los Traques. Reads sessions newer than a cursor across both personal and standard Claude installs, joins to PRs by worktree slug when possible. Use only from the /blog-mine orchestrator.
+tools: Bash, Read
+---
+
+# transcript-miner
+
+You scan Claude Code transcript JSONL files for AI-dev meta-stories: prompts that worked vs didn't, multi-agent designs, hard-to-debug agent behaviors, the RFC-driven workflow in action, the "we built an agent team to do X" pattern.
+
+## Inputs (from the orchestrator prompt)
+
+- `since_transcript_mtime` — ISO timestamp; only consider files with mtime > this.
+- Transcript roots:
+  - `~/.claude-personal/projects/` (primary, `CLAUDE_CONFIG_DIR=~/.claude-personal`)
+  - `~/.claude/projects/` (standard install, occasional accidental use)
+
+## Steps
+
+1. List transcript files for this project from both roots:
+
+   ```bash
+   find ~/.claude-personal/projects -path '*a-los-traques*' -name '*.jsonl' -newermt <since> 2>/dev/null
+   find ~/.claude/projects -path '*a-los-traques*' -name '*.jsonl' -newermt <since> 2>/dev/null
+   ```
+
+2. For each session file, the directory name encodes the worktree:
+
+   - `-Users-simon-personal-a-los-traques` → main repo, no worktree.
+   - `-Users-simon-personal-a-los-traques--claude-worktrees-<slug>` → worktree `<slug>`.
+
+3. Each JSONL file may be large. Read in chunks; do not load entire transcripts into context if a file exceeds ~2000 lines:
+
+   ```bash
+   wc -l <file>
+   head -200 <file>          # initial setup, user prompt
+   tail -400 <file>          # final outcome, what shipped
+   ```
+
+   Sample middle chunks only if the start/end signal something interesting.
+
+4. Look for these meta-story patterns:
+
+   - **Multi-agent designs**: brainstorming an agent team (like this very feature).
+   - **Prompt iteration**: a skill that needed three rewrites before it stopped misfiring.
+   - **Hard agent debugging**: an agent that confidently produced wrong output; how it got caught.
+   - **RFC-driven cadence**: spec → plan → execution loops, esp. when the spec changed mid-flight.
+   - **Tooling discoveries**: skills, hooks, slash commands, subagent dispatch patterns.
+   - **Notable failures**: a session that wasted hours on the wrong thing.
+
+5. Try to join sessions to PRs: search the worktree slug against PR head branches:
+
+   ```bash
+   gh pr list --state merged --limit 200 --json number,headRefName --search "is:merged"
+   ```
+
+   If the slug matches `worktree-<branch>`, link the candidate's `supporting` to that PR.
+
+6. Output a JSON array on stdout (no prose, no fences) plus a cursor line:
+
+   ```json
+   {"_cursor": {"transcript": "2026-05-01T16:00:00Z"}}
+   ```
+
+   Cursor = ISO timestamp of the newest transcript file mtime you scanned.
+
+## Schema per item
+
+```json
+{
+  "title": "Designing an agent team to suggest blog posts about an agent-team-built game",
+  "hook": "We have 19 RFCs and 30 PRs of source material and zero blog posts. So we designed five agents to do the triage.",
+  "audience": "en-tech",
+  "targetLength": 2200,
+  "supporting": [
+    { "type": "transcript", "ref": "/Users/simon/.claude-personal/projects/.../<sessionid>.jsonl" }
+  ],
+  "rationale": "Meta-story about using subagent dispatch + brainstorming skill to design tooling for the project."
+}
+```
+
+When you can join to a PR, include both refs:
+
+```json
+"supporting": [
+  { "type": "transcript", "ref": "..." },
+  { "type": "pr", "number": 132 }
+]
+```
+
+## Hard constraints
+
+- No prose outside the JSON array and the `_cursor` line.
+- `transcript.ref` is the absolute path to the JSONL file.
+- Do not write to disk.
+- If a session is mostly noise (failed attempts, debugging an unrelated tool), skip it.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/agents/transcript-miner.md
+git commit -m "feat(blog-mine): add transcript-miner subagent"
+```
+
+---
+
+## Task 9: Define the `blog-drafter` subagent
+
+**Files:**
+- Create: `.claude/agents/blog-drafter.md`
+
+- [ ] **Step 1: Write the subagent**
+
+Create `.claude/agents/blog-drafter.md`:
+
+```markdown
+---
+name: blog-drafter
+description: Expands a single blog backlog entry into a draft Markdown post under apps/web/content/blog/_drafts/. Reads supporting refs (PRs, RFCs, transcripts, code) to verify claims and quote accurately. Voice depends on the entry's audience tag. Use only from the /blog-expand orchestrator.
+tools: Bash, Read, Write, Grep
+---
+
+# blog-drafter
+
+You expand one backlog entry into a draft Markdown post. The orchestrator passes you the entry JSON and the path to write to.
+
+## Inputs (from the orchestrator prompt)
+
+- The full entry JSON.
+- `draft_path` — relative path under `apps/web/content/blog/_drafts/<slug>.md`.
+
+## Steps
+
+1. Read every `supporting` ref:
+
+   - `pr` → `gh pr view <N> --json title,body,files,reviewComments,commits` then `gh pr diff <N> | head -300`.
+   - `rfc` → `cat docs/rfcs/<ref>`.
+   - `commit` → `git show <sha> --stat` then `git show <sha> -- <file>` for relevant files.
+   - `code` → `Read` the file (slice if large).
+   - `transcript` → `head -200` and `tail -400` of the JSONL; sample middle chunks if needed.
+
+2. **Verify claims against source code, not PR descriptions.** PR descriptions can be wrong or out of date. If a claim in the hook is contradicted by the code, prefer the code and adjust the post.
+
+3. Write the post to `draft_path` with frontmatter:
+
+   ```markdown
+   ---
+   title: "<title>"
+   date: "TBD"
+   summary: "<one-sentence summary>"
+   audience: "<es-friends|en-tech|both>"
+   status: "draft"
+   ---
+   ```
+
+4. Apply voice rules per `audience`:
+
+   ### es-friends
+   - Warm, casual, project-diary. In-jokes about friends-as-fighters welcome.
+   - Short paragraphs. First-person plural ("hicimos", "decidimos", "nos rompimos").
+   - 300–600 words.
+   - Reference one-shot: read `apps/web/content/blog/welcome.md` for tone.
+
+   ### en-tech
+   - Concrete, no-fluff, code over prose. Julia Evans / Dan Luu vibe.
+   - Lead with the bug or surprising fact, not "in this post we will".
+   - Short paragraphs, code blocks with `file:line` refs, no apology paragraphs.
+   - 1200–2500 words.
+
+   ### both
+   - Pick the primary language from the source material (most RFCs are English; transcripts are mixed).
+   - Lean tech-English voice. The other language is produced by a separate `/blog-expand` run after manually flipping the audience tag (out of scope here).
+
+5. **Honor `notes`** as steering. Examples: "lead with the bug, not the architecture", "skip the merge timeline", "pair with PR #97 for the asymmetric variant". Notes override your own structural instincts.
+
+6. Add a "Sources" section at the end listing the supporting refs as links:
+   - PRs: `[#N — title](https://github.com/<owner>/<repo>/pull/N)` (find owner/repo via `gh repo view --json nameWithOwner -q .nameWithOwner`).
+   - RFCs: relative link `[<filename>](../docs/rfcs/<filename>)`.
+   - Code: `[<path>](../<path>#L<line>)`.
+   - Transcripts: do **not** link (they're local files); list as plain text.
+
+7. Print to stdout the relative path you wrote: `apps/web/content/blog/_drafts/<slug>.md`. No other output.
+
+## Hard constraints
+
+- Do not modify `docs/blog-backlog.json` — the orchestrator does that.
+- Do not move files out of `_drafts/`.
+- Never invent code, file paths, line numbers, or PR numbers. Always quote from what you read.
+- If you can't verify a claim, soften it ("I think", "from the diff it looks like") or drop it.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/agents/blog-drafter.md
+git commit -m "feat(blog-expand): add blog-drafter subagent"
+```
+
+---
+
+## Task 10: `/blog-mine` slash command
+
+**Files:**
+- Create: `.claude/skills/blog-mine/SKILL.md`
+
+This is the orchestrator. It runs in the main thread, dispatches the three miners in parallel, runs LLM-judged dedup, calls `cli.js apply` to write back.
+
+- [ ] **Step 1: Write the skill**
+
+Create `.claude/skills/blog-mine/SKILL.md`:
+
+````markdown
+---
+name: blog-mine
+description: Run the blog-post backlog miner. Reads the cursor in docs/blog-backlog.json, dispatches pr-miner / rfc-miner / transcript-miner in parallel, runs LLM-judged dedup against existing entries, and writes the updated backlog. Incremental — only scans material since the last run. Use when the user types /blog-mine or asks to "find new blog ideas", "scan PRs for posts", "update the backlog".
+---
+
+# /blog-mine
+
+Mine new blog-post ideas from PRs, RFCs, and Claude Code transcripts.
+
+## Workflow
+
+### 1. Bootstrap
+
+```bash
+node scripts/blog-backlog/cli.js init
+```
+
+(no-op if the backlog already exists).
+
+### 2. Read the current cursor
+
+```bash
+node scripts/blog-backlog/cli.js cursor
+```
+
+The output is a JSON object like `{"pr": 151, "rfc": "0019-nextjs-monorepo-restructure.md", "transcript": "2026-05-01T16:00:00Z"}`.
+
+### 3. Read the existing backlog (for dedup judgment)
+
+```bash
+cat docs/blog-backlog.json
+```
+
+You'll need the existing entries' `id`, `title`, `hook`, `supporting`, `status` to judge dedup. Do **not** consider entries with `status: "rejected"` for merging — they're suppressed forever — but **do** consider them for skip-suggestion (don't re-suggest a rejected idea).
+
+### 4. Dispatch the three miners in parallel
+
+Use a single message with three Agent tool calls (see "## Using your tools" in the system prompt — independent calls go in one message).
+
+```
+Agent({ subagent_type: "pr-miner", prompt: "since_pr_number=<N>, repo_path=<cwd>. <full pr-miner prompt>" })
+Agent({ subagent_type: "rfc-miner", prompt: "since_rfc_filename=<F>, repo_path=<cwd>. <full rfc-miner prompt>" })
+Agent({ subagent_type: "transcript-miner", prompt: "since_transcript_mtime=<T>. <full transcript-miner prompt>" })
+```
+
+Each subagent returns its candidate JSON array + `_cursor` line on stdout (in its final message).
+
+### 5. Parse miner outputs
+
+Each miner's last message ends with a `_cursor` JSON line. Strip it from the candidates array. Aggregate all candidates from all three miners into one list.
+
+### 6. Run LLM-judged dedup against the existing backlog
+
+For each candidate, decide one of:
+
+- **`new`** — no existing entry covers this material.
+- **`merge` into `<id>`** — an existing entry covers the same story (semantic overlap on title+hook, OR overlapping `supporting` set, OR clear topical match). Pick the existing entry whose scope subsumes this candidate.
+- **`skip`** — exact dup of an existing rejected entry, or this candidate is too thin to add value.
+
+**Mechanical rule (always applies first):** if a candidate's `supporting` set has a PR# or RFC ref already present in any non-rejected entry, default to merge into that entry unless the title/hook clearly indicate a different story.
+
+### 7. Build the merge plan
+
+```json
+{
+  "new": [<candidate>, ...],
+  "merge": [{ "intoId": "<existing-id>", "candidate": <candidate> }, ...],
+  "skip": [<candidate>, ...],
+  "cursor": {
+    "pr": <highest pr scanned>,
+    "rfc": "<lexicographically last rfc scanned>",
+    "transcript": "<latest transcript mtime scanned>"
+  }
+}
+```
+
+Write to a temp file:
+
+```bash
+cat > /tmp/blog-mine-plan.json <<'EOF'
+<plan json>
+EOF
+```
+
+### 8. Apply the plan
+
+```bash
+node scripts/blog-backlog/cli.js apply --plan /tmp/blog-mine-plan.json
+```
+
+Output is `{"added": N, "merged": M, "skipped": K, "cursor": {...}}`.
+
+### 9. Report
+
+Tell the user:
+
+- N new entries added (list titles).
+- M existing entries had refs merged in (list ids + titles).
+- K candidates skipped.
+- New cursor.
+- Suggest: "Review `docs/blog-backlog.json`. Edit `status: greenlit` on ones you want, `status: rejected` on ones you don't, and use `notes:` to steer the drafter. Run `/blog-expand <id>` to draft a post."
+
+## Failure modes
+
+- **A miner returns malformed JSON** → log to the user, skip that miner's output, continue with the others. Do not abort.
+- **`gh` not authenticated** → tell the user `gh auth login` is needed for pr-miner.
+- **No new material since last cursor** → all three miners return empty arrays. Print "Nothing new since last run." and exit without writing.
+
+## Hard constraints
+
+- Never edit `docs/blog-backlog.json` directly. Always go through `cli.js apply`.
+- Never edit the `status` or `notes` fields of existing entries during a merge — those are user-owned.
+- Do not call `/blog-expand` automatically. The user picks which ideas to expand.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/blog-mine/SKILL.md
+git commit -m "feat(blog-mine): add /blog-mine slash command orchestrator"
+```
+
+---
+
+## Task 11: `/blog-expand` slash command
+
+**Files:**
+- Create: `.claude/skills/blog-expand/SKILL.md`
+
+- [ ] **Step 1: Write the skill**
+
+Create `.claude/skills/blog-expand/SKILL.md`:
+
+````markdown
+---
+name: blog-expand
+description: Expand a single blog backlog entry into a draft Markdown post under apps/web/content/blog/_drafts/. Reads supporting refs (PRs, RFCs, transcripts, code) to verify claims. Use when the user types /blog-expand <id> or asks to "draft the post about X", "expand backlog entry Y", "write the rollback post".
+---
+
+# /blog-expand
+
+Expand one backlog entry into a draft post.
+
+## Workflow
+
+### 1. Resolve the id
+
+The user passes an id as the slash command argument (e.g. `/blog-expand rollback-resimulation-events-2a3f`).
+
+If no id is provided, list `proposed` and `greenlit` entries with their ids and ask the user which to expand.
+
+### 2. Fetch the entry
+
+```bash
+node scripts/blog-backlog/cli.js get <id>
+```
+
+If the CLI exits non-zero, the id is wrong. Suggest the closest matches by listing `id`s from `cat docs/blog-backlog.json`.
+
+### 3. Refuse on bad status
+
+- `status: rejected` → refuse: "this entry is rejected; flip status to `proposed` if you want to resurrect it."
+- `status: published` → refuse.
+- `status: drafted` → ask the user explicitly: "draft already exists at `<draftPath>`. Overwrite? (yes/no)"
+
+### 4. Compute draft path
+
+```
+apps/web/content/blog/_drafts/<id>.md
+```
+
+### 5. Dispatch the drafter subagent
+
+```
+Agent({
+  subagent_type: "blog-drafter",
+  prompt: `Entry: <full entry JSON>. draft_path: apps/web/content/blog/_drafts/<id>.md. <full blog-drafter prompt>`
+})
+```
+
+The drafter writes the file directly and returns the relative path on stdout.
+
+### 6. Update the backlog
+
+```bash
+node scripts/blog-backlog/cli.js update <id> --status drafted --draftPath "apps/web/content/blog/_drafts/<id>.md"
+```
+
+### 7. Report to the user
+
+- Path to the draft.
+- Word count: `wc -w apps/web/content/blog/_drafts/<id>.md`.
+- Reminder: drafts under `_drafts/` are not picked up by `apps/web/lib/blog.ts`. Move the file up one directory and set `date:` (replacing `TBD`) when ready to publish.
+
+## Failure modes
+
+- **Drafter writes nothing** → don't update the backlog. Report the failure.
+- **Path collision** with an existing draft → covered by the `drafted` status check above.
+
+## Hard constraints
+
+- Don't move the draft out of `_drafts/`. Publication is a manual step.
+- Don't change `audience`, `notes`, `rationale`, or `supporting` on the entry.
+- Don't overwrite without explicit consent.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/blog-expand/SKILL.md
+git commit -m "feat(blog-expand): add /blog-expand slash command orchestrator"
+```
+
+---
+
+## Task 12: Lint check + final test sweep
+
+- [ ] **Step 1: Run all backlog tests**
+
+Run: `bun run test:run tests/blog-backlog/`
+Expected: PASS — all tests across backlog.test.js, id.test.js, dedup.test.js, cli.test.js.
+
+- [ ] **Step 2: Lint**
+
+Run: `bun run lint:fix && bun run lint`
+Expected: clean exit. If Biome flags new files, accept formatting changes via `lint:fix`.
+
+- [ ] **Step 3: Commit lint fixes if any**
+
+```bash
+git status
+# if any formatting changes:
+git add -A && git commit -m "chore: apply biome formatting"
+```
+
+---
+
+## Task 13: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+Add a section under "Documentation" so future sessions know the blog backlog system exists.
+
+- [ ] **Step 1: Read current CLAUDE.md "Documentation" section**
+
+```bash
+grep -n "^## Documentation" CLAUDE.md
+```
+
+Note the line number so you can append after the existing list.
+
+- [ ] **Step 2: Append the new section**
+
+Insert this block after the "Documentation" section's RFC list (before the "## Balance Simulation" header):
+
+```markdown
+## Blog Backlog
+
+A five-agent system mines this repo's PRs, RFCs, and Claude Code session transcripts for blog-post candidates, deduped into `docs/blog-backlog.json`. Voice and audience are tagged per article (`es-friends`, `en-tech`, or `both`).
+
+- **`/blog-mine`** — incremental scan. Reads the cursor in `docs/blog-backlog.json`, dispatches `pr-miner` / `rfc-miner` / `transcript-miner` in parallel, dedups against existing entries, writes updated backlog. Run after merging interesting PRs.
+- **`/blog-expand <id>`** — promote one backlog entry to a draft under `apps/web/content/blog/_drafts/<id>.md`. Drafter reads supporting refs (PR diffs, RFCs, transcripts, code) and verifies claims against source — PR descriptions are hints, not authoritative. Move the draft up one directory + set `date:` to publish.
+- **Manual feedback loop**: edit `status` (`proposed | greenlit | rejected | drafted | published`) and `notes` on backlog entries to steer the system. The orchestrator respects user-set fields on merge.
+- **Backlog manipulation CLI**: `node scripts/blog-backlog/cli.js {init|cursor|apply|get|update}`. Used internally by the slash commands; safe to call by hand.
+- Transcript ingestion reads both `~/.claude-personal/projects/*a-los-traques*` and `~/.claude/projects/*a-los-traques*` (some sessions accidentally landed on the company install).
+- Spec: `docs/superpowers/specs/2026-05-01-blog-article-agent-team-design.md`. Plan: `docs/superpowers/plans/2026-05-01-blog-article-agent-team.md`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(CLAUDE): document blog backlog agents and slash commands"
+```
+
+---
+
+## Task 14: End-to-end smoke run
+
+This is a manual validation step, not automated. The miners and drafter are prompt artifacts; their behavior is judged by inspection.
+
+- [ ] **Step 1: Run `/blog-mine`**
+
+In the Claude Code session, type `/blog-mine`. Watch:
+
+- Three Agent tool calls dispatched in parallel.
+- Each miner returns a JSON array + `_cursor` line.
+- Orchestrator builds a merge plan, calls `cli.js apply`.
+- Backlog file populated. Summary printed.
+
+**Expected:** at least 5–10 candidate entries from the existing 30+ PRs and 19 RFCs. Cursor advanced to PR #151, RFC `0019-...md`, recent transcript timestamp.
+
+- [ ] **Step 2: Inspect `docs/blog-backlog.json`**
+
+```bash
+node scripts/blog-backlog/cli.js cursor
+jq '.entries | length' docs/blog-backlog.json
+jq '.entries[].title' docs/blog-backlog.json
+```
+
+Sanity-check titles, audience tags, supporting refs.
+
+- [ ] **Step 3: Pick one entry and run `/blog-expand <id>`**
+
+Pick a tech-English entry (probably one of the rollback or determinism ones).
+
+```
+/blog-expand <id>
+```
+
+Watch the drafter dispatch and inspect the resulting `apps/web/content/blog/_drafts/<id>.md`.
+
+- [ ] **Step 4: Pick one friends-Spanish entry and run `/blog-expand <id>`**
+
+Verify voice matches `welcome.md` tone.
+
+- [ ] **Step 5: Re-run `/blog-mine` to verify incremental behavior**
+
+```
+/blog-mine
+```
+
+**Expected:** "Nothing new since last run." (or near-empty output if any new transcripts landed).
+
+- [ ] **Step 6: Commit the populated backlog and drafts**
+
+```bash
+git add docs/blog-backlog.json apps/web/content/blog/_drafts/
+git commit -m "chore(blog-backlog): seed backlog from initial /blog-mine run
+
+Includes initial drafts for two entries to validate the /blog-expand
+flow end-to-end."
+```
+
+---
+
+## Self-Review Checklist
+
+Run through this once after the plan is written.
+
+**Spec coverage:**
+
+- [x] PR mining (Task 6 + 10)
+- [x] RFC mining (Task 7 + 10)
+- [x] Transcript mining from both Claude install roots (Task 8 + 10)
+- [x] Editor-orchestrator with parallel dispatch + dedup (Task 10)
+- [x] Drafter with audience-aware voice + verification against source code (Task 9 + 11)
+- [x] Backlog JSON schema with status enum (Task 1)
+- [x] Stable IDs (Task 2)
+- [x] Mechanical dedup + cursor management (Task 3)
+- [x] CLI for safe backlog mutation (Task 4)
+- [x] Bootstrap + drafts dir (Task 5)
+- [x] User feedback loop via status + notes preservation on merge (Task 3 + 9 + 10)
+- [x] Concurrent-run lock — **gap, intentionally deferred**: spec mentions a `.lock` file, but `cli.js apply` is a single short atomic write and the slash commands serialize in one Claude Code session. Skip for v1.
+- [x] CLAUDE.md update (Task 13)
+
+**Placeholder scan:** none found.
+
+**Type consistency:** ref shapes match across `id.js`, `dedup.js`, miner schemas, drafter input. `audience` enum identical in spec, schema, and agents. CLI flag names (`--file`, `--plan`, `--status`, `--notes`, `--draftPath`) consistent across uses.
+
+**Out-of-scope (called out in spec, intentionally not in plan):**
+- GitHub-issue surface
+- Auto-translate
+- `/schedule` integration
+- `last-run-summary.md` artifact
+- Concurrent-run lock file (deferred per above)

--- a/docs/superpowers/specs/2026-05-01-blog-article-agent-team-design.md
+++ b/docs/superpowers/specs/2026-05-01-blog-article-agent-team-design.md
@@ -1,0 +1,228 @@
+# Blog Article Agent Team — Design
+
+**Date:** 2026-05-01
+**Status:** Approved by Simon, ready for implementation plan
+**Owner:** Simon Soriano
+
+## Problem
+
+A Los Traques is a learning/artistic project between friends with rich source material for technical blog posts: 19 RFCs, ~30+ merged PRs covering rollback netcode, simulation determinism, AI asset generation, RFC-driven workflow, multiplayer debuggability, and more. Today the blog has a single welcome post. Manually trawling history to identify article-worthy stories is slow and easy to skip.
+
+We want a team of Claude agents that mines the repo's history (PRs, RFCs, code) plus Claude Code session transcripts, proposes a backlog of article ideas with supporting refs, and on demand expands a chosen idea into a draft post.
+
+## Goals
+
+- Generate a maintained backlog of candidate article ideas, each with a supporting evidence trail.
+- Support both **friends-Spanish** (warm, project-diary) and **tech-English** (concrete, generalizable) audiences, tagged per article.
+- Be incremental — re-runs only consider new material, deduplicate against existing entries, respect user feedback (status + notes).
+- Keep the heavy work (reading code, verifying claims) for on-demand expansion, not backlog generation.
+- Treat source code and commit history as ground truth; PR descriptions are hints, not authoritative.
+
+## Non-Goals
+
+- Auto-publish. Drafts always sit in `_drafts/` until manually moved.
+- Auto-translate. `audience: both` produces a single-language draft per run; the other language requires a separate run.
+- Image generation for posts.
+- Touching live blog files outside `_drafts/`.
+- Self-improving prompts, online learning, RLHF.
+- GitHub-issue surface for the backlog (may be added later).
+
+## Architecture
+
+Five named Claude agents and two slash commands. The Editor is the only writer of the backlog file.
+
+```
+/blog-mine                       /blog-expand <id>
+     │                                  │
+     ▼                                  ▼
+┌─────────────┐                   ┌──────────────┐
+│  Editor     │                   │  Drafter     │
+│ (orches.)   │                   │  (single)    │
+└─────┬───────┘                   └──────┬───────┘
+      │ reads cursor                     │
+      │ dispatches in parallel:          │ reads supporting refs
+      │                                  │ writes _drafts/<slug>.md
+      ▼                                  ▼
+┌──────────┬──────────┬─────────────┐
+│ pr-miner │ rfc-miner│ transcript- │
+│          │          │ miner       │
+└────┬─────┴────┬─────┴──────┬──────┘
+     │          │            │
+     └──────────┴────────────┘
+                │ candidates → Editor
+                ▼
+       merge + dedupe → docs/blog-backlog.json
+```
+
+### Components
+
+#### `pr-miner` (subagent, parallel)
+
+- **Input:** `since_pr_number`, repo path.
+- **Reads:** `gh pr list --state merged --search "merged:>X"` then `gh pr view <n> --json title,body,files,reviewComments` per PR.
+- **Judges interestingness against:** rollback/netcode, simulation/determinism, AI asset generation, RFC-driven process, multiplayer debuggability, asset pipeline, gnarly bug stories. Skips routine fixes/lints/format-only PRs.
+- **Output:** array of candidate entries (see schema below).
+
+#### `rfc-miner` (subagent, parallel)
+
+- **Input:** `since_rfc_filename`.
+- **Reads:** `docs/rfcs/*.md` newer than the cursor (file mtime + filename ordering).
+- **Behavior:** Most RFCs are already half-written posts. The miner identifies (a) RFCs that *are* the post (lift-and-edit), (b) RFCs that need pairing with a PR for implementation reality, (c) RFCs too dry to stand alone.
+- **Output:** array of candidate entries.
+
+#### `transcript-miner` (subagent, parallel)
+
+- **Input:** `since_transcript_mtime`, both transcript roots:
+  - `~/.claude-personal/projects/*a-los-traques*` (primary, `CLAUDE_CONFIG_DIR=~/.claude-personal`)
+  - `~/.claude/projects/*a-los-traques*` (occasional accidental use of company install)
+- **Reads:** JSONL session files. Streams in chunks (500-line) to stay in token budget; summarises per chunk and synthesises across chunks per session.
+- **Joins:** worktree slug → branch name → PR number when possible.
+- **Looks for:** AI-dev meta-stories — prompts that worked vs. didn't, multi-agent designs, hard-to-debug agent behaviors, the RFC-driven workflow in action.
+- **Output:** candidate entries with `supporting` referencing transcript paths + linked PR/RFC where joinable.
+
+#### `editor` (orchestrator, invoked by `/blog-mine`)
+
+- Loads `docs/blog-backlog.json` (initialises if absent).
+- Dispatches the three miners in parallel via the Agent tool.
+- Receives candidate arrays and runs dedup (LLM-judged, not algorithmic):
+  - Same `supporting.pr` already present and `status != rejected` → skip.
+  - Semantic overlap on title+hook OR overlapping `supporting` set → merge into existing entry (append refs, preserve user-set `status`/`notes`/`rationale`).
+- Assigns stable `id` (kebab-case from title + 4-char hash from supporting refs).
+- Writes back to JSON, bumps cursors.
+- Reports a summary: N new, M merged, K skipped.
+
+#### `drafter` (single agent, invoked by `/blog-expand <id>`)
+
+- Loads the entry. Refuses if `status` ∈ `{rejected, published}`.
+- Reads each `supporting` ref via the appropriate tool: `gh pr view --json files`, `git show <commit>`, `Read` for code files, JSONL chunks for transcripts.
+- Drafts to `apps/web/content/blog/_drafts/<slug>.md` with frontmatter `title`, `date: TBD`, `summary`, `audience`, `status: draft`.
+- Updates the backlog entry: `status: drafted`, `draftPath: "..."`.
+- Voice rules baked into the agent prompt per `audience` tag (see Voice Rules below).
+
+## Backlog Schema (`docs/blog-backlog.json`)
+
+```json
+{
+  "version": 1,
+  "cursor": {
+    "pr": 151,
+    "rfc": "0019-nextjs-monorepo-restructure.md",
+    "transcript": "2026-05-01T16:00:00Z"
+  },
+  "entries": [
+    {
+      "id": "rollback-resimulation-events-2a3f",
+      "title": "Rollback netcode: why we kill audio during resimulation",
+      "hook": "GGPO-style rollback re-runs the simulation up to 7 frames per misprediction. Naive code re-fires every hit-spark and KO sound. Here's the event-bus refactor that fixed it.",
+      "audience": "en-tech",
+      "targetLength": 1800,
+      "supporting": [
+        {"type": "rfc", "ref": "0001-networking-redesign.md"},
+        {"type": "pr", "number": 91},
+        {"type": "code", "ref": "packages/sim/src/CombatSim.js"}
+      ],
+      "status": "proposed",
+      "notes": "",
+      "rationale": "Concrete bug → architectural fix → generalizable lesson. Strong title.",
+      "createdAt": "2026-05-01T16:30:00Z",
+      "lastSeenAt": "2026-05-01T16:30:00Z",
+      "draftPath": null
+    }
+  ]
+}
+```
+
+### Field semantics
+
+- **`cursor.pr`**: highest merged-PR number scanned. Next run scans PRs merged after this.
+- **`cursor.rfc`**: lexicographically last RFC filename scanned. Next run scans RFCs alphabetically greater than this.
+- **`cursor.transcript`**: ISO timestamp of the newest transcript file mtime scanned. Next run scans transcripts with mtime > this.
+- **`id`**: kebab-case slug from title + 4-char hash of supporting refs. Stable across re-runs.
+- **`audience`**: one of `es-friends`, `en-tech`, `both`.
+- **`targetLength`**: integer word count. Friends posts 300–600, tech posts 1200–2500.
+- **`supporting[].type`**: `pr` | `rfc` | `transcript` | `commit` | `code`. Each type has its own ref shape (`number` for PR, filename for RFC/transcript/code, sha for commit). Miners typically emit `pr`/`rfc`/`transcript`; the Drafter adds `commit`/`code` refs as it verifies claims during expansion.
+- **`status`**: `proposed | greenlit | rejected | drafted | published`. User-editable; agents respect it.
+- **`notes`**: free-form user steering for the Drafter. Empty by default.
+- **`rationale`**: agent's one-line justification for proposing this entry.
+- **`draftPath`**: relative path under `apps/web/content/blog/_drafts/` once expanded.
+
+## User Surface
+
+### Slash commands
+
+- **`/blog-mine`** — runs the Editor + three miners in parallel. Incremental (since last cursor). Reports summary at end.
+- **`/blog-expand <id>`** — runs the Drafter on one entry. Refuses if status is `rejected`/`published`.
+
+### Feedback loop (manual JSON edits)
+
+- Set `status: rejected` to permanently dismiss; the Editor blocks re-suggestion on dedup match.
+- Set `status: greenlit` to mark "I want this written"; `/blog-expand` operates on `proposed` or `greenlit`.
+- Edit `notes` to steer the next expansion ("lead with the bug, not the architecture", "skip the merge timeline", "pair with PR #97 for the asymmetric variant").
+
+## Voice Rules
+
+Encoded in the Drafter agent prompt; selected per `audience` tag.
+
+### `es-friends`
+
+- Warm, casual, project-diary. In-jokes about friends-as-fighters welcome.
+- Short paragraphs. First-person plural ("hicimos", "decidimos", "nos rompimos").
+- One-shot example pulled from `apps/web/content/blog/welcome.md`.
+- Target length: 300–600 words.
+
+### `en-tech`
+
+- Concrete, no-fluff, code over prose. Julia Evans / Dan Luu reference vibe.
+- Lead with the bug or the surprising fact, not "in this post we will".
+- Short paragraphs, code blocks with file:line refs, no apology paragraphs.
+- Target length: 1200–2500 words.
+
+### `both`
+
+- Drafter picks the primary language from the source material (most RFCs are English; transcripts are mixed). The other language is produced by a separate `/blog-expand <id>` run after manually flipping the audience tag (out of scope for v1 automation).
+
+## Defaults & Sources
+
+- **Source scope:** PRs + RFCs + transcripts at backlog-generation time. Code + commit history loaded on demand by the Drafter for verification.
+- **Drafts location:** `apps/web/content/blog/_drafts/`. The existing `apps/web/lib/blog.ts` only reads top-level `.md`/`.mdx`, so drafts under `_drafts/` won't ship until manually moved.
+- **Backlog file:** `docs/blog-backlog.json`. Committed to repo so friends can browse and dedup state survives machine swaps.
+
+## Error Handling & Edge Cases
+
+- **Miner returns empty / errors** → Editor logs and continues with the others. A single bad miner doesn't kill the run.
+- **Backlog file missing** → Editor initialises with `cursor: {pr: 0, rfc: "", transcript: "1970-01-01T00:00:00Z"}` and treats first run as full backfill.
+- **Transcript JSONL too large for one read** → transcript-miner reads in 500-line chunks, summarises per chunk, then synthesises across chunks. (Not solving "infinite transcript" — if it's a problem, add a per-session token budget later.)
+- **Dedup false negatives** (same idea, different wording) → user sees both, sets one to `rejected` with `notes: "duplicate of <id>"`. Editor learns nothing automatically; the rejected entry just blocks re-suggestion.
+- **Drafter on a friends-Spanish post** → voice rules in the agent prompt + one-shot example from `welcome.md`.
+- **Concurrent runs** → file-level lock (`docs/blog-backlog.json.lock`); Editor fails loudly if present.
+- **`/blog-expand` on missing id** → Drafter errors clearly listing the closest matching ids.
+- **`/blog-expand` on already-`drafted` entry** → Drafter offers to overwrite the existing draft after explicit confirmation.
+
+## Testing
+
+- **Backlog schema:** small Vitest suite under `tests/blog-backlog/` validating JSON parses, status enums, supporting-ref shapes.
+- **Editor dedup:** unit tests with synthetic candidate arrays + an existing backlog → asserts merge/skip/append behavior. No real agent calls.
+- **Miner agents:** prompt-only artifacts, not unit-tested. Validate by eye on first run.
+- **Drafter:** not unit-tested. Validate by inspecting the first 2-3 drafts produced.
+
+## Files Created
+
+- `docs/blog-backlog.json` — the backlog (committed).
+- `docs/superpowers/specs/2026-05-01-blog-article-agent-team-design.md` — this design doc.
+- `.claude/skills/blog-mine/SKILL.md` — slash command + Editor orchestrator instructions.
+- `.claude/skills/blog-expand/SKILL.md` — slash command + Drafter invocation instructions.
+- `.claude/agents/pr-miner.md` — subagent definition.
+- `.claude/agents/rfc-miner.md` — subagent definition.
+- `.claude/agents/transcript-miner.md` — subagent definition.
+- `.claude/agents/blog-drafter.md` — subagent definition.
+- `tests/blog-backlog/schema.test.ts` — schema validation tests.
+- `tests/blog-backlog/dedup.test.ts` — Editor dedup behavior tests.
+
+## Open Questions
+
+None at design-approval time. Future iterations may add:
+
+- GitHub-issue surface for greenlit ideas (commenting + reactions for friends).
+- Auto-translate from `both` audience.
+- `/schedule` integration for weekly background mining.
+- A `last-run-summary.md` artifact next to the backlog for at-a-glance reporting.

--- a/scripts/blog-backlog/backlog.js
+++ b/scripts/blog-backlog/backlog.js
@@ -1,0 +1,55 @@
+import { promises as fs } from 'node:fs';
+
+const VALID_STATUS = new Set(['proposed', 'greenlit', 'rejected', 'drafted', 'published']);
+const VALID_AUDIENCE = new Set(['es-friends', 'en-tech', 'both']);
+const VALID_REF_TYPE = new Set(['pr', 'rfc', 'transcript', 'commit', 'code']);
+
+export function emptyBacklog() {
+  return {
+    version: 1,
+    cursor: { pr: 0, rfc: '', transcript: '1970-01-01T00:00:00Z' },
+    entries: [],
+  };
+}
+
+function validate(b) {
+  if (!b || typeof b !== 'object') throw new Error('backlog: not an object');
+  if (b.version !== 1) throw new Error(`backlog: unsupported version ${b.version}`);
+  if (!b.cursor || typeof b.cursor !== 'object') throw new Error('backlog: missing cursor');
+  if (!Array.isArray(b.entries)) throw new Error('backlog: entries must be an array');
+  for (const e of b.entries) {
+    if (!VALID_STATUS.has(e.status)) {
+      throw new Error(`backlog: entry ${e.id} has invalid status "${e.status}"`);
+    }
+    if (!VALID_AUDIENCE.has(e.audience)) {
+      throw new Error(`backlog: entry ${e.id} has invalid audience "${e.audience}"`);
+    }
+    if (!Array.isArray(e.supporting)) {
+      throw new Error(`backlog: entry ${e.id} supporting must be an array`);
+    }
+    for (const s of e.supporting) {
+      if (!VALID_REF_TYPE.has(s.type)) {
+        throw new Error(`backlog: entry ${e.id} ref has invalid type "${s.type}"`);
+      }
+    }
+  }
+}
+
+export async function loadBacklog(file) {
+  let raw;
+  try {
+    raw = await fs.readFile(file, 'utf-8');
+  } catch (err) {
+    if (err.code === 'ENOENT') return emptyBacklog();
+    throw err;
+  }
+  const parsed = JSON.parse(raw);
+  validate(parsed);
+  return parsed;
+}
+
+export async function saveBacklog(file, backlog) {
+  validate(backlog);
+  const json = `${JSON.stringify(backlog, null, 2)}\n`;
+  await fs.writeFile(file, json, 'utf-8');
+}

--- a/scripts/blog-backlog/cli.js
+++ b/scripts/blog-backlog/cli.js
@@ -9,7 +9,7 @@
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import { loadBacklog, saveBacklog, emptyBacklog } from './backlog.js';
+import { emptyBacklog, loadBacklog, saveBacklog } from './backlog.js';
 import { applyPlan } from './dedup.js';
 
 const DEFAULT_FILE = path.resolve(process.cwd(), 'docs/blog-backlog.json');

--- a/scripts/blog-backlog/cli.js
+++ b/scripts/blog-backlog/cli.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+/**
+ * cli.js -- Blog backlog CLI for A Los Traques
+ *
+ * Subcommands: init, cursor, apply, get, update
+ * All commands print JSON to stdout; logs go to stderr.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { loadBacklog, saveBacklog, emptyBacklog } from './backlog.js';
+import { applyPlan } from './dedup.js';
+
+const DEFAULT_FILE = path.resolve(process.cwd(), 'docs/blog-backlog.json');
+
+function parseArgs(argv) {
+  const positional = [];
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        flags[key] = true;
+      } else {
+        flags[key] = next;
+        i++;
+      }
+    } else {
+      positional.push(a);
+    }
+  }
+  return { positional, flags };
+}
+
+async function cmdInit(file) {
+  try {
+    await fs.access(file);
+    process.stderr.write(`backlog: ${file} already exists, no-op\n`);
+    return;
+  } catch {}
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await saveBacklog(file, emptyBacklog());
+  process.stderr.write(`backlog: initialised ${file}\n`);
+}
+
+async function cmdCursor(file) {
+  const b = await loadBacklog(file);
+  process.stdout.write(`${JSON.stringify(b.cursor)}\n`);
+}
+
+async function cmdApply(file, planPath) {
+  const planRaw = await fs.readFile(planPath, 'utf-8');
+  const plan = JSON.parse(planRaw);
+  const backlog = await loadBacklog(file);
+  const summary = applyPlan(backlog, plan, new Date().toISOString());
+  await saveBacklog(file, backlog);
+  process.stdout.write(`${JSON.stringify(summary)}\n`);
+}
+
+async function cmdGet(file, id) {
+  const backlog = await loadBacklog(file);
+  const entry = backlog.entries.find((e) => e.id === id);
+  if (!entry) {
+    process.stderr.write(`backlog: entry "${id}" not found\n`);
+    process.exit(1);
+  }
+  process.stdout.write(`${JSON.stringify(entry)}\n`);
+}
+
+async function cmdUpdate(file, id, flags) {
+  const backlog = await loadBacklog(file);
+  const entry = backlog.entries.find((e) => e.id === id);
+  if (!entry) {
+    process.stderr.write(`backlog: entry "${id}" not found\n`);
+    process.exit(1);
+  }
+  if (flags.status !== undefined) entry.status = flags.status;
+  if (flags.notes !== undefined) entry.notes = flags.notes;
+  if (flags.draftPath !== undefined) entry.draftPath = flags.draftPath;
+  await saveBacklog(file, backlog);
+  process.stdout.write(`${JSON.stringify(entry)}\n`);
+}
+
+async function main() {
+  const [sub, ...rest] = process.argv.slice(2);
+  const { positional, flags } = parseArgs(rest);
+  const file = path.resolve(flags.file ?? DEFAULT_FILE);
+
+  switch (sub) {
+    case 'init':
+      return cmdInit(file);
+    case 'cursor':
+      return cmdCursor(file);
+    case 'apply':
+      if (!flags.plan) {
+        process.stderr.write('apply: --plan PATH is required\n');
+        process.exit(2);
+      }
+      return cmdApply(file, path.resolve(flags.plan));
+    case 'get':
+      return cmdGet(file, positional[0]);
+    case 'update':
+      return cmdUpdate(file, positional[0], flags);
+    default:
+      process.stderr.write('usage: cli.js {init|cursor|apply|get|update} [...]\n');
+      process.exit(2);
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`backlog: ${err.message}\n`);
+  process.exit(1);
+});

--- a/scripts/blog-backlog/dedup.js
+++ b/scripts/blog-backlog/dedup.js
@@ -1,0 +1,67 @@
+import { makeId } from './id.js';
+
+function refKey(r) {
+  if (r.type === 'pr') return `pr:${r.number}`;
+  return `${r.type}:${r.ref}`;
+}
+
+function maxString(a, b) {
+  if (!a) return b;
+  if (!b) return a;
+  return a > b ? a : b;
+}
+
+function maxNumber(a, b) {
+  if (a == null) return b;
+  if (b == null) return a;
+  return a > b ? a : b;
+}
+
+export function applyPlan(backlog, plan, now) {
+  for (const c of plan.new ?? []) {
+    const id = makeId(c.title, c.supporting);
+    backlog.entries.push({
+      id,
+      title: c.title,
+      hook: c.hook,
+      audience: c.audience,
+      targetLength: c.targetLength,
+      supporting: c.supporting.slice(),
+      status: 'proposed',
+      notes: '',
+      rationale: c.rationale ?? '',
+      createdAt: now,
+      lastSeenAt: now,
+      draftPath: null,
+    });
+  }
+
+  for (const m of plan.merge ?? []) {
+    const target = backlog.entries.find((e) => e.id === m.intoId);
+    if (!target) {
+      throw new Error(`applyPlan: merge target ${m.intoId} not found`);
+    }
+    const existing = new Set(target.supporting.map(refKey));
+    for (const r of m.candidate.supporting ?? []) {
+      if (!existing.has(refKey(r))) {
+        target.supporting.push(r);
+        existing.add(refKey(r));
+      }
+    }
+    target.lastSeenAt = now;
+  }
+
+  const c = plan.cursor ?? {};
+  backlog.cursor = {
+    pr: maxNumber(backlog.cursor.pr, c.pr),
+    rfc: maxString(backlog.cursor.rfc, c.rfc),
+    transcript: maxString(backlog.cursor.transcript, c.transcript),
+  };
+
+  return {
+    added: (plan.new ?? []).length,
+    merged: (plan.merge ?? []).length,
+    skipped: (plan.skip ?? []).length,
+    cursor: { ...backlog.cursor },
+  };
+}

--- a/scripts/blog-backlog/id.js
+++ b/scripts/blog-backlog/id.js
@@ -1,0 +1,23 @@
+import { createHash } from 'node:crypto';
+
+export function slugify(input) {
+  const ascii = input
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, ''); // strip combining diacriticals
+  const lower = ascii.toLowerCase();
+  const dashed = lower.replace(/[^a-z0-9]+/g, '-');
+  const trimmed = dashed.replace(/^-+|-+$/g, '');
+  return trimmed.slice(0, 60);
+}
+
+function refKey(r) {
+  if (r.type === 'pr') return `pr:${r.number}`;
+  return `${r.type}:${r.ref}`;
+}
+
+export function makeId(title, supporting) {
+  const slug = slugify(title);
+  const refs = supporting.map(refKey).sort().join('|');
+  const hash = createHash('sha1').update(refs).digest('hex').slice(0, 4);
+  return `${slug}-${hash}`;
+}

--- a/scripts/blog-backlog/id.js
+++ b/scripts/blog-backlog/id.js
@@ -1,9 +1,7 @@
 import { createHash } from 'node:crypto';
 
 export function slugify(input) {
-  const ascii = input
-    .normalize('NFKD')
-    .replace(/[̀-ͯ]/g, ''); // strip combining diacriticals
+  const ascii = input.normalize('NFKD').replace(/[̀-ͯ]/g, ''); // strip combining diacriticals
   const lower = ascii.toLowerCase();
   const dashed = lower.replace(/[^a-z0-9]+/g, '-');
   const trimmed = dashed.replace(/^-+|-+$/g, '');

--- a/tests/blog-backlog/backlog.test.js
+++ b/tests/blog-backlog/backlog.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { loadBacklog, saveBacklog, emptyBacklog } from '../../scripts/blog-backlog/backlog.js';
+
+let tmpDir;
+let file;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'backlog-'));
+  file = path.join(tmpDir, 'blog-backlog.json');
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('emptyBacklog', () => {
+  it('produces a v1 backlog with epoch cursor and no entries', () => {
+    const b = emptyBacklog();
+    expect(b).toEqual({
+      version: 1,
+      cursor: { pr: 0, rfc: '', transcript: '1970-01-01T00:00:00Z' },
+      entries: [],
+    });
+  });
+});
+
+describe('loadBacklog', () => {
+  it('returns emptyBacklog when file is absent', async () => {
+    const b = await loadBacklog(file);
+    expect(b).toEqual(emptyBacklog());
+  });
+
+  it('round-trips through saveBacklog', async () => {
+    const original = emptyBacklog();
+    original.cursor.pr = 42;
+    original.entries.push({
+      id: 'sample-abcd',
+      title: 'Sample',
+      hook: 'A test entry',
+      audience: 'en-tech',
+      targetLength: 1500,
+      supporting: [{ type: 'pr', number: 42 }],
+      status: 'proposed',
+      notes: '',
+      rationale: 'because',
+      createdAt: '2026-05-01T00:00:00Z',
+      lastSeenAt: '2026-05-01T00:00:00Z',
+      draftPath: null,
+    });
+    await saveBacklog(file, original);
+    const reloaded = await loadBacklog(file);
+    expect(reloaded).toEqual(original);
+  });
+
+  it('rejects backlog with unknown version', async () => {
+    await fs.writeFile(file, JSON.stringify({ version: 999, cursor: {}, entries: [] }));
+    await expect(loadBacklog(file)).rejects.toThrow(/version/i);
+  });
+
+  it('rejects entry with invalid status', async () => {
+    const bad = emptyBacklog();
+    bad.entries.push({
+      id: 'x',
+      title: 't',
+      hook: 'h',
+      audience: 'en-tech',
+      targetLength: 100,
+      supporting: [],
+      status: 'banana',
+      notes: '',
+      rationale: '',
+      createdAt: '2026-05-01T00:00:00Z',
+      lastSeenAt: '2026-05-01T00:00:00Z',
+      draftPath: null,
+    });
+    await fs.writeFile(file, JSON.stringify(bad));
+    await expect(loadBacklog(file)).rejects.toThrow(/status/i);
+  });
+});

--- a/tests/blog-backlog/backlog.test.js
+++ b/tests/blog-backlog/backlog.test.js
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'node:fs';
-import path from 'node:path';
 import os from 'node:os';
-import { loadBacklog, saveBacklog, emptyBacklog } from '../../scripts/blog-backlog/backlog.js';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { emptyBacklog, loadBacklog, saveBacklog } from '../../scripts/blog-backlog/backlog.js';
 
 let tmpDir;
 let file;

--- a/tests/blog-backlog/cli.test.js
+++ b/tests/blog-backlog/cli.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '../../scripts/blog-backlog/cli.js');
+
+let tmpDir;
+let file;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cli-'));
+  file = path.join(tmpDir, 'blog-backlog.json');
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function run(args) {
+  return execFileSync('node', [CLI, ...args], { encoding: 'utf-8' });
+}
+
+describe('cli init', () => {
+  it('creates an empty backlog when file is absent', async () => {
+    run(['init', '--file', file]);
+    const raw = JSON.parse(await fs.readFile(file, 'utf-8'));
+    expect(raw.version).toBe(1);
+    expect(raw.entries).toEqual([]);
+  });
+
+  it('is a no-op when the file already exists', async () => {
+    run(['init', '--file', file]);
+    const before = await fs.readFile(file, 'utf-8');
+    run(['init', '--file', file]);
+    const after = await fs.readFile(file, 'utf-8');
+    expect(after).toBe(before);
+  });
+});
+
+describe('cli cursor', () => {
+  it('prints the current cursor as JSON', () => {
+    run(['init', '--file', file]);
+    const out = run(['cursor', '--file', file]);
+    expect(JSON.parse(out)).toEqual({ pr: 0, rfc: '', transcript: '1970-01-01T00:00:00Z' });
+  });
+});
+
+describe('cli apply', () => {
+  it('applies a plan and prints a summary', async () => {
+    run(['init', '--file', file]);
+    const planFile = path.join(tmpDir, 'plan.json');
+    await fs.writeFile(
+      planFile,
+      JSON.stringify({
+        new: [
+          {
+            title: 'Hello world',
+            hook: 'a hook',
+            audience: 'en-tech',
+            targetLength: 1000,
+            supporting: [{ type: 'pr', number: 7 }],
+            rationale: 'because',
+          },
+        ],
+        merge: [],
+        skip: [],
+        cursor: { pr: 7 },
+      }),
+    );
+    const out = run(['apply', '--plan', planFile, '--file', file]);
+    const summary = JSON.parse(out);
+    expect(summary.added).toBe(1);
+    expect(summary.cursor.pr).toBe(7);
+
+    const reloaded = JSON.parse(await fs.readFile(file, 'utf-8'));
+    expect(reloaded.entries).toHaveLength(1);
+    expect(reloaded.entries[0].title).toBe('Hello world');
+  });
+});
+
+describe('cli get', () => {
+  it('prints the entry as JSON', async () => {
+    run(['init', '--file', file]);
+    const planFile = path.join(tmpDir, 'plan.json');
+    await fs.writeFile(
+      planFile,
+      JSON.stringify({
+        new: [
+          {
+            title: 'X',
+            hook: 'h',
+            audience: 'en-tech',
+            targetLength: 1000,
+            supporting: [{ type: 'pr', number: 1 }],
+            rationale: '',
+          },
+        ],
+        merge: [],
+        skip: [],
+        cursor: {},
+      }),
+    );
+    run(['apply', '--plan', planFile, '--file', file]);
+    const reloaded = JSON.parse(await fs.readFile(file, 'utf-8'));
+    const id = reloaded.entries[0].id;
+
+    const out = run(['get', id, '--file', file]);
+    expect(JSON.parse(out).id).toBe(id);
+  });
+
+  it('exits non-zero when the id is missing', () => {
+    run(['init', '--file', file]);
+    expect(() => run(['get', 'nope-zzzz', '--file', file])).toThrow();
+  });
+});
+
+describe('cli update', () => {
+  it('patches status and notes', async () => {
+    run(['init', '--file', file]);
+    const planFile = path.join(tmpDir, 'plan.json');
+    await fs.writeFile(
+      planFile,
+      JSON.stringify({
+        new: [
+          {
+            title: 'X',
+            hook: 'h',
+            audience: 'en-tech',
+            targetLength: 1000,
+            supporting: [{ type: 'pr', number: 1 }],
+            rationale: '',
+          },
+        ],
+        merge: [],
+        skip: [],
+        cursor: {},
+      }),
+    );
+    run(['apply', '--plan', planFile, '--file', file]);
+    const reloaded = JSON.parse(await fs.readFile(file, 'utf-8'));
+    const id = reloaded.entries[0].id;
+
+    const out = run([
+      'update',
+      id,
+      '--status',
+      'greenlit',
+      '--notes',
+      'do this one',
+      '--file',
+      file,
+    ]);
+    const updated = JSON.parse(out);
+    expect(updated.status).toBe('greenlit');
+    expect(updated.notes).toBe('do this one');
+  });
+});

--- a/tests/blog-backlog/cli.test.js
+++ b/tests/blog-backlog/cli.test.js
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { promises as fs } from 'node:fs';
-import path from 'node:path';
-import os from 'node:os';
 import { execFileSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI = path.resolve(__dirname, '../../scripts/blog-backlog/cli.js');

--- a/tests/blog-backlog/dedup.test.js
+++ b/tests/blog-backlog/dedup.test.js
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { applyPlan } from '../../scripts/blog-backlog/dedup.js';
+import { describe, expect, it } from 'vitest';
 import { emptyBacklog } from '../../scripts/blog-backlog/backlog.js';
+import { applyPlan } from '../../scripts/blog-backlog/dedup.js';
 
 const NOW = '2026-05-01T12:00:00Z';
 

--- a/tests/blog-backlog/dedup.test.js
+++ b/tests/blog-backlog/dedup.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { applyPlan } from '../../scripts/blog-backlog/dedup.js';
+import { emptyBacklog } from '../../scripts/blog-backlog/backlog.js';
+
+const NOW = '2026-05-01T12:00:00Z';
+
+function candidate(overrides = {}) {
+  return {
+    title: 'Sample',
+    hook: 'A hook',
+    audience: 'en-tech',
+    targetLength: 1500,
+    supporting: [{ type: 'pr', number: 42 }],
+    rationale: 'because',
+    ...overrides,
+  };
+}
+
+describe('applyPlan', () => {
+  it('appends new candidates with assigned id and proposed status', () => {
+    const backlog = emptyBacklog();
+    const summary = applyPlan(
+      backlog,
+      {
+        new: [candidate()],
+        merge: [],
+        skip: [],
+        cursor: { pr: 42 },
+      },
+      NOW,
+    );
+    expect(summary.added).toBe(1);
+    expect(backlog.entries).toHaveLength(1);
+    const e = backlog.entries[0];
+    expect(e.id).toMatch(/^sample-[0-9a-f]{4}$/);
+    expect(e.status).toBe('proposed');
+    expect(e.notes).toBe('');
+    expect(e.createdAt).toBe(NOW);
+    expect(e.lastSeenAt).toBe(NOW);
+    expect(e.draftPath).toBeNull();
+    expect(backlog.cursor.pr).toBe(42);
+  });
+
+  it('merges supporting refs into the existing entry without touching user-set fields', () => {
+    const backlog = emptyBacklog();
+    backlog.entries.push({
+      id: 'existing-aaaa',
+      title: 'Existing',
+      hook: 'Old hook',
+      audience: 'en-tech',
+      targetLength: 1500,
+      supporting: [{ type: 'pr', number: 10 }],
+      status: 'greenlit',
+      notes: 'lead with the bug',
+      rationale: 'old rationale',
+      createdAt: '2026-04-01T00:00:00Z',
+      lastSeenAt: '2026-04-01T00:00:00Z',
+      draftPath: null,
+    });
+
+    applyPlan(
+      backlog,
+      {
+        new: [],
+        merge: [
+          {
+            intoId: 'existing-aaaa',
+            candidate: candidate({
+              title: 'Different title',
+              hook: 'Different hook',
+              supporting: [
+                { type: 'pr', number: 10 },
+                { type: 'rfc', ref: 'X.md' },
+              ],
+            }),
+          },
+        ],
+        skip: [],
+        cursor: {},
+      },
+      NOW,
+    );
+
+    const e = backlog.entries[0];
+    expect(e.title).toBe('Existing');
+    expect(e.hook).toBe('Old hook');
+    expect(e.status).toBe('greenlit');
+    expect(e.notes).toBe('lead with the bug');
+    expect(e.rationale).toBe('old rationale');
+    expect(e.supporting).toEqual([
+      { type: 'pr', number: 10 },
+      { type: 'rfc', ref: 'X.md' },
+    ]);
+    expect(e.lastSeenAt).toBe(NOW);
+  });
+
+  it('does not duplicate refs that already exist on the merge target', () => {
+    const backlog = emptyBacklog();
+    backlog.entries.push({
+      id: 'x-aaaa',
+      title: 'x',
+      hook: 'h',
+      audience: 'en-tech',
+      targetLength: 100,
+      supporting: [{ type: 'pr', number: 1 }],
+      status: 'proposed',
+      notes: '',
+      rationale: '',
+      createdAt: NOW,
+      lastSeenAt: NOW,
+      draftPath: null,
+    });
+    applyPlan(
+      backlog,
+      {
+        new: [],
+        merge: [
+          { intoId: 'x-aaaa', candidate: candidate({ supporting: [{ type: 'pr', number: 1 }] }) },
+        ],
+        skip: [],
+        cursor: {},
+      },
+      NOW,
+    );
+    expect(backlog.entries[0].supporting).toEqual([{ type: 'pr', number: 1 }]);
+  });
+
+  it('throws if merge.intoId does not exist', () => {
+    const backlog = emptyBacklog();
+    expect(() =>
+      applyPlan(
+        backlog,
+        {
+          new: [],
+          merge: [{ intoId: 'missing-zzzz', candidate: candidate() }],
+          skip: [],
+          cursor: {},
+        },
+        NOW,
+      ),
+    ).toThrow(/missing-zzzz/);
+  });
+
+  it('keeps the higher cursor value for each source', () => {
+    const backlog = emptyBacklog();
+    backlog.cursor = { pr: 100, rfc: '0050.md', transcript: '2026-04-01T00:00:00Z' };
+    applyPlan(
+      backlog,
+      {
+        new: [],
+        merge: [],
+        skip: [],
+        cursor: { pr: 50, rfc: '0099.md', transcript: '2026-04-15T00:00:00Z' },
+      },
+      NOW,
+    );
+    expect(backlog.cursor).toEqual({
+      pr: 100,
+      rfc: '0099.md',
+      transcript: '2026-04-15T00:00:00Z',
+    });
+  });
+
+  it('counts skipped candidates in summary without mutating backlog', () => {
+    const backlog = emptyBacklog();
+    const summary = applyPlan(
+      backlog,
+      {
+        new: [],
+        merge: [],
+        skip: [candidate(), candidate()],
+        cursor: {},
+      },
+      NOW,
+    );
+    expect(summary.skipped).toBe(2);
+    expect(backlog.entries).toHaveLength(0);
+  });
+});

--- a/tests/blog-backlog/id.test.js
+++ b/tests/blog-backlog/id.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { makeId, slugify } from '../../scripts/blog-backlog/id.js';
+
+describe('slugify', () => {
+  it('lowercases and dashes', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+  it('strips punctuation', () => {
+    expect(slugify('Rollback netcode: why we kill audio!')).toBe(
+      'rollback-netcode-why-we-kill-audio',
+    );
+  });
+  it('handles spanish characters', () => {
+    expect(slugify('Cómo diseñamos los hitboxes')).toBe('como-disenamos-los-hitboxes');
+  });
+  it('collapses repeated dashes and trims', () => {
+    expect(slugify('  --foo--bar--  ')).toBe('foo-bar');
+  });
+  it('truncates very long titles to 60 chars', () => {
+    const long = 'a'.repeat(120);
+    expect(slugify(long)).toHaveLength(60);
+  });
+});
+
+describe('makeId', () => {
+  it('combines slug and 4-char hash', () => {
+    const id = makeId('Rollback netcode', [{ type: 'pr', number: 91 }]);
+    expect(id).toMatch(/^rollback-netcode-[0-9a-f]{4}$/);
+  });
+  it('is stable for the same inputs', () => {
+    const a = makeId('Title', [
+      { type: 'pr', number: 1 },
+      { type: 'rfc', ref: 'X.md' },
+    ]);
+    const b = makeId('Title', [
+      { type: 'pr', number: 1 },
+      { type: 'rfc', ref: 'X.md' },
+    ]);
+    expect(a).toBe(b);
+  });
+  it('is order-independent on supporting refs', () => {
+    const a = makeId('Title', [
+      { type: 'pr', number: 1 },
+      { type: 'rfc', ref: 'X.md' },
+    ]);
+    const b = makeId('Title', [
+      { type: 'rfc', ref: 'X.md' },
+      { type: 'pr', number: 1 },
+    ]);
+    expect(a).toBe(b);
+  });
+  it('differs when supporting refs differ', () => {
+    const a = makeId('Title', [{ type: 'pr', number: 1 }]);
+    const b = makeId('Title', [{ type: 'pr', number: 2 }]);
+    expect(a).not.toBe(b);
+  });
+});

--- a/tests/blog-backlog/id.test.js
+++ b/tests/blog-backlog/id.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { makeId, slugify } from '../../scripts/blog-backlog/id.js';
 
 describe('slugify', () => {


### PR DESCRIPTION
## Summary

Five-agent system that mines this repo for blog-post candidates and expands chosen entries into drafts.

- **`/blog-mine`** dispatches three parallel subagents (`pr-miner`, `rfc-miner`, `transcript-miner`) and an editor pass that dedups against `docs/blog-backlog.json`. Transcripts are read from both `~/.claude-personal/projects/*a-los-traques*` and `~/.claude/projects/*a-los-traques*`, joined to PRs by worktree slug when possible.
- **`/blog-expand <id>`** dispatches a `blog-drafter` subagent that reads supporting refs (PRs, RFCs, transcripts, code), **verifies claims against source code rather than PR descriptions**, and writes to `apps/web/content/blog/_drafts/<id>.md`. Voice rules per audience tag (`es-friends` / `en-tech` / `both`).
- **Backlog manipulation CLI** (`scripts/blog-backlog/cli.js`) handles all deterministic mutation. The slash command does LLM-judged dedup; the CLI does the writes. 27 unit tests cover load/save, schema validation, ID generation, and merge-plan application.
- First end-to-end run produced 39 raw candidates, deduped to 31 backlog entries (29 en-tech, 2 es-friends). Two drafts shipped to validate both voice paths — the drafter caught real source-of-truth issues in the candidate hooks (grace period is 20s not 5s, rollback predicts 7 frames not 8, fighter count is 17 not 16).

Spec: `docs/superpowers/specs/2026-05-01-blog-article-agent-team-design.md`. Plan: `docs/superpowers/plans/2026-05-01-blog-article-agent-team.md`.

## Test plan

- [x] `bun run test:run` — 1011 tests pass (27 new in `tests/blog-backlog/`)
- [x] `bun run lint` — clean (5 pre-existing warnings on unrelated `Logger` class)
- [x] `/blog-mine` end-to-end on full repo history — 31 entries, cursor advanced to PR #151 / RFC 0019 / today's transcript timestamp
- [x] `/blog-expand` on `tier-listing-...` (en-tech, 1550 words, target 1200–2500)
- [x] `/blog-expand` on `5-segundos-...` (es-friends, 573 words, target 300–600)
- [ ] Re-run `/blog-mine` after merging this PR to verify incremental behavior — should report "Nothing new since last run" (or 1–2 new entries if other PRs landed)
- [ ] Edit `status: greenlit` / `notes:` on a backlog entry, run `/blog-expand`, verify notes steer the drafter
- [ ] Edit `status: rejected` on an entry, re-run `/blog-mine`, verify the editor doesn't re-suggest it

🤖 Generated with [Claude Code](https://claude.com/claude-code)